### PR TITLE
Refactor ProvisionOffer to return providers

### DIFF
--- a/engine/src/tangl/vm/planning/__init__.py
+++ b/engine/src/tangl/vm/planning/__init__.py
@@ -9,7 +9,7 @@ frontier* during :data:`~tangl.vm.frame.ResolutionPhase.PLANNING`:
   (dependency or affordance) with a provisioning policy.
 - :class:`~tangl.vm.planning.provisioning.Provisioner` is the default provider
   that searches registries, updates or clones, or creates new nodes from templates.
-- :class:`~tangl.vm.planning.offer.Offer` wraps a provisioner call as a proposal.
+- :class:`~tangl.vm.planning.offer.ProvisionOffer` wraps a provisioner call as a proposal.
 - :mod:`~tangl.vm.planning.simple_planning_handlers` wires the phase bus:
   collect offers → select & apply → compose a planning receipt.
 

--- a/engine/src/tangl/vm/planning/notes.md
+++ b/engine/src/tangl/vm/planning/notes.md
@@ -7,7 +7,8 @@ Flow (one frame, one cursor):
 
 2.	**Select**: A single “selector” handler merges and de-duplicates offers, applies policy (hard/soft, priority), and decides which to accept.
 
-3.	**Apply**: For each accepted offer, call offer.accept(ctx)—this performs the update.
+3.	**Apply**: For each accepted offer, call ``offer.accept(ctx)`` to compute a provider.
+	    The selector binds the provider and records receipts.
 
       - If Frame.event_sourced=True, your WatchedRegistry captures mutations → Events → a Patch is added in FINALIZE (already implemented).
 

--- a/engine/src/tangl/vm/planning/provisioning.py
+++ b/engine/src/tangl/vm/planning/provisioning.py
@@ -54,20 +54,17 @@ class Provisioner(Handler):
       across provided registries and the graph.
     * **Template application** – UPDATE/CLONE/CREATE use the requirement’s
       :attr:`Requirement.template` to modify or instantiate nodes.
-    * **Failure handling** – marks :attr:`Requirement.is_unresolvable` on failure.
+    * **Pure resolution** – :meth:`resolve` returns providers without mutating
+      requirements; callers decide how to handle success or failure.
 
     API
     ---
-    - :meth:`resolve()` – execute provisioning per policy.
+    - :meth:`resolve()` – execute provisioning per policy and return a provider or ``None``.
     - :meth:`_resolve_existing()` – locate existing provider.
     - :meth:`_resolve_update()` – mutate in place using template.
     - :meth:`_resolve_clone()` – duplicate and evolve a reference provider.
     - :meth:`_resolve_create()` – instantiate from template.
 
-    Notes
-    -----
-    On success, the resolved provider is assigned to
-    :attr:`Requirement.provider` and added to the graph if missing.
     """
     phase: str = "PLANNING.OFFER"
     result_type: Type = list['ProvisionOffer']
@@ -209,10 +206,7 @@ class Provisioner(Handler):
         )
 
     def resolve(self, requirement: Requirement) -> Optional[Node]:
-        """
-        Attempt to directly resolve a provider for an independently complete
-        requirement with a single policy.
-        """
+        """Return a provider for ``requirement`` or ``None`` without side effects."""
 
         provider = None
 
@@ -243,7 +237,6 @@ class Provisioner(Handler):
                     provider_template=requirement.template
                     )
             case _:
-                raise ValueError(f"Unsupported provisioning policy {self.requirement.policy}")
+                raise ValueError(f"Unsupported provisioning policy {requirement.policy}")
 
-        if provider:
-            return provider
+        return provider


### PR DESCRIPTION
## Summary
- update ProvisionOffer so accepting an offer only resolves providers without mutating requirements
- make Provisioner.resolve a pure helper and update documentation for the new behavior
- move provider binding and BuildReceipt creation into the planning selector handlers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5545597e083298f78b51555525175