### PR TITLE
Fix planning receipt unresolved tracking

### DIFF
--- a/engine/src/tangl/vm/planning/offer.py
+++ b/engine/src/tangl/vm/planning/offer.py
@@ -173,12 +173,12 @@ class PlanningReceipt(JobReceipt):
         created = 0
         cloned = 0
 
-        unresolved_hard_requirements = []
+        unresolved_hard_requirements: list[UUID] = []
 
         for b in builds:
             if not b.accepted:
-                if b.hard_req:
-                    unresolved_hard_requirements.append(str(b.caller_id))
+                if b.caller_id is not None:
+                    unresolved_hard_requirements.append(b.caller_id)
                 continue
             match b.operation:
                 case ProvisioningPolicy.EXISTING: attached += 1

--- a/engine/tests/vm/test_planning_receipt.py
+++ b/engine/tests/vm/test_planning_receipt.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+from tangl.vm.planning import BuildReceipt, PlanningReceipt, ProvisioningPolicy
+
+
+def _build_receipt(*, caller_id, operation, accepted, hard_req=None, reason=None, provider_id=None):
+    return BuildReceipt(
+        provisioner_id=uuid4(),
+        requirement_id=caller_id,
+        provider_id=provider_id,
+        operation=operation,
+        accepted=accepted,
+        hard_req=hard_req,
+        reason=reason,
+    )
+
+
+def test_planning_receipt_marks_no_offers_unresolved():
+    requirement_id = uuid4()
+    receipt = _build_receipt(
+        caller_id=requirement_id,
+        operation=ProvisioningPolicy.CREATE,
+        accepted=False,
+        hard_req=True,
+        reason="no_offers",
+    )
+
+    summary = PlanningReceipt.summarize(receipt)
+
+    assert summary.unresolved_hard_requirements == [requirement_id]
+
+
+def test_planning_receipt_counters_preserved_for_positive_receipts():
+    unresolved_id = uuid4()
+    success_id = uuid4()
+
+    successful = _build_receipt(
+        caller_id=success_id,
+        operation=ProvisioningPolicy.CREATE,
+        accepted=True,
+        provider_id=uuid4(),
+    )
+    unresolved = _build_receipt(
+        caller_id=unresolved_id,
+        operation=ProvisioningPolicy.EXISTING,
+        accepted=False,
+        hard_req=True,
+        reason="no_offers",
+    )
+
+    summary = PlanningReceipt.summarize(successful, unresolved)
+
+    assert summary.created == 1
+    assert summary.attached == 0
+    assert summary.unresolved_hard_requirements == [unresolved_id]
+    assert isinstance(summary.unresolved_hard_requirements[0], UUID)


### PR DESCRIPTION
## Summary
- ensure planning receipts keep unresolved requirement IDs as UUIDs and mark every rejected build receipt
- add unit coverage for summarizing no-offers receipts alongside successful operations

## Testing
- PYTHONPATH=engine/src pytest engine/tests/vm/test_planning_receipt.py


------
https://chatgpt.com/codex/tasks/task_e_68e561564c40832995944fabd372ef49