### PR TITLE
Default record stream iteration to seq ordering

### DIFF
--- a/engine/tests/core/test_record_stream.py
+++ b/engine/tests/core/test_record_stream.py
@@ -53,6 +53,22 @@ def test_add_record_accepts_dict_and_assigns_seq():
     last = rs.last()
     assert last is not None and last.record_type == "patch" and last.seq == 0
 
+
+def test_find_all_defaults_to_seq_sorting_with_manual_seq_values():
+    rs = RecordStream()
+    manual = [
+        mkrec("journal", label="later", seq=10),
+        mkrec("journal", label="first", seq=3),
+        mkrec("journal", label="middle", seq=7),
+    ]
+
+    for rec in manual:
+        rs.add_record(rec)
+
+    ordered = list(rs.find_all())
+    assert [r.seq for r in ordered] == sorted(r.seq for r in manual)
+    assert [r.label for r in ordered] == ["first", "middle", "later"]
+
 # --- stream  ---------------------------------------
 
 def test_add_single_item():


### PR DESCRIPTION
## Summary
- default `StreamRegistry.find_all` to sort by `seq` when no explicit sort key is provided
- add a regression test covering manual `seq` values to ensure default ordering remains ascending

## Testing
- PYTHONPATH=./engine/src pytest engine/tests/core/test_record_stream.py


------
https://chatgpt.com/codex/tasks/task_e_68e5c86777588329990be63264a15090