### PR TITLE
Fix DomainNode child lookup helpers and add structural domain tests

### DIFF
--- a/engine/src/tangl/core/domain/structural.py
+++ b/engine/src/tangl/core/domain/structural.py
@@ -9,13 +9,16 @@ from typing import Iterator
 from tangl.core.graph import Subgraph, Node, Graph  # Graph for pydantic
 from .domain import Domain
 
+
 class DomainGraph(Graph, Domain):
     """A graph that provides a structural domain for registered items"""
     ...
 
+
 class DomainSubgraph(Subgraph, Domain):
     """A subgraph that provides a structural domain for member items"""
     ...
+
 
 class DomainNode(Node, Subgraph, Domain):
     """A node that anchors a structural domain for its children"""
@@ -30,10 +33,10 @@ class DomainNode(Node, Subgraph, Domain):
 
     def remove_child(self, child: Node) -> None:
         self.remove_edge_to(child)
-        return self.remove_member(child)
+        self.remove_member(child)
 
     def find_children(self, **criteria) -> Iterator[Node]:
-        return self.find_members(**criteria)
+        return self.find_all(**criteria)
 
     def find_child(self, **criteria) -> Node:
-        return self.find_member(**criteria)
+        return self.find_one(**criteria)

--- a/engine/tests/core/domain/test_structural_domain.py
+++ b/engine/tests/core/domain/test_structural_domain.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from tangl.core.graph import Graph
+from tangl.core.domain import DomainNode
+
+
+def test_domain_node_add_and_remove_child_wires_membership_and_edge():
+    graph = Graph(label="graph")
+    parent = DomainNode(label="parent", graph=graph)
+    child_a = DomainNode(label="child-a", graph=graph)
+    child_b = DomainNode(label="child-b", graph=graph)
+
+    parent.add_child(child_a)
+    parent.add_child(child_b)
+
+    children = list(parent.children())
+    assert child_a in children
+    assert child_b in children
+    assert parent.has_member(child_a)
+    assert parent.has_member(child_b)
+
+    edge = graph.find_edge(source=parent, destination=child_a, edge_type="child")
+    assert edge is not None
+    assert edge.source is parent
+    assert edge.destination is child_a
+
+    parent.remove_child(child_a)
+
+    assert parent.has_member(child_a) is False
+    assert child_a not in list(parent.children())
+    assert graph.find_edge(source=parent, destination=child_a, edge_type="child") is None
+    assert parent.has_member(child_b)
+
+
+def test_domain_node_find_helpers_filter_children_by_criteria():
+    graph = Graph(label="graph")
+    parent = DomainNode(label="parent", graph=graph)
+
+    alpha = DomainNode(label="alpha", graph=graph, tags={"shared"})
+    beta = DomainNode(label="beta", graph=graph, tags={"shared", "beta"})
+    gamma = DomainNode(label="gamma", graph=graph)
+
+    parent.add_child(alpha)
+    parent.add_child(beta)
+    parent.add_child(gamma)
+
+    shared_children = list(parent.find_children(has_tags={"shared"}))
+    assert shared_children == [alpha, beta]
+
+    assert parent.find_child(label="beta") is beta
+    assert parent.find_child(label="missing") is None


### PR DESCRIPTION
## Summary
- update `DomainNode.find_children` and `find_child` to delegate to the Subgraph search helpers
- add focused structural domain tests covering child membership, wiring, and filtered lookup

## Testing
- PYTHONPATH=./engine/src pytest engine/tests/core/domain -k structural

------
https://chatgpt.com/codex/tasks/task_e_68e5f06f593c83299f4f7bf69dd3b5d6