### PR TITLE
Add record stream and snapshot regression tests

### DIFF
--- a/engine/tests/vm/test_snapshot.py
+++ b/engine/tests/vm/test_snapshot.py
@@ -85,3 +85,13 @@ def test_recover_from_snapshot_then_multiple_patches():
     g2 = Ledger.recover_graph_from_stream(led.records)
     assert g2.find_one(label="C") is None
     assert g2.find_one(label="D") is not None
+
+
+def test_snapshot_restore_detects_tampering():
+    g = Graph(label="demo")
+    snap = Snapshot.from_item(g)
+
+    snap.item.label = "mutated"
+
+    with pytest.raises(RuntimeError):
+        snap.restore_item(verify=True)


### PR DESCRIPTION
## Summary
- add coverage for Record.blame, sequence normalization, dictionary normalization, and removal protections in the record stream tests
- exercise StreamRegistry logging and filtering behavior for empty pushes and unmatched queries
- ensure Snapshot.restore_item fails verification after the stored entity mutates

## Testing
- `PYTHONPATH=./engine/src pytest engine/tests/core/test_record_stream.py engine/tests/vm/test_snapshot.py` *(fails: ModuleNotFoundError: No module named 'wrapt')*

------
https://chatgpt.com/codex/tasks/task_e_68e5f0678168832996f609fcd9dc4c77