### PR TITLE
Add targeted VM planning, provisioning, and replay tests

### DIFF
--- a/engine/tests/vm/test_ledger.py
+++ b/engine/tests/vm/test_ledger.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from tangl.core import Graph, Node, StreamRegistry
+from tangl.vm.ledger import Ledger
+from tangl.vm.replay import Event, EventType, Patch
+
+
+def test_maybe_push_snapshot_respects_cadence_and_force():
+    graph = Graph(label="demo")
+    cursor = graph.add_node(label="cursor")
+    ledger = Ledger(graph=graph, cursor_id=cursor.uid)
+    ledger.records = StreamRegistry()
+
+    ledger.step = 1
+    ledger.maybe_push_snapshot(snapshot_cadence=3)
+    assert ledger.records.last(channel="snapshot") is None
+
+    ledger.step = 3
+    ledger.maybe_push_snapshot(snapshot_cadence=3)
+    first_snapshot = ledger.records.last(channel="snapshot")
+    assert first_snapshot is not None
+
+    ledger.step = 4
+    ledger.maybe_push_snapshot(snapshot_cadence=10)
+    assert ledger.records.last(channel="snapshot") is first_snapshot
+
+    ledger.step = 5
+    ledger.maybe_push_snapshot(force=True)
+    snapshots = list(ledger.records.iter_channel("snapshot"))
+    assert len(snapshots) == 2
+    assert snapshots[-1].seq >= snapshots[0].seq
+
+
+def test_recover_graph_from_stream_replays_patches():
+    graph = Graph(label="demo")
+    cursor = graph.add_node(label="cursor")
+    ledger = Ledger(graph=graph, cursor_id=cursor.uid)
+    ledger.records = StreamRegistry()
+
+    ledger.step = 0
+    ledger.push_snapshot()
+    snapshot = ledger.records.last(channel="snapshot")
+
+    created = Node(label="added")
+    event = Event(event_type=EventType.CREATE, source_id=graph.uid, value=created)
+    patch = Patch(
+        registry_id=graph.uid,
+        registry_state_hash=snapshot.item_state_hash,
+        events=[event],
+    )
+    ledger.records.add_record(patch)
+
+    recovered = Ledger.recover_graph_from_stream(ledger.records)
+    assert recovered.find_one(label="added") is not None

--- a/engine/tests/vm/test_patch.py
+++ b/engine/tests/vm/test_patch.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from tangl.core import Graph
+from tangl.vm.replay import Patch
+
+
+def test_patch_apply_allows_matching_registry():
+    graph = Graph(label="demo")
+    applied = Patch(registry_id=graph.uid, registry_state_hash=graph._state_hash(), events=[]).apply(graph)
+    assert applied is not graph
+    assert applied.unstructure() == graph.unstructure()
+
+
+def test_patch_apply_validates_registry_id():
+    graph = Graph(label="demo")
+    patch = Patch(registry_id=uuid.uuid4(), registry_state_hash=graph._state_hash(), events=[])
+    with pytest.raises(ValueError):
+        patch.apply(graph)
+
+
+def test_patch_apply_validates_state_hash():
+    graph = Graph(label="demo")
+    patch = Patch(registry_id=graph.uid, registry_state_hash=b"wrong", events=[])
+    with pytest.raises(ValueError):
+        patch.apply(graph)


### PR DESCRIPTION
## Summary
- add coverage for Provisioner registry iteration and policy fan-out
- exercise planning selector behaviour when handling mixed requirement outcomes
- cover ledger snapshot cadence and replay patch validation paths

## Testing
- PYTHONPATH=./engine/src pytest engine/tests/vm/test_provisioning.py engine/tests/vm/planning/test_planning_flow.py engine/tests/vm/test_ledger.py engine/tests/vm/test_patch.py

------
https://chatgpt.com/codex/tasks/task_e_68e5eee9f3cc832990b12cefd64d8ed6