### PR TITLE
Prioritize affordances when collecting planning offers

### DIFF
--- a/engine/src/tangl/core/domain/scope.py
+++ b/engine/src/tangl/core/domain/scope.py
@@ -101,4 +101,13 @@ class Scope(Entity):
         return self.merge_vars(*self.active_domains)
 
     def get_handlers(self, **criteria) -> Iterator[Handler]:
-        return Registry.chain_find_all(*(d.handlers for d in self.active_domains), **criteria, sort_key=lambda x: (x.priority, x.seq))
+        return Registry.chain_find_all(
+            *(d.handlers for d in self.active_domains),
+            **criteria,
+            sort_key=lambda x: (x.priority, x.seq),
+        )
+
+    def find_all(self, **criteria) -> Iterator[GraphItem]:
+        """Proxy :meth:`Graph.find_all` through the scope's graph."""
+
+        return self.graph.find_all(**criteria)

--- a/engine/tests/vm/planning/test_provisioner_discovery.py
+++ b/engine/tests/vm/planning/test_provisioner_discovery.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import copy
+
+from pydantic import Field
+
+from tangl.core import Graph, Node, Registry
+from tangl.core.domain import AffiliateDomain
+from tangl.vm import Frame, ResolutionPhase as P, ProvisioningPolicy
+from tangl.vm.context import Context
+from tangl.vm.planning import Dependency, ProvisionOffer, Provisioner, Requirement
+
+
+class ActorProvisioner(Provisioner):
+    """Provisioner that injects domain templates when collecting offers."""
+
+    def __init__(self, templates: dict[str, dict]):
+        super().__init__(label="actor_provisioner")
+        self._templates = templates
+
+    def get_offers(
+        self,
+        requirement: Requirement,
+        *,
+        ctx: Context | None = None,
+    ) -> list[ProvisionOffer]:
+        injected_template = False
+        original_template = requirement.template
+        template = self._templates.get(requirement.identifier)
+        if template is not None and requirement.template is None:
+            requirement.template = copy.deepcopy(template)
+            injected_template = True
+        try:
+            return super().get_offers(requirement, ctx=ctx)
+        finally:
+            if injected_template:
+                requirement.template = original_template
+
+
+class ActorDomain(AffiliateDomain):
+    """Domain that publishes an actor provisioner seeded with templates."""
+
+    selector_type = Node
+    templates: dict[str, dict] = Field(default_factory=dict)
+
+    def __init__(self, *, label: str, templates: dict[str, dict]):
+        super().__init__(label=label, templates=templates)
+        self.handlers.add(ActorProvisioner(self.templates))
+
+
+def test_custom_provisioner_from_domain_creates_actor():
+    graph = Graph(label="story")
+    scene = graph.add_node(label="scene", tags={"domain:actors"})
+
+    requirement = Requirement[Node](
+        graph=graph,
+        identifier="rogue",
+        policy=ProvisioningPolicy.ANY,
+        hard_requirement=True,
+    )
+    Dependency[Node](
+        graph=graph,
+        source_id=scene.uid,
+        requirement=requirement,
+        label="needs_actor",
+    )
+
+    actor_templates = {
+        "rogue": {"obj_cls": Node, "label": "rogue", "tags": {"role:actor"}},
+    }
+    domain_registry: Registry[AffiliateDomain] = Registry(label="domains")
+    domain_registry.add(ActorDomain(label="actors", templates=actor_templates))
+
+    frame = Frame(graph=graph, cursor_id=scene.uid, domain_registries=[domain_registry])
+    frame.run_phase(P.PLANNING)
+
+    provider = requirement.provider
+    assert provider is not None, "Planning should create a provider from domain template"
+    assert provider.label == "rogue"
+    assert provider in graph
+    assert provider.has_tags({"role:actor"})
+    assert list(graph.find_nodes(label="rogue")) == [provider]


### PR DESCRIPTION
## Summary
- add a scope-level `find_all` helper and use scoped affordance/dependency enumeration when collecting planning offers
- prioritize affordance-sourced offers during selection so existing providers win over provisioning
- extend planning tests to cover affordance precedence and enable the affordance creation scenario
- add a domain-scoped provisioner discovery test that proves custom templates can satisfy requirements

## Testing
- PYTHONPATH=./engine/src pytest engine/tests/vm/planning -v

------
https://chatgpt.com/codex/tasks/task_e_68e70f4d5a6c8329acfe4cc39fd717c5