### PR TITLE
Improve dirty audit helpers and registry duplication checks

### DIFF
--- a/engine/tests/core/test_registry.py
+++ b/engine/tests/core/test_registry.py
@@ -33,13 +33,16 @@ def test_registry_add_find():
     assert r.find_one(label="hero") == e
     assert next(r.find_all(label="hero")) == e
 
-@pytest.mark.xfail(reason="allow_overwrite not implemented yet in current rev")
 def test_registry_prevent_duplicate():
     r = Registry()
     e = Entity(label="hero")
     r.add(e)
-    with pytest.raises(ValueError):
-        r.add(e)  # Should raise because allow_overwrite=False by default
+    # re-adding same reference is idempotent
+    r.add(e)
+
+    e_dup = Entity(uid=e.uid, label="villain")
+    with pytest.raises(ValueError, match="already exists"):
+        r.add(e_dup)
 
 def test_registry_unstructure_structure():
     r = Registry()


### PR DESCRIPTION
## Summary
- add a `mark_dirty` helper and documentation update so entities log non-reproducible mutations
- guard against UUID collisions when adding to a registry and expose helpers to inspect dirty members
- refresh the registry duplicate test to cover idempotent re-adds and duplicate rejection

## Testing
- PYTHONPATH=./engine/src pytest engine/tests/core/test_registry.py


------
https://chatgpt.com/codex/tasks/task_e_68e7ecbc6b2c8329bedf7500dbfa3540