### PR TITLE
Add SimpleScene domain with edge projection tests

### DIFF
--- a/engine/src/tangl/core/domain/scope.py
+++ b/engine/src/tangl/core/domain/scope.py
@@ -101,4 +101,13 @@ class Scope(Entity):
         return self.merge_vars(*self.active_domains)
 
     def get_handlers(self, **criteria) -> Iterator[Handler]:
-        return Registry.chain_find_all(*(d.handlers for d in self.active_domains), **criteria, sort_key=lambda x: (x.priority, x.seq))
+        return Registry.chain_find_all(
+            *(d.handlers for d in self.active_domains),
+            **criteria,
+            sort_key=lambda x: (x.priority, x.seq),
+        )
+
+    def find_all(self, **criteria) -> Iterator[GraphItem]:
+        """Proxy :meth:`Graph.find_all` through the scope's graph."""
+
+        return self.graph.find_all(**criteria)

--- a/engine/src/tangl/story/reference_domain/__init__.py
+++ b/engine/src/tangl/story/reference_domain/__init__.py
@@ -1,0 +1,13 @@
+"""Reference story primitives shipped with StoryTangl."""
+
+from __future__ import annotations
+
+from .block import SimpleBlock
+from .concept import SimpleConcept
+from .scene import SimpleScene
+
+__all__ = [
+    "SimpleBlock",
+    "SimpleConcept",
+    "SimpleScene",
+]

--- a/engine/src/tangl/story/reference_domain/block.py
+++ b/engine/src/tangl/story/reference_domain/block.py
@@ -1,0 +1,141 @@
+"""Block primitive for the reference narrative domain."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from tangl.core import BaseFragment, Graph, Node, global_domain
+from tangl.vm.context import Context
+from tangl.vm.frame import ChoiceEdge, ResolutionPhase as P
+
+from .concept import SimpleConcept
+
+__all__ = ["SimpleBlock"]
+
+
+def _normalize_ns(ns: Any) -> Mapping[str, Any] | None:
+    """Return a mapping suitable for formatting or ``None`` if unavailable."""
+
+    if ns is None:
+        return None
+    if isinstance(ns, Mapping):
+        return ns
+    try:
+        return dict(ns)
+    except TypeError:
+        return None
+
+
+class SimpleBlock(Node):
+    """SimpleBlock(label: str, content: str = "")
+
+    Structural node that groups :class:`SimpleConcept` children and presents
+    player choices.
+
+    Why
+    ----
+    Blocks act as the smallest interactive unit—collecting prose fragments and
+    then surfacing decisions to advance the story.
+
+    Key Features
+    ------------
+    * **Inline prose** – optional :attr:`content` rendered before child concepts.
+    * **Concept aggregation** – :meth:`get_concepts` yields child
+      :class:`SimpleConcept` nodes in creation order.
+    * **Choice presentation** – :meth:`get_choices` filters available
+      :class:`~tangl.vm.frame.ChoiceEdge` options using the active namespace.
+
+    API
+    ---
+    - :attr:`content` – convenience prose field.
+    - :meth:`get_concepts` – iterate child concepts.
+    - :meth:`get_choices` – list available choices for UI rendering.
+    """
+
+    content: str = ""
+
+    def get_concepts(self) -> list[SimpleConcept]:
+        """Return child :class:`SimpleConcept` nodes in stable order."""
+
+        concepts: list[SimpleConcept] = []
+        for edge in self.edges_out():
+            destination = edge.destination
+            if isinstance(destination, SimpleConcept):
+                concepts.append(destination)
+        return concepts
+
+    def get_choices(self, *, ns: Mapping[str, Any] | None = None) -> list[ChoiceEdge]:
+        """Return available :class:`ChoiceEdge` instances from this block."""
+
+        choices: list[ChoiceEdge] = []
+        for edge in self.edges_out(is_instance=ChoiceEdge):
+            if ns is not None and not edge.available(ns):
+                continue
+            choices.append(edge)
+        return choices
+
+
+@global_domain.handlers.register(
+    phase=P.JOURNAL,
+    priority=40,
+    selection_criteria={"is_instance": SimpleBlock},
+)
+def render_block(cursor: SimpleBlock, *, ctx: Context, **_: Any) -> list[BaseFragment] | None:
+    """Render inline content, child concepts, and choice menu for a block."""
+
+    ns_raw = ctx.get_ns()
+    ns = _normalize_ns(ns_raw)
+    fragments: list[BaseFragment] = []
+
+    if not isinstance(cursor, SimpleBlock):  # pragma: no cover - defensive guard
+        return None
+
+    if cursor.content:
+        if ns is None:
+            inline_text = cursor.content
+        else:
+            try:
+                inline_text = cursor.content.format_map(ns)
+            except (KeyError, ValueError):
+                inline_text = cursor.content
+        fragments.append(
+            BaseFragment(
+                content=inline_text,
+                source_id=cursor.uid,
+                source_label=cursor.label,
+                fragment_type="block_content",
+            )
+        )
+
+    for concept in cursor.get_concepts():
+        rendered = concept.render(ns_raw)
+        fragments.append(
+            BaseFragment(
+                content=rendered,
+                source_id=concept.uid,
+                source_label=concept.label,
+                fragment_type="concept",
+            )
+        )
+
+    choices = cursor.get_choices(ns=ns)
+    if choices:
+        lines = [""]
+        for index, choice in enumerate(choices, start=1):
+            destination = choice.destination
+            label = choice.label or (destination.label if destination is not None else "")
+            lines.append(f"{index}. {label}")
+        fragments.append(
+            BaseFragment(
+                content="\n".join(lines),
+                source_id=cursor.uid,
+                source_label=f"{cursor.label}_menu",
+                fragment_type="choice_menu",
+            )
+        )
+
+    return fragments or None
+
+
+SimpleBlock.model_rebuild(_types_namespace={"Graph": Graph})

--- a/engine/src/tangl/story/reference_domain/concept.py
+++ b/engine/src/tangl/story/reference_domain/concept.py
@@ -1,0 +1,87 @@
+"""Simple concept node for the reference narrative domain."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from tangl.core import BaseFragment, Graph, Node, global_domain
+from tangl.core.domain import NS
+from tangl.vm.context import Context
+from tangl.vm.frame import ResolutionPhase as P
+
+__all__ = ["SimpleConcept"]
+
+
+class SimpleConcept(Node):
+    """SimpleConcept(label: str, content: str = "")
+
+    Minimal narrative node that stores textual content and renders it into the
+    journal.
+
+    Why
+    ----
+    Story graphs need a lightweight primitive for emitting prose without pulling
+    in application-specific abstractions. ``SimpleConcept`` keeps the behavior
+    focused on formatting text during the JOURNAL phase.
+
+    Key Features
+    ------------
+    * **Text content** – the :attr:`content` field holds raw prose for the node.
+    * **Templating** – :meth:`render` performs best-effort ``str.format``
+      substitution from the active namespace.
+    * **Auto-journal** – a domain handler converts the rendered text into a
+      :class:`~tangl.core.fragment.BaseFragment`.
+
+    API
+    ---
+    - :attr:`content` – raw string assigned by builders or parsers.
+    - :meth:`render` – resolve the content against a namespace mapping.
+    """
+
+    content: str = ""
+
+    def render(self, ns: NS | Mapping[str, Any]) -> str:
+        """Return :attr:`content` with namespace variables substituted.
+
+        Parameters
+        ----------
+        ns:
+            Namespace mapping exposed by the active :class:`~tangl.core.domain.Scope`.
+
+        Notes
+        -----
+        Missing keys or malformed format strings fall back to the raw content to
+        ensure journal output is never interrupted by template errors.
+        """
+
+        mapping: Mapping[str, Any]
+        if isinstance(ns, Mapping):
+            mapping = ns
+        else:
+            mapping = dict(ns)
+
+        try:
+            return self.content.format_map(mapping)
+        except (KeyError, ValueError):
+            return self.content
+
+
+@global_domain.handlers.register(phase=P.JOURNAL, priority=45)
+def render_concept_to_fragment(cursor: Node, *, ctx: Context, **_: Any) -> BaseFragment | None:
+    """Emit a :class:`~tangl.core.fragment.BaseFragment` when the cursor is a concept."""
+
+    if not isinstance(cursor, SimpleConcept):  # pragma: no cover - defensive guard
+        return None
+
+    ns = ctx.get_ns()
+    rendered = cursor.render(ns)
+    return BaseFragment(
+        content=rendered,
+        source_id=cursor.uid,
+        source_label=cursor.label,
+        fragment_type="content",
+    )
+
+
+SimpleConcept.model_rebuild(_types_namespace={"Graph": Graph})

--- a/engine/src/tangl/story/reference_domain/scene.py
+++ b/engine/src/tangl/story/reference_domain/scene.py
@@ -1,0 +1,140 @@
+"""Scene primitive for the reference narrative domain."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import PrivateAttr
+
+from tangl.core import Graph, Node
+from tangl.vm.domain import TraversableDomain
+from tangl.vm.planning import Affordance, Dependency
+
+from .block import SimpleBlock
+
+__all__ = ["SimpleScene"]
+
+
+class SimpleScene(TraversableDomain):
+    """SimpleScene(label: str, member_ids: list[Node], entry_ids: list[Node] | None = None, exit_ids: list[Node] | None = None)
+
+    Structural domain that groups :class:`SimpleBlock` members and projects
+    satisfied edges into the namespace.
+
+    Why
+    ----
+    Scenes provide the narrative boundary around a set of blocks. They expose
+    a canonical source/sink for traversal, aggregate shared resources, and make
+    dependency results visible to prose through the namespace stack.
+
+    Key Features
+    ------------
+    * **Canonical traversal** – inherits single source/sink wiring from
+      :class:`~tangl.vm.domain.TraversableDomain`.
+    * **Block introspection** – :meth:`get_member_blocks` and the
+      :attr:`entry_blocks`/:attr:`exit_blocks` helpers expose structural members.
+    * **Edge projection** – :meth:`refresh_edge_projections` mirrors satisfied
+      :class:`~tangl.vm.planning.open_edge.Dependency` and
+      :class:`~tangl.vm.planning.open_edge.Affordance` edges into ``vars``.
+
+    API
+    ---
+    - :meth:`get_member_blocks` – list the :class:`SimpleBlock` members.
+    - :attr:`entry_blocks` / :attr:`exit_blocks` – resolve entry/exit members.
+    - :meth:`refresh_edge_projections` – update namespace mirrors for edges.
+    """
+
+    _base_vars: dict[str, Any] | None = PrivateAttr(default=None)
+    _projected_keys: set[str] = PrivateAttr(default_factory=set)
+
+    def get_member_blocks(self) -> list[SimpleBlock]:
+        """Return all member nodes that are :class:`SimpleBlock` instances."""
+
+        blocks: list[SimpleBlock] = []
+        for member_id in self.member_ids:
+            node = self.graph.get(member_id)
+            if isinstance(node, SimpleBlock):
+                blocks.append(node)
+        return blocks
+
+    @property
+    def entry_blocks(self) -> list[SimpleBlock]:
+        """Return entry nodes filtered to :class:`SimpleBlock` instances."""
+
+        blocks: list[SimpleBlock] = []
+        for uid in self.entry_node_ids:
+            node = self.graph.get(uid)
+            if isinstance(node, SimpleBlock):
+                blocks.append(node)
+        return blocks
+
+    @property
+    def exit_blocks(self) -> list[SimpleBlock]:
+        """Return exit nodes filtered to :class:`SimpleBlock` instances."""
+
+        blocks: list[SimpleBlock] = []
+        for uid in self.exit_node_ids:
+            node = self.graph.get(uid)
+            if isinstance(node, SimpleBlock):
+                blocks.append(node)
+        return blocks
+
+    def refresh_edge_projections(self) -> None:
+        """Project satisfied dependency and affordance edges into ``vars``."""
+
+        current_vars = dict(self.vars)
+        previous_projected = getattr(self, "_projected_keys", set())
+        base_vars = getattr(self, "_base_vars", None)
+
+        if base_vars is None:
+            base_vars = current_vars
+        else:
+            # Remove base keys that were deleted between refreshes.
+            for key in list(base_vars.keys()):
+                if key not in current_vars and key not in previous_projected:
+                    base_vars.pop(key, None)
+            # Capture manual updates to non-projected keys.
+            for key, value in current_vars.items():
+                if key not in previous_projected:
+                    base_vars[key] = value
+
+        projected = dict(base_vars)
+        projected_keys: set[str] = set()
+
+        for block in self.get_member_blocks():
+            for edge in block.edges_out(is_instance=Dependency):
+                label = edge.label
+                if not label:
+                    continue
+                satisfied_key = f"{label}_satisfied"
+                provider = edge.destination
+                if provider is not None:
+                    projected[label] = provider
+                elif label not in base_vars:
+                    projected.pop(label, None)
+                projected[satisfied_key] = edge.satisfied
+                projected_keys.add(label)
+                projected_keys.add(satisfied_key)
+
+            for edge in block.edges_in(is_instance=Affordance):
+                label = edge.label
+                if not label:
+                    continue
+                satisfied_key = f"{label}_satisfied"
+                provider = edge.source
+                if provider is not None:
+                    projected[label] = provider
+                elif label not in base_vars:
+                    projected.pop(label, None)
+                projected[satisfied_key] = edge.satisfied
+                projected_keys.add(label)
+                projected_keys.add(satisfied_key)
+
+        # Update the existing mapping in-place so cached namespaces keep the reference.
+        self.vars.clear()
+        self.vars.update(projected)
+        self._base_vars = base_vars
+        self._projected_keys = projected_keys
+
+
+SimpleScene.model_rebuild(_types_namespace={"Graph": Graph, "Node": Node})

--- a/engine/src/tangl/vm/__init__.py
+++ b/engine/src/tangl/vm/__init__.py
@@ -61,6 +61,7 @@ from .planning import (
 from .context import Context
 from .frame import Frame, ChoiceEdge, ResolutionPhase
 from .ledger import Ledger
+from .domain import TraversableDomain
 
 Offer = ProvisionOffer
 
@@ -73,5 +74,5 @@ __all__ = [
     # planning
     "Requirement", "Provisioner", "Dependency", "Affordance", "ProvisioningPolicy", "Offer", "ProvisionOffer", "BuildReceipt", "PlanningReceipt",
     # resolution
-    "Frame", "ChoiceEdge", "ResolutionPhase", "Ledger", "Context",
+    "Frame", "ChoiceEdge", "ResolutionPhase", "Ledger", "Context", "TraversableDomain",
     ]

--- a/engine/src/tangl/vm/domain/__init__.py
+++ b/engine/src/tangl/vm/domain/__init__.py
@@ -1,0 +1,5 @@
+"""Resolution-oriented domain helpers for the virtual machine layer."""
+
+from .traversable import TraversableDomain
+
+__all__ = ["TraversableDomain"]

--- a/engine/src/tangl/vm/domain/traversable.py
+++ b/engine/src/tangl/vm/domain/traversable.py
@@ -1,0 +1,195 @@
+"""Canonical traversal domains for VM resolution flow."""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Mapping
+from typing import Any
+from uuid import UUID
+
+from pydantic import ConfigDict, Field, PrivateAttr, model_validator
+
+from tangl.core import Graph, Node
+from tangl.core.domain import DomainSubgraph
+from tangl.vm.frame import ChoiceEdge
+
+__all__ = ["TraversableDomain"]
+
+
+class TraversableDomain(DomainSubgraph):
+    """TraversableDomain(label: str, member_ids: list[UUID], entry_ids: list[UUID] | None = None, exit_ids: list[UUID] | None = None)
+
+    Structural domain that exposes a canonical source/sink for resolution flow.
+
+    Why
+    ----
+    Frame traversal needs well-defined entry/exit anchors so bounded sections can
+    detect forward progress and softlocks deterministically. ``TraversableDomain``
+    wires hidden source/sink nodes to the supplied members, ensuring that every
+    bounded section presents a single inbound edge and a single outbound edge.
+
+    Key Features
+    ------------
+    * **Canonical wiring** – introduces hidden ``SOURCE``/``SINK`` nodes and
+      links entries/exits with :class:`~tangl.vm.frame.ChoiceEdge` instances.
+    * **Reachability checks** – :meth:`has_forward_progress` verifies that the
+      sink is reachable from a given node using only satisfied choice edges.
+    * **Composable sections** – the synthetic nodes let nested domains connect
+      without rewriting member graphs.
+
+    API
+    ---
+    - :attr:`entry_node_ids` / :attr:`exit_node_ids` – real nodes used as entry
+      and exit points.
+    - :meth:`source` / :meth:`sink` – synthetic nodes that anchor traversal.
+    - :meth:`has_forward_progress` – detect whether the sink is reachable from a
+      given node.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    entry_node_ids: list[UUID] = Field(default_factory=list, alias="entry_ids")
+    exit_node_ids: list[UUID] = Field(default_factory=list, alias="exit_ids")
+    _source_id: UUID | None = PrivateAttr(default=None)
+    _sink_id: UUID | None = PrivateAttr(default=None)
+
+    @model_validator(mode="after")
+    def _initialize_canonical_wiring(self) -> "TraversableDomain":
+        if not self.entry_node_ids and self.member_ids:
+            self.entry_node_ids = [self.member_ids[0]]
+        if not self.exit_node_ids and self.member_ids:
+            self.exit_node_ids = [self.member_ids[-1]]
+        self._create_source_sink()
+        return self
+
+    @property
+    def source(self) -> Node:
+        """Return the synthetic entry node."""
+
+        if self._source_id is None:
+            raise RuntimeError(f"Domain {self.label!r} has no source node")
+        source = self.graph.get(self._source_id)
+        if source is None:
+            raise RuntimeError(f"Domain {self.label!r} lost its source node")
+        return source
+
+    @property
+    def sink(self) -> Node:
+        """Return the synthetic exit node."""
+
+        if self._sink_id is None:
+            raise RuntimeError(f"Domain {self.label!r} has no sink node")
+        sink = self.graph.get(self._sink_id)
+        if sink is None:
+            raise RuntimeError(f"Domain {self.label!r} lost its sink node")
+        return sink
+
+    def has_forward_progress(self, from_node: Node, *, ns: Mapping[str, Any] | None = None) -> bool:
+        """Return ``True`` when the sink is reachable from ``from_node``.
+
+        The traversal only considers destination nodes that remain within the
+        domain's membership (plus the synthetic source/sink) and ignores
+        :class:`ChoiceEdge` instances that are unavailable or marked as
+        unsatisfied. This keeps reachability checks deterministic and scoped to
+        the bounded section represented by the domain.
+        """
+
+        if from_node.graph is not self.graph:
+            raise ValueError("Node does not belong to this domain's graph")
+
+        allowed: set[UUID] = set(self.member_ids)
+        if self._source_id is not None:
+            allowed.add(self._source_id)
+        if self._sink_id is not None:
+            allowed.add(self._sink_id)
+
+        if from_node.uid not in allowed:
+            raise ValueError("Node is not a member of this traversable domain")
+
+        visited: set[UUID] = set()
+        queue = deque([from_node])
+
+        while queue:
+            current = queue.popleft()
+            if current.uid in visited:
+                continue
+            visited.add(current.uid)
+
+            if current.uid == self._sink_id:
+                return True
+
+            for edge in current.edges_out(is_instance=ChoiceEdge):
+                destination = edge.destination
+                if destination is None or destination.uid not in allowed:
+                    continue
+                if ns is not None and not edge.available(ns):
+                    continue
+                if not getattr(edge, "satisfied", True):
+                    continue
+                queue.append(destination)
+
+        return False
+
+    def _create_source_sink(self) -> None:
+        if self.graph is None:
+            return
+
+        source_label = f"{self.label}__SOURCE"
+        sink_label = f"{self.label}__SINK"
+
+        source = self.graph.find_node(label=source_label)
+        if source is None:
+            source = self.graph.add_node(
+                label=source_label,
+                tags=["abstract", "source", "hidden"],
+            )
+
+        sink = self.graph.find_node(label=sink_label)
+        if sink is None:
+            sink = self.graph.add_node(
+                label=sink_label,
+                tags=["abstract", "sink", "hidden"],
+            )
+
+        self._source_id = source.uid
+        self._sink_id = sink.uid
+
+        if source.uid not in self.member_ids:
+            self.add_member(source)
+        if sink.uid not in self.member_ids:
+            self.add_member(sink)
+
+        for entry_id in self.entry_node_ids:
+            entry = self.graph.get(entry_id)
+            if entry is None:
+                continue
+            if self.graph.find_edge(
+                source=source,
+                destination=entry,
+                is_instance=ChoiceEdge,
+            ) is None:
+                ChoiceEdge(
+                    graph=self.graph,
+                    source_id=source.uid,
+                    destination_id=entry.uid,
+                    label=f"enter_{self.label}",
+                )
+
+        for exit_id in self.exit_node_ids:
+            exit_node = self.graph.get(exit_id)
+            if exit_node is None:
+                continue
+            if self.graph.find_edge(
+                source=exit_node,
+                destination=sink,
+                is_instance=ChoiceEdge,
+            ) is None:
+                ChoiceEdge(
+                    graph=self.graph,
+                    source_id=exit_node.uid,
+                    destination_id=sink.uid,
+                    label=f"exit_{self.label}",
+                )
+
+
+TraversableDomain.model_rebuild(_types_namespace={"Graph": Graph})

--- a/engine/src/tangl/vm/simple_handlers.py
+++ b/engine/src/tangl/vm/simple_handlers.py
@@ -12,7 +12,9 @@ examples. Real applications can register additional handlers in their domains.
 
 import logging
 
-from tangl.core import Node, global_domain, BaseFragment
+from collections.abc import Iterable
+
+from tangl.core import BaseFragment, Node, global_domain
 from tangl.core.domain import NS
 from tangl.vm.context import Context
 from tangl.vm.frame import ResolutionPhase as P, ChoiceEdge
@@ -88,13 +90,24 @@ def journal_line(cursor: Node, *, ctx: Context, **kwargs):
 @global_domain.handlers.register(phase=P.JOURNAL, priority=100)
 def coerce_to_fragments(*args, ctx: Context, **kwargs):
     """Coerce mixed handler outputs into a list of :class:`~tangl.core.fragment.BaseFragment`.  Runs LAST."""
-    fragments = []
+    fragments: list[BaseFragment] = []
+
+    def _extend(value: object) -> None:
+        if value is None:
+            return
+        if isinstance(value, BaseFragment):
+            fragments.append(value)
+            return
+        if isinstance(value, str):
+            fragments.append(BaseFragment(content=value))
+            return
+        if isinstance(value, Iterable):
+            for item in value:
+                _extend(item)
+            return
+        fragments.append(BaseFragment(content=str(value)))
+
     for receipt in ctx.job_receipts:
-        result = receipt.result
-        if isinstance(result, BaseFragment):
-            fragments.append(result)
-        else:
-            f = BaseFragment(content=result)
-            fragments.append(f)
+        _extend(receipt.result)
     logger.debug(f"JOURNAL: Outputting fragments: {fragments}")
     return fragments

--- a/engine/tests/conftest.py
+++ b/engine/tests/conftest.py
@@ -1,4 +1,33 @@
 import logging
+import sys
+import types
+
+try:  # pragma: no cover - optional dependency shim for tests
+    import wrapt  # type: ignore  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover - executed in CI environment
+    class _ObjectProxy:
+        """Minimal stand-in for :class:`wrapt.ObjectProxy` used in tests."""
+
+        def __init__(self, wrapped):
+            object.__setattr__(self, "__wrapped__", wrapped)
+
+        def __getattr__(self, name):
+            return getattr(object.__getattribute__(self, "__wrapped__"), name)
+
+        def __setattr__(self, name, value):
+            if name == "__wrapped__" or name.startswith("_self_"):
+                object.__setattr__(self, name, value)
+            else:
+                setattr(object.__getattribute__(self, "__wrapped__"), name, value)
+
+        def __delattr__(self, name):
+            if name == "__wrapped__" or name.startswith("_self_"):
+                object.__delattr__(self, name)
+            else:
+                delattr(object.__getattribute__(self, "__wrapped__"), name)
+
+    stub = types.SimpleNamespace(ObjectProxy=_ObjectProxy)
+    sys.modules["wrapt"] = stub
 
 logging.basicConfig(level=logging.INFO)
 logging.getLogger("markdown_it").setLevel(logging.WARNING)

--- a/engine/tests/story/reference_domain/test_block.py
+++ b/engine/tests/story/reference_domain/test_block.py
@@ -1,0 +1,124 @@
+"""Tests for :mod:`tangl.story.reference_domain.block`."""
+
+from __future__ import annotations
+
+from tangl.core import BaseFragment, Graph
+from tangl.story.reference_domain import SimpleBlock, SimpleConcept
+from tangl.vm import ChoiceEdge, Frame, ResolutionPhase as P
+
+
+def _by_fragment_type(fragments: list[BaseFragment], fragment_type: str) -> list[BaseFragment]:
+    return [f for f in fragments if isinstance(f, BaseFragment) and f.fragment_type == fragment_type]
+
+
+def test_block_stores_inline_content() -> None:
+    block = SimpleBlock(label="block", content="Inline text")
+
+    assert block.content == "Inline text"
+    assert block.label == "block"
+
+
+def test_get_concepts_returns_only_concepts() -> None:
+    g = Graph(label="test")
+    block = SimpleBlock(graph=g, label="parent")
+    concept = SimpleConcept(graph=g, label="child", content="text")
+    other = SimpleBlock(graph=g, label="other")
+
+    g.add_edge(block, concept)
+    g.add_edge(block, other)
+
+    concepts = block.get_concepts()
+
+    assert concepts == [concept]
+
+
+def test_get_choices_filters_by_availability() -> None:
+    g = Graph(label="test")
+    start = SimpleBlock(graph=g, label="start")
+    left = SimpleBlock(graph=g, label="left")
+    right = SimpleBlock(graph=g, label="right")
+
+    locked = ChoiceEdge(graph=g, source_id=start.uid, destination_id=left.uid, label="locked")
+    open_edge = ChoiceEdge(graph=g, source_id=start.uid, destination_id=right.uid, label="open")
+
+    locked.predicate = lambda ns: ns.get("has_key", False)
+
+    assert start.get_choices() == [locked, open_edge]
+    assert start.get_choices(ns={"has_key": False}) == [open_edge]
+    assert start.get_choices(ns={"has_key": True}) == [locked, open_edge]
+
+
+def test_block_journal_renders_inline_content() -> None:
+    g = Graph(label="test")
+    block = SimpleBlock(graph=g, label="block", content="Inline text")
+
+    frame = Frame(graph=g, cursor_id=block.uid)
+    fragments = frame.run_phase(P.JOURNAL)
+
+    inline = _by_fragment_type(fragments, "block_content")
+    assert len(inline) == 1
+    assert "Inline text" in inline[0].content
+
+
+def test_block_journal_renders_child_concepts() -> None:
+    g = Graph(label="test")
+    block = SimpleBlock(graph=g, label="block")
+    first = SimpleConcept(graph=g, label="first", content="First")
+    second = SimpleConcept(graph=g, label="second", content="Second")
+    g.add_edge(block, first)
+    g.add_edge(block, second)
+
+    frame = Frame(graph=g, cursor_id=block.uid)
+    fragments = frame.run_phase(P.JOURNAL)
+
+    concept_frags = _by_fragment_type(fragments, "concept")
+    assert len(concept_frags) == 2
+    contents = {f.content for f in concept_frags}
+    assert {"First", "Second"} <= contents
+
+
+def test_block_journal_renders_choice_menu() -> None:
+    g = Graph(label="test")
+    start = SimpleBlock(graph=g, label="start")
+    left = SimpleBlock(graph=g, label="left")
+    right = SimpleBlock(graph=g, label="right")
+    ChoiceEdge(graph=g, source_id=start.uid, destination_id=left.uid, label="Left")
+    ChoiceEdge(graph=g, source_id=start.uid, destination_id=right.uid, label="Right")
+
+    frame = Frame(graph=g, cursor_id=start.uid)
+    fragments = frame.run_phase(P.JOURNAL)
+
+    menus = _by_fragment_type(fragments, "choice_menu")
+    assert len(menus) == 1
+    menu_text = menus[0].content
+    assert "1. Left" in menu_text
+    assert "2. Right" in menu_text
+
+
+def test_block_with_concepts_and_choices_emits_all_fragments() -> None:
+    g = Graph(label="test")
+    block = SimpleBlock(graph=g, label="tavern", content="You enter the tavern.")
+    smell = SimpleConcept(graph=g, label="smell", content="It smells of ale.")
+    sound = SimpleConcept(graph=g, label="sound", content="Music plays softly.")
+    g.add_edge(block, smell)
+    g.add_edge(block, sound)
+
+    bar = SimpleBlock(graph=g, label="bar")
+    corner = SimpleBlock(graph=g, label="corner")
+    ChoiceEdge(graph=g, source_id=block.uid, destination_id=bar.uid, label="Approach bar")
+    ChoiceEdge(graph=g, source_id=block.uid, destination_id=corner.uid, label="Find corner")
+
+    frame = Frame(graph=g, cursor_id=block.uid)
+    fragments = frame.run_phase(P.JOURNAL)
+
+    inline = _by_fragment_type(fragments, "block_content")
+    concepts = _by_fragment_type(fragments, "concept")
+    menus = _by_fragment_type(fragments, "choice_menu")
+
+    assert inline and concepts and menus
+
+    inline_index = fragments.index(inline[0])
+    first_concept_index = fragments.index(concepts[0])
+    menu_index = fragments.index(menus[0])
+
+    assert inline_index < first_concept_index < menu_index

--- a/engine/tests/story/reference_domain/test_concept.py
+++ b/engine/tests/story/reference_domain/test_concept.py
@@ -1,0 +1,88 @@
+"""Tests for :mod:`tangl.story.reference_domain.concept`."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pytest
+
+from tangl.core import BaseFragment, Graph, Node
+from tangl.core.domain import global_domain
+from tangl.story.reference_domain import SimpleConcept
+from tangl.vm import Frame, ResolutionPhase as P
+
+
+def collect_fragment(fragments: Iterable[BaseFragment], *, source_id) -> BaseFragment:
+    for fragment in fragments:
+        if isinstance(fragment, BaseFragment) and fragment.source_id == source_id:
+            return fragment
+    raise AssertionError("Expected fragment from source was not produced")
+
+
+class TestSimpleConcept:
+    def test_stores_content(self):
+        concept = SimpleConcept(label="test", content="Hello world")
+
+        assert concept.content == "Hello world"
+        assert concept.label == "test"
+
+    def test_render_with_namespace(self):
+        concept = SimpleConcept(label="greeting", content="Hello, {name}!")
+        rendered = concept.render({"name": "Alice"})
+
+        assert rendered == "Hello, Alice!"
+
+    def test_render_without_variables(self):
+        concept = SimpleConcept(label="plain", content="This is plain text.")
+
+        rendered = concept.render({})
+        assert rendered == "This is plain text."
+
+    def test_render_missing_variables_returns_raw_content(self):
+        concept = SimpleConcept(label="incomplete", content="Hello, {name}!")
+
+        rendered = concept.render({})
+        assert rendered == "Hello, {name}!"
+
+    def test_journal_handler_emits_fragment(self):
+        graph = Graph(label="test")
+        concept = SimpleConcept(graph=graph, label="greeting", content="Welcome to the story.")
+
+        frame = Frame(graph=graph, cursor_id=concept.uid)
+        fragments = frame.run_phase(P.JOURNAL)
+        fragment = collect_fragment(fragments, source_id=concept.uid)
+
+        assert "Welcome to the story." in fragment.content
+        assert fragment.source_id == concept.uid
+
+    def test_render_uses_frame_namespace(self):
+        graph = Graph(label="test")
+        concept = SimpleConcept(graph=graph, label="greeting", content="Hello, {player_name}!")
+
+        global_domain.vars.setdefault("player_name", "Bob")
+        try:
+            frame = Frame(graph=graph, cursor_id=concept.uid)
+            fragments = frame.run_phase(P.JOURNAL)
+            fragment = collect_fragment(fragments, source_id=concept.uid)
+        finally:
+            global_domain.vars.pop("player_name", None)
+
+        assert "Hello, Bob!" in fragment.content
+
+    def test_handler_ignores_plain_nodes(self):
+        graph = Graph(label="test")
+        node = Node(graph=graph, label="plain")
+        graph.add(node)
+
+        frame = Frame(graph=graph, cursor_id=node.uid)
+        fragments = frame.run_phase(P.JOURNAL)
+
+        assert any("cursor" in fragment.content for fragment in fragments)
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_domain_vars():
+    original = dict(global_domain.vars)
+    yield
+    global_domain.vars.clear()
+    global_domain.vars.update(original)

--- a/engine/tests/story/reference_domain/test_scene.py
+++ b/engine/tests/story/reference_domain/test_scene.py
@@ -1,0 +1,280 @@
+"""Tests for :mod:`tangl.story.reference_domain.scene`."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from tangl.core import Graph, Node
+from tangl.story.reference_domain import SimpleBlock, SimpleConcept, SimpleScene
+from tangl.vm import (
+    Affordance,
+    ChoiceEdge,
+    Dependency,
+    Frame,
+    ProvisioningPolicy,
+    Requirement,
+    ResolutionPhase as P,
+)
+
+
+def _destination_ids(node: Node) -> set[UUID]:
+    return {
+        edge.destination.uid
+        for edge in node.edges_out(is_instance=ChoiceEdge)
+        if edge.destination is not None
+    }
+
+
+def test_scene_creates_source_and_sink() -> None:
+    g = Graph(label="test")
+    first = SimpleBlock(graph=g, label="first")
+    second = SimpleBlock(graph=g, label="second")
+
+    scene = SimpleScene(graph=g, label="scene", member_ids=[first.uid, second.uid])
+
+    assert scene.source in g
+    assert scene.sink in g
+    assert scene.source.label.endswith("_SOURCE")
+    assert scene.sink.label.endswith("_SINK")
+
+
+def test_scene_links_source_to_entry_blocks() -> None:
+    g = Graph(label="test")
+    entry_one = SimpleBlock(graph=g, label="entry_one")
+    entry_two = SimpleBlock(graph=g, label="entry_two")
+    middle = SimpleBlock(graph=g, label="middle")
+
+    scene = SimpleScene(
+        graph=g,
+        label="scene",
+        member_ids=[entry_one.uid, entry_two.uid, middle.uid],
+        entry_ids=[entry_one.uid, entry_two.uid],
+    )
+
+    destinations = _destination_ids(scene.source)
+
+    assert entry_one.uid in destinations
+    assert entry_two.uid in destinations
+    assert middle.uid not in destinations
+
+
+def test_scene_links_exit_blocks_to_sink() -> None:
+    g = Graph(label="test")
+    middle = SimpleBlock(graph=g, label="middle")
+    exit_one = SimpleBlock(graph=g, label="exit_one")
+    exit_two = SimpleBlock(graph=g, label="exit_two")
+
+    scene = SimpleScene(
+        graph=g,
+        label="scene",
+        member_ids=[middle.uid, exit_one.uid, exit_two.uid],
+        exit_ids=[exit_one.uid, exit_two.uid],
+    )
+
+    assert scene.sink.uid in _destination_ids(exit_one)
+    assert scene.sink.uid in _destination_ids(exit_two)
+
+
+def test_scene_defaults_entry_exit_to_first_last() -> None:
+    g = Graph(label="test")
+    first = SimpleBlock(graph=g, label="first")
+    middle = SimpleBlock(graph=g, label="middle")
+    last = SimpleBlock(graph=g, label="last")
+
+    scene = SimpleScene(graph=g, label="scene", member_ids=[first.uid, middle.uid, last.uid])
+
+    assert scene.entry_node_ids == [first.uid]
+    assert scene.exit_node_ids == [last.uid]
+    assert scene.entry_blocks == [first]
+    assert scene.exit_blocks == [last]
+
+
+def test_get_member_blocks_returns_only_blocks() -> None:
+    g = Graph(label="test")
+    block_one = SimpleBlock(graph=g, label="block_one")
+    block_two = SimpleBlock(graph=g, label="block_two")
+    concept = SimpleConcept(graph=g, label="concept", content="text")
+
+    scene = SimpleScene(
+        graph=g,
+        label="scene",
+        member_ids=[block_one.uid, concept.uid, block_two.uid],
+    )
+
+    members = scene.get_member_blocks()
+
+    assert members == [block_one, block_two]
+
+
+def test_refresh_edge_projections_for_dependencies() -> None:
+    g = Graph(label="test")
+    block = SimpleBlock(graph=g, label="block")
+    companion = Node(graph=g, label="companion")
+
+    requirement = Requirement[Node](
+        graph=g,
+        identifier="companion",
+        policy=ProvisioningPolicy.EXISTING,
+    )
+    dependency = Dependency[Node](
+        graph=g,
+        source_id=block.uid,
+        requirement=requirement,
+        label="companion",
+    )
+    dependency.requirement.provider = companion
+
+    scene = SimpleScene(graph=g, label="scene", member_ids=[block.uid])
+    scene.refresh_edge_projections()
+
+    assert scene.vars["companion"] is companion
+    assert scene.vars["companion_satisfied"] is True
+
+
+def test_refresh_edge_projections_for_affordances() -> None:
+    g = Graph(label="test")
+    block = SimpleBlock(graph=g, label="block")
+    provider = Node(graph=g, label="provider")
+
+    requirement = Requirement[Node](
+        graph=g,
+        identifier="service",
+        policy=ProvisioningPolicy.EXISTING,
+    )
+    affordance = Affordance[Node](
+        graph=g,
+        source_id=provider.uid,
+        destination_id=block.uid,
+        requirement=requirement,
+        label="service",
+    )
+    affordance.requirement.provider = provider
+
+    scene = SimpleScene(graph=g, label="scene", member_ids=[block.uid])
+    scene.refresh_edge_projections()
+
+    assert scene.vars["service"] is provider
+    assert scene.vars["service_satisfied"] is True
+
+
+def test_refresh_edge_projections_marks_unsatisfied() -> None:
+    g = Graph(label="test")
+    block = SimpleBlock(graph=g, label="block")
+
+    requirement = Requirement[Node](
+        graph=g,
+        identifier="missing",
+        policy=ProvisioningPolicy.EXISTING,
+        hard_requirement=True,
+    )
+    Dependency[Node](graph=g, source_id=block.uid, requirement=requirement, label="missing")
+
+    scene = SimpleScene(graph=g, label="scene", member_ids=[block.uid])
+    scene.refresh_edge_projections()
+
+    assert "missing" not in scene.vars
+    assert scene.vars["missing_satisfied"] is False
+
+
+def test_refresh_edge_projections_preserves_existing_vars() -> None:
+    g = Graph(label="test")
+    block = SimpleBlock(graph=g, label="block")
+    requirement = Requirement[Node](
+        graph=g,
+        identifier="prop",
+        policy=ProvisioningPolicy.EXISTING,
+    )
+    Dependency[Node](graph=g, source_id=block.uid, requirement=requirement, label="prop")
+
+    scene = SimpleScene(graph=g, label="scene", member_ids=[block.uid])
+    scene.vars["region"] = "Tavern"
+
+    scene.refresh_edge_projections()
+
+    assert scene.vars["region"] == "Tavern"
+    assert scene.vars["prop_satisfied"] is False
+
+
+def test_has_forward_progress_reachable() -> None:
+    g = Graph(label="test")
+    start = SimpleBlock(graph=g, label="start")
+    middle = SimpleBlock(graph=g, label="middle")
+    end = SimpleBlock(graph=g, label="end")
+
+    ChoiceEdge(graph=g, source_id=start.uid, destination_id=middle.uid)
+    ChoiceEdge(graph=g, source_id=middle.uid, destination_id=end.uid)
+
+    scene = SimpleScene(
+        graph=g,
+        label="scene",
+        member_ids=[start.uid, middle.uid, end.uid],
+        entry_ids=[start.uid],
+        exit_ids=[end.uid],
+    )
+
+    assert scene.has_forward_progress(start) is True
+    assert scene.has_forward_progress(middle) is True
+
+
+def test_has_forward_progress_softlock() -> None:
+    g = Graph(label="test")
+    start = SimpleBlock(graph=g, label="start")
+    dead_end = SimpleBlock(graph=g, label="dead_end")
+    exit_block = SimpleBlock(graph=g, label="exit")
+
+    ChoiceEdge(graph=g, source_id=start.uid, destination_id=dead_end.uid)
+
+    scene = SimpleScene(
+        graph=g,
+        label="scene",
+        member_ids=[start.uid, dead_end.uid, exit_block.uid],
+        entry_ids=[start.uid],
+        exit_ids=[exit_block.uid],
+    )
+
+    assert scene.has_forward_progress(dead_end) is False
+
+
+def test_scene_namespace_available_during_journal() -> None:
+    g = Graph(label="test")
+    block = SimpleBlock(graph=g, label="block", content="Hello {npc_name}!")
+    scene = SimpleScene(graph=g, label="tavern", member_ids=[block.uid])
+    scene.vars["npc_name"] = "Bartender Bob"
+    scene.refresh_edge_projections()
+
+    frame = Frame(graph=g, cursor_id=block.uid)
+    fragments = frame.run_phase(P.JOURNAL)
+
+    text = "\n".join(getattr(fragment, "content", "") for fragment in fragments)
+    assert "Hello Bartender Bob!" in text
+
+
+def test_refresh_edge_projections_updates_namespace_in_place() -> None:
+    g = Graph(label="test")
+    block = SimpleBlock(graph=g, label="block")
+    actor = Node(graph=g, label="villain")
+
+    requirement = Requirement[Node](
+        graph=g,
+        identifier="npc",
+        policy=ProvisioningPolicy.EXISTING,
+    )
+    dependency = Dependency[Node](
+        graph=g,
+        source_id=block.uid,
+        requirement=requirement,
+        label="npc",
+    )
+
+    scene = SimpleScene(graph=g, label="scene", member_ids=[block.uid])
+
+    frame = Frame(graph=g, cursor_id=block.uid)
+    namespace = frame.context.scope.namespace
+
+    assert "npc" not in namespace
+
+    dependency.destination = actor
+    scene.refresh_edge_projections()
+
+    assert namespace["npc"] is actor
+    assert namespace["npc_satisfied"] is True

--- a/engine/tests/vm/domain/__init__.py
+++ b/engine/tests/vm/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for VM domain helpers."""

--- a/engine/tests/vm/domain/test_traversable.py
+++ b/engine/tests/vm/domain/test_traversable.py
@@ -1,0 +1,203 @@
+"""Tests for :mod:`tangl.vm.domain.traversable`."""
+
+from __future__ import annotations
+
+from tangl.core import Graph
+from tangl.vm.domain import TraversableDomain
+from tangl.vm.frame import ChoiceEdge
+
+
+class TestTraversableDomain:
+    """Behavioural coverage for :class:`TraversableDomain`."""
+
+    def test_creates_source_and_sink_nodes(self) -> None:
+        graph = Graph(label="test")
+        first = graph.add_node(label="first")
+        second = graph.add_node(label="second")
+
+        domain = TraversableDomain(
+            graph=graph,
+            label="section",
+            member_ids=[first.uid, second.uid],
+        )
+
+        assert graph.get(domain.source.uid) is domain.source
+        assert graph.get(domain.sink.uid) is domain.sink
+        assert "SOURCE" in domain.source.label
+        assert "SINK" in domain.sink.label
+        assert {"abstract", "source", "hidden"}.issubset(set(domain.source.tags))
+        assert {"abstract", "sink", "hidden"}.issubset(set(domain.sink.tags))
+
+    def test_source_links_to_entry_nodes(self) -> None:
+        graph = Graph(label="test")
+        entry_a = graph.add_node(label="entry_a")
+        entry_b = graph.add_node(label="entry_b")
+        middle = graph.add_node(label="middle")
+
+        domain = TraversableDomain(
+            graph=graph,
+            label="section",
+            member_ids=[entry_a.uid, entry_b.uid, middle.uid],
+            entry_ids=[entry_a.uid, entry_b.uid],
+        )
+
+        destinations = {
+            edge.destination.uid
+            for edge in domain.source.edges_out(is_instance=ChoiceEdge)
+            if edge.destination is not None
+        }
+        assert entry_a.uid in destinations
+        assert entry_b.uid in destinations
+        assert middle.uid not in destinations
+
+    def test_exit_nodes_link_to_sink(self) -> None:
+        graph = Graph(label="test")
+        middle = graph.add_node(label="middle")
+        exit_a = graph.add_node(label="exit_a")
+        exit_b = graph.add_node(label="exit_b")
+
+        domain = TraversableDomain(
+            graph=graph,
+            label="section",
+            member_ids=[middle.uid, exit_a.uid, exit_b.uid],
+            exit_ids=[exit_a.uid, exit_b.uid],
+        )
+
+        for node in (exit_a, exit_b):
+            destinations = {
+                edge.destination.uid
+                for edge in node.edges_out(is_instance=ChoiceEdge)
+                if edge.destination is not None
+            }
+            assert domain.sink.uid in destinations
+
+    def test_defaults_entry_and_exit_nodes(self) -> None:
+        graph = Graph(label="test")
+        first = graph.add_node(label="first")
+        middle = graph.add_node(label="middle")
+        last = graph.add_node(label="last")
+
+        domain = TraversableDomain(
+            graph=graph,
+            label="section",
+            member_ids=[first.uid, middle.uid, last.uid],
+        )
+
+        assert domain.entry_node_ids == [first.uid]
+        assert domain.exit_node_ids == [last.uid]
+
+        destinations = {
+            edge.destination.uid for edge in domain.source.edges_out(is_instance=ChoiceEdge)
+        }
+        assert first.uid in destinations
+
+        exit_destinations = {
+            edge.destination.uid for edge in last.edges_out(is_instance=ChoiceEdge)
+        }
+        assert domain.sink.uid in exit_destinations
+
+    def test_has_forward_progress_when_path_exists(self) -> None:
+        graph = Graph(label="test")
+        start = graph.add_node(label="start")
+        middle = graph.add_node(label="middle")
+        end = graph.add_node(label="end")
+
+        ChoiceEdge(graph=graph, source_id=start.uid, destination_id=middle.uid)
+        ChoiceEdge(graph=graph, source_id=middle.uid, destination_id=end.uid)
+
+        domain = TraversableDomain(
+            graph=graph,
+            label="section",
+            member_ids=[start.uid, middle.uid, end.uid],
+            entry_ids=[start.uid],
+            exit_ids=[end.uid],
+        )
+
+        assert domain.has_forward_progress(start) is True
+        assert domain.has_forward_progress(middle) is True
+        assert domain.has_forward_progress(end) is True
+
+    def test_has_forward_progress_detects_softlock(self) -> None:
+        graph = Graph(label="test")
+        start = graph.add_node(label="start")
+        dead_end = graph.add_node(label="dead_end")
+        exit_node = graph.add_node(label="exit")
+
+        ChoiceEdge(graph=graph, source_id=start.uid, destination_id=dead_end.uid)
+
+        domain = TraversableDomain(
+            graph=graph,
+            label="section",
+            member_ids=[start.uid, dead_end.uid, exit_node.uid],
+            entry_ids=[start.uid],
+            exit_ids=[exit_node.uid],
+        )
+
+        assert domain.has_forward_progress(dead_end) is False
+
+    def test_has_forward_progress_respects_namespace(self) -> None:
+        graph = Graph(label="test")
+        start = graph.add_node(label="start")
+        gate = graph.add_node(label="gate")
+        exit_node = graph.add_node(label="exit")
+
+        locked_edge = ChoiceEdge(
+            graph=graph,
+            source_id=start.uid,
+            destination_id=gate.uid,
+            predicate=lambda ns: ns.get("has_key", False),
+        )
+        ChoiceEdge(graph=graph, source_id=gate.uid, destination_id=exit_node.uid)
+
+        domain = TraversableDomain(
+            graph=graph,
+            label="section",
+            member_ids=[start.uid, gate.uid, exit_node.uid],
+            entry_ids=[start.uid],
+            exit_ids=[exit_node.uid],
+        )
+
+        assert domain.has_forward_progress(start, ns={"has_key": False}) is False
+        assert domain.has_forward_progress(start, ns={"has_key": True}) is True
+
+    def test_has_forward_progress_ignores_unsatisfied_edges(self) -> None:
+        graph = Graph(label="test")
+        start = graph.add_node(label="start")
+        gate = graph.add_node(label="gate")
+        exit_node = graph.add_node(label="exit")
+
+        edge_to_gate = ChoiceEdge(graph=graph, source_id=start.uid, destination_id=gate.uid)
+        ChoiceEdge(graph=graph, source_id=gate.uid, destination_id=exit_node.uid)
+
+        domain = TraversableDomain(
+            graph=graph,
+            label="section",
+            member_ids=[start.uid, gate.uid, exit_node.uid],
+            entry_ids=[start.uid],
+            exit_ids=[exit_node.uid],
+        )
+
+        object.__setattr__(edge_to_gate, "satisfied", False)
+        assert domain.has_forward_progress(start) is False
+
+        object.__setattr__(edge_to_gate, "satisfied", True)
+        assert domain.has_forward_progress(start) is True
+
+    def test_rejects_nodes_outside_domain(self) -> None:
+        graph = Graph(label="test")
+        first = graph.add_node(label="first")
+        second = graph.add_node(label="second")
+        outsider = graph.add_node(label="outsider")
+
+        domain = TraversableDomain(
+            graph=graph,
+            label="section",
+            member_ids=[first.uid, second.uid],
+        )
+
+        try:
+            domain.has_forward_progress(outsider)
+        except ValueError:
+            pass
+        else:  # pragma: no cover - defensive assertion
+            raise AssertionError("Expected ValueError for node outside domain")

--- a/engine/tests/vm/planning/test_provisioner_discovery.py
+++ b/engine/tests/vm/planning/test_provisioner_discovery.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import copy
+
+from pydantic import Field
+
+from tangl.core import Graph, Node, Registry
+from tangl.core.domain import AffiliateDomain
+from tangl.vm import Frame, ResolutionPhase as P, ProvisioningPolicy
+from tangl.vm.context import Context
+from tangl.vm.planning import Dependency, ProvisionOffer, Provisioner, Requirement
+
+
+class ActorProvisioner(Provisioner):
+    """Provisioner that injects domain templates when collecting offers."""
+
+    def __init__(self, templates: dict[str, dict]):
+        super().__init__(label="actor_provisioner")
+        self._templates = templates
+
+    def get_offers(
+        self,
+        requirement: Requirement,
+        *,
+        ctx: Context | None = None,
+    ) -> list[ProvisionOffer]:
+        injected_template = False
+        original_template = requirement.template
+        template = self._templates.get(requirement.identifier)
+        if template is not None and requirement.template is None:
+            requirement.template = copy.deepcopy(template)
+            injected_template = True
+        try:
+            return super().get_offers(requirement, ctx=ctx)
+        finally:
+            if injected_template:
+                requirement.template = original_template
+
+
+class ActorDomain(AffiliateDomain):
+    """Domain that publishes an actor provisioner seeded with templates."""
+
+    selector_type = Node
+    templates: dict[str, dict] = Field(default_factory=dict)
+
+    def __init__(self, *, label: str, templates: dict[str, dict]):
+        super().__init__(label=label, templates=templates)
+        self.handlers.add(ActorProvisioner(self.templates))
+
+
+def test_custom_provisioner_from_domain_creates_actor():
+    graph = Graph(label="story")
+    scene = graph.add_node(label="scene", tags={"domain:actors"})
+
+    requirement = Requirement[Node](
+        graph=graph,
+        identifier="rogue",
+        policy=ProvisioningPolicy.ANY,
+        hard_requirement=True,
+    )
+    Dependency[Node](
+        graph=graph,
+        source_id=scene.uid,
+        requirement=requirement,
+        label="needs_actor",
+    )
+
+    actor_templates = {
+        "rogue": {"obj_cls": Node, "label": "rogue", "tags": {"role:actor"}},
+    }
+    domain_registry: Registry[AffiliateDomain] = Registry(label="domains")
+    domain_registry.add(ActorDomain(label="actors", templates=actor_templates))
+
+    frame = Frame(graph=graph, cursor_id=scene.uid, domain_registries=[domain_registry])
+    frame.run_phase(P.PLANNING)
+
+    provider = requirement.provider
+    assert provider is not None, "Planning should create a provider from domain template"
+    assert provider.label == "rogue"
+    assert provider in graph
+    assert provider.has_tags({"role:actor"})
+    assert list(graph.find_nodes(label="rogue")) == [provider]

--- a/engine/tests/vm/test_planning_integration.py
+++ b/engine/tests/vm/test_planning_integration.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+from tangl.core import Graph, Node
+from tangl.utils.hashing import hashing_func
+from tangl.vm import (
+    Frame,
+    ChoiceEdge,
+    Requirement,
+    Dependency,
+    Affordance,
+    ProvisioningPolicy,
+    PlanningReceipt,
+    Patch,
+)
+from tangl.vm.frame import ResolutionPhase as P
+
+
+def _collect_step_records(frame: Frame, step: int):
+    marker = f"step-{step:04d}"
+    return list(frame.records.get_section(marker, marker_type="frame"))
+
+
+def _find_planning_receipt(records: list[object]) -> PlanningReceipt:
+    for record in records:
+        if isinstance(record, PlanningReceipt):
+            return record
+    raise AssertionError("planning receipt not found in records")
+
+
+def test_planning_cycle_with_mixed_requirements():
+    """Full planning pass reuses affordances, waives soft requirements, and creates new nodes."""
+
+    g = Graph(label="integration_test")
+
+    start = g.add_node(label="start")
+    node_a = g.add_node(label="node_a")
+    node_b = g.add_node(label="node_b")
+    end = g.add_node(label="end")
+
+    ChoiceEdge(graph=g, source_id=start.uid, destination_id=node_a.uid)
+    ChoiceEdge(graph=g, source_id=node_a.uid, destination_id=node_b.uid)
+    ChoiceEdge(graph=g, source_id=node_b.uid, destination_id=end.uid)
+
+    req_x = Requirement[Node](
+        graph=g,
+        identifier="resource_x",
+        policy=ProvisioningPolicy.CREATE,
+        template={"obj_cls": Node, "label": "resource_x"},
+        hard_requirement=True,
+    )
+    Dependency[Node](
+        graph=g,
+        source_id=node_a.uid,
+        requirement=req_x,
+        label="needs_resource_x",
+    )
+
+    req_y = Requirement[Node](
+        graph=g,
+        identifier="resource_y",
+        policy=ProvisioningPolicy.EXISTING,
+        hard_requirement=False,
+    )
+    Dependency[Node](
+        graph=g,
+        source_id=node_a.uid,
+        requirement=req_y,
+        label="needs_resource_y",
+    )
+
+    service_z = g.add_node(label="service_z")
+    req_z_aff = Requirement[Node](
+        graph=g,
+        identifier=service_z.uid,
+        policy=ProvisioningPolicy.EXISTING,
+        provider=service_z,
+        hard_requirement=False,
+    )
+    Affordance[Node](
+        graph=g,
+        source_id=service_z.uid,
+        destination_id=node_a.uid,
+        requirement=req_z_aff,
+        label="provides_service_z",
+    )
+
+    req_x_reuse = Requirement[Node](
+        graph=g,
+        identifier="resource_x",
+        policy=ProvisioningPolicy.EXISTING,
+        hard_requirement=True,
+    )
+    Dependency[Node](
+        graph=g,
+        source_id=node_b.uid,
+        requirement=req_x_reuse,
+        label="reuses_resource_x",
+    )
+
+    req_w = Requirement[Node](
+        graph=g,
+        identifier="tool_w",
+        policy=ProvisioningPolicy.CREATE,
+        template={"obj_cls": Node, "label": "tool_w"},
+        hard_requirement=True,
+    )
+    Dependency[Node](
+        graph=g,
+        source_id=node_b.uid,
+        requirement=req_w,
+        label="needs_tool_w",
+    )
+
+    frame = Frame(graph=g, cursor_id=start.uid)
+
+    edge_to_a = next(start.edges_out(is_instance=ChoiceEdge))
+    frame.follow_edge(edge_to_a)
+
+    step_1_records = _collect_step_records(frame, 1)
+    assert step_1_records
+    planning_receipt_1 = _find_planning_receipt(step_1_records)
+
+    assert planning_receipt_1.created >= 1
+    assert planning_receipt_1.attached >= 1
+    assert len(planning_receipt_1.waived_soft_requirements) == 1
+    assert not planning_receipt_1.unresolved_hard_requirements
+
+    resource_x = g.find_one(label="resource_x")
+    assert resource_x is not None
+    assert req_x.provider == resource_x
+
+    assert req_y.provider is None
+    assert g.find_one(label="resource_y") is None
+
+    assert req_z_aff.provider == service_z
+
+    edge_to_b = next(node_a.edges_out(is_instance=ChoiceEdge))
+    frame.follow_edge(edge_to_b)
+
+    step_2_records = _collect_step_records(frame, 2)
+    assert step_2_records
+    planning_receipt_2 = _find_planning_receipt(step_2_records)
+
+    assert planning_receipt_2.attached >= 1
+    assert planning_receipt_2.created >= 1
+    assert not planning_receipt_2.unresolved_hard_requirements
+
+    resource_x_nodes = [n for n in g.find_nodes(label="resource_x")]
+    assert len(resource_x_nodes) == 1
+    assert req_x_reuse.provider == resource_x_nodes[0]
+
+    tool_w = g.find_one(label="tool_w")
+    assert tool_w is not None
+    assert req_w.provider == tool_w
+
+    edge_to_end = next(node_b.edges_out(is_instance=ChoiceEdge))
+    frame.follow_edge(edge_to_end)
+
+    assert frame.cursor == end
+    assert frame.step == 3
+
+
+def test_softlock_detection_and_prevention():
+    """Unresolvable hard requirements are surfaced in planning receipts and block progress."""
+
+    g = Graph(label="softlock_test")
+
+    start = g.add_node(label="start")
+    gate = g.add_node(label="gate")
+    end = g.add_node(label="end")
+
+    ChoiceEdge(graph=g, source_id=start.uid, destination_id=gate.uid)
+    edge_gate_to_end = ChoiceEdge(graph=g, source_id=gate.uid, destination_id=end.uid)
+
+    req_key = Requirement[Node](
+        graph=g,
+        identifier="key",
+        policy=ProvisioningPolicy.EXISTING,
+        hard_requirement=True,
+    )
+    Dependency[Node](
+        graph=g,
+        source_id=gate.uid,
+        requirement=req_key,
+        label="needs_key",
+    )
+
+    frame = Frame(graph=g, cursor_id=start.uid)
+
+    edge_to_gate = next(start.edges_out(is_instance=ChoiceEdge))
+    frame.follow_edge(edge_to_gate)
+
+    step_records = _collect_step_records(frame, 1)
+    assert step_records
+    planning_receipt = _find_planning_receipt(step_records)
+
+    assert planning_receipt.unresolved_hard_requirements == [req_key.uid]
+    assert req_key.provider is None
+    assert req_key.is_unresolvable
+
+
+def test_affordance_precedence_over_creation():
+    """Affordances allow existing providers to satisfy dependencies instead of creating new nodes."""
+
+    # Without an affordance, a hard dependency provisions a new companion.
+    g_no_aff = Graph(label="affordance_baseline")
+    start_no_aff = g_no_aff.add_node(label="start")
+    scene_no_aff = g_no_aff.add_node(label="scene")
+    ChoiceEdge(graph=g_no_aff, source_id=start_no_aff.uid, destination_id=scene_no_aff.uid)
+
+    create_requirement = Requirement[Node](
+        graph=g_no_aff,
+        identifier="companion",
+        policy=ProvisioningPolicy.CREATE,
+        template={"obj_cls": Node, "label": "new_companion"},
+        hard_requirement=True,
+    )
+    Dependency[Node](
+        graph=g_no_aff,
+        source_id=scene_no_aff.uid,
+        requirement=create_requirement,
+        label="needs_companion",
+    )
+
+    frame_no_aff = Frame(graph=g_no_aff, cursor_id=start_no_aff.uid)
+    frame_no_aff.follow_edge(next(start_no_aff.edges_out(is_instance=ChoiceEdge)))
+
+    baseline_receipt = _find_planning_receipt(_collect_step_records(frame_no_aff, 1))
+    assert baseline_receipt.created == 1
+    assert create_requirement.provider is not None
+
+    # With an affordance exposing an existing companion, no creation occurs.
+    g = Graph(label="affordance_test")
+
+    start = g.add_node(label="start")
+    scene = g.add_node(label="scene")
+
+    ChoiceEdge(graph=g, source_id=start.uid, destination_id=scene.uid)
+
+    existing_companion = g.add_node(label="companion")
+
+    companion_requirement = Requirement[Node](
+        graph=g,
+        identifier=existing_companion.uid,
+        policy=ProvisioningPolicy.ANY,
+        hard_requirement=True,
+    )
+    Dependency[Node](
+        graph=g,
+        source_id=scene.uid,
+        requirement=companion_requirement,
+        label="needs_companion",
+    )
+
+    Affordance[Node](
+        graph=g,
+        source_id=existing_companion.uid,
+        destination_id=scene.uid,
+        requirement=companion_requirement,
+        label="has_companion",
+    )
+
+    frame = Frame(graph=g, cursor_id=start.uid)
+
+    edge_to_scene = next(start.edges_out(is_instance=ChoiceEdge))
+    frame.follow_edge(edge_to_scene)
+
+    assert companion_requirement.provider == existing_companion
+
+    planning_receipt = _find_planning_receipt(_collect_step_records(frame, 1))
+    assert planning_receipt.created == 0
+
+
+def test_event_sourced_planning_replay():
+    """Event-sourced planning produces deterministic patches that replay cleanly."""
+
+    g = Graph(label="replay_test")
+
+    start = g.add_node(label="start")
+    node = g.add_node(label="node")
+
+    ChoiceEdge(graph=g, source_id=start.uid, destination_id=node.uid)
+
+    req = Requirement[Node](
+        graph=g,
+        identifier="created",
+        policy=ProvisioningPolicy.CREATE,
+        template={"obj_cls": Node, "label": "created"},
+        hard_requirement=True,
+    )
+    Dependency[Node](
+        graph=g,
+        source_id=node.uid,
+        requirement=req,
+        label="needs_created",
+    )
+
+    baseline_hash = hashing_func(g._state_hash())
+    baseline_graph = Graph.structure(g.unstructure())
+
+    frame = Frame(graph=g, cursor_id=start.uid, event_sourced=True)
+
+    edge_to_node = next(start.edges_out(is_instance=ChoiceEdge))
+    frame.follow_edge(edge_to_node)
+
+    step_records = _collect_step_records(frame, 1)
+    assert step_records
+    planning_receipt = _find_planning_receipt(step_records)
+
+    patch = frame.phase_outcome.get(P.FINALIZE)
+    assert isinstance(patch, Patch)
+    assert patch.registry_state_hash == baseline_hash
+
+    replayed_graph = patch.apply(baseline_graph)
+    assert replayed_graph.find_one(label="created") is not None
+    assert g.find_one(label="created") is None
+
+    final_hash = hashing_func(g._state_hash())
+    replayed_hash = hashing_func(replayed_graph._state_hash())
+    assert final_hash != replayed_hash
+    assert frame.event_watcher.events == []


### PR DESCRIPTION
## Summary
- add the SimpleScene traversable domain that projects satisfied dependencies and affordances into the scene namespace
- export the new domain alongside SimpleBlock/Concept and provide a test shim for wrapt so VM tests run without the optional dependency
- cover scene behaviour with dedicated tests for canonical wiring, namespace projections, and journal namespace access
- ensure `refresh_edge_projections` mutates the existing vars mapping so cached namespaces observe new projections and add a regression test for the behaviour

## Testing
- PYTHONPATH=./engine/src pytest engine/tests/story/reference_domain/test_scene.py -v


------
https://chatgpt.com/codex/tasks/task_e_68e70f4d5a6c8329acfe4cc39fd717c5