### PR TITLE
Refactor ledger persistence and user ledger tracking

### DIFF
--- a/engine/src/tangl/persistence/serializers.py
+++ b/engine/src/tangl/persistence/serializers.py
@@ -91,7 +91,7 @@ class JsonSerializationHandler:
             except (TypeError, ValueError):
                 try:
                     obj[key] = UUID(value)
-                except (ValueError, AttributeError):
+                except (ValueError, AttributeError, TypeError):
                     pass
         return obj
 

--- a/engine/src/tangl/service/user/user.py
+++ b/engine/src/tangl/service/user/user.py
@@ -63,7 +63,7 @@ class User(Entity):
 
     privileged: bool = False  # User is authorized to use dev controllers
 
-    current_story_id: StoryId = None
+    current_ledger_id: UUID | None = None
 
     # @property
     # def current_story(self):

--- a/engine/src/tangl/vm/ledger.py
+++ b/engine/src/tangl/vm/ledger.py
@@ -2,16 +2,18 @@
 """
 State holder for the live graph, cursor, and record stream (snapshots, patches, journal).
 """
-from typing import TYPE_CHECKING, Self
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Mapping, Optional
 from pydantic import Field
 from uuid import UUID
 
 from tangl.type_hints import UnstructuredData
 from tangl.core import Entity, Graph, Node, Domain, Record, StreamRegistry, Snapshot
-from tangl.type_hints import StringMap
 from .frame import Frame
 
 if TYPE_CHECKING:
+    from tangl.service.user.user import User
     from .replay import Patch
 
 class Ledger(Entity):
@@ -59,12 +61,14 @@ class Ledger(Entity):
     singletons; other domain styles are not supported here and should live on
     graph items where scope discovery can rehydrate them dynamically.
     """
-    graph: Graph = Field(None, exclude=True)
+    graph: Graph
     cursor_id: UUID = None
     step: int = -1
     domains: list[Domain] = Field(default_factory=list)  # ledger-level singletons only
     records: StreamRegistry = Field(default_factory=StreamRegistry)
     snapshot_cadence: int = 1
+    event_sourced: bool = False
+    user: Optional["User"] = Field(None, exclude=True)
 
     def push_snapshot(self):
         # No particular need to unstructure/serialize this separately from
@@ -110,21 +114,72 @@ class Ledger(Entity):
     #       entity-typed model fields using introspection (see registry)
 
     @classmethod
-    def structure(cls, data) -> Self:
-        _graph = data.pop("_graph")
-        _domains = data.pop("_domains")
-        _records = data.pop("_records")
-        obj = super().structure(data)
-        obj.graph = Graph.structure(_graph)
-        obj.domains = [ Domain.structure(d) for d in _domains ]
-        obj.records = StreamRegistry.structure(_records)
-        return obj
+    def structure(cls, data: Mapping[str, Any], **kwargs) -> "Ledger":
+        payload = dict(data)
+        graph_data = payload.pop("graph", None)
+        domain_data = payload.pop("domains", None)
+        record_data = payload.pop("records", None)
+        if "graph" not in payload:
+            payload["graph"] = Graph()
+        ledger = super().structure(payload, **kwargs)
+
+        if graph_data is not None:
+            ledger.graph = Graph.structure(graph_data)
+
+        if domain_data is not None:
+            ledger.domains = [Domain.structure(item) for item in domain_data]
+        else:
+            ledger.domains = []
+
+        if record_data is not None:
+            raw_records = list(record_data.get("_data", []))
+            for entry in raw_records:
+                item_payload = entry.get("item") if isinstance(entry, Mapping) else None
+                if isinstance(item_payload, Mapping):
+                    obj_cls = item_payload.get("obj_cls")
+                    if obj_cls in {Graph, Graph.__name__, Graph.__qualname__}:
+                        entry["item"] = Graph.structure(dict(item_payload))
+            ledger.records = StreamRegistry.structure(record_data)
+        else:
+            ledger.records = StreamRegistry()
+
+        if ledger.event_sourced and (graph_data is None or not getattr(ledger.graph, "data", {})):
+            ledger.graph = cls.recover_graph_from_stream(ledger.records)
+
+        return ledger
 
     def unstructure(self) -> UnstructuredData:
         data = super().unstructure()
-        # Only need to save graph if we are event sourced
-        data['_graph'] = self.graph.unstructure()
-        data['_domains'] = [ d.unstructure() for d in self.domains ]
-        data['_records'] = self.records.unstructure()
+        graph_payload = self.graph.unstructure()
+        graph_payload.pop("data", None)
+        data["graph"] = graph_payload
+
+        data["domains"] = [domain.unstructure() for domain in self.domains]
+
+        records_payload = self.records.unstructure()
+        sanitized_records: list[UnstructuredData] = []
+        for record in self.records.data.values():
+            record_payload = record.unstructure()
+            item = getattr(record, "item", None)
+            if hasattr(item, "unstructure"):
+                item_payload = item.unstructure()
+                if isinstance(item_payload, dict):
+                    item_payload.pop("data", None)
+                record_payload["item"] = item_payload
+            sanitized_records.append(record_payload)
+        records_payload["_data"] = sanitized_records
+        data["records"] = records_payload
+
+        if self.event_sourced:
+            data["graph"] = {
+                "uid": self.graph.uid,
+                "label": self.graph.label,
+            }
+
         return data
+
+
+from tangl.service.user.user import User as _LedgerUser
+
+Ledger.model_rebuild(_types_namespace={"User": _LedgerUser})
 

--- a/engine/tests/fake_types.py
+++ b/engine/tests/fake_types.py
@@ -39,15 +39,15 @@ class FakeWorld:
         return FakeStory(uid=f"story-{self.label}", user=user)
 
 class FakeUser:
-    def __init__(self, uid, access_level=AccessLevel.USER, current_story_id=None):
+    def __init__(self, uid, access_level=AccessLevel.USER, current_ledger_id=None):
         self.uid = uid
         self.access_level = access_level
-        self.current_story_id = current_story_id
+        self.current_ledger_id = current_ledger_id
         self.story_ids = []
 
     def add_story(self, story_id):
         self.story_ids.append(story_id)
-        self.current_story_id = story_id
+        self.current_ledger_id = story_id
 
 
 class FakeJournal(list):

--- a/engine/tests/service/test_orchestrator_basic.py
+++ b/engine/tests/service/test_orchestrator_basic.py
@@ -5,7 +5,6 @@ from uuid import UUID, uuid4
 import pytest
 
 from tangl.core import Graph, StreamRegistry
-from tangl.persistence import LedgerEnvelope
 from tangl.service import ApiEndpoint, HasApiEndpoints, MethodType, Orchestrator, ResponseType
 from tangl.vm.frame import Frame
 from tangl.vm.ledger import Ledger
@@ -100,13 +99,12 @@ def test_orchestrator_hydrates_user_and_ledger(
     fake_persistence: FakePersistence, minimal_ledger: Ledger
 ) -> None:
     ledger = minimal_ledger
-    ledger_envelope = LedgerEnvelope.from_ledger(ledger).model_dump()
     ledger_id = ledger.uid
     user_id = uuid4()
     user = StubUser(user_id, ledger_id)
 
     fake_persistence[user_id] = user
-    fake_persistence[ledger_id] = ledger_envelope
+    fake_persistence[ledger_id] = ledger.unstructure()
 
     orchestrator = Orchestrator(fake_persistence)
     orchestrator.register_controller(LedgerController)
@@ -127,9 +125,8 @@ def test_orchestrator_hydrates_user_and_ledger(
 def test_orchestrator_requires_user_id_for_user_hydration(
     fake_persistence: FakePersistence, minimal_ledger: Ledger
 ) -> None:
-    ledger_envelope = LedgerEnvelope.from_ledger(minimal_ledger).model_dump()
     ledger_id = minimal_ledger.uid
-    fake_persistence[ledger_id] = ledger_envelope
+    fake_persistence[ledger_id] = minimal_ledger.unstructure()
 
     orchestrator = Orchestrator(fake_persistence)
     orchestrator.register_controller(LedgerController)
@@ -141,9 +138,8 @@ def test_orchestrator_requires_user_id_for_user_hydration(
 def test_orchestrator_reuses_cached_ledger_for_frame(
     fake_persistence: FakePersistence, minimal_ledger: Ledger
 ) -> None:
-    ledger_envelope = LedgerEnvelope.from_ledger(minimal_ledger).model_dump()
     ledger_id = minimal_ledger.uid
-    fake_persistence[ledger_id] = ledger_envelope
+    fake_persistence[ledger_id] = minimal_ledger.unstructure()
 
     orchestrator = Orchestrator(fake_persistence)
     orchestrator.register_controller(FrameController)
@@ -160,9 +156,8 @@ def test_orchestrator_reuses_cached_ledger_for_frame(
 def test_orchestrator_persists_mutations(
     fake_persistence: FakePersistence, minimal_ledger: Ledger
 ) -> None:
-    ledger_envelope = LedgerEnvelope.from_ledger(minimal_ledger).model_dump()
     ledger_id = minimal_ledger.uid
-    fake_persistence[ledger_id] = ledger_envelope
+    fake_persistence[ledger_id] = minimal_ledger.unstructure()
 
     orchestrator = Orchestrator(fake_persistence)
     orchestrator.register_controller(UpdateController)
@@ -178,9 +173,8 @@ def test_orchestrator_persists_mutations(
 def test_read_endpoint_does_not_write_back(
     fake_persistence: FakePersistence, minimal_ledger: Ledger
 ) -> None:
-    ledger_envelope = LedgerEnvelope.from_ledger(minimal_ledger).model_dump()
     ledger_id = minimal_ledger.uid
-    fake_persistence[ledger_id] = ledger_envelope
+    fake_persistence[ledger_id] = minimal_ledger.unstructure()
 
     orchestrator = Orchestrator(fake_persistence)
     orchestrator.register_controller(ReadController)

--- a/engine/tests/vm/test_ledger_structures.py
+++ b/engine/tests/vm/test_ledger_structures.py
@@ -18,33 +18,42 @@ def _make_minimal_ledger():
 
 
 def test_ledger_unstructure_shape():
-    """unstructure() returns a dict with private payloads (_graph/_domains/_records)
-    plus the standard Entity fields."""
+    """unstructure() returns a dict with graph/domains/records payloads."""
     ld, _ = _make_minimal_ledger()
 
     data = ld.unstructure()
 
     assert isinstance(data, dict)
-    # Entity-level metadata
     assert "uid" in data
     assert "obj_cls" in data
-    # Ledger private payloads
-    assert "_graph" in data
-    assert "_domains" in data
-    assert len(data["_domains"]) == 1 and data["_domains"][0] == my_test_domain.unstructure()
-    assert "_records" in data
 
-    # Graph payload should look like a Registry payload with _data
-    gdata = data["_graph"]
-    assert isinstance(gdata, dict)
-    assert "_data" in gdata
-    assert len(gdata["_data"]) >= 1  # at least our 'start' node
+    assert "graph" in data
+    graph_payload = data["graph"]
+    assert isinstance(graph_payload, dict)
+    assert "_data" in graph_payload
+    assert len(graph_payload["_data"]) >= 1
 
-    # Records payload should look like a StreamRegistry payload with _data
-    rdata = data["_records"]
-    assert isinstance(rdata, dict)
-    assert "_data" in rdata
-    assert len(rdata["_data"]) >= 1  # at least the snapshot we pushed
+    assert "domains" in data
+    assert len(data["domains"]) == 1
+    assert data["domains"][0] == my_test_domain.unstructure()
+
+    assert "records" in data
+    records_payload = data["records"]
+    assert isinstance(records_payload, dict)
+    assert "_data" in records_payload
+    assert len(records_payload["_data"]) >= 1
+
+
+def test_ledger_unstructure_event_sourced_stubs_graph():
+    ld, _ = _make_minimal_ledger()
+    ld.event_sourced = True
+
+    data = ld.unstructure()
+
+    assert data["graph"] == {"uid": ld.graph.uid, "label": ld.graph.label}
+
+    rebuilt = Ledger.structure(dict(data))
+    assert rebuilt.graph.find_one(label="start") is not None
 
 
 def test_ledger_structure_round_trip():


### PR DESCRIPTION
## Summary
- teach `Ledger` to serialize itself, including event-sourced stubbing and recovery paths
- persist ledgers directly in the orchestrator and derive `current_ledger_id` from users
- refresh persistence/orchestrator test coverage and supporting fakes for the new shapes

## Testing
- PYTHONPATH=./engine/src pytest engine/tests/persistence/test_ledger_persistence.py -q
- PYTHONPATH=./engine/src pytest engine/tests/service/test_orchestrator_basic.py -q
- PYTHONPATH=./engine/src pytest engine/tests/integration/test_service_layer.py -q
- PYTHONPATH=./engine/src pytest engine/tests/vm/test_ledger_structures.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ec7e13fc888329be07bae7d3caf719