### PR TITLE
Implement cross-domain portal redirects

### DIFF
--- a/engine/src/tangl/vm/context.py
+++ b/engine/src/tangl/vm/context.py
@@ -111,3 +111,13 @@ class Context:
     def get_handlers(self, **criteria) -> Iterator[Handler]:
         # can pass phase in filter criteria if useful
         return self.scope.get_handlers(**criteria)
+
+    def get_traversable_domain_for_node(self, node: Node) -> "TraversableDomain" | None:
+        """Return the :class:`TraversableDomain` that contains ``node`` if available."""
+
+        from tangl.vm.domain import TraversableDomain  # Local import to avoid cycle
+
+        for domain in self.scope.active_domains:
+            if isinstance(domain, TraversableDomain) and node.uid in domain.member_ids:
+                return domain
+        return None


### PR DESCRIPTION
## Summary
- extend the VM context with a lookup helper for traversable domains
- enhance prereq redirects to auto-transition across domain sources and sinks
- add a portal traversal integration test covering nested scene domains

## Testing
- PYTHONPATH=./engine/src pytest engine/tests/vm/domain/test_traversable.py --log-cli-level=INFO

------
https://chatgpt.com/codex/tasks/task_e_68ec7e4ceadc8329ae2e816287bf2422