### PR TITLE
Improve ledger recovery and orchestrator pipeline coverage

### DIFF
--- a/engine/src/tangl/core/domain/structural.py
+++ b/engine/src/tangl/core/domain/structural.py
@@ -28,10 +28,41 @@ class DomainNode(Node, Subgraph, Domain):
         return self.members
 
     def add_child(self, child: Node) -> None:
-        self.add_edge_to(child, edge_type="child")
-        self.add_member(child)
+        """Attach ``child`` to this domain, enforcing single-parent membership."""
+
+        if child.graph is not self.graph:
+            raise ValueError("Child node must belong to the same graph as the domain")
+
+        # Remove the child from any existing domain membership to enforce exclusivity.
+        try:
+            current_parent = child.parent
+        except AttributeError:
+            current_parent = None
+
+        if current_parent is self:
+            # Already attached; make sure both membership and edge exist and return.
+            if not self.has_member(child):
+                self.add_member(child)
+            if self.graph.find_edge(source=self, destination=child, edge_type="child") is None:
+                self.add_edge_to(child, edge_type="child")
+            return
+
+        if current_parent is not None:
+            if isinstance(current_parent, DomainNode):
+                current_parent.remove_child(child)
+            else:
+                current_parent.remove_member(child)
+
+        if not self.has_member(child):
+            self.add_member(child)
+
+        if self.graph.find_edge(source=self, destination=child, edge_type="child") is None:
+            self.add_edge_to(child, edge_type="child")
 
     def remove_child(self, child: Node) -> None:
+        if not self.has_member(child):
+            return
+
         self.remove_edge_to(child)
         self.remove_member(child)
 

--- a/engine/tests/service/test_api_endpoints.py
+++ b/engine/tests/service/test_api_endpoints.py
@@ -3,7 +3,15 @@ from typing import Any
 import pytest
 
 
-from tangl.service.api_endpoint import HasApiEndpoints, ApiEndpoint, MethodType, ResponseType, AccessLevel
+from tangl.service.api_endpoint import (
+    AccessLevel,
+    ApiEndpoint,
+    HasApiEndpoints,
+    MethodType,
+    PostprocessResult,
+    PreprocessResult,
+    ResponseType,
+)
 
 # -------------------------------------------------------------------
 # 1. Fixtures & Sample Controller / Classes to Decorate
@@ -217,4 +225,62 @@ def test_pre_postprocessors():
 
     # Return should be {"wrapped": {"value": 99}}
     assert out == {"wrapped": {"value": 99}}
+
+
+def test_preprocessors_can_short_circuit():
+    calls: list[str] = []
+
+    def pre_skip(args, kwargs):
+        calls.append("pre1")
+        return PreprocessResult.skip({"status": "skipped"})
+
+    def pre_never(args, kwargs):  # pragma: no cover - defensive
+        calls.append("pre2")
+        return args, kwargs
+
+    def post_never(result):  # pragma: no cover - defensive
+        calls.append("post")
+        return result
+
+    class ShortCircuitController(HasApiEndpoints):
+        @ApiEndpoint.annotate(
+            preprocessors=[pre_skip, pre_never],
+            postprocessors=[post_never],
+            response_type=ResponseType.INFO,
+        )
+        def get_value(self) -> dict[str, str]:
+            raise AssertionError("Endpoint body should not run when preprocessor skips")
+
+    controller = ShortCircuitController()
+    endpoint = controller.get_api_endpoints()["get_value"]
+
+    result = endpoint(controller)
+
+    assert result == {"status": "skipped"}
+    assert calls == ["pre1"]
+
+
+def test_postprocessors_can_short_circuit():
+    post_calls: list[str] = []
+
+    def post_first(result):
+        post_calls.append("post1")
+        return PostprocessResult.stop_with({"wrapped": result})
+
+    def post_second(result):  # pragma: no cover - defensive
+        post_calls.append("post2")
+        return {"second": result}
+
+    class PostStopController(HasApiEndpoints):
+        @ApiEndpoint.annotate(postprocessors=[post_first, post_second], response_type=ResponseType.INFO)
+        def get_payload(self) -> dict[str, int]:
+            return {"value": 1}
+
+    controller = PostStopController()
+    endpoint = controller.get_api_endpoints()["get_payload"]
+
+    result = endpoint(controller)
+
+    assert result == {"wrapped": {"value": 1}}
+    assert post_calls == ["post1"]
 


### PR DESCRIPTION
## Summary
- enforce single-parent semantics for DomainNode.add_child and make removals idempotent
- allow ApiEndpoint preprocessors and postprocessors to short-circuit via explicit helper results
- add focused tests covering ledger snapshot cadence, stream channel bookmarks, dispatch determinism, API endpoint short-circuiting, and orchestrator persistence

## Testing
- PYTHONPATH=./engine/src pytest engine/tests/core/domain/test_structural_domain.py engine/tests/core/test_record_stream.py engine/tests/core/test_handlers.py engine/tests/service/test_api_endpoints.py engine/tests/service/test_orchestrator_basic.py engine/tests/vm/test_ledger.py -q --disable-warnings --log-cli-level=CRITICAL


------
https://chatgpt.com/codex/tasks/task_e_68edcd2f3670832995feef96d0343733