### PR TITLE
Fix Provisioner handler signature and context namespace usage

### DIFF
--- a/engine/src/tangl/vm/planning/provisioning.py
+++ b/engine/src/tangl/vm/planning/provisioning.py
@@ -25,16 +25,29 @@ API
 - :meth:`_resolve_existing` / :meth:`_resolve_update` / :meth:`_resolve_clone` / :meth:`_resolve_create` – internal helpers implementing each policy.
 """
 from __future__ import annotations
-from typing import Iterable, Optional, Sequence, Type, TYPE_CHECKING
+from typing import Any, Iterable, Optional, Sequence, Type, TYPE_CHECKING
 import functools
 
 from tangl.type_hints import StringMap, Identifier, UnstructuredData
 from tangl.core import Node, Registry, Handler, JobReceipt
+from tangl.core.dispatch import HandlerFunc
 from .requirement import Requirement, ProvisioningPolicy
 
 if TYPE_CHECKING:
     from .offer import ProvisionOffer
     from ..context import Context
+
+
+def _provisioner_stub(
+    requirement: "Requirement",
+    *,
+    ctx: "Context" | None = None,
+    other: Any | None = None,
+    result: Any | None = None,
+) -> list["ProvisionOffer"]:
+    """Placeholder callable satisfying :class:`Handler`'s signature contract."""
+
+    raise NotImplementedError("Provisioner delegates execution via get_offers/resolve")
 
 
 class Provisioner(Handler):
@@ -69,7 +82,7 @@ class Provisioner(Handler):
     """
     phase: str = "PLANNING.OFFER"
     result_type: Type = list['ProvisionOffer']
-    func: None = None
+    func: HandlerFunc = _provisioner_stub
 
     @staticmethod
     def _resolve_existing(*registries: Registry,

--- a/engine/tests/story/episode/test_scene.py
+++ b/engine/tests/story/episode/test_scene.py
@@ -270,7 +270,7 @@ def test_refresh_edge_projections_updates_namespace_in_place() -> None:
     scene = Scene(graph=g, label="scene", member_ids=[block.uid])
 
     frame = Frame(graph=g, cursor_id=block.uid)
-    namespace = frame.context.scope.namespace
+    namespace = frame.context.get_ns()
 
     assert "npc" not in namespace
 


### PR DESCRIPTION
## Summary
- add a stub callable so Provisioner satisfies the Handler signature during validation
- have prereq/postreq redirect handlers pull namespaces from the Context instead of expecting an injected argument
- update the scene namespace test to use Context.get_ns()

## Testing
- PYTHONPATH=./engine/src pytest engine/tests/vm/planning/test_provisioning.py::test_planning_resolves_dependency_existing -q
- PYTHONPATH=./engine/src pytest engine/tests/service/controllers/test_runtime_controller.py -q --disable-warnings
- PYTHONPATH=./engine/src pytest engine/tests/story/episode/test_scene.py::test_refresh_edge_projections_updates_namespace_in_place -q


------
https://chatgpt.com/codex/tasks/task_e_68f2b957a690832993a337d77235dfe4