### PR TITLE
Add graph-based dependency offers for existing nodes

### DIFF
--- a/engine/src/tangl/vm/provision/__init__.py
+++ b/engine/src/tangl/vm/provision/__init__.py
@@ -18,6 +18,7 @@ builders without modifying core VM code.
 """
 from .requirement import ProvisioningPolicy, Requirement
 from .provisioner import Provisioner
+from .graph_provisioner import GraphProvisioner
 from .open_edge import Dependency, Affordance
 from .offer import BuildReceipt, ProvisionOffer, PlanningReceipt
 from .offers import ProvisionCost, DependencyOffer, AffordanceOffer

--- a/engine/src/tangl/vm/provision/graph_provisioner.py
+++ b/engine/src/tangl/vm/provision/graph_provisioner.py
@@ -1,0 +1,124 @@
+"""Graph-aware provisioner that surfaces existing node offers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterator, Sequence, TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from tangl.core.graph import Graph, Node
+
+from .offers import DependencyOffer, DependencyAcceptor, ProvisionCost
+from .requirement import Requirement, ProvisioningPolicy
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard
+    from tangl.vm.context import Context
+    from .open_edge import Dependency
+
+
+@dataclass(slots=True)
+class GraphProvisioner:
+    """Collect existing graph nodes as dependency offers."""
+
+    graphs: Sequence[Graph] = field(default_factory=tuple)
+    uid: UUID = field(default_factory=uuid4, init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "graphs", tuple(self.graphs))
+
+    def iter_dependency_offers(
+        self,
+        requirement: Requirement,
+        *,
+        dependency: Dependency | None = None,
+        ctx: Context | None = None,
+    ) -> Iterator[DependencyOffer]:
+        """Yield dependency offers that attach existing nodes."""
+
+        criteria = requirement.get_selection_criteria()
+        if not criteria:
+            return
+
+        seen_nodes: set[UUID] = set()
+        for proximity, layer_graph in enumerate(
+            self._iter_graph_layers(requirement=requirement, ctx=ctx)
+        ):
+            for node in layer_graph.find_nodes(**criteria):
+                if node.uid in seen_nodes:
+                    continue
+                seen_nodes.add(node.uid)
+                yield self._build_offer(
+                    requirement=requirement,
+                    dependency=dependency,
+                    node=node,
+                    layer_graph=layer_graph,
+                    proximity=proximity,
+                )
+
+    def _iter_graph_layers(
+        self,
+        *,
+        requirement: Requirement,
+        ctx: Context | None,
+    ) -> Iterator[Graph]:
+        seen: set[UUID] = set()
+        ordered: list[Graph] = []
+
+        def add_graph(graph: Graph | None) -> None:
+            if graph is None or graph.uid in seen:
+                return
+            seen.add(graph.uid)
+            ordered.append(graph)
+
+        for graph in self.graphs:
+            add_graph(graph)
+        add_graph(requirement.graph)
+        if ctx is not None:
+            add_graph(getattr(ctx, "graph", None))
+
+        yield from ordered
+
+    def _build_offer(
+        self,
+        *,
+        requirement: Requirement,
+        dependency: Dependency | None,
+        node: Node,
+        layer_graph: Graph,
+        proximity: int,
+    ) -> DependencyOffer:
+        return DependencyOffer(
+            requirement_id=requirement.uid,
+            dependency_id=getattr(dependency, "uid", None),
+            cost=self._cost_for_layer(proximity),
+            operation=ProvisioningPolicy.EXISTING,
+            acceptor=self._make_acceptor(node),
+            layer_id=layer_graph.uid,
+            source_provisioner_id=self.uid,
+            proximity=proximity,
+        )
+
+    @staticmethod
+    def _make_acceptor(node: Node) -> DependencyAcceptor:
+        node_ref = node
+        node_id = node.uid
+
+        def acceptor(
+            *,
+            ctx: Context,
+            requirement: Requirement,
+            dependency: Dependency | None = None,
+            **_: object,
+        ) -> Node | None:
+            if node_ref.graph is ctx.graph:
+                return node_ref
+            return ctx.graph.get(node_id)
+
+        return acceptor
+
+    @staticmethod
+    def _cost_for_layer(proximity: int) -> ProvisionCost:
+        return ProvisionCost(weight=1.0 + float(proximity), proximity=proximity)
+
+
+__all__ = ["GraphProvisioner"]

--- a/engine/src/tangl/vm/provision/offers.py
+++ b/engine/src/tangl/vm/provision/offers.py
@@ -16,6 +16,8 @@ from uuid import UUID
 
 from tangl.core.graph import Edge, Node
 
+from .requirement import ProvisioningPolicy
+
 if TYPE_CHECKING:  # pragma: no cover - import cycle guard
     from tangl.vm.context import Context
     from .open_edge import Affordance, Dependency
@@ -132,6 +134,7 @@ class DependencyOffer:
     dependency_id: Optional[UUID]
     cost: ProvisionCost
     acceptor: DependencyAcceptor = field(repr=False)
+    operation: ProvisioningPolicy = ProvisioningPolicy.EXISTING
     layer_id: Optional[UUID] = None
     source_provisioner_id: Optional[UUID] = None
     proximity: Optional[int] = None

--- a/engine/tests/vm/provision/test_graph_provisioner.py
+++ b/engine/tests/vm/provision/test_graph_provisioner.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import pytest
+
+from tangl.core.graph import Graph
+from tangl.vm.context import Context
+from tangl.vm.provision.graph_provisioner import GraphProvisioner
+from tangl.vm.provision.open_edge import Dependency
+from tangl.vm.provision.requirement import ProvisioningPolicy, Requirement
+
+
+@pytest.fixture
+def graph_setup():
+    graph = Graph()
+    source = graph.add_node(label="source")
+    matching = graph.add_node(label="target")
+    _ = graph.add_node(label="bystander")
+
+    requirement = Requirement(
+        graph=graph,
+        criteria={"label": "target"},
+        policy=ProvisioningPolicy.EXISTING,
+    )
+    dependency = Dependency(graph=graph, source=source, requirement=requirement)
+
+    return {
+        "graph": graph,
+        "source": source,
+        "matching": matching,
+        "requirement": requirement,
+        "dependency": dependency,
+    }
+
+
+def test_graph_provisioner_only_emits_matching_offers(graph_setup):
+    provisioner = GraphProvisioner()
+    requirement = graph_setup["requirement"]
+    dependency = graph_setup["dependency"]
+
+    offers = list(
+        provisioner.iter_dependency_offers(
+            requirement,
+            dependency=dependency,
+        )
+    )
+
+    assert len(offers) == 1
+    offer = offers[0]
+
+    assert offer.operation is ProvisioningPolicy.EXISTING
+    assert offer.layer_id == graph_setup["graph"].uid
+    assert offer.cost.proximity == 0
+    assert offer.proximity == 0
+
+
+def test_graph_provisioner_accept_returns_existing_node(graph_setup):
+    provisioner = GraphProvisioner()
+    graph = graph_setup["graph"]
+    source = graph_setup["source"]
+    requirement = graph_setup["requirement"]
+    dependency = graph_setup["dependency"]
+    matching = graph_setup["matching"]
+
+    offers = list(
+        provisioner.iter_dependency_offers(
+            requirement,
+            dependency=dependency,
+        )
+    )
+
+    ctx = Context(graph=graph, cursor_id=source.uid)
+
+    assert requirement.provider is None
+
+    offer = offers[0]
+    provider = offer.accept(ctx=ctx)
+
+    assert provider is matching
+    assert requirement.provider is None
+
+    # Graph should remain unchanged during offer generation and acceptance.
+    nodes = list(graph.find_nodes())
+    labels = {node.label for node in nodes}
+    assert labels == {"source", "target", "bystander"}

--- a/engine/tests/vm/provision/test_offers.py
+++ b/engine/tests/vm/provision/test_offers.py
@@ -140,6 +140,7 @@ def test_dependency_offer_accept_is_lazy(dependency_offer_setup):
     assert offer.requirement_id == requirement.uid
     assert offer.dependency_id == dependency.uid
     assert offer.proximity == 2
+    assert offer.operation is ProvisioningPolicy.EXISTING
 
 
 def test_affordance_offer_accept_allows_destination_override(affordance_offer_setup):


### PR DESCRIPTION
## Summary
- add a graph provisioner that yields DependencyOffer records for existing nodes with layer-aware cost metadata
- surface the default EXISTING operation on dependency offers
- cover the new provisioner and offer metadata with unit tests

## Testing
- PYTHONPATH=./engine/src pytest engine/tests/vm/provision/test_graph_provisioner.py

------
https://chatgpt.com/codex/tasks/task_e_6907d41e0be08329bc82d9eedfd59c64