### PR TITLE
Refactor story graph creation to return graph

### DIFF
--- a/engine/src/tangl/core/graph/graph.py
+++ b/engine/src/tangl/core/graph/graph.py
@@ -126,6 +126,8 @@ class Graph(Registry[GraphItem]):
     # def add(self, *args) -> None:
     #     raise NotImplementedError("Graph is read-only")
 
+    initial_cursor_id: UUID | None = None
+
     # special adds
     def add(self, item: GraphItem) -> None:
         item.graph = self

--- a/engine/src/tangl/story/__init__.py
+++ b/engine/src/tangl/story/__init__.py
@@ -1,6 +1,26 @@
 
-from .concepts import Concept
-from .episode import Scene, Block
-from .fabula import World
+__all__ = ["Concept", "Scene", "Block", "World", "story_dispatch"]
 
-from .dispatch import story_dispatch
+
+def __getattr__(name: str):
+    if name == "World":
+        from .fabula import World as _World
+
+        return _World
+    if name == "Concept":
+        from .concepts import Concept as _Concept
+
+        return _Concept
+    if name == "Scene":
+        from .episode import Scene as _Scene
+
+        return _Scene
+    if name == "Block":
+        from .episode import Block as _Block
+
+        return _Block
+    if name == "story_dispatch":
+        from .dispatch import story_dispatch as _dispatch
+
+        return _dispatch
+    raise AttributeError(name)

--- a/engine/src/tangl/story/concepts/__init__.py
+++ b/engine/src/tangl/story/concepts/__init__.py
@@ -1,1 +1,9 @@
-from .concept import Concept
+__all__ = ["Concept"]
+
+
+def __getattr__(name: str):
+    if name == "Concept":
+        from .concept import Concept as _Concept
+
+        return _Concept
+    raise AttributeError(name)

--- a/engine/src/tangl/story/fabula/__init__.py
+++ b/engine/src/tangl/story/fabula/__init__.py
@@ -30,12 +30,13 @@ Create a new story instance.
 - `story_label`: Unique identifier for this story instance
 - `mode`: Materialization mode ('full', 'hybrid', 'lazy')
 
-**Returns**: Graph ready for navigation
+**Returns**: Graph ready for navigation. Inspect ``graph.initial_cursor_id`` for the
+starting node identifier.
 
 **Example**:
 ```python
 story = world.create_story(user=player_1)
-frame = story.cursor
+start_node = story.get(story.initial_cursor_id)
 ```
 
 ### Managers

--- a/engine/src/tangl/vm/ledger.py
+++ b/engine/src/tangl/vm/ledger.py
@@ -136,23 +136,13 @@ class Ledger(Entity):
     def init_cursor(self) -> None:
         """Enter the current cursor to bootstrap the ledger journal."""
 
-        from tangl.core.graph.edge import AnonymousEdge
-        from .frame import ChoiceEdge
-        from .resolution_phase import ResolutionPhase as P
-
         start_node = self.graph.get(self.cursor_id)
         if start_node is None:
             raise RuntimeError(f"Initial cursor {self.cursor_id} not found in graph")
 
-        bootstrap_edge = AnonymousEdge(source=start_node, destination=start_node)
         frame = self.get_frame()
 
-        next_edge = frame.follow_edge(bootstrap_edge)
-        while (
-            isinstance(next_edge, ChoiceEdge)
-            and getattr(next_edge, "trigger_phase", None) == P.PREREQS
-        ):
-            next_edge = frame.follow_edge(next_edge)
+        frame.jump_to_node(start_node)
 
         self.cursor_id = frame.cursor_id
         self.step = frame.step

--- a/engine/tests/service/controllers/test_runtime_controller.py
+++ b/engine/tests/service/controllers/test_runtime_controller.py
@@ -256,8 +256,7 @@ def test_create_story_handles_prereq_redirects(
             destination_id=forced.uid,
             trigger_phase=ResolutionPhase.PREREQS,
         )
-        frame = Frame(graph=graph, cursor_id=start.uid)
-        object.__setattr__(graph, "cursor", frame)
+        graph.initial_cursor_id = start.uid
         return graph
 
     stub_world = SimpleNamespace(label="stub_world", create_story=_create_redirect_story)

--- a/engine/tests/story/fabula/test_world_materialization.py
+++ b/engine/tests/story/fabula/test_world_materialization.py
@@ -162,8 +162,10 @@ def test_create_story_full_returns_populated_graph() -> None:
 
     edges = list(story_graph.find_edges())
     assert edges and edges[0].destination_id in story_graph.data
-    assert story_graph.cursor is not None
-    assert story_graph.cursor.cursor.label in {"start", "next"}
+    assert story_graph.initial_cursor_id is not None
+    start_node = story_graph.get(story_graph.initial_cursor_id)
+    assert start_node is not None
+    assert start_node.label in {"start", "next"}
 
 
 def test_create_story_full_uses_metadata_start_at() -> None:
@@ -190,7 +192,10 @@ def test_create_story_full_uses_metadata_start_at() -> None:
     world = _make_world(script)
     story_graph = world.create_story("story")
 
-    assert story_graph.cursor.cursor.label == "next"
+    assert story_graph.initial_cursor_id is not None
+    start_node = story_graph.get(story_graph.initial_cursor_id)
+    assert start_node is not None
+    assert start_node.label == "next"
 
 
 def test_create_story_full_defaults_to_first_block() -> None:
@@ -208,7 +213,10 @@ def test_create_story_full_defaults_to_first_block() -> None:
     world = _make_world(script)
     story_graph = world.create_story("story")
 
-    assert story_graph.cursor.cursor.label == "start"
+    assert story_graph.initial_cursor_id is not None
+    start_node = story_graph.get(story_graph.initial_cursor_id)
+    assert start_node is not None
+    assert start_node.label == "start"
 
 
 def test_story_creation_uses_default_classes_when_obj_cls_missing() -> None:

--- a/engine/tests/story/fabula/test_world_vm_boundary.py
+++ b/engine/tests/story/fabula/test_world_vm_boundary.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _run_check(code: str) -> bool:
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip() == "False"
+
+
+def test_import_world_does_not_pull_vm_modules() -> None:
+    code = (
+        "import importlib, sys; "
+        "importlib.import_module('tangl.story.fabula.world'); "
+        "print(any(name.startswith('tangl.vm') for name in sys.modules))"
+    )
+    assert _run_check(code)
+
+
+def test_import_vm_does_not_pull_story_modules() -> None:
+    code = (
+        "import importlib, sys; "
+        "importlib.import_module('tangl.vm'); "
+        "print(any(name.startswith('tangl.story') for name in sys.modules))"
+    )
+    assert _run_check(code)

--- a/engine/tests/vm/test_frame.py
+++ b/engine/tests/vm/test_frame.py
@@ -136,6 +136,21 @@ def test_prereq_redirect_and_journal_line():
     assert "[step " in line
     assert "end" in line
 
+
+def test_jump_to_node_handles_prereq_redirects():
+    g = Graph(label="demo")
+    start = g.add_node(label="start")
+    forced = g.add_node(label="forced")
+
+    ChoiceEdge(graph=g, source_id=start.uid, destination_id=forced.uid, trigger_phase=P.PREREQS)
+
+    frame = Frame(graph=g, cursor_id=start.uid)
+    frame.jump_to_node(start.uid)
+
+    assert frame.cursor_id == forced.uid
+    assert frame.cursor.uid == forced.uid
+    assert frame.step >= 1
+
 def test_postreq_redirect():
     g = Graph(); a = g.add_node(label="A"); b = g.add_node(label="B")
     ChoiceEdge(graph=g, source_id=a.uid, destination_id=b.uid, trigger_phase=P.POSTREQS)


### PR DESCRIPTION
## Summary
- track an initial cursor on `Graph` objects and return plain graphs from `World.create_story`
- add a `Frame.jump_to_node` helper, update the ledger/session controller to use it, and avoid eager VM imports in the story package
- adjust story integration tests and add a boundary test to ensure importing the story world stays VM-free

## Testing
- `PYTHONPATH=./engine/src pytest engine/tests/story/test_demo_script.py engine/tests/story/test_script_to_graph_integration.py engine/tests/story/fabula/test_world_materialization.py engine/tests/story/fabula/test_world_vm_boundary.py engine/tests/service/controllers/test_runtime_controller.py engine/tests/vm/test_frame.py::test_jump_to_node_handles_prereq_redirects engine/tests/vm/test_ledger.py::test_init_cursor_follows_prereq_redirects`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f92c73b8c8329a4910710a1d3d5a0)