### PR TITLE
Add tier2 demo walkthrough test

### DIFF
--- a/engine/tests/resources/tier2_demo.yaml
+++ b/engine/tests/resources/tier2_demo.yaml
@@ -1,0 +1,124 @@
+label: tier2_demo
+metadata:
+  title: "The Quest for the Crystal"
+  author: "Test Harness"
+
+globals:
+  has_crystal: false
+  has_map: false
+  visited_shrine: false
+  companion_trust: 0
+
+items:
+  crystal:
+    obj_cls: tangl.story.concepts.item.Item
+    name: "Ancient Crystal"
+    description: "A shard that hums with latent power."
+  map:
+    obj_cls: tangl.story.concepts.item.Item
+    name: "Treasure Map"
+    description: "A weathered chart marking the shrine."
+
+actors:
+  companion:
+    obj_cls: tangl.story.concepts.actor.actor.Actor
+    name: "Aria the Ranger"
+    tags: [npc, ally]
+
+scenes:
+  village:
+    roles:
+      companion:
+        obj_cls: tangl.story.concepts.actor.role.Role
+        actor_ref: companion
+    blocks:
+      start:
+        content: "You arrive in a quiet village."
+        actions:
+          - text: "Talk to Aria"
+            successor: meet_companion
+          - text: "Visit the shrine"
+            successor: shrine.entrance
+          - text: "Head into the wilds"
+            successor: wilds.trail
+
+      meet_companion:
+        content: "Aria greets you and offers to guide your search."
+        effects:
+          - "companion_trust = max(companion_trust, 2)"
+        actions:
+          - text: "Ask for guidance"
+            successor: guidance
+          - text: "Request her help"
+            successor: start
+            effects:
+              - "companion_trust = max(companion_trust, 4)"
+
+      guidance:
+        content: "She mentions an old shrine where the crystal is kept."
+        continues:
+          - successor: start
+            trigger: last
+
+  wilds:
+    roles:
+      companion:
+        obj_cls: tangl.story.concepts.actor.role.Role
+        actor_ref: companion
+    blocks:
+      trail:
+        content: "You follow Aria into the thick forest trails."
+        actions:
+          - text: "Search for the map"
+            successor: shrine.entrance
+            conditions:
+              - "companion_trust >= 2"
+              - "'companion' in {concept.label for concept in ctx.cursor.get_concepts()}"
+            effects:
+              - "Item.acquire('map', graph=graph)"
+              - "has_map = True"
+          - text: "Return to the village"
+            successor: village.start
+
+  shrine:
+    roles:
+      companion:
+        obj_cls: tangl.story.concepts.actor.role.Role
+        actor_ref: companion
+    blocks:
+      entrance:
+        content: "An ancient shrine stands before you."
+        effects:
+          - "visited_shrine = True"
+        actions:
+          - text: "Ask Aria to translate the runes"
+            successor: lore
+            conditions:
+              - "'companion' in {concept.label for concept in ctx.cursor.get_concepts()}"
+          - text: "Take the crystal"
+            successor: crystal_obtained
+            conditions:
+              - "companion_trust >= 5"
+              - "has_map"
+          - text: "Return to the village"
+            successor: village.start
+
+      lore:
+        content: "The inscriptions reveal a trial of worthiness."
+        effects:
+          - "companion_trust = companion_trust + 2 if has_map else companion_trust + 1"
+        continues:
+          - successor: entrance
+            trigger: last
+
+      crystal_obtained:
+        content: "The crystal hums as you lift it from the altar."
+        effects:
+          - "Item.acquire('crystal', graph=graph)"
+          - "has_crystal = True"
+        actions:
+          - text: "Return triumphantly"
+            successor: finale
+
+      finale:
+        content: "With Aria at your side, you depart with the Ancient Crystal."

--- a/engine/tests/story/test_tier2_integration.py
+++ b/engine/tests/story/test_tier2_integration.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+from tangl.core import BaseFragment, StreamRegistry
+from tangl.story.concepts.actor.actor import Actor
+from tangl.story.concepts.item import Item
+from tangl.story.fabula.script_manager import ScriptManager
+from tangl.story.fabula.world import World
+from tangl.vm.frame import Frame
+from tangl.vm.ledger import Ledger
+
+
+def _load_tier2_ledger(resources_dir: Path) -> tuple[Ledger, Frame]:
+    script_path = resources_dir / "tier2_demo.yaml"
+    data = yaml.safe_load(script_path.read_text())
+
+    World.clear_instances()
+    script_manager = ScriptManager.from_data(data)
+    world = World(label="tier2_demo_world", script_manager=script_manager)
+    story = world.create_story("tier2_demo_story")
+
+    ledger = Ledger(
+        graph=story,
+        cursor_id=story.initial_cursor_id,
+        records=StreamRegistry(),
+        label="tier2_demo_ledger",
+    )
+    ledger.push_snapshot()
+    ledger.init_cursor()
+    frame = ledger.get_frame()
+    return ledger, frame
+
+
+def _choice_labels(choices: Iterable[BaseFragment]) -> set[str]:
+    return {choice.get_content().replace("_", " ") for choice in choices}
+
+
+def _choose_action(ledger: Ledger, frame: Frame, choice_text: str) -> Frame:
+    choices = frame.cursor.get_choices(ctx=frame.context)
+    labels = _choice_labels(choices)
+    assert choice_text in labels, f"Expected {choice_text} in choices {labels}"
+
+    choice = next(choice for choice in choices if choice.get_content().replace("_", " ") == choice_text)
+    frame.resolve_choice(choice)
+    ledger.cursor_id = frame.cursor_id
+    ledger.step = frame.step
+    return frame
+
+
+def test_tier2_complete_walkthrough(resources_dir: Path) -> None:
+    ledger, frame = _load_tier2_ledger(resources_dir)
+
+    assert frame.cursor.label == "start"
+    companion = next(concept for concept in frame.cursor.get_concepts() if concept.label == "companion")
+    assert isinstance(companion, Actor)
+    assert ledger.graph.locals["companion_trust"] == 0
+
+    frame = _choose_action(ledger, frame, "Talk to Aria")
+    assert ledger.graph.locals["companion_trust"] >= 2
+
+    frame = _choose_action(ledger, frame, "Request her help")
+    assert ledger.graph.locals["companion_trust"] >= 4
+    assert frame.cursor.label == "start"
+
+    trail_edge = next(
+        edge
+        for edge in ledger.graph.find_edges(source_id=frame.cursor.uid)
+        if getattr(ledger.graph.get(edge.destination_id), "label", None) == "trail"
+    )
+    frame.follow_edge(trail_edge)
+    ledger.cursor_id = frame.cursor_id
+    ledger.step = frame.step
+    frame = ledger.get_frame()
+    assert frame.cursor.label == "trail"
+
+    trail_choices = _choice_labels(frame.cursor.get_choices(ctx=frame.context))
+    assert "Search for the map" in trail_choices
+
+    frame = _choose_action(ledger, frame, "Search for the map")
+    assert frame.cursor.label == "entrance"
+    assert Item.has_item("map", graph=ledger.graph)
+    assert ledger.graph.locals["has_map"] is True
+    assert ledger.graph.locals["visited_shrine"] is True
+
+    entrance_choices = _choice_labels(frame.cursor.get_choices(ctx=frame.context))
+    assert "Take the crystal" not in entrance_choices
+    assert ledger.graph.locals["companion_trust"] < 5
+
+    frame = _choose_action(ledger, frame, "Ask Aria to translate the runes")
+    assert frame.cursor.label == "entrance"
+    assert ledger.graph.locals["companion_trust"] >= 5
+
+    frame = _choose_action(ledger, frame, "Take the crystal")
+    assert Item.has_item("crystal", graph=ledger.graph)
+    assert ledger.graph.locals["has_crystal"] is True
+
+    frame = _choose_action(ledger, frame, "Return triumphantly")
+    finale_frame = ledger.get_frame()
+    assert finale_frame.cursor.label in {"finale", "shrine_SINK"}


### PR DESCRIPTION
## Summary
- add a Tier 2 demo story covering state tracking, item gating, and actor-driven conditions
- add an integration walkthrough test that verifies the full quest flow and gating rules

## Testing
- PYTHONPATH=./engine/src pytest engine/tests/story/test_tier2_integration.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691beac69ad883299ab2b0a4582e9f7e)