### PR TITLE
Handle alternating redirects in jump_to_node

### DIFF
--- a/engine/src/tangl/vm/frame.py
+++ b/engine/src/tangl/vm/frame.py
@@ -274,18 +274,18 @@ class Frame:
         bootstrap_edge = AnonymousEdge(destination=node)
         next_edge = self.follow_edge(bootstrap_edge)
 
-        while (
-            isinstance(next_edge, ChoiceEdge)
-            and getattr(next_edge, "trigger_phase", None) == P.PREREQS
-        ):
-            next_edge = self.follow_edge(next_edge)
+        while isinstance(next_edge, ChoiceEdge):
+            trigger_phase = getattr(next_edge, "trigger_phase", None)
 
-        if include_postreq:
-            while (
-                isinstance(next_edge, ChoiceEdge)
-                and getattr(next_edge, "trigger_phase", None) == P.POSTREQS
-            ):
+            if trigger_phase == P.PREREQS:
                 next_edge = self.follow_edge(next_edge)
+                continue
+
+            if trigger_phase == P.POSTREQS and include_postreq:
+                next_edge = self.follow_edge(next_edge)
+                continue
+
+            break
 
     def resolve_choice(self, choice: ChoiceEdge) -> None:
         """

--- a/engine/tests/vm/test_frame.py
+++ b/engine/tests/vm/test_frame.py
@@ -160,6 +160,24 @@ def test_postreq_redirect():
     assert nxt is None  # but ensure POSTREQS found and would have been returned if available
     # Or directly assert f.run_phase(P.POSTREQS) returns the ChoiceEdge
 
+
+def test_jump_to_node_follows_alternating_redirects():
+    g = Graph(label="demo")
+    start = g.add_node(label="start")
+    prereq_target = g.add_node(label="prereq-target")
+    postreq_target = g.add_node(label="postreq-target")
+    final = g.add_node(label="final")
+
+    ChoiceEdge(graph=g, source_id=start.uid, destination_id=prereq_target.uid, trigger_phase=P.PREREQS)
+    ChoiceEdge(graph=g, source_id=prereq_target.uid, destination_id=postreq_target.uid, trigger_phase=P.POSTREQS)
+    ChoiceEdge(graph=g, source_id=postreq_target.uid, destination_id=final.uid, trigger_phase=P.PREREQS)
+
+    frame = Frame(graph=g, cursor_id=start.uid)
+    frame.jump_to_node(start.uid, include_postreq=True)
+
+    assert frame.cursor_id == final.uid
+    assert frame.step == 4
+
 def test_rand_is_deterministic_for_same_context():
     guid = uuid.uuid4()
     nuid = uuid.uuid4()


### PR DESCRIPTION
## Summary
- ensure `Frame.jump_to_node` keeps following chained prereq/postreq redirects until no auto-trigger remains
- add coverage for alternating prereq and postreq redirects

## Testing
- PYTHONPATH=./engine/src pytest engine/tests/vm/test_frame.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c62ade7148329903803419cdc5697)