### PR TITLE
Expose choices in story update responses

### DIFF
--- a/apps/server/tests/test_multi_world_switching.py
+++ b/apps/server/tests/test_multi_world_switching.py
@@ -158,13 +158,15 @@ def test_multi_world_switching_flow(
     payload_one = update_one.json()
     fragments_one = payload_one["fragments"]
     assert _fragment_contains(fragments_one, "crossroads")
-    assert len(extract_choices_from_fragments(fragments_one)) >= 2
+    choices_one = payload_one["choices"]
+    assert choices_one == extract_choices_from_fragments(fragments_one)
+    assert len(choices_one) >= 2
 
     status_before = client.get("story/status", headers=headers)
     assert status_before.status_code == 200
     step_before = status_before.json()["step"]
 
-    first_choice_frag = extract_choices_from_fragments(fragments_one)[0]
+    first_choice_frag = choices_one[0]
     first_choice = first_choice_frag.get("uid") or first_choice_frag.get("source_id")
     choose_resp = client.post("story/do", json={"uid": first_choice}, headers=headers)
     assert choose_resp.status_code == 200
@@ -177,6 +179,7 @@ def test_multi_world_switching_flow(
     assert update_two.status_code == 200
     payload_two = update_two.json()
     assert payload_two["fragments"]
+    assert payload_two["choices"] == extract_choices_from_fragments(payload_two["fragments"])
 
     drop_demo = client.delete(
         "story/drop",
@@ -203,7 +206,8 @@ def test_multi_world_switching_flow(
     payload_three = update_three.json()
     fragments_three = payload_three["fragments"]
     assert _fragment_contains(fragments_three, "journey at dawn")
-    third_choices = extract_choices_from_fragments(fragments_three)
+    third_choices = payload_three["choices"]
+    assert third_choices == extract_choices_from_fragments(fragments_three)
     assert len(third_choices) == 1
 
     continue_choice = third_choices[0].get("uid") or third_choices[0].get("source_id")

--- a/apps/server/tests/test_story_branching_endpoints.py
+++ b/apps/server/tests/test_story_branching_endpoints.py
@@ -70,7 +70,8 @@ def test_branching_story_left_path_rest(branching_story_client: tuple[TestClient
 
     assert _fragment_contains(fragments, "You stand at a crossroads in the forest.")
 
-    choices = extract_choices_from_fragments(fragments)
+    choices = payload["choices"]
+    assert choices == extract_choices_from_fragments(fragments)
     assert len(choices) == 3
 
     left_choice = _find_choice(choices, "left")
@@ -83,7 +84,7 @@ def test_branching_story_left_path_rest(branching_story_client: tuple[TestClient
 
     fragments_two = payload_two["fragments"]
     assert _fragment_contains(fragments_two, "peaceful garden")
-    assert extract_choices_from_fragments(fragments_two) == []
+    assert payload_two["choices"] == []
 
 
 def test_branching_story_enter_cave_rest(branching_story_client: tuple[TestClient, dict[str, str]]) -> None:
@@ -95,7 +96,8 @@ def test_branching_story_enter_cave_rest(branching_story_client: tuple[TestClien
     payload = first_update.json()
     fragments = payload["fragments"]
 
-    choices = extract_choices_from_fragments(fragments)
+    choices = payload["choices"]
+    assert choices == extract_choices_from_fragments(fragments)
     right_choice = _find_choice(choices, "right")
     resolve_right = client.post("story/do", json={"uid": right_choice["uid"]}, headers=headers)
     assert resolve_right.status_code == 200
@@ -105,7 +107,8 @@ def test_branching_story_enter_cave_rest(branching_story_client: tuple[TestClien
     fragments_two = payload_two["fragments"]
 
     assert _fragment_contains(fragments_two, "dark cave")
-    choices_two = extract_choices_from_fragments(fragments_two)
+    choices_two = payload_two["choices"]
+    assert choices_two == extract_choices_from_fragments(fragments_two)
     assert len(choices_two) == 2
     assert _find_choice(choices_two, "enter")
     assert _find_choice(choices_two, "back")
@@ -119,7 +122,7 @@ def test_branching_story_enter_cave_rest(branching_story_client: tuple[TestClien
 
     fragments_three = payload_three["fragments"]
     assert _fragment_contains(fragments_three, "deeper than you thought")
-    assert extract_choices_from_fragments(fragments_three) == []
+    assert payload_three["choices"] == []
 
 
 def test_branching_story_backtrack_rest(branching_story_client: tuple[TestClient, dict[str, str]]) -> None:
@@ -128,12 +131,12 @@ def test_branching_story_backtrack_rest(branching_story_client: tuple[TestClient
     client.post("story/story/create", params={"world_id": "the_crossroads"}, headers=headers)
 
     first_update = client.get("story/update", headers=headers).json()
-    first_choices = extract_choices_from_fragments(first_update["fragments"])
+    first_choices = first_update["choices"]
     right_choice = _find_choice(first_choices, "right")
     client.post("story/do", json={"uid": right_choice["uid"]}, headers=headers)
 
     second_update = client.get("story/update", headers=headers).json()
-    second_choices = extract_choices_from_fragments(second_update["fragments"])
+    second_choices = second_update["choices"]
     back_choice = _find_choice(second_choices, "back")
     resolve_back = client.post("story/do", json={"uid": back_choice["uid"]}, headers=headers)
     assert resolve_back.status_code == 200
@@ -147,7 +150,7 @@ def test_branching_story_backtrack_rest(branching_story_client: tuple[TestClient
         fragments_three,
         "You stand at a crossroads in the forest.",
     )
-    choices_three = extract_choices_from_fragments(fragments_three)
+    choices_three = payload_three["choices"]
     assert len(choices_three) == 3
     assert _find_choice(choices_three, "guide")
     assert _find_choice(choices_three, "left")

--- a/apps/server/tests/test_story_linear_endpoints.py
+++ b/apps/server/tests/test_story_linear_endpoints.py
@@ -62,7 +62,8 @@ def test_linear_story_rest_flow(linear_story_client: tuple[TestClient, dict[str,
     fragments = payload["fragments"]
     assert _fragment_contains(fragments, "You begin your journey at dawn.")
 
-    choices = extract_choices_from_fragments(fragments)
+    choices = payload["choices"]
+    assert choices == extract_choices_from_fragments(fragments)
     assert choices, "Expected an initial choice to be available"
 
     first_choice = choices[0].get("uid") or choices[0].get("source_id")
@@ -78,7 +79,8 @@ def test_linear_story_rest_flow(linear_story_client: tuple[TestClient, dict[str,
         "The path winds through ancient woods.",
     )
 
-    choices_two = extract_choices_from_fragments(fragments_two)
+    choices_two = payload_two["choices"]
+    assert choices_two == extract_choices_from_fragments(fragments_two)
     assert choices_two, "Expected a continuation choice after the middle block"
 
     second_choice = choices_two[0].get("uid") or choices_two[0].get("source_id")
@@ -90,4 +92,4 @@ def test_linear_story_rest_flow(linear_story_client: tuple[TestClient, dict[str,
     payload_three = update_three.json()
     fragments_three = payload_three["fragments"]
     assert _fragment_contains(fragments_three, "You arrive at the village.")
-    assert extract_choices_from_fragments(fragments_three) == []
+    assert payload_three["choices"] == []

--- a/engine/tests/helpers/test_fragment_helpers_choices.py
+++ b/engine/tests/helpers/test_fragment_helpers_choices.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from helpers.fragment_helpers import extract_all_choices, extract_blocks_with_choices
+
+
+def test_extract_all_choices_and_blocks_with_choices() -> None:
+    choice_in_block = SimpleNamespace(fragment_type="choice", content="Enter cave")
+    standalone_choice = SimpleNamespace(fragment_type="choice", content="Wait")
+    block_fragment = SimpleNamespace(fragment_type="block", choices=[choice_in_block])
+
+    fragments = [block_fragment, standalone_choice]
+
+    choices = extract_all_choices(fragments)
+    assert choice_in_block in choices
+    assert standalone_choice in choices
+
+    blocks_with_choices = extract_blocks_with_choices(fragments)
+    assert blocks_with_choices == [(block_fragment, [choice_in_block])]


### PR DESCRIPTION
## Summary
- add choice extraction helper for story update responses and return choices alongside fragments
- update story REST endpoint tests to assert provided choices match the fragment stream
- add engine fragment helper coverage for extracting choices from block and standalone fragments

## Testing
- PYTHONPATH=./engine/src pytest engine/tests/helpers/test_fragment_helpers_choices.py apps/server/tests/test_story_linear_endpoints.py apps/server/tests/test_story_branching_endpoints.py apps/server/tests/test_multi_world_switching.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920ec65dcf48329919e2485876a9ff3)