### PR TITLE
Add native choice and story info responses

### DIFF
--- a/engine/src/tangl/core/record/snapshot.py
+++ b/engine/src/tangl/core/record/snapshot.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
-from typing import TypeVar, Generic, Literal
+from typing import Generic, Literal, Optional, TypeVar
 import logging
 from copy import deepcopy
 
 from tangl.core.entity import Entity
+from tangl.type_hints import Hash
 from .content_addressable import ContentAddressable
 from .record import Record
 
@@ -64,4 +65,7 @@ class Snapshot(Record, ContentAddressable, Generic[EntityT]):
         if verify and item._state_hash() != self.content_hash:
             raise RuntimeError("Recovered item state does not match item state hash.")
         return item
+
+
+Snapshot.model_rebuild()
 

--- a/engine/src/tangl/ir/story_ir/story_script_models.py
+++ b/engine/src/tangl/ir/story_ir/story_script_models.py
@@ -13,7 +13,7 @@ from typing import Any, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
-from tangl.type_hints import UniqueLabel, StringMap
+from tangl.type_hints import Hash, StringMap, UniqueLabel
 from tangl.ir.core_ir import BaseScriptItem, MasterScript
 from .scene_script_models import SceneScript, BlockScript, MenuBlockScript
 from .actor_script_models import ActorScript, RoleScript
@@ -58,10 +58,14 @@ class ScopeSelector(BaseModel):
         )
 
 
-ActorScript.model_rebuild(_types_namespace={"ScopeSelector": ScopeSelector})
-LocationScript.model_rebuild(_types_namespace={"ScopeSelector": ScopeSelector})
-RoleScript.model_rebuild(_types_namespace={"ActorScript": ActorScript})
-SettingScript.model_rebuild(_types_namespace={"LocationScript": LocationScript})
+_types_namespace = {"ScopeSelector": ScopeSelector, "Hash": Hash}
+
+ActorScript.model_rebuild(_types_namespace=_types_namespace)
+LocationScript.model_rebuild(_types_namespace=_types_namespace)
+RoleScript.model_rebuild(_types_namespace={"ActorScript": ActorScript, "Hash": Hash})
+SettingScript.model_rebuild(
+    _types_namespace={"LocationScript": LocationScript, "Hash": Hash}
+)
 BlockScript.model_rebuild()
 MenuBlockScript.model_rebuild()
 SceneScript.model_rebuild()

--- a/engine/src/tangl/service/controllers/runtime_controller.py
+++ b/engine/src/tangl/service/controllers/runtime_controller.py
@@ -15,7 +15,7 @@ from tangl.service.api_endpoint import (
     ResponseType,
 )
 from tangl.service.exceptions import InvalidOperationError
-from tangl.service.response import RuntimeInfo, StoryInfo
+from tangl.service.response import ChoiceInfo, RuntimeInfo, StoryInfo
 from tangl.vm.frame import ChoiceEdge, Frame
 from tangl.vm.ledger import Ledger
 from tangl.service.user.user import User
@@ -155,12 +155,38 @@ class RuntimeController(HasApiEndpoints):
     def get_story_info(self, ledger: Ledger) -> StoryInfo:
         """Summarize the current ledger state for diagnostics."""
 
+        cursor_node = ledger.graph.get(ledger.cursor_id)
+
         return StoryInfo(
             title=ledger.graph.label,
             step=ledger.step,
             cursor_id=ledger.cursor_id,
             journal_size=sum(1 for _ in ledger.records.iter_channel("fragment")),
+            cursor_label=cursor_node.label if cursor_node else None,
         )
+
+    @ApiEndpoint.annotate(
+        access_level=AccessLevel.PUBLIC,
+        response_type=ResponseType.INFO,
+    )
+    def get_available_choices(self, ledger: Ledger) -> list[ChoiceInfo]:
+        """Return available choices from the ledger cursor."""
+
+        cursor = ledger.graph.get(ledger.cursor_id)
+        if cursor is None:
+            return []
+
+        choices: list[ChoiceInfo] = []
+        for edge in cursor.edges_out(is_instance=ChoiceEdge):
+            choices.append(
+                ChoiceInfo(
+                    uid=edge.uid,
+                    label=edge.label or "unnamed",
+                    active=True,
+                )
+            )
+
+        return choices
 
     @ApiEndpoint.annotate(
         access_level=AccessLevel.RESTRICTED,

--- a/engine/src/tangl/service/response/__init__.py
+++ b/engine/src/tangl/service/response/__init__.py
@@ -5,7 +5,7 @@ from .native_response import (
     NativeResponse,
     RuntimeInfo,
 )
-from .info_response import UserInfo, SystemInfo, WorldInfo, StoryInfo
+from .info_response import ChoiceInfo, StoryInfo, SystemInfo, UserInfo, WorldInfo
 from .base_response import BaseResponse
 from .content_response import ContentResponse
 from .content_response_handler import ResponseHandler
@@ -16,10 +16,11 @@ __all__ = [
     "MediaNative",
     "NativeResponse",
     "RuntimeInfo",
-    "UserInfo",
-    "SystemInfo",
-    "WorldInfo",
+    "ChoiceInfo",
     "StoryInfo",
+    "SystemInfo",
+    "UserInfo",
+    "WorldInfo",
     "BaseResponse",
     "ContentResponse",
     "ResponseHandler",

--- a/engine/src/tangl/service/response/info_response/__init__.py
+++ b/engine/src/tangl/service/response/info_response/__init__.py
@@ -1,8 +1,16 @@
 from tangl.service.response.native_response import RuntimeInfo
 
-from .user_info import UserInfo
-from .system_info import SystemInfo
-from .world_info import WorldInfo
+from .choice_info import ChoiceInfo
 from .story_info import StoryInfo
+from .system_info import SystemInfo
+from .user_info import UserInfo
+from .world_info import WorldInfo
 
-__all__ = ["RuntimeInfo", "UserInfo", "SystemInfo", "WorldInfo", "StoryInfo"]
+__all__ = [
+    "RuntimeInfo",
+    "ChoiceInfo",
+    "StoryInfo",
+    "SystemInfo",
+    "UserInfo",
+    "WorldInfo",
+]

--- a/engine/src/tangl/service/response/info_response/choice_info.py
+++ b/engine/src/tangl/service/response/info_response/choice_info.py
@@ -1,0 +1,29 @@
+"""Choice metadata response."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import Field
+
+from tangl.service.response.native_response import InfoModel
+
+
+class ChoiceInfo(InfoModel):
+    """Metadata describing an available choice for the current cursor."""
+
+    uid: UUID = Field(..., alias="id")
+    """Unique identifier for the choice edge."""
+
+    label: str
+    """Human-readable label for the choice."""
+
+    active: bool = True
+    """Whether the choice can currently be selected."""
+
+    reason: str | None = None
+    """Explanation for inactive choices."""
+
+    class Config:
+        populate_by_name = True
+        """Allow field population via ``uid`` or alias ``id``."""

--- a/engine/src/tangl/service/response/info_response/story_info.py
+++ b/engine/src/tangl/service/response/info_response/story_info.py
@@ -8,7 +8,19 @@ from tangl.service.response.native_response import InfoModel
 
 
 class StoryInfo(InfoModel):
+    """Metadata describing the current story ledger."""
+
     title: str
+    """Story/world title."""
+
     step: int
+    """Current step count."""
+
     cursor_id: UUID
+    """Current cursor identifier within the story graph."""
+
     journal_size: int
+    """Number of fragments present in the journal."""
+
+    cursor_label: str | None = None
+    """Label for the current cursor node, if available."""

--- a/engine/src/tangl/story/fabula/world.py
+++ b/engine/src/tangl/story/fabula/world.py
@@ -404,6 +404,7 @@ class World(Singleton):
         for scene_label, scene_data in scenes.items():
             blocks = self._normalize_section(scene_data.get("blocks"))
             for block_label, block_data in blocks.items():
+                block_data = block_data or {}
                 qualified_label = f"{scene_label}.{block_label}"
                 cls = self.domain_manager.resolve_class(
                     block_data.get("obj_cls") or block_data.get("block_cls")
@@ -412,7 +413,7 @@ class World(Singleton):
                 scripts = {
                     key: [
                         self._normalize_action_entry(self._to_dict(entry))
-                        for entry in block_data.get(key, [])
+                        for entry in (block_data.get(key) or [])
                     ]
                     for key in ("actions", "continues", "redirects")
                 }


### PR DESCRIPTION
## Summary
- add a ChoiceInfo model and update RuntimeController to return typed choice metadata
- extend StoryInfo to include cursor labels and export new native responses
- harden script serialization and snapshot rebuilding to satisfy controller tests

## Testing
- PYTHONPATH=./engine/src pytest engine/tests/service/controllers/test_runtime_controller.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920eb9f3c4c832982bc3d4dc29cdeb8)