### PR TITLE
Ensure story updates use RuntimeInfo and add media fixture

### DIFF
--- a/engine/src/tangl/service/controllers/runtime_controller.py
+++ b/engine/src/tangl/service/controllers/runtime_controller.py
@@ -176,7 +176,7 @@ class RuntimeController(HasApiEndpoints):
         access_level=AccessLevel.PUBLIC,
         response_type=ResponseType.RUNTIME,
     )
-    def get_story_update(self, *, ledger: Ledger, frame: Frame, **_: Any) -> dict:
+    def get_story_update(self, *, ledger: Ledger, frame: Frame, **_: Any) -> RuntimeInfo:
         """Return the current story update, dereferencing media fragments to URLs."""
 
         world_id = self._world_id_for_ledger(ledger)
@@ -194,11 +194,12 @@ class RuntimeController(HasApiEndpoints):
             else:
                 output_fragments.append({"content": str(fragment)})
 
-        return {
-            "fragments": output_fragments,
-            "cursor_id": str(frame.cursor_id),
-            "step": ledger.step,
-        }
+        return RuntimeInfo.ok(
+            cursor_id=frame.cursor_id,
+            step=ledger.step,
+            message="Story update",
+            fragments=output_fragments,
+        )
 
     @ApiEndpoint.annotate(
         access_level=AccessLevel.PUBLIC,

--- a/engine/tests/resources/worlds/media_e2e/media/tavern.svg
+++ b/engine/tests/resources/worlds/media_e2e/media/tavern.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120">
+  <rect width="120" height="120" fill="#1f2937" rx="10" ry="10" />
+  <path d="M20 90 L60 20 L100 90 Z" fill="#fbbf24" stroke="#111827" stroke-width="4" />
+  <rect x="50" y="60" width="20" height="30" fill="#374151" stroke="#111827" stroke-width="3" />
+  <circle cx="60" cy="72" r="4" fill="#f3f4f6" />
+</svg>

--- a/engine/tests/service/controllers/test_runtime_controller_media.py
+++ b/engine/tests/service/controllers/test_runtime_controller_media.py
@@ -1,10 +1,17 @@
 from pathlib import Path
 from uuid import uuid4
 
+from tangl.core import StreamRegistry
+from tangl.journal.content import ContentFragment
 from tangl.journal.media import MediaFragment
 from tangl.media.media_data_type import MediaDataType
 from tangl.media.media_resource.media_resource_inv_tag import MediaResourceInventoryTag as MediaRIT
 from tangl.service.controllers.runtime_controller import RuntimeController
+from tangl.service.response import RuntimeInfo
+from tangl.story.episode.block import Block
+from tangl.story.story_graph import StoryGraph
+from tangl.vm.frame import Frame
+from tangl.vm.ledger import Ledger
 
 
 def test_dereference_media_fragment_to_url():
@@ -43,3 +50,63 @@ def test_dereference_media_fragment_to_url():
     assert result["media_type"] == MediaDataType.IMAGE.value
     assert result["text"] == "A fierce dragon"
     assert result["source_id"] == str(fragment.source_id)
+
+
+def test_get_story_update_returns_runtime_info_with_fragments() -> None:
+    class _WorldStub:
+        def __init__(self, uid: str) -> None:
+            self.uid = uid
+
+        def unstructure(self) -> dict[str, str]:
+            return {"uid": self.uid}
+
+    graph = StoryGraph(label="media_story")
+    start = graph.add_node(obj_cls=Block, label="start")
+    graph.world = _WorldStub(uid="media_world")
+    ledger = Ledger(graph=graph, cursor_id=start.uid, records=StreamRegistry())
+    ledger.push_snapshot()
+
+    media_path = (
+        Path(__file__).resolve().parents[4]
+        / "engine"
+        / "tests"
+        / "resources"
+        / "worlds"
+        / "media_mvp"
+        / "media"
+        / "test_image.svg"
+    )
+
+    fragments = [
+        ContentFragment(content="[step 0001]: cursor at start"),
+        ContentFragment(content="Narration"),
+        MediaFragment(
+            content=MediaRIT(path=media_path, data_type=MediaDataType.IMAGE),
+            content_format="rit",
+            content_type=MediaDataType.IMAGE,
+            media_role="narrative_im",
+            text="Illustration",
+            source_id=uuid4(),
+        ),
+    ]
+
+    ledger.records.push_records(*fragments, marker_type="journal", marker_name="step-0001")
+
+    controller = RuntimeController()
+    frame = Frame(graph=graph, cursor_id=start.uid)
+
+    result = controller.get_story_update(ledger=ledger, frame=frame)
+
+    assert isinstance(result, RuntimeInfo)
+    assert result.status == "ok"
+    assert result.cursor_id == start.uid
+    assert result.step == ledger.step
+
+    payload = result.details or {}
+    fragment_payloads = payload.get("fragments", [])
+
+    assert fragment_payloads, "Expected dereferenced fragments in runtime update"
+    assert any(frag.get("fragment_type") == "media" for frag in fragment_payloads)
+    assert any(
+        frag.get("url", "").endswith("/test_image.svg") for frag in fragment_payloads
+    )


### PR DESCRIPTION
## Summary
- return RuntimeInfo from RuntimeController.get_story_update and keep cursor metadata
- add regression coverage for runtime story updates including media dereferencing
- populate the media_e2e tavern SVG fixture with non-empty vector content

## Testing
- PYTHONPATH=./engine/src pytest engine/tests/service/test_response_contract.py apps/server/tests/test_media_server_integration.py engine/tests/service/controllers/test_runtime_controller_media.py::test_get_story_update_returns_runtime_info_with_fragments


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69286528af5c8329b788bc284d59f0f6)