### PR TITLE
Add slotted assembly containers with selectable slots

### DIFF
--- a/engine/src/tangl/mechanics/assembly/README.md
+++ b/engine/src/tangl/mechanics/assembly/README.md
@@ -1,0 +1,14 @@
+# Mechanics: Assembly
+
+Composable slot-based containers for arranging components into loadouts. Slots use
+`tangl.core.entity.Entity.matches()` to determine eligibility, enabling both declarative
+criteria (tags, type checks) and custom predicates without duplicating selector logic.
+
+Key pieces:
+
+- `Slot` / `SlotGroup`: selection criteria and aggregate constraints.
+- `SlottedContainer`: generic container that enforces slot rules and optional resource budgets.
+- `HasSlottedContainer`: mixin for embedding a container on an entity (facet-style).
+- `BudgetTracker`: helper for tracking resource usage (power, weight, etc.).
+
+See `examples/vehicle.py` and `examples/outfit.py` for usage patterns.

--- a/engine/src/tangl/mechanics/assembly/__init__.py
+++ b/engine/src/tangl/mechanics/assembly/__init__.py
@@ -1,0 +1,17 @@
+"""
+Composable loadout containers built on :class:`tangl.core.entity.Entity.matches`.
+"""
+
+from .base import HasResourceCost, HasSlottedContainer, SlottedContainer
+from .budget import BudgetTracker, ResourceBudget
+from .slot import Slot, SlotGroup
+
+__all__ = [
+    "HasResourceCost",
+    "HasSlottedContainer",
+    "SlottedContainer",
+    "BudgetTracker",
+    "ResourceBudget",
+    "Slot",
+    "SlotGroup",
+]

--- a/engine/src/tangl/mechanics/assembly/base.py
+++ b/engine/src/tangl/mechanics/assembly/base.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, ClassVar, Generic, Optional, Protocol, TypeVar
+
+from pydantic import BaseModel, Field, model_validator
+
+from tangl.core import Entity
+from .budget import BudgetTracker
+from .slot import Slot, SlotGroup
+
+CT = TypeVar("CT", bound=Entity)
+
+
+class HasResourceCost(Protocol):
+    """Protocol for components that consume named resources."""
+
+    def get_cost(self, resource: str) -> float:
+        ...
+
+
+class SlottedContainer(BaseModel, Generic[CT]):
+    """Generic container that assigns components into named slots.
+
+    Slots declare selection criteria that mirror :meth:`Entity.matches` so that eligibility is
+    resolved by the components themselves. Subclasses define ``slots`` and may enable resource
+    tracking via ``tracked_resources``.
+    """
+
+    slots: ClassVar[dict[str, Slot]] = {}
+    slot_groups: ClassVar[list[SlotGroup]] = []
+    tracked_resources: ClassVar[list[str]] = []
+
+    assignments: dict[str, list[CT]] = Field(default_factory=lambda: defaultdict(list))
+    budgets: Optional[BudgetTracker] = None
+    owner: Any = Field(default=None, exclude=True)
+
+    @model_validator(mode="after")
+    def _initialize_budgets(self) -> "SlottedContainer[CT]":
+        if self.tracked_resources and not self.budgets:
+            self.budgets = BudgetTracker()
+            for resource in self.tracked_resources:
+                capacity = None
+                if self.owner:
+                    capacity = getattr(self.owner, f"max_{resource}", None)
+                if capacity is not None:
+                    self.budgets.add_budget(resource, capacity)
+        return self
+
+    def assign(self, slot_name: str, component: CT) -> None:
+        can_assign, reason = self.can_assign(slot_name, component)
+        if not can_assign:
+            raise ValueError(f"Cannot assign {getattr(component, 'label', component)!r} to {slot_name}: {reason}")
+
+        self.assignments[slot_name].append(component)
+
+        if self.budgets:
+            self.budgets.recalculate(self.all_components())
+
+    def unassign(self, slot_name: str, component: CT) -> None:
+        if slot_name not in self.assignments:
+            return
+
+        if component in self.assignments[slot_name]:
+            self.assignments[slot_name].remove(component)
+            if self.budgets:
+                self.budgets.recalculate(self.all_components())
+
+    def get_slot(self, slot_name: str) -> list[CT]:
+        return self.assignments.get(slot_name, [])
+
+    def all_components(self) -> list[CT]:
+        result: list[CT] = []
+        for components in self.assignments.values():
+            result.extend(components)
+        return result
+
+    def can_assign(self, slot_name: str, component: CT) -> tuple[bool, str]:
+        if slot_name not in self.slots:
+            return False, f"No such slot: {slot_name}"
+
+        slot = self.slots[slot_name]
+        selects, reason = slot.selects_for(component)
+        if not selects:
+            return False, reason
+
+        current_count = len(self.assignments.get(slot_name, []))
+        if current_count >= slot.max_count:
+            return False, f"Slot full ({current_count}/{slot.max_count})"
+
+        if self.budgets and hasattr(component, "get_cost"):
+            for name, budget in self.budgets.budgets.items():
+                cost = getattr(component, "get_cost")(name)
+                if not budget.can_afford(cost):
+                    return False, f"Insufficient {name}: need {cost}, have {budget.available}"
+
+        return True, ""
+
+    def validate(self) -> list[str]:
+        errors: list[str] = []
+
+        for slot_name, slot in self.slots.items():
+            if slot.required and not self.assignments.get(slot_name):
+                errors.append(f"Required slot empty: {slot_name}")
+
+        for group in self.slot_groups:
+            total = sum(len(self.assignments.get(name, [])) for name in group.slot_names)
+            if group.min_total is not None and total < group.min_total:
+                errors.append(f"Group '{group.name}': {total} < {group.min_total} (min)")
+            if group.max_total is not None and total > group.max_total:
+                errors.append(f"Group '{group.name}': {total} > {group.max_total} (max)")
+
+        if self.budgets:
+            errors.extend(self.budgets.get_errors())
+
+        errors.extend(self._validate_custom())
+        return errors
+
+    def _validate_custom(self) -> list[str]:
+        return []
+
+    @property
+    def is_valid(self) -> bool:
+        return len(self.validate()) == 0
+
+
+class HasSlottedContainer:
+    """Mixin for entities that own a :class:`SlottedContainer`.
+
+    Place the mixin *before* Pydantic models in the inheritance list so its
+    serialization helpers run (e.g., ``class Vehicle(HasSlottedContainer, Node)``).
+    """
+
+    _container_class: ClassVar[type[SlottedContainer]] = SlottedContainer
+    _container: Optional[SlottedContainer] = None
+
+    @property
+    def loadout(self) -> SlottedContainer:
+        if self._container is None:
+            self._container = self._container_class(owner=self)
+        return self._container
+
+    def model_dump(self, **kwargs: Any) -> dict[str, Any]:  # type: ignore[override]
+        data = super().model_dump(**kwargs)  # type: ignore[misc]
+        if self._container:
+            data["_container"] = self._container.model_dump()
+        return data
+
+    @classmethod
+    def model_validate(cls, obj: Any, **kwargs: Any):  # type: ignore[override]
+        instance = super().model_validate(obj, **kwargs)  # type: ignore[misc]
+        if "_container" in obj:
+            instance._container = instance._container_class.model_validate(obj["_container"])
+            instance._container.owner = instance
+        return instance

--- a/engine/src/tangl/mechanics/assembly/budget.py
+++ b/engine/src/tangl/mechanics/assembly/budget.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from pydantic import BaseModel, Field
+
+from tangl.core import Entity
+
+
+class ResourceBudget(BaseModel):
+    """ResourceBudget(name: str, capacity: float)
+
+    Track consumption against a named capacity (power, weight, etc.).
+    """
+
+    name: str
+    capacity: float
+    consumed: float = 0.0
+
+    @property
+    def available(self) -> float:
+        return self.capacity - self.consumed
+
+    def can_afford(self, cost: float) -> bool:
+        return self.consumed + cost <= self.capacity
+
+    def update(self, cost: float) -> None:
+        self.consumed = cost
+
+
+class BudgetTracker(BaseModel):
+    """Collection of :class:`ResourceBudget` entries keyed by resource name."""
+
+    budgets: dict[str, ResourceBudget] = Field(default_factory=dict)
+
+    def add_budget(self, name: str, capacity: float) -> None:
+        self.budgets[name] = ResourceBudget(name=name, capacity=capacity)
+
+    def recalculate(self, components: Iterable[Entity]) -> None:
+        for budget in self.budgets.values():
+            total = 0.0
+            for component in components:
+                if hasattr(component, "get_cost"):
+                    total += float(getattr(component, "get_cost")(budget.name))
+            budget.update(total)
+
+    def get_errors(self) -> list[str]:
+        errors = []
+        for budget in self.budgets.values():
+            if budget.consumed > budget.capacity:
+                errors.append(
+                    f"Over budget for {budget.name}: {budget.consumed:.1f}/{budget.capacity:.1f}"
+                )
+        return errors

--- a/engine/src/tangl/mechanics/assembly/examples/outfit.py
+++ b/engine/src/tangl/mechanics/assembly/examples/outfit.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from tangl.core import Node
+from tangl.lang.body_parts import BodyRegion
+from tangl.mechanics.presence.wearable import Wearable
+from tangl.mechanics.presence.wearable.enums import WearableLayer
+from tangl.mechanics.assembly import HasSlottedContainer, Slot, SlottedContainer
+
+
+class OutfitManager(SlottedContainer[Wearable]):
+    """Manage wearable items across body regions and clothing layers."""
+
+    slots = {
+        f"{region.name.lower()}_{layer.value}": Slot(
+            name=f"{region.name.lower()}_{layer.value}",
+            selection_criteria={
+                "predicate": (
+                    lambda wearable, r=region, l=layer.value: r in wearable.covers and wearable.layer.value <= l
+                )
+            },
+            max_count=3,
+        )
+        for region in BodyRegion
+        for layer in WearableLayer
+    }
+
+    def _validate_custom(self) -> list[str]:
+        errors: list[str] = []
+
+        uniform_count = sum(1 for comp in self.all_components() if comp.has_tags("uniform"))
+        if 0 < uniform_count < 3:
+            errors.append(f"Need 3+ uniform pieces (have {uniform_count})")
+
+        for region in BodyRegion:
+            items_here = [component for component in self.all_components() if region in component.covers]
+            items_here.sort(key=lambda wearable: wearable.layer.value)
+
+            for idx, item in enumerate(items_here[:-1]):
+                if getattr(item, "state", None) and item.state.name == "OPEN":
+                    covering_item = items_here[idx + 1]
+                    if getattr(covering_item, "state", None) and covering_item.state.name == "CLOSED":
+                        errors.append(
+                            f"{item.label} is open but covered by closed {covering_item.label}"
+                        )
+
+        return errors
+
+
+class OutfitOwner(HasSlottedContainer, Node):
+    """Example entity with an attached outfit manager."""
+
+    _container_class = OutfitManager

--- a/engine/src/tangl/mechanics/assembly/examples/vehicle.py
+++ b/engine/src/tangl/mechanics/assembly/examples/vehicle.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import ClassVar
+
+from pydantic import Field
+
+from tangl.core import Node
+from tangl.mechanics.assembly import HasResourceCost, HasSlottedContainer, Slot, SlottedContainer
+
+
+class VehicleComponent(Node, HasResourceCost):
+    """Base class for vehicle parts used in :class:`VehicleLoadout`."""
+
+    power_cost: float = 0.0
+    weight_cost: float = 0.0
+
+    def get_cost(self, resource: str) -> float:
+        return getattr(self, f"{resource}_cost", 0.0)
+
+
+class VehicleLoadout(SlottedContainer[VehicleComponent]):
+    """Slot definitions and validation for a vehicle configuration."""
+
+    slots: ClassVar[dict[str, Slot]] = {
+        "chassis": Slot.for_tags("chassis", tags={"chassis"}, required=True),
+        "powerplant": Slot.for_tags("powerplant", tags={"powerplant"}, required=True),
+        "weapon_front": Slot.for_tags("weapon_front", tags={"weapon"}, max_count=2),
+        "weapon_rear": Slot.for_tags("weapon_rear", tags={"weapon"}, max_count=2),
+        "weapon_turret": Slot(
+            name="weapon_turret",
+            selection_criteria={
+                "has_tags": {"weapon"},
+                "predicate": lambda weapon: not weapon.has_tags({"melee"}),
+            },
+            max_count=1,
+        ),
+        "gadget": Slot.for_tags("gadget", tags={"gadget"}, max_count=5),
+    }
+
+    tracked_resources: ClassVar[list[str]] = ["power", "weight"]
+
+    def _validate_custom(self) -> list[str]:
+        errors: list[str] = []
+
+        chassis_list = self.get_slot("chassis")
+        if chassis_list and self.budgets:
+            chassis = chassis_list[0]
+            max_weight = getattr(chassis, "max_weight", None)
+            weight_budget = self.budgets.budgets.get("weight") if self.budgets else None
+            if max_weight is not None and weight_budget and weight_budget.consumed > max_weight:
+                errors.append(
+                    f"Weight exceeds chassis capacity: {weight_budget.consumed:.1f} > {max_weight}"
+                )
+
+        powerplant_list = self.get_slot("powerplant")
+        if powerplant_list and self.budgets:
+            powerplant = powerplant_list[0]
+            max_power = getattr(powerplant, "max_power_output", None)
+            power_budget = self.budgets.budgets.get("power") if self.budgets else None
+            if max_power is not None and power_budget and power_budget.consumed > max_power:
+                errors.append(
+                    f"Power exceeds powerplant capacity: {power_budget.consumed:.1f} > {max_power}"
+                )
+
+        return errors
+
+
+class Vehicle(HasSlottedContainer, Node):
+    """Vehicle entity with an attached :class:`VehicleLoadout`."""
+
+    _container_class: ClassVar[type[SlottedContainer]] = VehicleLoadout
+
+    max_power: float = Field(100.0, description="Power budget available to the loadout.")
+    max_weight: float = Field(1000.0, description="Weight budget available to the loadout.")
+
+    @property
+    def vehicle_loadout(self) -> VehicleLoadout:
+        return self.loadout  # type: ignore[return-value]

--- a/engine/src/tangl/mechanics/assembly/slot.py
+++ b/engine/src/tangl/mechanics/assembly/slot.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+from pydantic import BaseModel, Field
+
+from tangl.core import Entity
+
+
+class Slot(BaseModel):
+    """Slot(name: str, selection_criteria: dict[str, Any], max_count: int = 1, required: bool = False)
+
+    Container slot that delegates eligibility checks to :meth:`tangl.core.entity.Entity.matches`.
+
+    Key Features
+    ------------
+    * **Declarative selection** – ``selection_criteria`` mirrors the keyword arguments accepted by
+      :meth:`~tangl.core.entity.Entity.matches`, including ``is_instance``, ``has_tags``,
+      ``predicate``, and direct attribute comparisons.
+    * **Capacity limits** – ``max_count`` constrains how many components may occupy the slot.
+    * **Required slots** – ``required`` marks slots that must be populated during validation.
+
+    API
+    ---
+    - :meth:`selects_for` – check whether a component is eligible for the slot.
+    - :meth:`for_type` – convenience constructor keyed on a component type and optional tags.
+    - :meth:`for_tags` – convenience constructor keyed on required tags.
+    - :meth:`for_predicate` – convenience constructor keyed on an arbitrary predicate.
+    """
+
+    name: str
+    selection_criteria: dict[str, Any] = Field(default_factory=dict)
+    max_count: int = 1
+    required: bool = False
+
+    def selects_for(self, component: Entity) -> tuple[bool, str]:
+        """Return whether ``component`` satisfies the slot's criteria.
+
+        Parameters
+        ----------
+        component:
+            Entity candidate to evaluate.
+
+        Returns
+        -------
+        tuple[bool, str]
+            ``True`` with an empty reason when the component matches; otherwise ``False`` with
+            a human-readable explanation.
+        """
+
+        try:
+            if component.matches(**self.selection_criteria):
+                return True, ""
+            return False, f"Component doesn't match criteria: {self.selection_criteria}"
+        except Exception as exc:  # pragma: no cover - defensive logging
+            return False, f"Error matching: {exc}"
+
+    @classmethod
+    def for_type(
+        cls,
+        name: str,
+        component_type: type,
+        tags: Optional[set[str]] = None,
+        **kwargs: Any,
+    ) -> "Slot":
+        """Create a type-gated slot.
+
+        Parameters
+        ----------
+        name:
+            Slot identifier.
+        component_type:
+            Concrete ``Entity`` subclass required for membership.
+        tags:
+            Optional tag set to include in the selection criteria.
+        **kwargs:
+            Additional :class:`Slot` constructor kwargs.
+        """
+
+        criteria: dict[str, Any] = {"is_instance": component_type}
+        if tags:
+            criteria["has_tags"] = tags
+        return cls(name=name, selection_criteria=criteria, **kwargs)
+
+    @classmethod
+    def for_tags(cls, name: str, tags: set[str], **kwargs: Any) -> "Slot":
+        """Create a tag-gated slot using :meth:`Entity.has_tags` semantics."""
+
+        return cls(name=name, selection_criteria={"has_tags": tags}, **kwargs)
+
+    @classmethod
+    def for_predicate(
+        cls,
+        name: str,
+        predicate: Callable[[Entity], bool],
+        **kwargs: Any,
+    ) -> "Slot":
+        """Create a predicate-gated slot."""
+
+        return cls(name=name, selection_criteria={"predicate": predicate}, **kwargs)
+
+
+class SlotGroup(BaseModel):
+    """Aggregate validation constraints across multiple slots."""
+
+    name: str
+    slot_names: list[str]
+    min_total: Optional[int] = None
+    max_total: Optional[int] = None

--- a/engine/tests/mechanics/test_assembly.py
+++ b/engine/tests/mechanics/test_assembly.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import pytest
+
+from tangl.core import Entity
+from tangl.mechanics.assembly import HasSlottedContainer, Slot, SlotGroup, SlottedContainer
+
+
+class TestComponent(Entity):
+    power_cost: float = 0.0
+
+    def get_cost(self, resource: str) -> float:
+        return self.power_cost if resource == "power" else 0.0
+
+
+class TestContainer(SlottedContainer[TestComponent]):
+    slots = {
+        "alpha": Slot.for_type("alpha", TestComponent, tags={"alpha"}, required=True),
+        "beta": Slot.for_tags("beta", tags={"beta"}, max_count=2),
+    }
+    slot_groups = [SlotGroup(name="group", slot_names=["alpha", "beta"], min_total=1, max_total=3)]
+    tracked_resources = ["power"]
+
+    def _validate_custom(self) -> list[str]:
+        errors = super()._validate_custom()
+        if any(component.label == "forbidden" for component in self.all_components()):
+            errors.append("Forbidden component present")
+        return errors
+
+
+class TestHost(HasSlottedContainer, Entity):
+    _container_class = TestContainer
+    max_power: float = 2.0
+
+
+@pytest.fixture
+def component_alpha() -> TestComponent:
+    return TestComponent(label="alpha", tags={"alpha"}, power_cost=1.0)
+
+
+@pytest.fixture
+def component_beta() -> TestComponent:
+    return TestComponent(label="beta", tags={"beta"}, power_cost=0.5)
+
+
+def test_slot_matching(component_alpha: TestComponent, component_beta: TestComponent) -> None:
+    alpha_slot = Slot.for_type("alpha", TestComponent, tags={"alpha"})
+    beta_slot = Slot.for_tags("beta", tags={"beta"})
+
+    assert alpha_slot.selects_for(component_alpha)[0]
+    assert not alpha_slot.selects_for(component_beta)[0]
+    assert beta_slot.selects_for(component_beta)[0]
+
+
+def test_assignment_and_validation(component_alpha: TestComponent, component_beta: TestComponent) -> None:
+    container = TestContainer(owner=TestHost(label="owner"))
+
+    container.assign("alpha", component_alpha)
+    container.assign("beta", component_beta)
+
+    assert container.is_valid
+    assert container.validate() == []
+
+
+def test_required_slot_and_group_limits(component_beta: TestComponent) -> None:
+    container = TestContainer(owner=TestHost(label="owner"))
+
+    errors = container.validate()
+    assert "Required slot empty: alpha" in errors
+
+    container.assign("alpha", TestComponent(label="filled", tags={"alpha"}))
+    container.assign("beta", component_beta)
+    container.assign("beta", TestComponent(label="beta2", tags={"beta"}))
+
+    with pytest.raises(ValueError):
+        container.assign("beta", TestComponent(label="beta3", tags={"beta"}))
+
+
+def test_budget_check(component_alpha: TestComponent) -> None:
+    host = TestHost(label="owner", max_power=1.5)
+    container = TestContainer(owner=host)
+
+    container.assign("alpha", component_alpha)
+    with pytest.raises(ValueError):
+        container.assign("beta", TestComponent(label="power_hungry", tags={"beta"}, power_cost=2.0))
+
+
+def test_custom_validation(component_alpha: TestComponent) -> None:
+    container = TestContainer(owner=TestHost(label="owner"))
+    forbidden = TestComponent(label="forbidden", tags={"alpha"})
+    container.assign("alpha", forbidden)
+    errors = container.validate()
+    assert "Forbidden component present" in errors
+
+
+def test_container_serialization(component_alpha: TestComponent) -> None:
+    host = TestHost(label="owner")
+    host.loadout.assign("alpha", component_alpha)
+
+    dumped = host.model_dump()
+    restored = TestHost.model_validate(dumped)
+
+    assert restored.loadout.owner is restored
+    assert restored.loadout.get_slot("alpha")[0].label == "alpha"


### PR DESCRIPTION
## Summary
- add a mechanics.assembly package for slotted containers, selection criteria, and resource budgets
- include vehicle and outfit examples plus README guidance
- add tests covering assignment rules, budgeting, serialization, and selection helpers

## Testing
- PYTHONPATH=./engine/src pytest engine/tests/mechanics/test_assembly.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f465a21f08329ae3f7c1363228c17)