### PR TITLE
Add MenuBlock dynamic provisioning

### DIFF
--- a/engine/docs/story/menu_block.md
+++ b/engine/docs/story/menu_block.md
@@ -1,0 +1,83 @@
+## MenuBlock: Dynamic Choice Hubs
+
+MenuBlock extends Block to automatically provision choices from compatible blocks.
+
+### Use Cases
+
+- **Location menus**: "You're at the mall. Where to?"
+- **Scene selection**: "Which chapter would you like to visit?"
+- **Quest boards**: "Available quests" (with conditional availability)
+- **Context menus**: Actions based on current world state
+
+### Patterns
+
+**Pull Pattern (Dependencies)**
+Menu declares what it wants via `selection_criteria`:
+
+```python
+lobby = MenuBlock(
+    label="mall_lobby",
+    selection_criteria={'has_tags': {'mall_shop'}},
+)
+
+# These match and become menu options
+clothing = Block(label="clothing", tags={'mall_shop'})
+food = Block(label="food", tags={'mall_shop'})
+```
+
+**Push Pattern (Affordances)**
+Blocks offer themselves to compatible menus:
+
+```python
+parking = Block(label="parking")
+parking.offer_as_affordance(
+    target_criteria={'has_tags': {'mall_lobby'}}
+)
+
+# Parking appears even though menu didn't ask for it
+```
+
+**Bidirectional (Both)**
+Pull and push work together - menu gets both shops it asked for AND parking that volunteered.
+
+### Scope Control
+
+```python
+# Only find blocks in same scene
+menu = MenuBlock(
+    selection_criteria={...},
+    within_scene=True,  # Default
+)
+
+# Search entire graph
+menu = MenuBlock(
+    selection_criteria={...},
+    within_scene=False,
+)
+```
+
+### Action Labels
+
+MenuBlock checks block metadata in order:
+1. `locals['action_text']` - Explicit menu text
+2. `locals['menu_text']` - Alternative menu text
+3. `block.label` - Fallback to block's label
+
+```python
+shop = Block(
+    label="clothing_store_id",
+    locals={'action_text': "Shop for clothes"},  # This appears in menu
+)
+```
+
+### Scene Navigation
+
+When MenuBlock links to a Scene, it automatically creates Actions to `scene.source` (the canonical entry point), not to the Scene node itself.
+
+### Implementation Notes
+
+- Creates dependencies during PLANNING phase
+- Materializes Actions during UPDATE phase
+- Clears stale dynamic actions before reprovisioning
+- Supports both pull (dependency) and push (affordance) patterns
+- Inherits all Block rendering/journaling behavior

--- a/engine/src/tangl/story/episode/__init__.py
+++ b/engine/src/tangl/story/episode/__init__.py
@@ -5,3 +5,11 @@ from __future__ import annotations
 from .block import Block
 from .scene import Scene
 from .action import Action
+from .menu_block import MenuBlock
+
+__all__ = [
+    "Block",
+    "Scene",
+    "Action",
+    "MenuBlock",
+]

--- a/engine/src/tangl/story/episode/menu_block.py
+++ b/engine/src/tangl/story/episode/menu_block.py
@@ -1,82 +1,239 @@
+# tangl/story/episode/menu_block.py
+"""
+MenuBlock: hub block with dynamic choice provisioning.
+
+MenuBlock extends :class:`Block` with two VM handlers:
+
+* **PLANNING** – declare pull-style dependencies for compatible blocks.
+* **UPDATE** – convert satisfied dependencies and affordances into
+  :class:`Action` edges.
+
+Rendering and journaling reuse :class:`Block`'s existing handlers.
+"""
+
 from __future__ import annotations
+
+from typing import Any
 import logging
 
-from pydantic import Field, field_validator
+from pydantic import Field
 
-from tangl.type_hints import Tag, ClassName, Typelike
-from tangl.core import Entity, Graph  # noqa
-from .block import Block
+from tangl.core import Entity
+from tangl.core.behavior import HandlerPriority as Prio
+from tangl.core.entity import Selectable
+from tangl.vm import Affordance, Context, Dependency, ProvisioningPolicy, Requirement
+from tangl.vm import ResolutionPhase as P
+from tangl.vm.dispatch import on_planning, on_update
 from .action import Action
+from .block import Block
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.WARNING)
-
-# Menu blocks work by creating a set of local affordances for future possibilities
-# these affordances attach opportunistically and can be turned off by updating
-# availability (like "lambda self: not self.visited").  Then menu node can then be
-# re-entered repeatedly and always provides only currently open choices.
-
-# Prior version uses an ad-hoc selector.  Probably should leverage functions from the
-# 'Selectable' class with 'selection_criteria', which is a superset of has_cls and has_tags
-
-# class domain behaviors for menu blocks
-class MenuActionHandler:
-
-    @classmethod
-    def _unlink_dynamic_actions(cls, node: Block):
-        """Sub-classes with dynamically-assigned actions should invoke this when recomputing dynamics"""
-        node.discard_children(Action, with_tags=['dynamic'], delete_node=True)
-
-    @classmethod
-    def get_menu_actions(cls, node: Block) -> list[Action]:
-        cls._unlink_dynamic_actions(node)  # clear existing actions
-        blocks = cls.execute_task(node,"on_get_actions", result_mode="flatten")
-        actions = [ Action.from_node(b) for b in blocks ]
-        return actions
 
 
-class MenuBlock(Block):
+class MenuBlock(Block, Selectable):
     """
-    Menus are Blocks that can dynamically add actions based on other story nodes,
-    for example, a menu block that automatically adds actions pointing to every
-    scene's start bock, or a menu block pointing to other blocks with specific
-    tags.
+    MenuBlock(selection_criteria: dict, within_scene: bool = True, auto_provision: bool = True)
 
-    It takes 2 extra parameters:
+    Hub block that auto-provisions choices from compatible blocks.
 
-    :param with_cls: Traversable class that target nodes must subclass (default is Block)
-    :param with_tags: A set of tags that target nodes must match
+    Why
+    ---
+    Menu blocks act as hubs that surface available destinations without hardcoding
+    outgoing :class:`Action` edges. They support both pull-style discovery via
+    dependencies and push-style offerings via affordances.
+
+    Key Features
+    ------------
+    * **Pull pattern** – declare :attr:`selection_criteria` and create
+      dependencies during :class:`~tangl.vm.ResolutionPhase.PLANNING`.
+    * **Push pattern** – accept incoming affordances and convert them to actions
+      during :class:`~tangl.vm.ResolutionPhase.UPDATE`.
+    * **Dynamic refresh** – clears old dynamic actions every update pass to keep
+      menus in sync with the graph.
+
+    Notes
+    -----
+    Action labels respect ``locals['action_text']`` first, then
+    ``locals['menu_text']``, then the target label.
     """
 
-    # Use 'selection_criteria" for this, selects for cls -> is_instance, tags -> has_tags
-    with_cls: Typelike = Block
-    with_tags: set[Tag] = Field(default_factory=set)
-    # within_scene_only: bool = True  # limit search to children of the same root
-    # or use special tag like <scene.label>
+    within_scene: bool = Field(default=True)
+    auto_provision: bool = Field(default=True)
 
-    @field_validator("with_cls", mode="before")
-    @classmethod
-    def _deref_with_cls(cls, value):
-        # todo: this could/should be centralized by moving it into "graph._filter"
-        if isinstance(value, str):
-            node_cls = Entity.get_subclass_by_name(value)
-            if not node_cls:
-                logger.error(Entity.get_all_subclasses())
-                raise TypeError(f"Unable to deref {value}")
-            return node_cls
-        return value
+    @on_planning(priority=Prio.EARLY)
+    def menu_create_dependencies(self, *, ctx: Context, **_: Any) -> list[Dependency] | None:
+        """PLANNING: create dependencies for blocks matching ``selection_criteria``."""
 
-    @property
-    def actions(self) -> list[Action]:
-        dynamic_actions = MenuActionHandler.get_menu_actions(self)
-        return super().actions + dynamic_actions
+        if not self.auto_provision:
+            return None
 
-    # @MenuActionHandler.strategy('on_get_actions')
-    def _get_tagged_blocks(self):
-        logger.debug(f"Searching for actions {self.with_cls} and {self.with_tags}")
-        return list( self.story.find_nodes(self.with_cls, with_tags=self.with_tags) )
+        criteria = self.get_selection_criteria()
+        if not criteria:
+            return None
 
-    # todo: if no actions available, return redirect on enter if possible (skip)
-    # def enter(self):
-    #     if not self.actions or not any([ a.available() for a in self.actions ]):
-    #         # trigger any available continue ...
+        candidates = self._find_menu_candidates(ctx=ctx, criteria=criteria)
+        if not candidates:
+            return None
+
+        dependencies: list[Dependency] = []
+        for candidate in candidates:
+            if self._has_action_to(candidate):
+                continue
+
+            existing_deps = list(
+                self.graph.find_edges(
+                    source_id=self.uid,
+                    destination_id=candidate.uid,
+                    is_instance=Dependency,
+                )
+            )
+            if existing_deps:
+                continue
+
+            requirement = Requirement(
+                graph=self.graph,
+                identifier=candidate.uid,
+                criteria=criteria,
+                policy=ProvisioningPolicy.EXISTING,
+            )
+            requirement.provider = candidate
+
+            dependency = Dependency(
+                graph=self.graph,
+                source_id=self.uid,
+                destination_id=None,
+                requirement=requirement,
+                label=f"menu_target_{candidate.label}" if candidate.label else "menu_target",
+            )
+            dependencies.append(dependency)
+
+        return dependencies or None
+
+    @on_update(priority=Prio.NORMAL)
+    def menu_materialize_actions(self, *, ctx: Context, **_: Any) -> list[Action] | None:
+        """UPDATE: convert satisfied dependencies and affordances into :class:`Action` edges."""
+
+        if not self.auto_provision:
+            return None
+
+        self._clear_dynamic_menu_actions()
+
+        actions: list[Action] = []
+
+        menu_deps = list(
+            self.graph.find_edges(
+                source_id=self.uid,
+                is_instance=Dependency,
+            )
+        )
+        for dependency in menu_deps:
+            if not dependency.satisfied:
+                continue
+
+            target_block = dependency.destination
+            if target_block is None:
+                continue
+
+            action = self._create_menu_action(
+                target=target_block,
+                tags={"dynamic", "menu", "dependency"},
+            )
+            if action is not None:
+                actions.append(action)
+
+        affordances = list(
+            self.graph.find_edges(
+                destination_id=self.uid,
+                is_instance=Affordance,
+            )
+        )
+        for affordance in affordances:
+            if not affordance.satisfied:
+                continue
+
+            source_block = affordance.source
+            if source_block is None:
+                continue
+
+            action = self._create_menu_action(
+                target=source_block,
+                tags={"dynamic", "menu", "affordance"},
+            )
+            if action is not None:
+                actions.append(action)
+
+        return actions or None
+
+    def _create_menu_action(self, *, target: Entity, tags: set[str]) -> Action | None:
+        """Create an :class:`Action` edge to ``target`` unless one already exists."""
+
+        if self._has_action_to(target):
+            return None
+
+        destination = self._resolve_destination(target)
+        action_label = self._get_action_label(target)
+
+        return Action(
+            graph=self.graph,
+            source_id=self.uid,
+            destination_id=destination.uid,
+            label=action_label,
+            content=action_label,
+            tags=tags,
+        )
+
+    def _clear_dynamic_menu_actions(self) -> None:
+        """Remove stale dynamic actions before reprovisioning."""
+
+        for edge in list(
+            self.graph.find_edges(
+                source_id=self.uid,
+                is_instance=Action,
+                has_tags={"dynamic", "menu"},
+            )
+        ):
+            self.graph.remove(edge)
+
+    def _find_menu_candidates(self, *, ctx: Context, criteria: dict[str, Any] | None = None) -> list[Entity]:
+        """Return nodes matching ``selection_criteria`` within the configured scope."""
+
+        criteria = criteria or self.get_selection_criteria()
+        if self.within_scene:
+            scene = self._get_scene()
+            if scene is None:
+                candidates = list(self.graph.find_nodes(**criteria))
+            else:
+                candidates = list(scene.find_all(**criteria))
+        else:
+            candidates = list(self.graph.find_nodes(**criteria))
+
+        return [candidate for candidate in candidates if candidate.uid != self.uid]
+
+    def _get_scene(self):
+        from .scene import Scene
+
+        for scene in self.graph.find_nodes(is_instance=Scene):
+            if self.uid in scene.member_ids:
+                return scene
+        return None
+
+    def _resolve_destination(self, node: Entity) -> Entity:
+        from .scene import Scene
+
+        if isinstance(node, Scene):
+            return node.source
+        return node
+
+    def _get_action_label(self, block: Entity) -> str:
+        return (
+            getattr(block, "locals", {}).get("action_text")
+            or getattr(block, "locals", {}).get("menu_text")
+            or block.label
+        )
+
+    def _has_action_to(self, target: Entity) -> bool:
+        return self.graph.find_edge(
+            source_id=self.uid,
+            destination_id=target.uid,
+            is_instance=Action,
+        ) is not None

--- a/engine/tests/story/episode/test_menu_block.py
+++ b/engine/tests/story/episode/test_menu_block.py
@@ -1,0 +1,294 @@
+"""Tests for :class:`~tangl.story.episode.menu_block.MenuBlock`."""
+
+from tangl.vm import Affordance, Dependency, Frame, ProvisioningPolicy, Requirement
+from tangl.vm import ResolutionPhase as P
+from tangl.story.episode import Action, Block, MenuBlock, Scene
+from tangl.journal.discourse import ChoiceFragment
+from tangl.story.story_graph import StoryGraph
+
+
+class TestMenuBlockDependencies:
+    """Pull pattern: menu creates dependencies during PLANNING."""
+
+    def test_creates_dependencies_for_matching_blocks(self):
+        """MenuBlock creates dependencies for blocks matching ``selection_criteria``."""
+
+        graph = StoryGraph(label="test")
+
+        menu = MenuBlock(graph=graph, label="lobby", selection_criteria={"has_tags": {"shop"}})
+
+        shop1 = Block(graph=graph, label="clothing", tags={"shop"})
+        shop2 = Block(graph=graph, label="food", tags={"shop"})
+        Block(graph=graph, label="parking", tags={"parking"})
+
+        frame = Frame(graph=graph, cursor_id=menu.uid)
+        frame.run_phase(P.PLANNING)
+
+        dependencies = list(graph.find_edges(source_id=menu.uid, is_instance=Dependency))
+        assert len(dependencies) == 2
+
+        dep_targets = {dep.destination.uid for dep in dependencies}
+        assert shop1.uid in dep_targets
+        assert shop2.uid in dep_targets
+
+    def test_respects_within_scene_flag(self):
+        """MenuBlock with ``within_scene=True`` only targets members of the same scene."""
+
+        graph = StoryGraph(label="test")
+
+        scene = Scene(graph=graph, label="scene1", member_ids=[])
+        menu = MenuBlock(
+            graph=graph,
+            label="lobby",
+            selection_criteria={"has_tags": {"shop"}},
+            within_scene=True,
+        )
+
+        local_shop = Block(graph=graph, label="local", tags={"shop"})
+        Block(graph=graph, label="remote", tags={"shop"})
+
+        scene.member_ids = [menu.uid, local_shop.uid]
+
+        frame = Frame(graph=graph, cursor_id=menu.uid)
+        frame.run_phase(P.PLANNING)
+
+        dependencies = list(graph.find_edges(source_id=menu.uid, is_instance=Dependency))
+        assert len(dependencies) == 1
+        assert dependencies[0].destination.uid == local_shop.uid
+
+    def test_skips_blocks_with_existing_actions(self):
+        """MenuBlock does not create dependencies when an action already exists."""
+
+        graph = StoryGraph(label="test")
+        menu = MenuBlock(graph=graph, label="lobby", selection_criteria={"has_tags": {"shop"}})
+        shop = Block(graph=graph, label="shop", tags={"shop"})
+
+        Action(graph=graph, source_id=menu.uid, destination_id=shop.uid, label="Visit shop")
+
+        frame = Frame(graph=graph, cursor_id=menu.uid)
+        frame.run_phase(P.PLANNING)
+
+        dependencies = list(graph.find_edges(source_id=menu.uid, is_instance=Dependency))
+        assert len(dependencies) == 0
+
+    def test_auto_provision_false_disables_dependencies(self):
+        """MenuBlock with ``auto_provision=False`` behaves like a normal block."""
+
+        graph = StoryGraph(label="test")
+        menu = MenuBlock(
+            graph=graph,
+            label="lobby",
+            selection_criteria={"has_tags": {"shop"}},
+            auto_provision=False,
+        )
+
+        Block(graph=graph, label="shop", tags={"shop"})
+
+        frame = Frame(graph=graph, cursor_id=menu.uid)
+        frame.run_phase(P.PLANNING)
+
+        dependencies = list(graph.find_edges(source_id=menu.uid, is_instance=Dependency))
+        assert len(dependencies) == 0
+
+
+class TestMenuBlockActionMaterialization:
+    """UPDATE phase: converting dependencies and affordances into actions."""
+
+    def test_materializes_actions_from_dependencies(self):
+        """MenuBlock converts satisfied dependencies to :class:`Action` edges."""
+
+        graph = StoryGraph(label="test")
+        menu = MenuBlock(graph=graph, label="lobby", selection_criteria={"has_tags": {"shop"}})
+        shop = Block(graph=graph, label="shop", tags={"shop"}, locals={"action_text": "Visit the shop"})
+
+        frame = Frame(graph=graph, cursor_id=menu.uid)
+        frame.run_phase(P.PLANNING)
+        frame.run_phase(P.UPDATE)
+
+        actions = list(
+            graph.find_edges(
+                source_id=menu.uid,
+                destination_id=shop.uid,
+                is_instance=Action,
+            )
+        )
+        assert len(actions) == 1
+        assert actions[0].content == "Visit the shop"
+        assert "dynamic" in actions[0].tags
+        assert "menu" in actions[0].tags
+
+    def test_materializes_actions_from_affordances(self):
+        """MenuBlock converts incoming affordances to :class:`Action` edges."""
+
+        graph = StoryGraph(label="test")
+        menu = MenuBlock(graph=graph, label="lobby", selection_criteria={})
+        parking = Block(graph=graph, label="parking", locals={"action_text": "Go to parking"})
+
+        requirement = Requirement(
+            graph=graph,
+            identifier=parking.uid,
+            policy=ProvisioningPolicy.EXISTING,
+        )
+        requirement.provider = parking
+
+        Affordance(
+            graph=graph,
+            source_id=parking.uid,
+            destination_id=menu.uid,
+            requirement=requirement,
+            label="parking_affordance",
+        )
+
+        frame = Frame(graph=graph, cursor_id=menu.uid)
+        frame.run_phase(P.PLANNING)
+        frame.run_phase(P.UPDATE)
+
+        actions = list(
+            graph.find_edges(
+                source_id=menu.uid,
+                destination_id=parking.uid,
+                is_instance=Action,
+            )
+        )
+        assert len(actions) == 1
+        assert actions[0].content == "Go to parking"
+        assert "affordance" in actions[0].tags
+
+    def test_clears_stale_dynamic_actions(self):
+        """MenuBlock clears prior dynamic actions before recreating them."""
+
+        graph = StoryGraph(label="test")
+        menu = MenuBlock(graph=graph, label="lobby", selection_criteria={"has_tags": {"shop"}})
+        Block(graph=graph, label="shop", tags={"shop"})
+
+        frame = Frame(graph=graph, cursor_id=menu.uid)
+        frame.run_phase(P.PLANNING)
+        frame.run_phase(P.UPDATE)
+
+        actions_after_first = list(
+            graph.find_edges(
+                source_id=menu.uid,
+                is_instance=Action,
+                has_tags={"dynamic", "menu"},
+            )
+        )
+        assert len(actions_after_first) == 1
+        first_action_uid = actions_after_first[0].uid
+
+        frame.run_phase(P.PLANNING)
+        frame.run_phase(P.UPDATE)
+
+        actions_after_second = list(
+            graph.find_edges(
+                source_id=menu.uid,
+                is_instance=Action,
+                has_tags={"dynamic", "menu"},
+            )
+        )
+        assert len(actions_after_second) == 1
+        assert actions_after_second[0].uid != first_action_uid
+
+    def test_avoids_duplicate_actions_from_both_patterns(self):
+        """Dependency + affordance targeting the same block yield one action."""
+
+        graph = StoryGraph(label="test")
+        menu = MenuBlock(graph=graph, label="lobby", selection_criteria={"has_tags": {"shop"}})
+        shop = Block(graph=graph, label="shop", tags={"shop"})
+
+        requirement = Requirement(
+            graph=graph,
+            identifier=shop.uid,
+            policy=ProvisioningPolicy.EXISTING,
+        )
+        requirement.provider = shop
+
+        Affordance(
+            graph=graph,
+            source_id=shop.uid,
+            destination_id=menu.uid,
+            requirement=requirement,
+            label="shop_affordance",
+        )
+
+        frame = Frame(graph=graph, cursor_id=menu.uid)
+        frame.run_phase(P.PLANNING)
+        frame.run_phase(P.UPDATE)
+
+        actions = list(
+            graph.find_edges(
+                source_id=menu.uid,
+                destination_id=shop.uid,
+                is_instance=Action,
+            )
+        )
+        assert len(actions) == 1
+
+
+class TestMenuBlockSceneIntegration:
+    """Integration with scenes and canonical entry points."""
+
+    def test_links_to_scene_source_not_scene_itself(self):
+        """MenuBlock navigates to ``scene.source`` when targeting a :class:`Scene`."""
+
+        graph = StoryGraph(label="test")
+        menu = MenuBlock(
+            graph=graph,
+            label="chapter_menu",
+            selection_criteria={"is_instance": Scene},
+            within_scene=False,
+        )
+
+        scene = Scene(graph=graph, label="tavern_scene", member_ids=[])
+
+        frame = Frame(graph=graph, cursor_id=menu.uid)
+        frame.run_phase(P.PLANNING)
+        frame.run_phase(P.UPDATE)
+
+        actions = list(graph.find_edges(source_id=menu.uid, is_instance=Action))
+        assert len(actions) == 1
+        assert actions[0].destination_id == scene.source.uid
+        assert actions[0].destination_id != scene.uid
+
+
+class TestMenuBlockJournaling:
+    """Ensure dynamic actions render through block journaling handlers."""
+
+    def test_renders_dynamic_choices_via_block_handlers(self):
+        """MenuBlock uses :meth:`Block.get_choices` during JOURNAL rendering."""
+
+        graph = StoryGraph(label="test")
+        menu = MenuBlock(
+            graph=graph,
+            label="lobby",
+            content="Welcome to the mall.",
+            selection_criteria={"has_tags": {"shop"}},
+        )
+        Block(graph=graph, label="shop", tags={"shop"}, locals={"action_text": "Browse the shop"})
+
+        frame = Frame(graph=graph, cursor_id=menu.uid)
+        frame.run_phase(P.PLANNING)
+        frame.run_phase(P.UPDATE)
+        fragments = frame.run_phase(P.JOURNAL)
+        choice_fragments = [fragment for fragment in fragments if isinstance(fragment, ChoiceFragment)]
+
+        assert choice_fragments
+        assert "Browse the shop" in [fragment.content for fragment in choice_fragments]
+
+
+class TestMenuBlockHelperMethods:
+    """Unit coverage for MenuBlock helper methods."""
+
+    def test_get_action_label_precedence(self):
+        """``_get_action_label`` prefers ``action_text`` then ``menu_text`` then the label."""
+
+        graph = StoryGraph(label="test")
+        menu = MenuBlock(graph=graph, label="menu", selection_criteria={})
+
+        block1 = Block(graph=graph, label="default", locals={"action_text": "Custom action"})
+        assert menu._get_action_label(block1) == "Custom action"
+
+        block2 = Block(graph=graph, label="default", locals={"menu_text": "Menu text"})
+        assert menu._get_action_label(block2) == "Menu text"
+
+        block3 = Block(graph=graph, label="just_label")
+        assert menu._get_action_label(block3) == "just_label"


### PR DESCRIPTION
## Summary
- add a MenuBlock episode type that provisions menu actions from dependencies and affordances during planning/update
- expose the new block in the episode package and document usage patterns
- cover MenuBlock behaviors with targeted story tests

## Testing
- PYTHONPATH=./engine/src pytest engine/tests/story/episode/test_menu_block.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693334b81a408329acabaf499fed1fae)