### PR TITLE
Fix Template.is_instance return, normalize provisioning overlays, and test cleanups

### DIFF
--- a/engine/src/tangl/core/factory/template.py
+++ b/engine/src/tangl/core/factory/template.py
@@ -86,6 +86,7 @@ class Template(Selectable, ContentAddressable, Record, Generic[ET]):
                 return True
         elif isclass(obj_cls) and issubclass(self.obj_cls, obj_cls):
             return True
+        return False
 
     # Inherits label, tags as is
 
@@ -176,4 +177,3 @@ class Template(Selectable, ContentAddressable, Record, Generic[ET]):
         # will include the wrong templ.__class__
         data["obj_cls"] = self.obj_cls
         return data
-

--- a/engine/src/tangl/story/fabula/asset_manager.py
+++ b/engine/src/tangl/story/fabula/asset_manager.py
@@ -158,7 +158,7 @@ class AssetManager:
         raise KeyError(f"No asset class registered for '{asset_type}'")
 
     # ==================
-    # Token TemplateFactory
+    # TokenFactory
     # ==================
 
     def create_token(

--- a/engine/src/tangl/vm/provision/asset_provisioner.py
+++ b/engine/src/tangl/vm/provision/asset_provisioner.py
@@ -63,12 +63,16 @@ class AssetProvisioner(Provisioner):
 
         def _accept(ctx: "Context"):
             overlay = requirement.overlay or requirement.template or {}
+            if hasattr(overlay, "model_dump"):
+                overlay = overlay.model_dump()
+            elif not isinstance(overlay, dict):
+                overlay = dict(overlay)
 
             return asset_manager.create_token(
                 token_type=token_type,
                 label=token_label,
                 graph=ctx.graph,
-                overlay=dict(overlay),
+                overlay=overlay,
             )
 
         yield DependencyOffer(

--- a/engine/tests/core/graph/test_token.py
+++ b/engine/tests/core/graph/test_token.py
@@ -43,7 +43,7 @@ def test_token_getattr(ws):
     assert ws.b == 200
 
     with pytest.raises(ValueError):
-        # can't set an instance variable
+        # can't set a non-instance variable
         ws.a = 150
 
     # can set an instance variable
@@ -126,7 +126,3 @@ def test_token_delegation_works():
 
     # Delegates to base
     assert token.damage == 10
-
-    # Update base affects token
-    base = Weapon.get_instance("sword")
-    # Can't actually update frozen base, but concept works

--- a/engine/tests/vm/provision/test_asset_provisioner.py
+++ b/engine/tests/vm/provision/test_asset_provisioner.py
@@ -147,7 +147,9 @@ def test_asset_provisioner_supports_template_overlay(asset_manager: AssetManager
     assert getattr(token, "owner", None) == "player"
 
 
-def test_templates_preferred_for_story_roles(asset_manager: AssetManager) -> None:
+def test_neither_provisioner_offers_without_configured_sources(
+    asset_manager: AssetManager,
+) -> None:
     graph = _graph_with_assets(asset_manager)
 
     requirement = Requirement(


### PR DESCRIPTION
### Motivation

- Ensure `Template.is_instance` always returns a boolean to match its `-> bool` annotation and behavior of related `is_instance` implementations.
- Correct an inaccurate section heading in the asset manager so code comments reflect actual `TokenFactory` usage.
- Safely normalize provisioning overlays (including Pydantic models) before creating tokens so overlays are plain dicts suitable for JSON serialization.

### Description

- Added an explicit `return False` to `Template.is_instance` in `engine/src/tangl/core/factory/template.py` to guarantee a boolean result.
- Updated the section comment from "Token TemplateFactory" to "TokenFactory" in `engine/src/tangl/story/fabula/asset_manager.py` for clarity.
- Sanitized `requirement.overlay` in `engine/src/tangl/vm/provision/asset_provisioner.py` by calling `model_dump()` when available and converting non-dict overlays to `dict` before passing to `asset_manager.create_token`.
- Adjusted tests: corrected mutability comment in `engine/tests/core/graph/test_token.py` and removed an unused base assignment, and renamed the empty-offer test in `engine/tests/vm/provision/test_asset_provisioner.py` to reflect expected behavior.

### Testing

- Ran `PYTHONPATH=./engine/src poetry run pytest engine/tests/core engine/tests/vm engine/tests/story` and the suite completed successfully.
- Test results: `837 passed, 2 skipped, 6 xfailed` (with some warnings), indicating the changes did not regress core, VM, or story tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949eddec2ec8329aef5a6dcf1a2a2db)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed validation function to consistently return boolean values in all code paths.

* **Improvements**
  * Enhanced asset provisioning to support additional overlay data format types, enabling greater flexibility in configuration handling.

* **Tests**
  * Updated provisioner test assertions to verify behavior with unconfigured sources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->