### PR TITLE
refactor(materialization): cleanups and polish — address resolution docs, logging, and error handling

### DIFF
--- a/engine/src/tangl/loaders/compilers/script_compiler.py
+++ b/engine/src/tangl/loaders/compilers/script_compiler.py
@@ -19,8 +19,10 @@ def _iter_script_items(value: Any) -> list[Any]:
     if value is None:
         return []
     if isinstance(value, dict):
-        return value.values()
-    return value
+        return list(value.values())
+    if isinstance(value, list):
+        return value
+    return [value]
 
 
 def _mark_declared_instances(script: StoryScript) -> None:

--- a/engine/tests/story/fabula/test_address_resolution.py
+++ b/engine/tests/story/fabula/test_address_resolution.py
@@ -9,42 +9,9 @@ Organized by functionality:
 
 from __future__ import annotations
 
-from typing import Any
-
-import pytest
-
 from tangl.core.factory import HierarchicalTemplate, TemplateFactory
 from tangl.core.graph import Graph, Node
-from tangl.ir.story_ir import StoryScript
-from tangl.story.fabula import AssetManager, DomainManager, ScriptManager, World
-
-
-# ============================================================================
-# Fixtures and Helpers
-# ============================================================================
-
-@pytest.fixture(autouse=True)
-def clear_world_singleton() -> None:
-    """Reset the ``World`` singleton registry between tests."""
-
-    World.clear_instances()
-    yield
-    World.clear_instances()
-
-
-def build_world(story_data: dict[str, Any]) -> World:
-    """Helper that validates ``story_data`` and instantiates a ``World``."""
-
-    script = StoryScript.model_validate(story_data)
-    manager = ScriptManager.from_master_script(master_script=script)
-    return World(
-        label=story_data["label"],
-        script_manager=manager,
-        domain_manager=DomainManager(),
-        asset_manager=AssetManager(),
-        resource_manager=None,
-        metadata=story_data.get("metadata", {}),
-    )
+from .conftest import build_world
 
 
 # ============================================================================
@@ -83,14 +50,12 @@ class TestNamespaceCreation:
 
         assert graph.find_subgraph(label="a") is not None
         assert graph.find_subgraph(label="b") is not None
-        assert graph.find_subgraph(label="c") is not None
+        assert graph.find_subgraph(label="c") is None
 
-        c = graph.find_subgraph(label="c")
-        assert c is not None
-        assert c.parent is not None
-        assert c.parent.label == "b"
-        assert c.parent.parent is not None
-        assert c.parent.parent.label == "a"
+        b = graph.find_subgraph(label="b")
+        assert b is not None
+        assert b.parent is not None
+        assert b.parent.label == "a"
 
 
 # ============================================================================

--- a/engine/tests/story/fabula/test_address_resolver.py
+++ b/engine/tests/story/fabula/test_address_resolver.py
@@ -9,48 +9,20 @@ Organized by functionality:
 from __future__ import annotations
 
 import pytest
-from typing import Any
 
-from tangl.core.factory import HierarchicalTemplate, TemplateFactory
-from tangl.core.graph import Graph, Node
-from tangl.ir.story_ir import StoryScript
+from tangl.core.factory import HierarchicalTemplate, Template, TemplateFactory
+from tangl.core.graph import Graph, Node, Subgraph
 from tangl.story.episode.block import Block
-from tangl.story.fabula import AssetManager, DomainManager, ScriptManager, World
 from tangl.story.fabula.address_resolver import (
+    _get_prefixes,
+    _template_path_matches_address,
     ensure_instance,
     ensure_namespace,
+    iter_matching_templates,
     resolve_template_for_address,
 )
 from tangl.story.story_graph import StoryGraph
-
-
-# ============================================================================
-# Helpers
-# ============================================================================
-
-
-@pytest.fixture(autouse=True)
-def clear_world_singleton() -> None:
-    """Reset the ``World`` singleton registry between tests."""
-
-    World.clear_instances()
-    yield
-    World.clear_instances()
-
-
-def build_world(story_data: dict[str, Any]) -> World:
-    """Helper that validates ``story_data`` and instantiates a ``World``."""
-
-    script = StoryScript.model_validate(story_data)
-    manager = ScriptManager.from_master_script(master_script=script)
-    return World(
-        label=story_data["label"],
-        script_manager=manager,
-        domain_manager=DomainManager(),
-        asset_manager=AssetManager(),
-        resource_manager=None,
-        metadata=story_data.get("metadata", {}),
-    )
+from .conftest import build_world, create_minimal_world
 
 
 # ============================================================================
@@ -80,6 +52,75 @@ class TestResolveTemplateForAddress:
 
         assert result == template
 
+    def test_exact_path_match_requires_equality(self) -> None:
+        """Template paths must exactly match the address."""
+
+        template = HierarchicalTemplate(
+            label="shop",
+            obj_cls=Node,
+            declares_instance=True,
+        )
+        scene = HierarchicalTemplate(label="scene1", children={"shop": template})
+        root = HierarchicalTemplate(label="story", children={"scene1": scene})
+        resolved_template = root.children["scene1"].children["shop"]
+
+        assert _template_path_matches_address(resolved_template, "story.scene1.shop") is True
+        assert _template_path_matches_address(resolved_template, "shop") is False
+        assert _template_path_matches_address(resolved_template, "scene1.shop") is False
+        assert _template_path_matches_address(resolved_template, "other.scene1.shop") is False
+
+    def test_resolve_does_not_exact_match_on_suffix(self) -> None:
+        """Suffix-only addresses should not trigger exact-match logic."""
+
+        factory = TemplateFactory(label="test")
+        template = HierarchicalTemplate(
+            label="shop",
+            obj_cls=Node,
+            declares_instance=True,
+        )
+        scene = HierarchicalTemplate(label="scene1", children={"shop": template})
+        root = HierarchicalTemplate(label="story", children={"scene1": scene})
+        resolved_template = root.children["scene1"].children["shop"]
+        factory.add(resolved_template)
+
+        result = resolve_template_for_address(
+            factory,
+            "shop",
+            strict=False,
+        )
+
+        assert result is None
+
+    def test_iter_matching_templates_prefers_exact_matches(self) -> None:
+        """Exact path matches should short-circuit scope matches."""
+
+        exact_template = HierarchicalTemplate(
+            label="shop",
+            obj_cls=Node,
+            declares_instance=True,
+        )
+        scoped_template = HierarchicalTemplate(
+            label="shop",
+            obj_cls=Node,
+            declares_instance=True,
+            path_pattern="scene1.*",
+        )
+        scene = HierarchicalTemplate(label="scene1", children={"shop": exact_template})
+        root = HierarchicalTemplate(label="story", children={"scene1": scene})
+
+        factory = TemplateFactory(label="test")
+        factory.add(root.children["scene1"].children["shop"])
+        factory.add(scoped_template)
+
+        matches = list(
+            iter_matching_templates(
+                factory,
+                "story.scene1.shop",
+            )
+        )
+
+        assert matches == [(exact_template, -1.0, True)]
+
 
 # ============================================================================
 # Namespace creation
@@ -89,7 +130,7 @@ class TestEnsureNamespace:
     """Tests for namespace prefix creation."""
 
     def test_ensure_namespace_creates_prefix_chain(self) -> None:
-        """Ensure all prefix containers are created in order."""
+        """Ensure parent containers are created in order."""
 
         graph = Graph(label="test")
 
@@ -101,10 +142,33 @@ class TestEnsureNamespace:
 
         assert a is not None
         assert b is not None
-        assert c is not None
         assert b.parent == a
-        assert c.parent == b
-        assert result == c
+        assert c is None
+        assert result == b
+
+    def test_get_prefixes_excludes_leaf(self) -> None:
+        """Prefixes should not include the full address."""
+
+        assert _get_prefixes("a.b.c") == ["a", "a.b"]
+        assert _get_prefixes("a.b") == ["a"]
+        assert _get_prefixes("a") == []
+
+    def test_ensure_namespace_attaches_once(self) -> None:
+        """Containers should be attached to parent OR graph, not both."""
+
+        graph = Graph(label="test")
+
+        ensure_namespace(graph, "a.b.c")
+
+        a = graph.find_subgraph(label="a")
+        b = graph.find_subgraph(label="b")
+
+        assert a is not None
+        assert b is not None
+        assert a in graph.subgraphs
+        assert b in a.members
+        assert a.parent is None
+        assert b.parent == a
 
 
 # ============================================================================
@@ -148,6 +212,74 @@ class TestEnsureInstance:
         scene1 = graph.find_subgraph(path="scene1")
         assert scene1 is not None
         assert result.parent == scene1
+
+    def test_ensure_instance_no_duplicate_containers(self) -> None:
+        """Ensure container namespaces are reused instead of duplicated."""
+
+        factory = TemplateFactory(label="test")
+        template = HierarchicalTemplate(
+            label="start",
+            obj_cls=Block,
+            path_pattern="*",
+            declares_instance=True,
+        )
+        factory.add(template)
+
+        graph = Graph(label="test")
+        world = create_minimal_world()
+
+        instance1 = ensure_instance(graph, "scene1.start", factory, world=world)
+        scene1_containers = list(graph.find_all(label="scene1"))
+        assert len(scene1_containers) == 1
+
+        instance2 = ensure_instance(graph, "scene1.start", factory, world=world)
+
+        assert instance1 is instance2
+        assert len(list(graph.find_all(label="scene1"))) == 1
+
+    def test_ensure_instance_rejects_subgraph_for_non_container(self) -> None:
+        """Error when a container exists but the template expects a node."""
+
+        graph = Graph(label="test")
+        factory = TemplateFactory(label="test")
+
+        parent = ensure_namespace(graph, "scene1.start")
+        existing = Subgraph(label="start", graph=graph)
+        assert parent is not None
+        parent.add_member(existing)
+
+        template = Template(
+            label="start",
+            obj_cls=Block,
+            declares_instance=True,
+        )
+        factory.add(template)
+
+        world = create_minimal_world()
+
+        with pytest.raises(TypeError, match="Subgraph already exists but template expects Block"):
+            ensure_instance(graph, "scene1.start", factory, world=world)
+
+    def test_ensure_instance_reuses_subgraph_for_container_type(self) -> None:
+        """Reuse existing subgraphs when templates expect containers."""
+
+        graph = Graph(label="test")
+        factory = TemplateFactory(label="test")
+
+        existing = graph.add_subgraph(label="chapter1")
+
+        template = Template(
+            label="chapter1",
+            obj_cls=Subgraph,
+            declares_instance=True,
+        )
+        factory.add(template)
+
+        world = create_minimal_world()
+
+        result = ensure_instance(graph, "chapter1", factory, world=world)
+
+        assert result is existing
 
     def test_ensure_instance_without_world_uses_class_obj_cls(self) -> None:
         """Ensure class-based templates materialize without a world."""

--- a/engine/tests/story/fabula/test_world_start_address.py
+++ b/engine/tests/story/fabula/test_world_start_address.py
@@ -1,0 +1,97 @@
+"""Tests for world start address resolution.
+
+Organized by functionality:
+- Explicit start address metadata.
+- Fallback start address selection.
+- Address normalization consistency.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from .conftest import build_world
+
+
+# ============================================================================
+# Start address resolution
+# ============================================================================
+
+
+class TestWorldStartAddress:
+    """Tests for start address resolution behavior."""
+
+    def test_world_with_explicit_start_at(self) -> None:
+        """Explicit start_at should be used."""
+
+        script = {
+            "label": "test",
+            "metadata": {
+                "title": "Test",
+                "author": "Test",
+                "start_at": "scene2.middle",
+            },
+            "scenes": {
+                "scene1": {"blocks": {"start": {"obj_cls": "Block"}}},
+                "scene2": {"blocks": {"middle": {"obj_cls": "Block"}}},
+            },
+        }
+        world = build_world(script)
+        assert world._get_start_address() == "scene2.middle"
+
+    def test_world_without_start_at_uses_fallback(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Missing start_at should use lexicographically smallest leaf."""
+
+        script = {
+            "label": "test",
+            "metadata": {"title": "Test", "author": "Test"},
+            "scenes": {
+                "prologue": {"blocks": {"intro": {"obj_cls": "Block"}}},
+                "chapter1": {"blocks": {"start": {"obj_cls": "Block"}}},
+            },
+        }
+
+        world = build_world(script)
+
+        with caplog.at_level(logging.WARNING):
+            start_addr = world._get_start_address()
+
+        assert start_addr == "chapter1.start"
+        assert "No start_at specified" in caplog.text
+        assert "chapter1.start" in caplog.text
+
+    def test_world_without_start_at_and_no_templates_fails(self) -> None:
+        """No start_at and no templates should raise a clear error."""
+
+        script = {
+            "label": "test",
+            "metadata": {"title": "Test", "author": "Test"},
+            "templates": {},
+            "scenes": {},
+        }
+
+        world = build_world(script)
+
+        with pytest.raises(ValueError, match="Cannot determine starting point"):
+            world._get_start_address()
+
+    def test_normalization_consistency(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Leaf detection should work in normalized space."""
+
+        script = {
+            "label": "story",
+            "metadata": {"title": "Test", "author": "Test"},
+            "scenes": {
+                "scene1": {"blocks": {"start": {"obj_cls": "Block"}}},
+            },
+        }
+
+        world = build_world(script)
+
+        with caplog.at_level(logging.WARNING):
+            start_addr = world._get_start_address()
+
+        assert start_addr == "scene1.start"
+        assert not start_addr.startswith("story.")

--- a/engine/tests/vm/provision/test_provisioner_location_lookup.py
+++ b/engine/tests/vm/provision/test_provisioner_location_lookup.py
@@ -1,0 +1,262 @@
+"""Tests for qualified identifier lookups in provisioning.
+
+Organized by functionality:
+- Strict path matching precedence.
+- Location-based fallback when scope patterns apply.
+- Global-only guardrails and provenance tracking.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from tangl.core.factory import HierarchicalTemplate, TemplateFactory
+from tangl.core.graph import Graph, Node
+from tangl.vm.provision import (
+    ProvisioningPolicy,
+    Requirement,
+    TemplateProvisioner,
+)
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _ctx(graph: Graph, cursor: Node | None = None) -> SimpleNamespace:
+    cursor_id = cursor.uid if cursor is not None else None
+    return SimpleNamespace(graph=graph, cursor=cursor, cursor_id=cursor_id)
+
+
+# ============================================================================
+# Qualified identifier resolution
+# ============================================================================
+
+
+class TestQualifiedIdentifierLocationLookup:
+    """Tests for two-stage qualified identifier resolution."""
+
+    def test_stage1_strict_path_wins(self) -> None:
+        """Strict path lookup should take priority over scope matches."""
+
+        graph = Graph(label="test")
+        factory = TemplateFactory(label="test")
+
+        exact_template = HierarchicalTemplate(
+            label="shop",
+            obj_cls=Node,
+            declares_instance=True,
+            tags={"exact"},
+        )
+        root = HierarchicalTemplate(label="scene1", children={"shop": exact_template})
+        factory.add(root.children["shop"])
+
+        scoped_template = HierarchicalTemplate(
+            label="shop",
+            obj_cls=Node,
+            declares_instance=True,
+            path_pattern="scene1.*",
+            tags={"scoped"},
+        )
+        factory.add(scoped_template)
+
+        requirement = Requirement(
+            graph=graph,
+            template_ref="scene1.shop",
+            policy=ProvisioningPolicy.CREATE_TEMPLATE,
+        )
+
+        provisioner = TemplateProvisioner(factory=factory, layer="author")
+        ctx = _ctx(graph)
+
+        offers = list(provisioner.get_dependency_offers(requirement, ctx=ctx))
+
+        assert len(offers) == 1
+        provider = offers[0].accept(ctx=ctx)
+        assert "exact" in provider.tags
+        assert "scoped" not in provider.tags
+
+    def test_stage2_location_based_with_scope(self) -> None:
+        """Location-based matching should resolve scoped qualified refs."""
+
+        graph = Graph(label="test")
+        factory = TemplateFactory(label="test")
+
+        template = HierarchicalTemplate(
+            label="shop",
+            obj_cls=Node,
+            declares_instance=True,
+            path_pattern="scene1.*",
+            tags={"scoped"},
+        )
+        factory.add(template)
+
+        scene1 = graph.add_subgraph(label="scene1")
+        cursor = graph.add_node(label="start")
+        scene1.add_member(cursor)
+
+        requirement = Requirement(
+            graph=graph,
+            template_ref="scene1.shop",
+            policy=ProvisioningPolicy.CREATE_TEMPLATE,
+        )
+
+        provisioner = TemplateProvisioner(factory=factory, layer="author")
+        ctx = _ctx(graph, cursor)
+
+        offers = list(provisioner.get_dependency_offers(requirement, ctx=ctx))
+
+        assert len(offers) == 1
+        provider = offers[0].accept(ctx=ctx)
+        assert "scoped" in provider.tags
+
+    def test_stage2_rejects_global_only_template(self) -> None:
+        """Global-only templates should not match qualified refs."""
+
+        graph = Graph(label="test")
+        factory = TemplateFactory(label="test")
+
+        template = HierarchicalTemplate(
+            label="shop",
+            obj_cls=Node,
+            declares_instance=True,
+            path_pattern="*",
+            tags={"global"},
+        )
+        factory.add(template)
+
+        cursor = graph.add_node(label="start")
+
+        requirement = Requirement(
+            graph=graph,
+            template_ref="book1.shop",
+            policy=ProvisioningPolicy.CREATE_TEMPLATE,
+        )
+
+        provisioner = TemplateProvisioner(factory=factory, layer="author")
+        ctx = _ctx(graph, cursor)
+
+        offers = list(provisioner.get_dependency_offers(requirement, ctx=ctx))
+
+        assert offers == []
+
+    def test_stage2_without_context_fails_gracefully(self) -> None:
+        """Qualified refs without context should not resolve scope matches."""
+
+        graph = Graph(label="test")
+        factory = TemplateFactory(label="test")
+
+        template = HierarchicalTemplate(
+            label="shop",
+            obj_cls=Node,
+            declares_instance=True,
+            path_pattern="scene1.*",
+        )
+        factory.add(template)
+
+        requirement = Requirement(
+            graph=graph,
+            template_ref="scene1.shop",
+            policy=ProvisioningPolicy.CREATE_TEMPLATE,
+        )
+
+        provisioner = TemplateProvisioner(factory=factory, layer="author")
+        ctx = _ctx(graph, cursor=None)
+
+        offers = list(provisioner.get_dependency_offers(requirement, ctx=ctx))
+
+        assert offers == []
+
+    def test_provenance_tracking_stage1(self) -> None:
+        """Provenance should indicate strict path resolution."""
+
+        graph = Graph(label="test")
+        factory = TemplateFactory(label="test")
+
+        exact_template = HierarchicalTemplate(
+            label="shop",
+            obj_cls=Node,
+            declares_instance=True,
+        )
+        root = HierarchicalTemplate(label="scene1", children={"shop": exact_template})
+        factory.add(root.children["shop"])
+
+        provisioner = TemplateProvisioner(factory=factory, layer="author")
+        requirement = Requirement(
+            graph=graph,
+            template_ref="scene1.shop",
+            policy=ProvisioningPolicy.CREATE_TEMPLATE,
+        )
+
+        ctx = _ctx(graph, cursor=None)
+
+        resolved, provenance = provisioner._resolve_template(requirement, ctx=ctx)
+
+        assert resolved == exact_template
+        assert provenance["lookup_method"] == "strict_path"
+
+    def test_provenance_tracking_stage2(self) -> None:
+        """Provenance should indicate location-based resolution."""
+
+        graph = Graph(label="test")
+        factory = TemplateFactory(label="test")
+
+        template = HierarchicalTemplate(
+            label="shop",
+            obj_cls=Node,
+            declares_instance=True,
+            path_pattern="scene1.*",
+        )
+        factory.add(template)
+
+        scene1 = graph.add_subgraph(label="scene1")
+        cursor = graph.add_node(label="start")
+        scene1.add_member(cursor)
+
+        provisioner = TemplateProvisioner(factory=factory, layer="author")
+        requirement = Requirement(
+            graph=graph,
+            template_ref="scene1.shop",
+            policy=ProvisioningPolicy.CREATE_TEMPLATE,
+        )
+
+        ctx = _ctx(graph, cursor=cursor)
+
+        resolved, provenance = provisioner._resolve_template(requirement, ctx=ctx)
+
+        assert resolved == template
+        assert provenance["lookup_method"] == "location_based"
+        assert "location_score" in provenance
+
+
+class TestUnqualifiedIdentifierLookup:
+    """Tests for unqualified identifier lookups."""
+
+    def test_unqualified_uses_label_lookup(self) -> None:
+        """Unqualified refs should use label lookup."""
+
+        graph = Graph(label="test")
+        factory = TemplateFactory(label="test")
+
+        template = HierarchicalTemplate(
+            label="shop",
+            obj_cls=Node,
+            declares_instance=True,
+        )
+        factory.add(template)
+
+        requirement = Requirement(
+            graph=graph,
+            template_ref="shop",
+            policy=ProvisioningPolicy.CREATE_TEMPLATE,
+        )
+
+        provisioner = TemplateProvisioner(factory=factory, layer="author")
+        ctx = _ctx(graph, cursor=None)
+
+        offers = list(provisioner.get_dependency_offers(requirement, ctx=ctx))
+
+        assert len(offers) == 1
+        provider = offers[0].accept(ctx=ctx)
+        assert provider.label == "shop"


### PR DESCRIPTION
### Motivation

- Improve observability and debuggability of address→template resolution by documenting terminology and adding trace logging.  
- Avoid masking real bugs by narrowing broad `Exception` catches during eager materialization.  
- Make small API/behavior clarifications: ensure consistent return types, avoid duplicate test helpers, and provide more actionable error messages.  
- Support two-stage qualified-identifier resolution in provisioning with provenance so scoped lookups work correctly when context is available.

### Description

- Documented address/template concepts in `engine/src/tangl/story/fabula/address_resolver.py` and added `_log_resolution_trace` used by `resolve_template_for_address` to emit detailed debug traces.  
- Reworked matching behavior so `iter_matching_templates` yields exact matches first (short-circuit) and ` _template_path_matches_address` performs strict equality; `ensure_namespace` now returns parent prefixes (leaf excluded) and attaches containers only once.  
- Hardened eager materialization in `world._create_story_full` to catch only expected exceptions and collect/log materialization error summaries, and improved start-address normalization and fallback selection with clearer errors.  
- Normalized `_iter_script_items` to always return a concrete `list`, centralized shared test fixtures/helpers into `engine/tests/story/fabula/conftest.py`, and updated/added tests and provisioning logic in `engine/src/tangl/vm/provision/provisioner.py` to perform two-stage resolution (`_find_template` returns provenance, `_resolve_as_location`, and `_get_all_template_offers`).

### Testing

- Ran `PYTHONPATH=./engine/src poetry run pytest engine/tests/story/fabula/test_address_resolver.py -v` and it passed (13 tests).  
- Ran `PYTHONPATH=./engine/src poetry run pytest engine/tests/story/fabula/test_address_resolution.py -v` and it passed (4 tests).  
- Ran `PYTHONPATH=./engine/src poetry run pytest engine/tests/story/fabula/test_world_start_address.py -v` and it passed (4 tests).  
- New/updated tests include `engine/tests/vm/provision/test_provisioner_location_lookup.py`, `engine/tests/story/fabula/test_address_resolver.py`, `engine/tests/story/fabula/test_address_resolution.py`, and `engine/tests/story/fabula/test_world_start_address.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69596accf6c48329ae86c504ef1ddd24)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced template resolution with location-based matching and improved candidate selection.
  * Introduced comprehensive logging and trace output for debugging template resolution.

* **Bug Fixes**
  * Improved error messages with contextual suggestions when templates cannot be resolved.
  * Better handling of ambiguous template selections in strict mode.
  * Refined error handling during graph materialization with detailed error summaries.

* **Improvements**
  * Added warnings for missing configuration and deprecated usage patterns.
  * Optimized start address detection with fallback logic and clearer warnings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->