### PR TITLE
Refactor vm38 tests to require explicit graph.add() registration

### DIFF
--- a/engine/tests/vm38/conftest.py
+++ b/engine/tests/vm38/conftest.py
@@ -31,6 +31,18 @@ from tangl.vm38.traversable import (
 )
 
 
+def _node(graph: Graph, **kwargs) -> TraversableNode:
+    node = TraversableNode(**kwargs)
+    graph.add(node)
+    return node
+
+
+def _edge(graph: Graph, **kwargs) -> TraversableEdge:
+    edge = TraversableEdge(**kwargs)
+    graph.add(edge)
+    return edge
+
+
 # ============================================================================
 # Test record types
 # ============================================================================
@@ -121,11 +133,9 @@ def make_linear_graph(labels: list[str], *, graph: Graph | None = None) -> tuple
     ``TraversableEdge`` instances.
     """
     g = graph or Graph()
-    nodes = [TraversableNode(label=lbl, registry=g) for lbl in labels]
+    nodes = [_node(g, label=lbl) for lbl in labels]
     for i in range(len(nodes) - 1):
-        TraversableEdge(
-            registry=g,
-            predecessor_id=nodes[i].uid,
+        _edge(g, predecessor_id=nodes[i].uid,
             successor_id=nodes[i + 1].uid,
         )
     return g, nodes
@@ -142,20 +152,16 @@ def make_branching_graph(
     Returns ``(graph, root, [[branch0_nodes], [branch1_nodes], ...])``.
     """
     g = graph or Graph()
-    root = TraversableNode(label=root_label, registry=g)
+    root = _node(g, label=root_label)
     branches: list[list[TraversableNode]] = []
 
     for branch in branch_labels or [["b0a", "b0b"], ["b1a", "b1b"]]:
-        nodes = [TraversableNode(label=lbl, registry=g) for lbl in branch]
-        TraversableEdge(
-            registry=g,
-            predecessor_id=root.uid,
+        nodes = [_node(g, label=lbl) for lbl in branch]
+        _edge(g, predecessor_id=root.uid,
             successor_id=nodes[0].uid,
         )
         for i in range(len(nodes) - 1):
-            TraversableEdge(
-                registry=g,
-                predecessor_id=nodes[i].uid,
+            _edge(g, predecessor_id=nodes[i].uid,
                 successor_id=nodes[i + 1].uid,
             )
         branches.append(nodes)
@@ -178,8 +184,8 @@ def make_container(
     Returns ``(graph, container, [member0, member1, ...])``.
     """
     g = graph or Graph()
-    container = TraversableNode(label=container_label, registry=g)
-    members = [TraversableNode(label=lbl, registry=g) for lbl in member_labels]
+    container = _node(g, label=container_label)
+    members = [_node(g, label=lbl) for lbl in member_labels]
 
     for m in members:
         container.add_child(m)
@@ -189,9 +195,7 @@ def make_container(
     if len(members) > 1:
         container.sink_id = members[-1].uid
         for i in range(len(members) - 1):
-            TraversableEdge(
-                registry=g,
-                predecessor_id=members[i].uid,
+            _edge(g, predecessor_id=members[i].uid,
                 successor_id=members[i + 1].uid,
             )
 

--- a/engine/tests/vm38/test_dispatch.py
+++ b/engine/tests/vm38/test_dispatch.py
@@ -36,6 +36,12 @@ from tangl.vm38.dispatch import (
 from tangl.vm38.traversable import TraversableNode
 
 
+def _node(graph: Graph, **kwargs) -> TraversableNode:
+    node = TraversableNode(**kwargs)
+    graph.add(node)
+    return node
+
+
 # ============================================================================
 # Hook registration
 # ============================================================================
@@ -97,7 +103,7 @@ class TestDoValidate:
     def test_no_handlers_returns_true(self, null_ctx) -> None:
         """No validators registered → vacuously true."""
         g = Graph()
-        edge = TraversableNode(label="e", registry=g)
+        edge = _node(g, label="e")
         # all_true with no receipts returns True (vacuous truth)
         result = do_validate(edge, ctx=null_ctx)
         assert result is True
@@ -105,13 +111,13 @@ class TestDoValidate:
     def test_truthy_handler(self, null_ctx) -> None:
         on_validate(lambda *, caller, ctx, **kw: True)
         g = Graph()
-        edge = TraversableNode(label="e", registry=g)
+        edge = _node(g, label="e")
         assert do_validate(edge, ctx=null_ctx) is True
 
     def test_falsy_handler_blocks(self, null_ctx) -> None:
         on_validate(lambda *, caller, ctx, **kw: False)
         g = Graph()
-        edge = TraversableNode(label="e", registry=g)
+        edge = _node(g, label="e")
         assert do_validate(edge, ctx=null_ctx) is False
 
 
@@ -120,14 +126,14 @@ class TestDoPrereqs:
 
     def test_no_handlers_returns_none(self, null_ctx) -> None:
         g = Graph()
-        node = TraversableNode(label="n", registry=g)
+        node = _node(g, label="n")
         assert do_prereqs(node, ctx=null_ctx) is None
 
     def test_first_non_none_returned(self, null_ctx) -> None:
         on_prereqs(lambda *, caller, ctx, **kw: None)
         on_prereqs(lambda *, caller, ctx, **kw: "redirect_edge")
         g = Graph()
-        node = TraversableNode(label="n", registry=g)
+        node = _node(g, label="n")
         assert do_prereqs(node, ctx=null_ctx) == "redirect_edge"
 
 
@@ -136,14 +142,14 @@ class TestDoJournal:
 
     def test_no_handlers_returns_none(self, null_ctx) -> None:
         g = Graph()
-        node = TraversableNode(label="n", registry=g)
+        node = _node(g, label="n")
         assert do_journal(node, ctx=null_ctx) is None
 
     def test_last_handler_wins(self, null_ctx) -> None:
         on_journal(lambda *, caller, ctx, **kw: "first")
         on_journal(lambda *, caller, ctx, **kw: "second")
         g = Graph()
-        node = TraversableNode(label="n", registry=g)
+        node = _node(g, label="n")
         result = do_journal(node, ctx=null_ctx)
         assert result == "second"
 
@@ -155,7 +161,7 @@ class TestDoProvision:
         on_provision(lambda *, caller, ctx, **kw: "a")
         on_provision(lambda *, caller, ctx, **kw: "b")
         g = Graph()
-        node = TraversableNode(label="n", registry=g)
+        node = _node(g, label="n")
         result = do_provision(node, ctx=null_ctx)
         assert "a" in result and "b" in result
 
@@ -170,7 +176,7 @@ class TestDoGatherNs:
 
     def test_empty_ns_with_no_handlers(self, null_ctx) -> None:
         g = Graph()
-        node = TraversableNode(label="n", registry=g)
+        node = _node(g, label="n")
         ns = do_gather_ns(node, ctx=null_ctx)
         assert isinstance(ns, ChainMap)
         assert len(ns) == 0
@@ -184,7 +190,7 @@ class TestDoGatherNs:
             return None
 
         g = Graph()
-        node = TraversableNode(label="n", registry=g)
+        node = _node(g, label="n")
         node.locals = {"mood": "angry"}
         ns = do_gather_ns(node, ctx=null_ctx)
         assert ns["mood"] == "angry"
@@ -198,8 +204,8 @@ class TestDoGatherNs:
             return None
 
         g = Graph()
-        parent = TraversableNode(label="scene", registry=g)
-        child = TraversableNode(label="block", registry=g)
+        parent = _node(g, label="scene")
+        child = _node(g, label="block")
         parent.add_child(child)
 
         parent.locals = {"color": "red", "shared": "parent"}
@@ -218,7 +224,7 @@ class TestDoGatherNs:
             return None
 
         g = Graph()
-        node = TraversableNode(label="orphan", registry=g)
+        node = _node(g, label="orphan")
         node.locals = {"key": "val"}
         ns = do_gather_ns(node, ctx=null_ctx)
         assert ns["key"] == "val"

--- a/engine/tests/vm38/test_frame.py
+++ b/engine/tests/vm38/test_frame.py
@@ -31,6 +31,18 @@ from tangl.vm38.traversable import (
 )
 
 
+def _node(graph: Graph, **kwargs) -> TraversableNode:
+    node = TraversableNode(**kwargs)
+    graph.add(node)
+    return node
+
+
+def _edge(graph: Graph, **kwargs) -> TraversableEdge:
+    edge = TraversableEdge(**kwargs)
+    graph.add(edge)
+    return edge
+
+
 # ============================================================================
 # Helpers
 # ============================================================================
@@ -42,11 +54,9 @@ class SimpleFragment(Record):
 def _simple_graph(*labels: str) -> tuple[Graph, list[TraversableNode]]:
     """Quick linear graph: a→b→c..."""
     g = Graph()
-    nodes = [TraversableNode(label=lbl, registry=g) for lbl in labels]
+    nodes = [_node(g, label=lbl) for lbl in labels]
     for i in range(len(nodes) - 1):
-        TraversableEdge(
-            registry=g,
-            predecessor_id=nodes[i].uid,
+        _edge(g, predecessor_id=nodes[i].uid,
             successor_id=nodes[i + 1].uid,
         )
     return g, nodes
@@ -60,7 +70,7 @@ def _simple_graph(*labels: str) -> tuple[Graph, list[TraversableNode]]:
 class TestPhaseCtx:
     def test_registries_include_vm_dispatch(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
+        a = _node(g, label="a")
         ctx = PhaseCtx(graph=g, cursor_id=a.uid)
         registries = ctx.get_registries()
         # Should include at least the module-level vm_dispatch
@@ -68,7 +78,7 @@ class TestPhaseCtx:
 
     def test_ns_caching(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
+        a = _node(g, label="a")
         a.locals = {"key": "val"}
 
         @on_journal  # just to have _something_ registered, ns uses gather_ns
@@ -180,9 +190,9 @@ class TestFollowEdgeRedirects:
 
     def test_prereq_redirect(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
-        c = TraversableNode(label="c", registry=g)
+        a = _node(g, label="a")
+        b = _node(g, label="b")
+        c = _node(g, label="c")
 
         @on_prereqs
         def redirect_to_c(*, caller, ctx, **kw):
@@ -198,9 +208,9 @@ class TestFollowEdgeRedirects:
 
     def test_postreq_redirect(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
-        c = TraversableNode(label="c", registry=g)
+        a = _node(g, label="a")
+        b = _node(g, label="b")
+        c = _node(g, label="c")
 
         @on_postreqs
         def redirect_to_c(*, caller, ctx, **kw):
@@ -229,9 +239,9 @@ class TestResolveChoice:
     def test_follows_redirect_chain(self) -> None:
         """a→b redirects to c via prereqs."""
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
-        c = TraversableNode(label="c", registry=g)
+        a = _node(g, label="a")
+        b = _node(g, label="b")
+        c = _node(g, label="c")
 
         @on_prereqs
         def redirect(*, caller, ctx, **kw):
@@ -247,8 +257,8 @@ class TestResolveChoice:
     def test_recursion_guard(self) -> None:
         """Infinite redirect loop raises RecursionError."""
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
+        a = _node(g, label="a")
+        b = _node(g, label="b")
 
         @on_prereqs
         def infinite_loop(*, caller, ctx, **kw):
@@ -268,12 +278,11 @@ class TestResolveChoiceReturnStack:
 
     def test_call_and_return(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
+        a = _node(g, label="a")
+        b = _node(g, label="b")
 
         # a→b is a call edge: push b, return to a at UPDATE
-        call_edge = TraversableEdge(
-            registry=g, predecessor_id=a.uid, successor_id=b.uid,
+        call_edge = _edge(g, predecessor_id=a.uid, successor_id=b.uid,
             return_phase=ResolutionPhase.UPDATE,
         )
 

--- a/engine/tests/vm38/test_ledger.py
+++ b/engine/tests/vm38/test_ledger.py
@@ -22,6 +22,18 @@ from tangl.vm38.traversable import (
 )
 
 
+def _node(graph: Graph, **kwargs) -> TraversableNode:
+    node = TraversableNode(**kwargs)
+    graph.add(node)
+    return node
+
+
+def _edge(graph: Graph, **kwargs) -> TraversableEdge:
+    edge = TraversableEdge(**kwargs)
+    graph.add(edge)
+    return edge
+
+
 # ============================================================================
 # Helpers
 # ============================================================================
@@ -30,11 +42,9 @@ from tangl.vm38.traversable import (
 def _make_ledger(*labels: str) -> tuple[Ledger, list[TraversableNode]]:
     """Build a ledger with a linear graph and cursor at the first node."""
     g = Graph()
-    nodes = [TraversableNode(label=lbl, registry=g) for lbl in labels]
+    nodes = [_node(g, label=lbl) for lbl in labels]
     for i in range(len(nodes) - 1):
-        TraversableEdge(
-            registry=g,
-            predecessor_id=nodes[i].uid,
+        _edge(g, predecessor_id=nodes[i].uid,
             successor_id=nodes[i + 1].uid,
         )
     ledger = Ledger(graph=g, cursor_id=nodes[0].uid)
@@ -66,10 +76,9 @@ class TestLedgerCursor:
 class TestLedgerCallStack:
     def test_push_call_requires_return_phase(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
-        edge = TraversableEdge(
-            registry=g, predecessor_id=a.uid, successor_id=b.uid,
+        a = _node(g, label="a")
+        b = _node(g, label="b")
+        edge = _edge(g, predecessor_id=a.uid, successor_id=b.uid,
         )
         ledger = Ledger(graph=g, cursor_id=a.uid)
         with pytest.raises(ValueError):
@@ -77,10 +86,9 @@ class TestLedgerCallStack:
 
     def test_push_and_pop(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
-        call_edge = TraversableEdge(
-            registry=g, predecessor_id=a.uid, successor_id=b.uid,
+        a = _node(g, label="a")
+        b = _node(g, label="b")
+        call_edge = _edge(g, predecessor_id=a.uid, successor_id=b.uid,
             return_phase=ResolutionPhase.UPDATE,
         )
         ledger = Ledger(graph=g, cursor_id=a.uid)
@@ -90,7 +98,7 @@ class TestLedgerCallStack:
 
     def test_empty_pop_raises(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
+        a = _node(g, label="a")
         ledger = Ledger(graph=g, cursor_id=a.uid)
         with pytest.raises(IndexError):
             ledger.pop_call()

--- a/engine/tests/vm38/test_resolver.py
+++ b/engine/tests/vm38/test_resolver.py
@@ -27,6 +27,18 @@ from tangl.vm38.provision import (
 from tangl.vm38.traversable import TraversableNode
 
 
+def _node(graph: Graph, **kwargs) -> TraversableNode:
+    node = TraversableNode(**kwargs)
+    graph.add(node)
+    return node
+
+
+def _dependency(graph: Graph, **kwargs) -> Dependency:
+    dependency = Dependency(**kwargs)
+    graph.add(dependency)
+    return dependency
+
+
 # ============================================================================
 # FindProvisioner — search existing entities
 # ============================================================================
@@ -125,12 +137,12 @@ class TestResolverDependencyResolution:
 class TestResolverFrontierNode:
     def test_node_with_all_deps_satisfied(self) -> None:
         g = Graph()
-        node = TraversableNode(label="room", registry=g)
-        sword = TraversableNode(label="sword", registry=g)
+        node = _node(g, label="room")
+        sword = _node(g, label="sword")
 
-        dep = Dependency(
+        dep = _dependency(
+            g,
             requirement=Requirement.from_identifier("sword"),
-            registry=g,
             predecessor_id=node.uid,
         )
 
@@ -141,14 +153,12 @@ class TestResolverFrontierNode:
 
     def test_node_with_unresolvable_deps(self) -> None:
         g = Graph()
-        node = TraversableNode(label="room", registry=g)
-        dep = Dependency(
+        node = _node(g, label="room")
+        dep = _dependency(g, 
             requirement=Requirement(
                 has_identifier="missing",
                 provision_policy=ProvisionPolicy.EXISTING,
-            ),
-            registry=g,
-            predecessor_id=node.uid,
+            ), predecessor_id=node.uid,
         )
 
         resolver = Resolver(entity_groups=[])

--- a/engine/tests/vm38/test_system_handlers.py
+++ b/engine/tests/vm38/test_system_handlers.py
@@ -33,6 +33,18 @@ from tangl.vm38.traversable import (
     TraversableNode,
 )
 
+
+def _node(graph: Graph, **kwargs) -> TraversableNode:
+    node = TraversableNode(**kwargs)
+    graph.add(node)
+    return node
+
+
+def _edge(graph: Graph, **kwargs) -> TraversableEdge:
+    edge = TraversableEdge(**kwargs)
+    graph.add(edge)
+    return edge
+
 # Import registers the handlers — must happen after clean_vm_dispatch yields
 import tangl.vm38.system_handlers as sh
 
@@ -71,14 +83,14 @@ def ctx() -> SimpleNamespace:
 class TestContributeLocals:
     def test_returns_locals_dict(self) -> None:
         g = Graph()
-        node = TraversableNode(label="n", registry=g)
+        node = _node(g, label="n")
         node.locals = {"key": "val"}
         result = sh.contribute_locals(caller=node, ctx=None)
         assert result == {"key": "val"}
 
     def test_returns_none_if_no_locals(self) -> None:
         g = Graph()
-        node = TraversableNode(label="n", registry=g)
+        node = _node(g, label="n")
         node.locals = {}
         result = sh.contribute_locals(caller=node, ctx=None)
         # falsy dict returns None
@@ -86,7 +98,7 @@ class TestContributeLocals:
 
     def test_fires_through_gather_ns(self, ctx) -> None:
         g = Graph()
-        node = TraversableNode(label="n", registry=g)
+        node = _node(g, label="n")
         node.locals = {"mood": "happy"}
         ns = do_gather_ns(node, ctx=ctx)
         assert ns["mood"] == "happy"
@@ -100,24 +112,24 @@ class TestContributeLocals:
 class TestValidateSuccessorExists:
     def test_edge_with_successor_passes(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
-        edge = TraversableEdge(registry=g, predecessor_id=a.uid, successor_id=b.uid)
+        a = _node(g, label="a")
+        b = _node(g, label="b")
+        edge = _edge(g, predecessor_id=a.uid, successor_id=b.uid)
         result = sh.validate_successor_exists(caller=edge, ctx=None)
         assert result is True
 
     def test_anonymous_edge_passes(self) -> None:
         g = Graph()
-        b = TraversableNode(label="b", registry=g)
+        b = _node(g, label="b")
         edge = AnonymousEdge(successor=b)
         result = sh.validate_successor_exists(caller=edge, ctx=None)
         assert result is True
 
     def test_fires_through_do_validate(self, ctx) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
-        edge = TraversableEdge(registry=g, predecessor_id=a.uid, successor_id=b.uid)
+        a = _node(g, label="a")
+        b = _node(g, label="b")
+        edge = _edge(g, predecessor_id=a.uid, successor_id=b.uid)
         assert do_validate(edge, ctx=ctx) is True
 
 
@@ -129,8 +141,8 @@ class TestValidateSuccessorExists:
 class TestDescendIntoContainer:
     def test_container_returns_enter_edge(self) -> None:
         g = Graph()
-        container = TraversableNode(label="scene", registry=g)
-        entry = TraversableNode(label="entry", registry=g)
+        container = _node(g, label="scene")
+        entry = _node(g, label="entry")
         container.add_child(entry)
         container.source_id = entry.uid
 
@@ -140,14 +152,14 @@ class TestDescendIntoContainer:
 
     def test_leaf_returns_none(self) -> None:
         g = Graph()
-        leaf = TraversableNode(label="leaf", registry=g)
+        leaf = _node(g, label="leaf")
         result = sh.descend_into_container(caller=leaf, ctx=None)
         assert result is None
 
     def test_fires_through_do_prereqs(self, ctx) -> None:
         g = Graph()
-        container = TraversableNode(label="scene", registry=g)
-        entry = TraversableNode(label="entry", registry=g)
+        container = _node(g, label="scene")
+        entry = _node(g, label="entry")
         container.add_child(entry)
         container.source_id = entry.uid
 
@@ -164,10 +176,9 @@ class TestDescendIntoContainer:
 class TestFollowTriggeredPrereqs:
     def test_prereq_triggered_edge_returned(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
-        TraversableEdge(
-            registry=g, predecessor_id=a.uid, successor_id=b.uid,
+        a = _node(g, label="a")
+        b = _node(g, label="b")
+        _edge(g, predecessor_id=a.uid, successor_id=b.uid,
             trigger_phase=ResolutionPhase.PREREQS,
         )
         result = sh.follow_triggered_prereqs(caller=a, ctx=None)
@@ -176,18 +187,17 @@ class TestFollowTriggeredPrereqs:
 
     def test_no_triggered_edges_returns_none(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
-        TraversableEdge(registry=g, predecessor_id=a.uid, successor_id=b.uid)
+        a = _node(g, label="a")
+        b = _node(g, label="b")
+        _edge(g, predecessor_id=a.uid, successor_id=b.uid)
         result = sh.follow_triggered_prereqs(caller=a, ctx=None)
         assert result is None
 
     def test_postreq_triggered_not_returned(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
-        TraversableEdge(
-            registry=g, predecessor_id=a.uid, successor_id=b.uid,
+        a = _node(g, label="a")
+        b = _node(g, label="b")
+        _edge(g, predecessor_id=a.uid, successor_id=b.uid,
             trigger_phase=ResolutionPhase.POSTREQS,
         )
         result = sh.follow_triggered_prereqs(caller=a, ctx=None)
@@ -202,7 +212,7 @@ class TestFollowTriggeredPrereqs:
 class TestMarkVisited:
     def test_sets_visited_flag(self) -> None:
         g = Graph()
-        node = TraversableNode(label="n", registry=g)
+        node = _node(g, label="n")
         node.locals = {}
         sh.mark_visited(caller=node, ctx=None)
         assert node.locals["_visited"] is True
@@ -210,7 +220,7 @@ class TestMarkVisited:
 
     def test_increments_on_repeat(self) -> None:
         g = Graph()
-        node = TraversableNode(label="n", registry=g)
+        node = _node(g, label="n")
         node.locals = {}
         sh.mark_visited(caller=node, ctx=None)
         sh.mark_visited(caller=node, ctx=None)
@@ -218,14 +228,14 @@ class TestMarkVisited:
 
     def test_initializes_none_locals(self) -> None:
         g = Graph()
-        node = TraversableNode(label="n", registry=g)
+        node = _node(g, label="n")
         node.locals = None
         sh.mark_visited(caller=node, ctx=None)
         assert node.locals["_visited"] is True
 
     def test_fires_through_do_update(self, ctx) -> None:
         g = Graph()
-        node = TraversableNode(label="n", registry=g)
+        node = _node(g, label="n")
         node.locals = {}
         do_update(node, ctx=ctx)
         assert node.locals["_visited"] is True
@@ -239,10 +249,9 @@ class TestMarkVisited:
 class TestFollowTriggeredPostreqs:
     def test_postreq_triggered_edge_returned(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
-        TraversableEdge(
-            registry=g, predecessor_id=a.uid, successor_id=b.uid,
+        a = _node(g, label="a")
+        b = _node(g, label="b")
+        _edge(g, predecessor_id=a.uid, successor_id=b.uid,
             trigger_phase=ResolutionPhase.POSTREQS,
         )
         result = sh.follow_triggered_postreqs(caller=a, ctx=None)
@@ -251,10 +260,9 @@ class TestFollowTriggeredPostreqs:
 
     def test_prereq_triggered_not_returned(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
-        TraversableEdge(
-            registry=g, predecessor_id=a.uid, successor_id=b.uid,
+        a = _node(g, label="a")
+        b = _node(g, label="b")
+        _edge(g, predecessor_id=a.uid, successor_id=b.uid,
             trigger_phase=ResolutionPhase.PREREQS,
         )
         result = sh.follow_triggered_postreqs(caller=a, ctx=None)

--- a/engine/tests/vm38/test_traversable.py
+++ b/engine/tests/vm38/test_traversable.py
@@ -23,6 +23,18 @@ from tangl.vm38.traversable import (
 )
 
 
+def _node(graph: Graph, **kwargs) -> TraversableNode:
+    node = TraversableNode(**kwargs)
+    graph.add(node)
+    return node
+
+
+def _edge(graph: Graph, **kwargs) -> TraversableEdge:
+    edge = TraversableEdge(**kwargs)
+    graph.add(edge)
+    return edge
+
+
 # ============================================================================
 # LCA
 # ============================================================================
@@ -33,32 +45,32 @@ class TestLCA:
 
     def test_same_node(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
+        a = _node(g, label="a")
         assert lca(a, a) is a
 
     def test_siblings_share_parent(self) -> None:
         g = Graph()
-        root = TraversableNode(label="root", registry=g)
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
+        root = _node(g, label="root")
+        a = _node(g, label="a")
+        b = _node(g, label="b")
         root.add_child(a)
         root.add_child(b)
         assert lca(a, b) is root
 
     def test_parent_child(self) -> None:
         g = Graph()
-        parent = TraversableNode(label="p", registry=g)
-        child = TraversableNode(label="c", registry=g)
+        parent = _node(g, label="p")
+        child = _node(g, label="c")
         parent.add_child(child)
         assert lca(parent, child) is parent
 
     def test_cousins(self) -> None:
         g = Graph()
-        root = TraversableNode(label="root", registry=g)
-        ch1 = TraversableNode(label="ch1", registry=g)
-        ch2 = TraversableNode(label="ch2", registry=g)
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
+        root = _node(g, label="root")
+        ch1 = _node(g, label="ch1")
+        ch2 = _node(g, label="ch2")
+        a = _node(g, label="a")
+        b = _node(g, label="b")
         root.add_child(ch1)
         root.add_child(ch2)
         ch1.add_child(a)
@@ -68,8 +80,8 @@ class TestLCA:
     def test_disjoint_returns_none(self) -> None:
         g1 = Graph()
         g2 = Graph()
-        a = TraversableNode(label="a", registry=g1)
-        b = TraversableNode(label="b", registry=g2)
+        a = _node(g1, label="a")
+        b = _node(g2, label="b")
         assert lca(a, b) is None
 
 
@@ -83,11 +95,11 @@ class TestDecomposeMove:
 
     def test_cross_branch_move(self) -> None:
         g = Graph()
-        root = TraversableNode(label="root", registry=g)
-        ch1 = TraversableNode(label="ch1", registry=g)
-        ch2 = TraversableNode(label="ch2", registry=g)
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
+        root = _node(g, label="root")
+        ch1 = _node(g, label="ch1")
+        ch2 = _node(g, label="ch2")
+        a = _node(g, label="a")
+        b = _node(g, label="b")
         root.add_child(ch1)
         root.add_child(ch2)
         ch1.add_child(a)
@@ -100,9 +112,9 @@ class TestDecomposeMove:
 
     def test_sibling_move(self) -> None:
         g = Graph()
-        parent = TraversableNode(label="p", registry=g)
-        a = TraversableNode(label="a", registry=g)
-        c = TraversableNode(label="c", registry=g)
+        parent = _node(g, label="p")
+        a = _node(g, label="a")
+        c = _node(g, label="c")
         parent.add_child(a)
         parent.add_child(c)
 
@@ -113,8 +125,8 @@ class TestDecomposeMove:
 
     def test_descent_into_child(self) -> None:
         g = Graph()
-        parent = TraversableNode(label="p", registry=g)
-        child = TraversableNode(label="c", registry=g)
+        parent = _node(g, label="p")
+        child = _node(g, label="c")
         parent.add_child(child)
 
         ex, en, pivot = decompose_move(parent, child)
@@ -124,8 +136,8 @@ class TestDecomposeMove:
 
     def test_ascent_to_parent(self) -> None:
         g = Graph()
-        parent = TraversableNode(label="p", registry=g)
-        child = TraversableNode(label="c", registry=g)
+        parent = _node(g, label="p")
+        child = _node(g, label="c")
         parent.add_child(child)
 
         ex, en, pivot = decompose_move(child, parent)
@@ -136,8 +148,8 @@ class TestDecomposeMove:
     def test_disjoint_raises(self) -> None:
         g1 = Graph()
         g2 = Graph()
-        a = TraversableNode(label="a", registry=g1)
-        b = TraversableNode(label="b", registry=g2)
+        a = _node(g1, label="a")
+        b = _node(g2, label="b")
         with pytest.raises(ValueError, match="no common ancestor"):
             decompose_move(a, b)
 
@@ -152,18 +164,18 @@ class TestTraversableNodeLeaf:
 
     def test_leaf_is_not_container(self) -> None:
         g = Graph()
-        node = TraversableNode(label="leaf", registry=g)
+        node = _node(g, label="leaf")
         assert not node.is_container
 
     def test_leaf_enter_raises(self) -> None:
         g = Graph()
-        node = TraversableNode(label="leaf", registry=g)
+        node = _node(g, label="leaf")
         with pytest.raises(ValueError, match="not a container"):
             node.enter()
 
     def test_source_none_for_leaf(self) -> None:
         g = Graph()
-        node = TraversableNode(label="leaf", registry=g)
+        node = _node(g, label="leaf")
         assert node.source is None
 
 
@@ -172,16 +184,16 @@ class TestTraversableNodeContainer:
 
     def test_is_container_when_source_set(self) -> None:
         g = Graph()
-        container = TraversableNode(label="scene", registry=g)
-        entry = TraversableNode(label="entry", registry=g)
+        container = _node(g, label="scene")
+        entry = _node(g, label="entry")
         container.add_child(entry)
         container.source_id = entry.uid
         assert container.is_container
 
     def test_enter_returns_anonymous_edge(self) -> None:
         g = Graph()
-        container = TraversableNode(label="scene", registry=g)
-        entry = TraversableNode(label="entry", registry=g)
+        container = _node(g, label="scene")
+        entry = _node(g, label="entry")
         container.add_child(entry)
         container.source_id = entry.uid
 
@@ -192,9 +204,9 @@ class TestTraversableNodeContainer:
 
     def test_sink_property(self) -> None:
         g = Graph()
-        container = TraversableNode(label="scene", registry=g)
-        entry = TraversableNode(label="entry", registry=g)
-        exit_node = TraversableNode(label="exit", registry=g)
+        container = _node(g, label="scene")
+        entry = _node(g, label="entry")
+        exit_node = _node(g, label="exit")
         container.add_child(entry)
         container.add_child(exit_node)
         container.source_id = entry.uid
@@ -205,8 +217,8 @@ class TestTraversableNodeContainer:
 
     def test_has_forward_progress_stub(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
+        a = _node(g, label="a")
+        b = _node(g, label="b")
         # MVP stub always returns True
         assert a.has_forward_progress(b)
 
@@ -221,29 +233,27 @@ class TestTraversableEdge:
 
     def test_default_phases_are_none(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
-        e = TraversableEdge(registry=g, predecessor_id=a.uid, successor_id=b.uid)
+        a = _node(g, label="a")
+        b = _node(g, label="b")
+        e = _edge(g, predecessor_id=a.uid, successor_id=b.uid)
         assert e.entry_phase is None
         assert e.return_phase is None
         assert e.trigger_phase is None
 
     def test_entry_phase_set(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
-        e = TraversableEdge(
-            registry=g, predecessor_id=a.uid, successor_id=b.uid,
+        a = _node(g, label="a")
+        b = _node(g, label="b")
+        e = _edge(g, predecessor_id=a.uid, successor_id=b.uid,
             entry_phase=ResolutionPhase.UPDATE,
         )
         assert e.entry_phase == ResolutionPhase.UPDATE
 
     def test_call_edge_return(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
-        call = TraversableEdge(
-            registry=g, predecessor_id=a.uid, successor_id=b.uid,
+        a = _node(g, label="a")
+        b = _node(g, label="b")
+        call = _edge(g, predecessor_id=a.uid, successor_id=b.uid,
             return_phase=ResolutionPhase.UPDATE,
         )
         ret = call.get_return_edge()
@@ -253,27 +263,26 @@ class TestTraversableEdge:
 
     def test_non_call_edge_return_raises(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
-        e = TraversableEdge(registry=g, predecessor_id=a.uid, successor_id=b.uid)
+        a = _node(g, label="a")
+        b = _node(g, label="b")
+        e = _edge(g, predecessor_id=a.uid, successor_id=b.uid)
         with pytest.raises(ValueError, match="not a call edge"):
             e.get_return_edge()
 
     def test_trigger_phase_for_auto_redirect(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
-        e = TraversableEdge(
-            registry=g, predecessor_id=a.uid, successor_id=b.uid,
+        a = _node(g, label="a")
+        b = _node(g, label="b")
+        e = _edge(g, predecessor_id=a.uid, successor_id=b.uid,
             trigger_phase=ResolutionPhase.PREREQS,
         )
         assert e.trigger_phase == ResolutionPhase.PREREQS
 
     def test_predecessor_successor_narrowing(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
-        e = TraversableEdge(registry=g, predecessor_id=a.uid, successor_id=b.uid)
+        a = _node(g, label="a")
+        b = _node(g, label="b")
+        e = _edge(g, predecessor_id=a.uid, successor_id=b.uid)
         assert e.predecessor is a
         assert e.successor is b
 
@@ -288,7 +297,7 @@ class TestAnonymousEdge:
 
     def test_minimal_construction(self) -> None:
         g = Graph()
-        b = TraversableNode(label="b", registry=g)
+        b = _node(g, label="b")
         e = AnonymousEdge(successor=b)
         assert e.successor is b
         assert e.predecessor is None
@@ -296,8 +305,8 @@ class TestAnonymousEdge:
 
     def test_full_construction(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
+        a = _node(g, label="a")
+        b = _node(g, label="b")
         e = AnonymousEdge(predecessor=a, successor=b, entry_phase=ResolutionPhase.UPDATE)
         assert e.predecessor is a
         assert e.successor is b
@@ -305,8 +314,8 @@ class TestAnonymousEdge:
 
     def test_repr_includes_labels(self) -> None:
         g = Graph()
-        a = TraversableNode(label="a", registry=g)
-        b = TraversableNode(label="b", registry=g)
+        a = _node(g, label="a")
+        b = _node(g, label="b")
         e = AnonymousEdge(predecessor=a, successor=b)
         r = repr(e)
         assert "a" in r and "b" in r
@@ -314,6 +323,6 @@ class TestAnonymousEdge:
     def test_no_return_phase(self) -> None:
         """AnonymousEdge is never a call edge — no return_phase attribute."""
         g = Graph()
-        b = TraversableNode(label="b", registry=g)
+        b = _node(g, label="b")
         e = AnonymousEdge(successor=b)
         assert not hasattr(e, "return_phase")


### PR DESCRIPTION
### Motivation

- Tests previously relied on constructor-time `registry=` wiring which hid whether entities/edges were actually registered in the active graph/registry and could mask bugs from Pydantic copying/ownership changes.
- Enforce explicit `graph.add(...)` semantics to make registration side-effects clear and ensure test failures reflect engine behavior rather than missing registration.

### Description

- Added local helpers `_node`, `_edge`, and `_dependency` to vm38 test modules and `conftest.py` that instantiate objects and call `graph.add(...)` so tests always register created items explicitly.
- Replaced constructor usages like `TraversableNode(..., registry=g)` and `TraversableEdge(..., registry=g)` with the new helpers across `engine/tests/vm38/*` (including `test_dispatch.py`, `test_frame.py`, `test_ledger.py`, `test_system_handlers.py`, `test_traversable.py`, `test_resolver.py`, and `conftest.py`).
- Updated graph-builder utilities (`make_linear_graph`, `make_branching_graph`, `make_container`) in `conftest.py` to use the helpers and ensure edges/nodes are added to the graph.
- Adjusted resolver/frontier tests to explicitly register `Dependency` instances via `_dependency(...)` so resolution logic is exercised on registered objects.

### Testing

- Ran the vm38 test suite with `poetry run env PYTHONPATH=./engine/src pytest engine/tests/vm38 -q` and verified success.
- Result: `119 passed, 1 xfailed` (no unexpected failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69932d603fc48329baf9c9b1b96c05ef)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure with simplified helper functions for graph construction.
  * Enhanced system handler test fixture registration for more reliable test execution.

* **Chores**
  * Refactored internal test utilities to reduce boilerplate and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->