### PR TITLE
Stabilize vm38.traversable doctests by using assertion-style examples

### DIFF
--- a/engine/src/tangl/vm38/traversable.py
+++ b/engine/src/tangl/vm38/traversable.py
@@ -78,18 +78,15 @@ def lca(a: HierarchicalNode, b: HierarchicalNode) -> Optional[HierarchicalNode]:
 
     Siblings share their parent:
 
-    >>> lca(a, b) is root
-    True
+    >>> assert lca(a, b) is root
 
     Children share the parent:
 
-    >>> lca(ch1, a) is ch1
-    True
+    >>> assert lca(ch1, a) is ch1
 
     Same node:
 
-    >>> lca(a, a) is a
-    True
+    >>> assert lca(a, a) is a
     """
     # ancestors includes self: [a, parent, grandparent, ...]
     ancestors_a = {id(n) for n in a.ancestors}
@@ -132,34 +129,25 @@ def decompose_move(
     Cross-branch move pops one side and pushes the other:
 
     >>> ex, en, pivot = decompose_move(a, b)
-    >>> [n.label for n in ex]
-    ['a', 'ch1']
-    >>> [n.label for n in en]
-    ['ch2', 'b']
-    >>> pivot.label
-    'root'
+    >>> assert [n.label for n in ex] == ["a", "ch1"]
+    >>> assert [n.label for n in en] == ["ch2", "b"]
+    >>> assert pivot.label == "root"
 
     Within-group move only swaps the leaf:
 
     >>> c = TraversableNode(label="c", registry=g)
     >>> ch1.add_child(c)
     >>> ex, en, pivot = decompose_move(a, c)
-    >>> [n.label for n in ex]
-    ['a']
-    >>> [n.label for n in en]
-    ['c']
-    >>> pivot.label
-    'ch1'
+    >>> assert [n.label for n in ex] == ["a"]
+    >>> assert [n.label for n in en] == ["c"]
+    >>> assert pivot.label == "ch1"
 
     Descent into child:
 
     >>> ex, en, pivot = decompose_move(ch1, a)
-    >>> [n.label for n in ex]
-    []
-    >>> [n.label for n in en]
-    ['a']
-    >>> pivot.label
-    'ch1'
+    >>> assert [n.label for n in ex] == []
+    >>> assert [n.label for n in en] == ["a"]
+    >>> assert pivot.label == "ch1"
     """
     pivot = lca(source, target)
     if pivot is None:
@@ -273,13 +261,10 @@ class TraversableNode(HasState, HierarchicalNode):
     >>> container.add_child(snk)
     >>> container.source_id = src.uid
     >>> container.sink_id = snk.uid
-    >>> container.is_container
-    True
+    >>> assert container.is_container
     >>> edge = container.enter()
-    >>> edge.successor is src
-    True
-    >>> edge.predecessor is container
-    True
+    >>> assert edge.successor is src
+    >>> assert edge.predecessor is container
     """
 
     source_id: Optional[UUID] = None
@@ -355,12 +340,9 @@ class TraversableNode(HasState, HierarchicalNode):
         >>> scene.add_child(enter)
         >>> scene.source_id = enter.uid
         >>> edge = scene.enter()
-        >>> edge.successor is enter
-        True
-        >>> edge.predecessor is scene
-        True
-        >>> edge.entry_phase is None
-        True
+        >>> assert edge.successor is enter
+        >>> assert edge.predecessor is scene
+        >>> assert edge.entry_phase is None
         """
         if not self.is_container:
             raise ValueError(f"{self!r} is not a container (source_id is None)")

--- a/engine/tests/vm38/test_traversable.py
+++ b/engine/tests/vm38/test_traversable.py
@@ -9,8 +9,11 @@ Organized by concept:
 
 from __future__ import annotations
 
+import doctest
+
 import pytest
 
+import tangl.vm38.traversable as traversable_module
 from tangl.core38 import Graph
 from tangl.vm38.resolution_phase import ResolutionPhase
 from tangl.vm38.traversable import (
@@ -326,3 +329,22 @@ class TestAnonymousEdge:
         b = _node(g, label="b")
         e = AnonymousEdge(successor=b)
         assert not hasattr(e, "return_phase")
+
+
+# ============================================================================
+# Doctest regression
+# ============================================================================
+
+
+class TestTraversableDocExamples:
+    """Regression coverage for ``traversable`` doctest examples."""
+
+    def test_doctest_examples_run_under_std_runner(self) -> None:
+        finder = doctest.DocTestFinder()
+        runner = doctest.DocTestRunner(optionflags=doctest.ELLIPSIS)
+
+        for test in finder.find(traversable_module):
+            runner.run(test)
+
+        result = runner.summarize(verbose=False)
+        assert result.failed == 0


### PR DESCRIPTION
### Motivation

- Several doctest examples in `tangl.vm38.traversable` were brittle under pytest's doctest execution (expression echo like `True` or raw list/string reprs showed up in captured stdout but were treated as empty by the runner), causing intermittent CI failures.
- The intent is to make the module examples deterministic and robust across doctest runners and pytest configurations by avoiding expression-echo checks.

### Description

- Converted expression-output doctest examples to explicit assertion-style examples in `engine/src/tangl/vm38/traversable.py` (replace `>>> <expr>\nTrue` / repr outputs with `>>> assert <expr>` or `>>> assert ... == [...]`).
- Added a regression test `TestTraversableDocExamples.test_doctest_examples_run_under_std_runner` to `engine/tests/vm38/test_traversable.py` that discovers and runs the module doctests via `doctest.DocTestFinder`/`DocTestRunner` and asserts zero failures.
- Kept examples behavior identical but made them resilient to runner/capture differences.

### Testing

- Ran doctests and unit tests for the modified modules with `poetry run env PYTHONPATH=./engine/src pytest engine/src/tangl/vm38/traversable.py engine/tests/vm38/test_traversable.py -q`, and the test run completed successfully with all tests passing for the affected modules (no failing doctests).
- Also exercised the module doctests with the stdlib `doctest` runner via an inline `doctest.testmod` invocation during local verification and observed the same passing behavior.
- The change was committed after validation and there are no regressions in the touched test modules.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699340d86eac83299c103ba3d066842d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added doctest integration tests for the traversable module to ensure documentation accuracy and reliability.

* **Documentation**
  * Updated documentation examples with improved assertion-based verification patterns for enhanced clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->