### PR TITLE
Codex/sandbox trait contributors

### DIFF
--- a/engine/src/tangl/mechanics/sandbox/README.md
+++ b/engine/src/tangl/mechanics/sandbox/README.md
@@ -20,14 +20,16 @@ Current first-pass surface:
 - `SandboxScope`: a chapter-like ancestor that donates sandbox rules to child
   locations and exposes a lightweight player asset holder.
 - `SandboxLocation`: a `MenuBlock` facade with location links, simple local
-  lockables, and held assets.
+  fixtures, and held assets.
 - `SandboxExit`: an optional structured link declaration for custom egress
   text, message exits, and fixture-gated traversal while preserving the simple
   `direction -> target` table form.
 - `SandboxInventory`: a ready-at-hand `HasAssets` holder used by sandbox scopes
   for player inventory in the first slice.
-- `SandboxLockable`: a tiny local fixture for locked doors, grates, and similar
-  objects that can project unlock choices.
+- `SandboxFixture`: a place-bound object composed from typed facets such as
+  `OpenableFacet` and `LockableFacet`.
+- `OpenableFacet` / `LockableFacet` / `SwitchableFacet` / `LightSourceFacet`:
+  runtime capability surfaces lowered from compact authoring traits.
 - `SandboxMob`: a graph-backed actor-like concept with stable location and
   mutable state that can project affordances when present.
 - `SandboxSliceCompiler`: an experimental compact-slice compiler that lowers
@@ -107,6 +109,9 @@ world concepts, traits, and initial state; reusable sandbox handlers and narrow
 world authorities should turn those declarations into behavior. That keeps
 object declarations as semantic facts like `portable`, `lockable`,
 `provides_light`, or `requires_charge` rather than miniature behavior scripts.
+Those traits are authoring compression: the compiler lowers them into typed
+runtime facets, and handlers project ordinary StoryTangl actions from the
+facets.
 The first executable slice lives in
 `engine/tests/mechanics/test_sandbox_adventure_slice.py` and now runs through
 `SandboxSliceCompiler`. This compiler is intentionally below the full loader

--- a/engine/src/tangl/mechanics/sandbox/README.md
+++ b/engine/src/tangl/mechanics/sandbox/README.md
@@ -28,8 +28,9 @@ Current first-pass surface:
   for player inventory in the first slice.
 - `SandboxFixture`: a place-bound object composed from typed facets such as
   `OpenableFacet` and `LockableFacet`.
-- `OpenableFacet` / `LockableFacet` / `SwitchableFacet` / `LightSourceFacet`:
-  runtime capability surfaces lowered from compact authoring traits.
+- `OpenableFacet` / `LockableFacet` / `SwitchableFacet` / `LightSourceFacet` /
+  `ContainerFacet`: runtime capability surfaces lowered from compact authoring
+  traits.
 - `SandboxMob`: a graph-backed actor-like concept with stable location and
   mutable state that can project affordances when present.
 - `SandboxSliceCompiler`: an experimental compact-slice compiler that lowers
@@ -87,6 +88,14 @@ player inventory. Generated take/drop actions call the normal
 text. This is enough for keys, lamps, leaflets, and treasures in a toy
 Adventure-like subset while leaving graph-backed ownership relations for a
 later asset slice.
+
+Container projection is the first transfer-preflight extension. A
+`ContainerFacet` can sit on a fixture or portable asset. Fixture containers use
+the fixture's open/locked state before exposing contents; portable containers
+carry their own open state. Generated put/take-from actions still move tokens
+through `AssetTransactionManager`, so capacity, trait acceptance, closed
+containers, and the current no-nested-containers rule are transaction policy
+rather than a second inventory path.
 
 Visibility projection is also deliberately modest. A scope or location can
 carry `SandboxVisibilityRule`s. The default rule models Adventure-like darkness:

--- a/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
+++ b/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
@@ -242,8 +242,11 @@ project `Take X` and `Read X`; player-held assets can project `Drop X`; carried
 assets can satisfy generated action availability such as `Unlock grate`.
 Take/drop effects use the story asset transaction manager, not ad hoc locals.
 This is enough for the toy Adventure subset's keys, lamp, leaflet, and
-treasures. Richer object ontologies, containers/supporters, quantities, actor
-inventory, and parser/client matching remain later slices.
+treasures. Container support is intentionally first-slice only:
+`ContainerFacet` can hold discrete assets, enforce count/trait acceptance,
+gate access on open state, and reject nested containers. Richer object
+ontologies, supporters, quantities, actor inventory, and parser/client matching
+remain later slices.
 
 Local fixture projection is similarly narrow. `SandboxFixture` is a place-bound
 object composed from typed facets. `OpenableFacet` owns open/closed state and
@@ -252,6 +255,16 @@ unlock text. Locked fixtures project `Unlock X`; openable fixtures project
 `Open X` or `Close X`; `through` exits can require that fixture to be open.
 This is enough for the key/grate demo without promoting a full fixture ontology
 yet.
+
+Container projection follows the same rule. A fixture can carry a
+`ContainerFacet`, in which case the fixture acts as the holder and the facet
+acts as policy. The fixture's own lock/open state controls whether contents are
+reachable. Portable container assets carry their own `ContainerFacet`; their
+sub-inventory is exposed only while the facet is open. Both paths call
+`AssetTransactionManager`, so "put in" and "take from" are transfer preflight
+problems, not bespoke inventory mutation. For now nested containers are
+rejected by policy to avoid bag-in-bag ambiguity until a relationship-backed
+holding model exists.
 
 Mob projection is the first answer to offscreen actors. `SandboxMob` is a
 graph-backed actor-like concept with a stable sandbox `location`, mutable

--- a/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
+++ b/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
@@ -108,7 +108,7 @@ a second non-sandbox consumer appears:
 - a broader scoped contribution provider that can return actions, journal
   fragments, suppressions, or schedules.
 
-Do not promote location-specific vocabulary such as exits, lockables, darkness,
+Do not promote location-specific vocabulary such as exits, fixtures, darkness,
 or player inventory into VM. Those are sandbox/story-mechanics specializations
 of the broader contribution pattern.
 
@@ -245,12 +245,13 @@ This is enough for the toy Adventure subset's keys, lamp, leaflet, and
 treasures. Richer object ontologies, containers/supporters, quantities, actor
 inventory, and parser/client matching remain later slices.
 
-Local fixture projection is similarly narrow. `SandboxLockable` remains the
-first-spike name, but it now carries enough fixture state for the Adventure
-grate pattern: locked/unlocked, open/closed, openable, key, and journal text.
-Locked fixtures project `Unlock X`; openable fixtures project `Open X` or
-`Close X`; `through` exits can require that fixture to be open. This is enough
-for the key/grate demo without promoting a full fixture ontology yet.
+Local fixture projection is similarly narrow. `SandboxFixture` is a place-bound
+object composed from typed facets. `OpenableFacet` owns open/closed state and
+open/close text; `LockableFacet` owns locked/unlocked state, key policy, and
+unlock text. Locked fixtures project `Unlock X`; openable fixtures project
+`Open X` or `Close X`; `through` exits can require that fixture to be open.
+This is enough for the key/grate demo without promoting a full fixture ontology
+yet.
 
 Mob projection is the first answer to offscreen actors. `SandboxMob` is a
 graph-backed actor-like concept with a stable sandbox `location`, mutable
@@ -428,6 +429,8 @@ Here `portable`, `switchable`, `provides_light`, `requires_charge`,
 object. They are invitations for generic sandbox contributors or
 world-specific authority handlers to publish take/drop, light, timer,
 open/close, lock/unlock, warning, scoring, or diagnostic affordances.
+Traits are authoring compression; facets are the runtime shape; handlers
+project affordances; actions remain the VM contract.
 
 This keeps the authoring surface small:
 

--- a/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
+++ b/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
@@ -249,12 +249,24 @@ ontologies, supporters, quantities, actor inventory, and parser/client matching
 remain later slices.
 
 Local fixture projection is similarly narrow. `SandboxFixture` is a place-bound
-object composed from typed facets. `OpenableFacet` owns open/closed state and
-open/close text; `LockableFacet` owns locked/unlocked state, key policy, and
-unlock text. Locked fixtures project `Unlock X`; openable fixtures project
-`Open X` or `Close X`; `through` exits can require that fixture to be open.
-This is enough for the key/grate demo without promoting a full fixture ontology
-yet.
+object composed from typed facets. This is the shortest correct shape for the
+current slice because it avoids monolithic fixture variants such as
+openable-only, lockable-only, and openable+lockable while still supporting the
+second use case of containers. Implemented facet uses are:
+
+- `OpenableFacet` owns open/closed state and open/close text for the grate and
+  for openable fixture/container surfaces.
+- `LockableFacet` owns locked/unlocked state, key policy, and lock/unlock text
+  for the grate and any other concrete lockable fixture.
+- `ContainerFacet` owns first-slice container policy for fixture containers and
+  portable container assets.
+
+Implemented projection is still modest: locked fixtures project `Unlock X`;
+openable fixtures project `Open X` or `Close X`; `through` exits can require
+that fixture to be open; container facets project simple put/take-from choices
+through the asset transaction manager. Aspirational object work still includes
+richer object ontologies, supporters, quantities, actor inventory, and nested
+containers.
 
 Container projection follows the same rule. A fixture can carry a
 `ContainerFacet`, in which case the fixture acts as the holder and the facet

--- a/engine/src/tangl/mechanics/sandbox/__init__.py
+++ b/engine/src/tangl/mechanics/sandbox/__init__.py
@@ -24,6 +24,7 @@ from .compiler import (
     SandboxSourceSpec,
     SandboxStableMaterializationSpec,
 )
+from .facets import LightSourceFacet, LockableFacet, OpenableFacet, SwitchableFacet
 from .handlers import (
     advance_sandbox_time_on_wait,
     compose_sandbox_visibility_journal,
@@ -40,8 +41,8 @@ from .handlers import (
 from .mob import SandboxMob, SandboxMobAffordance
 from .location import (
     SandboxExit,
+    SandboxFixture,
     SandboxLocation,
-    SandboxLockable,
     normalize_sandbox_direction,
 )
 from .schedule import Schedule, ScheduleEntry, ScheduledEvent, ScheduledPresence
@@ -57,13 +58,16 @@ __all__ = [
     "SandboxExitSpec",
     "SandboxExit",
     "SandboxFixtureSpec",
+    "SandboxFixture",
     "SandboxInventory",
     "SandboxInitialAssetSpec",
     "SandboxInitialFixtureSpec",
     "SandboxInitialMobSpec",
     "SandboxLocation",
     "SandboxLocationSpec",
-    "SandboxLockable",
+    "LightSourceFacet",
+    "LockableFacet",
+    "OpenableFacet",
     "SandboxMaterializationSpec",
     "SandboxMob",
     "SandboxMobActionSpec",
@@ -83,6 +87,7 @@ __all__ = [
     "ScheduleEntry",
     "ScheduledEvent",
     "ScheduledPresence",
+    "SwitchableFacet",
     "WorldTime",
     "advance_sandbox_time_on_wait",
     "advance_world_turn",

--- a/engine/src/tangl/mechanics/sandbox/__init__.py
+++ b/engine/src/tangl/mechanics/sandbox/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from .compiler import (
     SandboxAssetSpec,
+    SandboxContainerSpec,
     SandboxCompiledAssetType,
     SandboxCompiledSlice,
     SandboxDescriptionSpec,
@@ -24,7 +25,13 @@ from .compiler import (
     SandboxSourceSpec,
     SandboxStableMaterializationSpec,
 )
-from .facets import LightSourceFacet, LockableFacet, OpenableFacet, SwitchableFacet
+from .facets import (
+    ContainerFacet,
+    LightSourceFacet,
+    LockableFacet,
+    OpenableFacet,
+    SwitchableFacet,
+)
 from .handlers import (
     advance_sandbox_time_on_wait,
     compose_sandbox_visibility_journal,
@@ -52,6 +59,7 @@ from .visibility import SandboxProjectionState, SandboxVisibilityRule
 
 __all__ = [
     "SandboxAssetSpec",
+    "SandboxContainerSpec",
     "SandboxCompiledAssetType",
     "SandboxCompiledSlice",
     "SandboxDescriptionSpec",
@@ -65,6 +73,7 @@ __all__ = [
     "SandboxInitialMobSpec",
     "SandboxLocation",
     "SandboxLocationSpec",
+    "ContainerFacet",
     "LightSourceFacet",
     "LockableFacet",
     "OpenableFacet",

--- a/engine/src/tangl/mechanics/sandbox/compiler.py
+++ b/engine/src/tangl/mechanics/sandbox/compiler.py
@@ -11,7 +11,13 @@ from tangl.core import Token
 from tangl.story import StoryGraph
 from tangl.story.concepts.asset import AssetType
 
-from .facets import LightSourceFacet, LockableFacet, OpenableFacet, SwitchableFacet
+from .facets import (
+    ContainerFacet,
+    LightSourceFacet,
+    LockableFacet,
+    OpenableFacet,
+    SwitchableFacet,
+)
 from .location import SandboxExit, SandboxFixture, SandboxLocation
 from .mob import SandboxMob, SandboxMobAffordance
 from .scope import SandboxScope
@@ -23,11 +29,16 @@ class SandboxCompiledAssetType(AssetType):
 
     name: str = ""
     kind: str = ""
+    traits: set[str] = Field(default_factory=set)
     portable: bool = False
     readable: bool = False
     read_text: str | None = None
     switchable: SwitchableFacet | None = None
     light_source: LightSourceFacet | None = None
+    container: ContainerFacet | None = Field(
+        default=None,
+        json_schema_extra={"instance_var": True},
+    )
     lit: bool = Field(default=False, json_schema_extra={"instance_var": True})
     charge: int | None = Field(default=None, json_schema_extra={"instance_var": True})
     turn_on_text: str | None = None
@@ -158,6 +169,14 @@ class SandboxInitialAssetSpec(BaseModel):
     state: dict[str, Any] = Field(default_factory=dict)
 
 
+class SandboxContainerSpec(BaseModel):
+    """Container capacity and acceptance hints for compact sandbox entities."""
+
+    max_items: int | None = None
+    accepts_traits: list[str] = Field(default_factory=list)
+    allow_nested_containers: bool = False
+
+
 class SandboxAssetSpec(BaseModel):
     """Authored compact sandbox asset."""
 
@@ -167,6 +186,7 @@ class SandboxAssetSpec(BaseModel):
     kind: str = ""
     traits: list[str] = Field(default_factory=list)
     initial: SandboxInitialAssetSpec
+    capacity: SandboxContainerSpec | None = None
     descriptions: SandboxDescriptionSpec = Field(default_factory=SandboxDescriptionSpec)
     runtime_identity: SandboxRuntimeIdentitySpec = Field(
         default_factory=SandboxRuntimeIdentitySpec
@@ -190,6 +210,7 @@ class SandboxFixtureSpec(BaseModel):
     traits: list[str] = Field(default_factory=list)
     initial: SandboxInitialFixtureSpec = Field(default_factory=SandboxInitialFixtureSpec)
     key: str = "key"
+    capacity: SandboxContainerSpec | None = None
     descriptions: SandboxDescriptionSpec = Field(default_factory=SandboxDescriptionSpec)
     runtime_identity: SandboxRuntimeIdentitySpec = Field(
         default_factory=SandboxRuntimeIdentitySpec
@@ -457,6 +478,7 @@ class SandboxSliceCompiler:
         return {
             "name": spec.name,
             "kind": spec.kind,
+            "traits": set(traits),
             "portable": "portable" in traits,
             "readable": "readable" in traits,
             "switchable": SwitchableFacet() if "switchable" in traits else None,
@@ -464,6 +486,12 @@ class SandboxSliceCompiler:
                 LightSourceFacet(requires_switch="switchable" in traits)
                 if "provides_light" in traits
                 else None
+            ),
+            "container": self._compile_container(
+                traits=traits,
+                state=state,
+                capacity=spec.capacity,
+                descriptions=spec.descriptions,
             ),
             "lit": bool(state.get("lit", False)),
             "charge": state.get("charge"),
@@ -477,6 +505,27 @@ class SandboxSliceCompiler:
             "take_text": spec.descriptions.take,
             "drop_text": spec.descriptions.drop,
         }
+
+    def _compile_container(
+        self,
+        *,
+        traits: set[str],
+        state: dict[str, Any],
+        capacity: SandboxContainerSpec | None,
+        descriptions: SandboxDescriptionSpec,
+    ) -> ContainerFacet | None:
+        if "container" not in traits:
+            return None
+        return ContainerFacet(
+            is_open=bool(state.get("open", True)),
+            max_items=capacity.max_items if capacity else None,
+            accepts_traits=set(capacity.accepts_traits if capacity else []),
+            allow_nested_containers=(
+                bool(capacity.allow_nested_containers) if capacity else False
+            ),
+            open_text=descriptions.open or "Opened.",
+            close_text=descriptions.close or "Closed.",
+        )
 
     def _compile_fixtures(
         self,
@@ -515,6 +564,12 @@ class SandboxSliceCompiler:
                     )
                     if "openable" in traits
                     else None
+                ),
+                container=self._compile_container(
+                    traits=traits,
+                    state=state,
+                    capacity=fixture_spec.capacity,
+                    descriptions=fixture_spec.descriptions,
                 ),
             )
             for location_label in fixture_spec.initial.locations:

--- a/engine/src/tangl/mechanics/sandbox/compiler.py
+++ b/engine/src/tangl/mechanics/sandbox/compiler.py
@@ -11,7 +11,8 @@ from tangl.core import Token
 from tangl.story import StoryGraph
 from tangl.story.concepts.asset import AssetType
 
-from .location import SandboxExit, SandboxLocation, SandboxLockable
+from .facets import LightSourceFacet, LockableFacet, OpenableFacet, SwitchableFacet
+from .location import SandboxExit, SandboxFixture, SandboxLocation
 from .mob import SandboxMob, SandboxMobAffordance
 from .scope import SandboxScope
 from .visibility import SandboxVisibilityRule
@@ -25,7 +26,8 @@ class SandboxCompiledAssetType(AssetType):
     portable: bool = False
     readable: bool = False
     read_text: str | None = None
-    light_source: bool = False
+    switchable: SwitchableFacet | None = None
+    light_source: LightSourceFacet | None = None
     lit: bool = Field(default=False, json_schema_extra={"instance_var": True})
     charge: int | None = Field(default=None, json_schema_extra={"instance_var": True})
     turn_on_text: str | None = None
@@ -266,7 +268,7 @@ class SandboxCompiledSlice:
     scope: SandboxScope
     locations: dict[str, SandboxLocation]
     assets: dict[str, Token]
-    fixtures: dict[str, SandboxLockable]
+    fixtures: dict[str, SandboxFixture]
     mobs: dict[str, SandboxMob]
     materialization: SandboxMaterializationSpec = field(
         default_factory=SandboxMaterializationSpec
@@ -457,7 +459,12 @@ class SandboxSliceCompiler:
             "kind": spec.kind,
             "portable": "portable" in traits,
             "readable": "readable" in traits,
-            "light_source": "provides_light" in traits,
+            "switchable": SwitchableFacet() if "switchable" in traits else None,
+            "light_source": (
+                LightSourceFacet(requires_switch="switchable" in traits)
+                if "provides_light" in traits
+                else None
+            ),
             "lit": bool(state.get("lit", False)),
             "charge": state.get("charge"),
             "read_text": spec.descriptions.examine,
@@ -476,24 +483,39 @@ class SandboxSliceCompiler:
         *,
         locations: dict[str, SandboxLocation],
         spec: SandboxSliceSpec,
-    ) -> dict[str, SandboxLockable]:
-        fixtures: dict[str, SandboxLockable] = {}
+    ) -> dict[str, SandboxFixture]:
+        fixtures: dict[str, SandboxFixture] = {}
         for label, fixture_spec in spec.fixtures.items():
             traits = set(fixture_spec.traits)
             state = fixture_spec.initial.state
-            fixture = SandboxLockable(
+            fixture = SandboxFixture(
                 label=label,
                 name=fixture_spec.name,
-                key=fixture_spec.key,
-                locked=bool(state.get("locked", False)),
-                open=bool(state.get("open", False)),
-                openable="openable" in traits,
-                unlock_text=(
-                    fixture_spec.descriptions.unlock
-                    or f"The key turns with a click. The {label} unlocks."
+                lockable=(
+                    LockableFacet(
+                        key=fixture_spec.key,
+                        is_locked=bool(state.get("locked", False)),
+                        unlock_text=(
+                            fixture_spec.descriptions.unlock
+                            or f"The key turns with a click. The {label} unlocks."
+                        ),
+                    )
+                    if "lockable" in traits
+                    else None
                 ),
-                open_text=fixture_spec.descriptions.open or f"The {label} opens.",
-                close_text=fixture_spec.descriptions.close or f"The {label} closes.",
+                openable=(
+                    OpenableFacet(
+                        is_open=bool(state.get("open", False)),
+                        open_text=(
+                            fixture_spec.descriptions.open or f"The {label} opens."
+                        ),
+                        close_text=(
+                            fixture_spec.descriptions.close or f"The {label} closes."
+                        ),
+                    )
+                    if "openable" in traits
+                    else None
+                ),
             )
             for location_label in fixture_spec.initial.locations:
                 self._require_location(
@@ -502,7 +524,7 @@ class SandboxSliceCompiler:
                     source_kind="Fixture",
                     source_label=label,
                     relation="is placed in",
-                ).lockables.append(fixture)
+                ).fixtures.append(fixture)
             fixtures[label] = fixture
         return fixtures
 

--- a/engine/src/tangl/mechanics/sandbox/facets.py
+++ b/engine/src/tangl/mechanics/sandbox/facets.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Protocol
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+from tangl.core import Token
+from tangl.story.concepts.asset import HasAssets
 
 
 class SwitchState(Protocol):
@@ -99,3 +102,53 @@ class LightSourceFacet(BaseModel):
         if self.requires_switch or switchable is not None:
             return is_on
         return True
+
+
+class ContainerFacet(HasAssets):
+    """Asset holder policy for simple sandbox containers."""
+
+    is_open: bool = True
+    max_items: int | None = None
+    accepts_traits: set[str] = Field(default_factory=set)
+    allow_nested_containers: bool = False
+    open_text: str = "Opened."
+    close_text: str = "Closed."
+    open_action_text: str = ""
+    close_action_text: str = ""
+
+    def can_open(self) -> bool:
+        """Return whether this container can currently open."""
+        return not self.is_open
+
+    def open(self) -> None:
+        """Mark this container open."""
+        self.is_open = True
+
+    def can_close(self) -> bool:
+        """Return whether this container can currently close."""
+        return self.is_open
+
+    def close(self) -> None:
+        """Mark this container closed."""
+        self.is_open = False
+
+    def can_accept_asset(self, asset: Token, *, current_count: int) -> bool:
+        """Return whether this container policy accepts the asset."""
+        if not self.is_open:
+            return False
+        if self.max_items is not None and current_count >= self.max_items:
+            return False
+        asset_traits = asset.traits
+        if not self.allow_nested_containers and "container" in asset_traits:
+            return False
+        return not self.accepts_traits or bool(self.accepts_traits & asset_traits)
+
+    def can_receive_asset(self, asset: Token, giver: HasAssets | None = None) -> bool:
+        """Return whether this container can receive a discrete asset."""
+        _ = giver
+        return self.can_accept_asset(asset, current_count=len(self.assets))
+
+    def can_give_asset(self, asset: Token, receiver: HasAssets | None = None) -> bool:
+        """Return whether this container can release a discrete asset."""
+        _ = receiver
+        return self.is_open and self.has_asset(asset)

--- a/engine/src/tangl/mechanics/sandbox/facets.py
+++ b/engine/src/tangl/mechanics/sandbox/facets.py
@@ -49,7 +49,9 @@ class LockableFacet(BaseModel):
     is_locked: bool = True
     key: str | None = "key"
     unlock_text: str = "The key turns with a click. The lock opens."
+    lock_text: str = "The lock clicks shut."
     unlock_action_text: str = ""
+    lock_action_text: str = ""
 
     def can_unlock(self, *, has_key: Callable[[str], bool]) -> bool:
         """Return whether this facet can currently unlock."""

--- a/engine/src/tangl/mechanics/sandbox/facets.py
+++ b/engine/src/tangl/mechanics/sandbox/facets.py
@@ -1,0 +1,101 @@
+"""Typed sandbox capability facets lowered from compact authoring traits."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Protocol
+
+from pydantic import BaseModel
+
+
+class SwitchState(Protocol):
+    """Mutable on/off state carried by a switchable runtime surface."""
+
+    lit: bool
+
+
+class OpenableFacet(BaseModel):
+    """Open/close state and policy for a sandbox fixture."""
+
+    is_open: bool = False
+    open_text: str = "Opened."
+    close_text: str = "Closed."
+    open_action_text: str = ""
+    close_action_text: str = ""
+
+    def can_open(self, *, locked: bool = False) -> bool:
+        """Return whether this facet can currently open."""
+        return not self.is_open and not locked
+
+    def can_close(self) -> bool:
+        """Return whether this facet can currently close."""
+        return self.is_open
+
+    def open(self) -> None:
+        """Mark this facet open."""
+        self.is_open = True
+
+    def close(self) -> None:
+        """Mark this facet closed."""
+        self.is_open = False
+
+
+class LockableFacet(BaseModel):
+    """Lock/unlock state and key policy for a sandbox fixture."""
+
+    is_locked: bool = True
+    key: str | None = "key"
+    unlock_text: str = "The key turns with a click. The lock opens."
+    unlock_action_text: str = ""
+
+    def can_unlock(self, *, has_key: Callable[[str], bool]) -> bool:
+        """Return whether this facet can currently unlock."""
+        if not self.is_locked:
+            return False
+        return self.key is None or has_key(self.key)
+
+    def unlock(self) -> None:
+        """Mark this facet unlocked."""
+        self.is_locked = False
+
+    def can_lock(self, *, has_key: Callable[[str], bool]) -> bool:
+        """Return whether this facet can currently lock."""
+        if self.is_locked:
+            return False
+        return self.key is None or has_key(self.key)
+
+    def lock(self) -> None:
+        """Mark this facet locked."""
+        self.is_locked = True
+
+
+class SwitchableFacet(BaseModel):
+    """On/off policy for a sandbox asset."""
+
+    def can_switch_on(self, *, is_on: bool) -> bool:
+        """Return whether the surface can switch on."""
+        return not is_on
+
+    def can_switch_off(self, *, is_on: bool) -> bool:
+        """Return whether the surface can switch off."""
+        return is_on
+
+    def switch_on(self, state: SwitchState) -> None:
+        """Switch the supplied state-bearing surface on."""
+        state.lit = True
+
+    def switch_off(self, state: SwitchState) -> None:
+        """Switch the supplied state-bearing surface off."""
+        state.lit = False
+
+
+class LightSourceFacet(BaseModel):
+    """Illumination policy for a sandbox asset."""
+
+    requires_switch: bool = True
+
+    def illuminates(self, *, is_on: bool, switchable: SwitchableFacet | None) -> bool:
+        """Return whether this light source currently illuminates its scope."""
+        if self.requires_switch or switchable is not None:
+            return is_on
+        return True

--- a/engine/src/tangl/mechanics/sandbox/handlers.py
+++ b/engine/src/tangl/mechanics/sandbox/handlers.py
@@ -414,6 +414,12 @@ def _fixture_can_unlock(location: SandboxLocation, label: str) -> bool:
     return bool(fixture and fixture.can_unlock(has_key=lambda key: key in inventory))
 
 
+def _fixture_can_lock(location: SandboxLocation, label: str) -> bool:
+    fixture = _fixture_by_label(location, label)
+    inventory = _sandbox_inventory(location)
+    return bool(fixture and fixture.can_lock(has_key=lambda key: key in inventory))
+
+
 def _fixture_can_open(location: SandboxLocation, label: str) -> bool:
     fixture = _fixture_by_label(location, label)
     inventory = _sandbox_inventory(location)
@@ -703,6 +709,10 @@ def contribute_sandbox_inventory_helpers(*, caller, ctx, **_kw):
             caller,
             str(label),
         ),
+        "sandbox_fixture_can_lock": lambda label: _fixture_can_lock(
+            caller,
+            str(label),
+        ),
         "sandbox_fixture_can_open": lambda label: _fixture_can_open(
             caller,
             str(label),
@@ -980,6 +990,26 @@ def _project_carried_asset_actions(
             )
         if projection_state.suppress_asset_affordances:
             continue
+        read_text = _asset_read_text(asset)
+        if read_text:
+            Action(
+                registry=graph,
+                label=f"sandbox_read_{location.get_label()}_{asset_label}",
+                predecessor_id=location.uid,
+                successor_id=location.uid,
+                text=f"Read {asset_name}",
+                journal_text=read_text,
+                tags={"dynamic", "sandbox", "asset", "read"},
+                ui_hints=_sandbox_contribution_hints(
+                    location,
+                    source="sandbox_asset",
+                    contribution="read",
+                    source_label=asset_label,
+                    source_kind="asset",
+                    verb="read",
+                    asset=asset_label,
+                ),
+            )
         Action(
             registry=graph,
             label=f"sandbox_drop_{location.get_label()}_{asset_label}",
@@ -1201,11 +1231,11 @@ def project_sandbox_asset_actions(*, caller, ctx, **_kw):
         player_assets=player_assets,
         projection_state=projection_state,
     )
+    _project_asset_container_actions(caller, graph=graph, player_assets=player_assets)
     if projection_state.suppress_asset_affordances:
         return None
 
     _project_fixture_container_actions(caller, graph=graph, player_assets=player_assets)
-    _project_asset_container_actions(caller, graph=graph, player_assets=player_assets)
     return None
 
 
@@ -1224,28 +1254,53 @@ def project_sandbox_unlocks(*, caller, ctx, **_kw):
         return None
 
     _clear_dynamic_sandbox_actions(caller, action_kind="unlock", ctx=ctx)
+    _clear_dynamic_sandbox_actions(caller, action_kind="lock", ctx=ctx)
     if _projection_state(caller, ctx).suppress_fixture_affordances:
         return None
 
     for fixture in caller.fixtures:
-        if not fixture.lockable or not fixture.locked:
+        if not fixture.lockable:
+            continue
+        if fixture.locked:
+            Action(
+                registry=graph,
+                label=f"sandbox_unlock_{caller.get_label()}_{fixture.label}",
+                predecessor_id=caller.uid,
+                successor_id=caller.uid,
+                text=fixture.action_text(),
+                availability=[
+                    Predicate(expr=f"sandbox_fixture_can_unlock({fixture.label!r})")
+                ],
+                effects=[Effect(expr=f"_s.unlock_fixture({fixture.label!r})")],
+                journal_text=fixture.unlock_text,
+                tags={"dynamic", "sandbox", "unlock"},
+                ui_hints=_sandbox_contribution_hints(
+                    caller,
+                    source="sandbox_fixture",
+                    contribution="unlock",
+                    source_label=fixture.label,
+                    source_kind="fixture",
+                    target=fixture.label,
+                    key=fixture.key,
+                ),
+            )
             continue
         Action(
             registry=graph,
-            label=f"sandbox_unlock_{caller.get_label()}_{fixture.label}",
+            label=f"sandbox_lock_{caller.get_label()}_{fixture.label}",
             predecessor_id=caller.uid,
             successor_id=caller.uid,
-            text=fixture.action_text(),
+            text=fixture.lock_text_label(),
             availability=[
-                Predicate(expr=f"sandbox_fixture_can_unlock({fixture.label!r})")
+                Predicate(expr=f"sandbox_fixture_can_lock({fixture.label!r})")
             ],
-            effects=[Effect(expr=f"_s.unlock_fixture({fixture.label!r})")],
-            journal_text=fixture.unlock_text,
-            tags={"dynamic", "sandbox", "unlock"},
+            effects=[Effect(expr=f"_s.lock_fixture({fixture.label!r})")],
+            journal_text=fixture.lock_text,
+            tags={"dynamic", "sandbox", "lock"},
             ui_hints=_sandbox_contribution_hints(
                 caller,
                 source="sandbox_fixture",
-                contribution="unlock",
+                contribution="lock",
                 source_label=fixture.label,
                 source_kind="fixture",
                 target=fixture.label,

--- a/engine/src/tangl/mechanics/sandbox/handlers.py
+++ b/engine/src/tangl/mechanics/sandbox/handlers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, Protocol, runtime_checkable
 
-from tangl.core import Selector, Token
+from tangl.core import Graph, Selector, Token
 from tangl.core.behavior import Priority
 from tangl.core.runtime_op import Effect, Predicate
 from tangl.journal.fragments import ContentFragment
@@ -856,79 +856,71 @@ def project_sandbox_location_links(*, caller, ctx, **_kw):
     return None
 
 
-@on_provision(
-    wants_caller_kind=SandboxLocation,
-    wants_exact_kind=False,
-)
-def project_sandbox_asset_actions(*, caller, ctx, **_kw):
-    """Project present and carried assets into ordinary sandbox actions."""
-    if not isinstance(caller, SandboxLocation):
-        return None
-    if not caller.auto_provision:
-        return None
-    graph = getattr(caller, "graph", None)
-    if graph is None or bool(getattr(graph, "frozen_shape", False)):
-        return None
+def _project_location_asset_actions(
+    location: SandboxLocation,
+    *,
+    graph: Graph,
+) -> None:
+    for asset_label, asset in sorted(location.assets.items()):
+        asset_name = _asset_name(asset)
+        if _asset_portable(asset):
+            Action(
+                registry=graph,
+                label=f"sandbox_take_{location.get_label()}_{asset_label}",
+                predecessor_id=location.uid,
+                successor_id=location.uid,
+                text=f"Take {asset_name}",
+                effects=[Effect(expr=f"sandbox_take_asset({asset_label!r})")],
+                journal_text=_asset_take_text(asset),
+                tags={"dynamic", "sandbox", "asset", "take"},
+                ui_hints=_sandbox_contribution_hints(
+                    location,
+                    source="sandbox_asset",
+                    contribution="take",
+                    source_label=asset_label,
+                    source_kind="asset",
+                    verb="take",
+                    asset=asset_label,
+                ),
+            )
+        read_text = _asset_read_text(asset)
+        if read_text:
+            Action(
+                registry=graph,
+                label=f"sandbox_read_{location.get_label()}_{asset_label}",
+                predecessor_id=location.uid,
+                successor_id=location.uid,
+                text=f"Read {asset_name}",
+                journal_text=read_text,
+                tags={"dynamic", "sandbox", "asset", "read"},
+                ui_hints=_sandbox_contribution_hints(
+                    location,
+                    source="sandbox_asset",
+                    contribution="read",
+                    source_label=asset_label,
+                    source_kind="asset",
+                    verb="read",
+                    asset=asset_label,
+                ),
+            )
 
-    _clear_dynamic_sandbox_actions(caller, action_kind="asset", ctx=ctx)
-    projection_state = _projection_state(caller, ctx)
 
-    if not projection_state.suppress_asset_affordances:
-        for asset_label, asset in sorted(caller.assets.items()):
-            asset_name = _asset_name(asset)
-            if _asset_portable(asset):
-                Action(
-                    registry=graph,
-                    label=f"sandbox_take_{caller.get_label()}_{asset_label}",
-                    predecessor_id=caller.uid,
-                    successor_id=caller.uid,
-                    text=f"Take {asset_name}",
-                    effects=[Effect(expr=f"sandbox_take_asset({asset_label!r})")],
-                    journal_text=_asset_take_text(asset),
-                    tags={"dynamic", "sandbox", "asset", "take"},
-                    ui_hints=_sandbox_contribution_hints(
-                        caller,
-                        source="sandbox_asset",
-                        contribution="take",
-                        source_label=asset_label,
-                        source_kind="asset",
-                        verb="take",
-                        asset=asset_label,
-                    ),
-                )
-            read_text = _asset_read_text(asset)
-            if read_text:
-                Action(
-                    registry=graph,
-                    label=f"sandbox_read_{caller.get_label()}_{asset_label}",
-                    predecessor_id=caller.uid,
-                    successor_id=caller.uid,
-                    text=f"Read {asset_name}",
-                    journal_text=read_text,
-                    tags={"dynamic", "sandbox", "asset", "read"},
-                    ui_hints=_sandbox_contribution_hints(
-                        caller,
-                        source="sandbox_asset",
-                        contribution="read",
-                        source_label=asset_label,
-                        source_kind="asset",
-                        verb="read",
-                        asset=asset_label,
-                    ),
-                )
-
-    player_assets = _player_asset_holder(caller)
-    if player_assets is None:
-        return None
+def _project_carried_asset_actions(
+    location: SandboxLocation,
+    *,
+    graph: Graph,
+    player_assets: HasAssets,
+    projection_state: SandboxProjectionState,
+) -> None:
     for asset_label, asset in sorted(player_assets.assets.items()):
         asset_name = _asset_name(asset)
         if _asset_is_switchable(asset):
             lit = _asset_lit(asset)
             Action(
                 registry=graph,
-                label=f"sandbox_light_{caller.get_label()}_{asset_label}",
-                predecessor_id=caller.uid,
-                successor_id=caller.uid,
+                label=f"sandbox_light_{location.get_label()}_{asset_label}",
+                predecessor_id=location.uid,
+                successor_id=location.uid,
                 text=f"Turn {'off' if lit else 'on'} {asset_name}",
                 effects=[
                     Effect(
@@ -939,10 +931,12 @@ def project_sandbox_asset_actions(*, caller, ctx, **_kw):
                         )
                     )
                 ],
-                journal_text=_asset_turn_off_text(asset) if lit else _asset_turn_on_text(asset),
+                journal_text=(
+                    _asset_turn_off_text(asset) if lit else _asset_turn_on_text(asset)
+                ),
                 tags={"dynamic", "sandbox", "asset", "light"},
                 ui_hints=_sandbox_contribution_hints(
-                    caller,
+                    location,
                     source="sandbox_asset",
                     contribution="light",
                     source_label=asset_label,
@@ -955,9 +949,9 @@ def project_sandbox_asset_actions(*, caller, ctx, **_kw):
             is_open = asset.container.is_open
             Action(
                 registry=graph,
-                label=f"sandbox_container_toggle_{caller.get_label()}_{asset_label}",
-                predecessor_id=caller.uid,
-                successor_id=caller.uid,
+                label=f"sandbox_container_toggle_{location.get_label()}_{asset_label}",
+                predecessor_id=location.uid,
+                successor_id=location.uid,
                 text=_asset_container_action_text(asset),
                 effects=[
                     Effect(
@@ -975,7 +969,7 @@ def project_sandbox_asset_actions(*, caller, ctx, **_kw):
                 ),
                 tags={"dynamic", "sandbox", "asset", "container"},
                 ui_hints=_sandbox_contribution_hints(
-                    caller,
+                    location,
                     source="sandbox_asset",
                     contribution="container",
                     source_label=asset_label,
@@ -984,30 +978,36 @@ def project_sandbox_asset_actions(*, caller, ctx, **_kw):
                     asset=asset_label,
                 ),
             )
-        if not projection_state.suppress_asset_affordances:
-            Action(
-                registry=graph,
-                label=f"sandbox_drop_{caller.get_label()}_{asset_label}",
-                predecessor_id=caller.uid,
-                successor_id=caller.uid,
-                text=f"Drop {asset_name}",
-                effects=[Effect(expr=f"sandbox_drop_asset({asset_label!r})")],
-                journal_text=_asset_drop_text(asset),
-                tags={"dynamic", "sandbox", "asset", "drop"},
-                ui_hints=_sandbox_contribution_hints(
-                    caller,
-                    source="sandbox_asset",
-                    contribution="drop",
-                    source_label=asset_label,
-                    source_kind="asset",
-                    verb="drop",
-                    asset=asset_label,
-                ),
-            )
-    if projection_state.suppress_asset_affordances:
-        return None
+        if projection_state.suppress_asset_affordances:
+            continue
+        Action(
+            registry=graph,
+            label=f"sandbox_drop_{location.get_label()}_{asset_label}",
+            predecessor_id=location.uid,
+            successor_id=location.uid,
+            text=f"Drop {asset_name}",
+            effects=[Effect(expr=f"sandbox_drop_asset({asset_label!r})")],
+            journal_text=_asset_drop_text(asset),
+            tags={"dynamic", "sandbox", "asset", "drop"},
+            ui_hints=_sandbox_contribution_hints(
+                location,
+                source="sandbox_asset",
+                contribution="drop",
+                source_label=asset_label,
+                source_kind="asset",
+                verb="drop",
+                asset=asset_label,
+            ),
+        )
 
-    for fixture in caller.fixtures:
+
+def _project_fixture_container_actions(
+    location: SandboxLocation,
+    *,
+    graph: Graph,
+    player_assets: HasAssets,
+) -> None:
+    for fixture in location.fixtures:
         if fixture.container is None:
             continue
         for asset_label, asset in sorted(player_assets.assets.items()):
@@ -1015,11 +1015,11 @@ def project_sandbox_asset_actions(*, caller, ctx, **_kw):
             Action(
                 registry=graph,
                 label=(
-                    f"sandbox_put_{caller.get_label()}_{asset_label}_"
+                    f"sandbox_put_{location.get_label()}_{asset_label}_"
                     f"in_{fixture.label}"
                 ),
-                predecessor_id=caller.uid,
-                successor_id=caller.uid,
+                predecessor_id=location.uid,
+                successor_id=location.uid,
                 text=f"Put {asset_name} in {fixture.name or fixture.label}",
                 availability=[
                     Predicate(
@@ -1040,7 +1040,7 @@ def project_sandbox_asset_actions(*, caller, ctx, **_kw):
                 journal_text="Done.",
                 tags={"dynamic", "sandbox", "asset", "container", "put"},
                 ui_hints=_sandbox_contribution_hints(
-                    caller,
+                    location,
                     source="sandbox_fixture",
                     contribution="put",
                     source_label=fixture.label,
@@ -1056,11 +1056,11 @@ def project_sandbox_asset_actions(*, caller, ctx, **_kw):
             Action(
                 registry=graph,
                 label=(
-                    f"sandbox_take_{caller.get_label()}_{asset_label}_"
+                    f"sandbox_take_{location.get_label()}_{asset_label}_"
                     f"from_{fixture.label}"
                 ),
-                predecessor_id=caller.uid,
-                successor_id=caller.uid,
+                predecessor_id=location.uid,
+                successor_id=location.uid,
                 text=f"Take {asset_name} from {fixture.name or fixture.label}",
                 effects=[
                     Effect(
@@ -1073,7 +1073,7 @@ def project_sandbox_asset_actions(*, caller, ctx, **_kw):
                 journal_text=_asset_take_text(asset),
                 tags={"dynamic", "sandbox", "asset", "container", "take"},
                 ui_hints=_sandbox_contribution_hints(
-                    caller,
+                    location,
                     source="sandbox_fixture",
                     contribution="take_from_container",
                     source_label=fixture.label,
@@ -1083,6 +1083,13 @@ def project_sandbox_asset_actions(*, caller, ctx, **_kw):
                 ),
             )
 
+
+def _project_asset_container_actions(
+    location: SandboxLocation,
+    *,
+    graph: Graph,
+    player_assets: HasAssets,
+) -> None:
     for container_label, container_asset in sorted(player_assets.assets.items()):
         container = container_asset.container
         if container is None:
@@ -1095,11 +1102,11 @@ def project_sandbox_asset_actions(*, caller, ctx, **_kw):
             Action(
                 registry=graph,
                 label=(
-                    f"sandbox_put_{caller.get_label()}_{asset_label}_"
+                    f"sandbox_put_{location.get_label()}_{asset_label}_"
                     f"in_{container_label}"
                 ),
-                predecessor_id=caller.uid,
-                successor_id=caller.uid,
+                predecessor_id=location.uid,
+                successor_id=location.uid,
                 text=f"Put {asset_name} in {container_name}",
                 availability=[
                     Predicate(
@@ -1120,7 +1127,7 @@ def project_sandbox_asset_actions(*, caller, ctx, **_kw):
                 journal_text="Done.",
                 tags={"dynamic", "sandbox", "asset", "container", "put"},
                 ui_hints=_sandbox_contribution_hints(
-                    caller,
+                    location,
                     source="sandbox_asset",
                     contribution="put",
                     source_label=container_label,
@@ -1137,11 +1144,11 @@ def project_sandbox_asset_actions(*, caller, ctx, **_kw):
             Action(
                 registry=graph,
                 label=(
-                    f"sandbox_take_{caller.get_label()}_{asset_label}_"
+                    f"sandbox_take_{location.get_label()}_{asset_label}_"
                     f"from_{container_label}"
                 ),
-                predecessor_id=caller.uid,
-                successor_id=caller.uid,
+                predecessor_id=location.uid,
+                successor_id=location.uid,
                 text=f"Take {asset_name} from {container_name}",
                 effects=[
                     Effect(
@@ -1154,7 +1161,7 @@ def project_sandbox_asset_actions(*, caller, ctx, **_kw):
                 journal_text=_asset_take_text(asset),
                 tags={"dynamic", "sandbox", "asset", "container", "take"},
                 ui_hints=_sandbox_contribution_hints(
-                    caller,
+                    location,
                     source="sandbox_asset",
                     contribution="take_from_container",
                     source_label=container_label,
@@ -1163,6 +1170,42 @@ def project_sandbox_asset_actions(*, caller, ctx, **_kw):
                     target=container_label,
                 ),
             )
+
+
+@on_provision(
+    wants_caller_kind=SandboxLocation,
+    wants_exact_kind=False,
+)
+def project_sandbox_asset_actions(*, caller, ctx, **_kw):
+    """Project present and carried assets into ordinary sandbox actions."""
+    if not isinstance(caller, SandboxLocation):
+        return None
+    if not caller.auto_provision:
+        return None
+    graph = getattr(caller, "graph", None)
+    if graph is None or bool(getattr(graph, "frozen_shape", False)):
+        return None
+
+    _clear_dynamic_sandbox_actions(caller, action_kind="asset", ctx=ctx)
+    projection_state = _projection_state(caller, ctx)
+
+    if not projection_state.suppress_asset_affordances:
+        _project_location_asset_actions(caller, graph=graph)
+
+    player_assets = _player_asset_holder(caller)
+    if player_assets is None:
+        return None
+    _project_carried_asset_actions(
+        caller,
+        graph=graph,
+        player_assets=player_assets,
+        projection_state=projection_state,
+    )
+    if projection_state.suppress_asset_affordances:
+        return None
+
+    _project_fixture_container_actions(caller, graph=graph, player_assets=player_assets)
+    _project_asset_container_actions(caller, graph=graph, player_assets=player_assets)
     return None
 
 

--- a/engine/src/tangl/mechanics/sandbox/handlers.py
+++ b/engine/src/tangl/mechanics/sandbox/handlers.py
@@ -14,10 +14,11 @@ from tangl.story.concepts.asset import AssetTransactionManager, HasAssets
 from tangl.vm import ResolutionPhase, TraversableNode, VmPhaseCtx, on_provision, on_update
 from tangl.vm.dispatch import on_compose_journal, on_gather_ns
 
+from .facets import LightSourceFacet, SwitchableFacet
 from .location import (
     SandboxExit,
+    SandboxFixture,
     SandboxLocation,
-    SandboxLockable,
     normalize_sandbox_direction,
 )
 from .mob import SandboxMob
@@ -56,7 +57,8 @@ class SandboxAssetSurface(Protocol):
     portable: bool
     readable: bool
     read_text: str | None
-    light_source: bool
+    switchable: SwitchableFacet | None
+    light_source: LightSourceFacet | None
     lit: bool
     turn_on_text: str | None
     turn_off_text: str | None
@@ -94,8 +96,18 @@ def _asset_lit(asset: SandboxAssetSurface) -> bool:
     return asset.lit
 
 
-def _asset_is_light_source(asset: SandboxAssetSurface) -> bool:
-    return asset.light_source
+def _asset_is_switchable(asset: SandboxAssetSurface) -> bool:
+    return asset.switchable is not None
+
+
+def _asset_illuminates(asset: SandboxAssetSurface) -> bool:
+    return bool(
+        asset.light_source
+        and asset.light_source.illuminates(
+            is_on=asset.lit,
+            switchable=asset.switchable,
+        )
+    )
 
 
 def _asset_turn_on_text(asset: SandboxAssetSurface) -> str:
@@ -349,21 +361,38 @@ def _visibility_rules(location: SandboxLocation) -> list[SandboxVisibilityRule]:
     return rules
 
 
-def _lockable_by_label(location: SandboxLocation, label: str) -> SandboxLockable | None:
-    for lockable in location.lockables:
-        if lockable.label == label:
-            return lockable
+def _fixture_by_label(location: SandboxLocation, label: str) -> SandboxFixture | None:
+    for fixture in location.fixtures:
+        if fixture.label == label:
+            return fixture
     return None
 
 
-def _lockable_locked(location: SandboxLocation, label: str) -> bool:
-    lockable = _lockable_by_label(location, label)
-    return bool(lockable and lockable.locked)
+def _fixture_locked(location: SandboxLocation, label: str) -> bool:
+    fixture = _fixture_by_label(location, label)
+    return bool(fixture and fixture.locked)
 
 
-def _lockable_open(location: SandboxLocation, label: str) -> bool:
-    lockable = _lockable_by_label(location, label)
-    return bool(lockable and lockable.open)
+def _fixture_open(location: SandboxLocation, label: str) -> bool:
+    fixture = _fixture_by_label(location, label)
+    return bool(fixture and fixture.open)
+
+
+def _fixture_can_unlock(location: SandboxLocation, label: str) -> bool:
+    fixture = _fixture_by_label(location, label)
+    inventory = _sandbox_inventory(location)
+    return bool(fixture and fixture.can_unlock(has_key=lambda key: key in inventory))
+
+
+def _fixture_can_open(location: SandboxLocation, label: str) -> bool:
+    fixture = _fixture_by_label(location, label)
+    inventory = _sandbox_inventory(location)
+    return bool(fixture and fixture.can_open(has_key=lambda key: key in inventory))
+
+
+def _fixture_can_close(location: SandboxLocation, label: str) -> bool:
+    fixture = _fixture_by_label(location, label)
+    return bool(fixture and fixture.can_close())
 
 
 def _player_asset_holder(location: SandboxLocation) -> HasAssets | None:
@@ -389,10 +418,7 @@ def _asset_inventory(holder: HasAssets | None) -> set[str]:
 def _holder_has_lit_light_source(holder: HasAssets | None) -> bool:
     if holder is None:
         return False
-    return any(
-        _asset_is_light_source(asset) and _asset_lit(asset)
-        for asset in holder.assets.values()
-    )
+    return any(_asset_illuminates(asset) for asset in holder.assets.values())
 
 
 def _location_lit(location: SandboxLocation) -> bool:
@@ -498,7 +524,12 @@ def _set_asset_lit(location: SandboxLocation, asset_label: str, lit: bool) -> To
     asset = player_assets.get_asset(asset_label)
     if asset is None:
         raise KeyError(asset_label)
-    asset.lit = lit
+    if asset.switchable is None:
+        raise ValueError(f"Asset {asset_label!r} is not switchable")
+    if lit:
+        asset.switchable.switch_on(asset)
+    else:
+        asset.switchable.switch_off(asset)
     return asset
 
 
@@ -526,8 +557,20 @@ def contribute_sandbox_inventory_helpers(*, caller, ctx, **_kw):
     return {
         "sandbox_inventory": inventory,
         "sandbox_has_key": lambda key: str(key) in inventory,
-        "sandbox_fixture_locked": lambda label: _lockable_locked(caller, str(label)),
-        "sandbox_fixture_open": lambda label: _lockable_open(caller, str(label)),
+        "sandbox_fixture_locked": lambda label: _fixture_locked(caller, str(label)),
+        "sandbox_fixture_open": lambda label: _fixture_open(caller, str(label)),
+        "sandbox_fixture_can_unlock": lambda label: _fixture_can_unlock(
+            caller,
+            str(label),
+        ),
+        "sandbox_fixture_can_open": lambda label: _fixture_can_open(
+            caller,
+            str(label),
+        ),
+        "sandbox_fixture_can_close": lambda label: _fixture_can_close(
+            caller,
+            str(label),
+        ),
         "sandbox_take_asset": lambda asset_label: _take_asset(caller, str(asset_label)),
         "sandbox_drop_asset": lambda asset_label: _drop_asset(caller, str(asset_label)),
         "sandbox_turn_on_asset": lambda asset_label: _set_asset_lit(
@@ -690,7 +733,7 @@ def project_sandbox_asset_actions(*, caller, ctx, **_kw):
         return None
     for asset_label, asset in sorted(player_assets.assets.items()):
         asset_name = _asset_name(asset)
-        if _asset_is_light_source(asset):
+        if _asset_is_switchable(asset):
             lit = _asset_lit(asset)
             Action(
                 registry=graph,
@@ -760,27 +803,29 @@ def project_sandbox_unlocks(*, caller, ctx, **_kw):
     if _projection_state(caller, ctx).suppress_fixture_affordances:
         return None
 
-    for lockable in caller.lockables:
-        if not lockable.locked:
+    for fixture in caller.fixtures:
+        if not fixture.lockable or not fixture.locked:
             continue
         Action(
             registry=graph,
-            label=f"sandbox_unlock_{caller.get_label()}_{lockable.label}",
+            label=f"sandbox_unlock_{caller.get_label()}_{fixture.label}",
             predecessor_id=caller.uid,
             successor_id=caller.uid,
-            text=lockable.action_text(),
-            availability=[Predicate(expr=f"sandbox_has_key({lockable.key!r})")],
-            effects=[Effect(expr=f"_s.unlock_lockable({lockable.label!r})")],
-            journal_text=lockable.unlock_text,
+            text=fixture.action_text(),
+            availability=[
+                Predicate(expr=f"sandbox_fixture_can_unlock({fixture.label!r})")
+            ],
+            effects=[Effect(expr=f"_s.unlock_fixture({fixture.label!r})")],
+            journal_text=fixture.unlock_text,
             tags={"dynamic", "sandbox", "unlock"},
             ui_hints=_sandbox_contribution_hints(
                 caller,
-                source="sandbox_lockable",
+                source="sandbox_fixture",
                 contribution="unlock",
-                source_label=lockable.label,
+                source_label=fixture.label,
                 source_kind="fixture",
-                target=lockable.label,
-                key=lockable.key,
+                target=fixture.label,
+                key=fixture.key,
             ),
         )
     return None
@@ -804,46 +849,49 @@ def project_sandbox_fixture_actions(*, caller, ctx, **_kw):
     if _projection_state(caller, ctx).suppress_fixture_affordances:
         return None
 
-    for lockable in caller.lockables:
-        if not lockable.openable:
+    for fixture in caller.fixtures:
+        if fixture.openable is None:
             continue
-        if lockable.open:
+        if fixture.open:
             Action(
                 registry=graph,
-                label=f"sandbox_close_{caller.get_label()}_{lockable.label}",
+                label=f"sandbox_close_{caller.get_label()}_{fixture.label}",
                 predecessor_id=caller.uid,
                 successor_id=caller.uid,
-                text=lockable.close_text_label(),
-                effects=[Effect(expr=f"_s.close_lockable({lockable.label!r})")],
-                journal_text=lockable.close_text,
+                text=fixture.close_text_label(),
+                availability=[
+                    Predicate(expr=f"sandbox_fixture_can_close({fixture.label!r})")
+                ],
+                effects=[Effect(expr=f"_s.close_fixture({fixture.label!r})")],
+                journal_text=fixture.close_text,
                 tags={"dynamic", "sandbox", "fixture", "close"},
                 ui_hints=_sandbox_contribution_hints(
                     caller,
-                    source="sandbox_lockable",
+                    source="sandbox_fixture",
                     contribution="close",
-                    source_label=lockable.label,
+                    source_label=fixture.label,
                     source_kind="fixture",
-                    target=lockable.label,
+                    target=fixture.label,
                 ),
             )
             continue
         Action(
             registry=graph,
-            label=f"sandbox_open_{caller.get_label()}_{lockable.label}",
+            label=f"sandbox_open_{caller.get_label()}_{fixture.label}",
             predecessor_id=caller.uid,
             successor_id=caller.uid,
-            text=lockable.open_text_label(),
-            availability=[Predicate(expr=f"not sandbox_fixture_locked({lockable.label!r})")],
-            effects=[Effect(expr=f"_s.open_lockable({lockable.label!r})")],
-            journal_text=lockable.open_text,
+            text=fixture.open_text_label(),
+            availability=[Predicate(expr=f"sandbox_fixture_can_open({fixture.label!r})")],
+            effects=[Effect(expr=f"_s.open_fixture({fixture.label!r})")],
+            journal_text=fixture.open_text,
             tags={"dynamic", "sandbox", "fixture", "open"},
             ui_hints=_sandbox_contribution_hints(
                 caller,
-                source="sandbox_lockable",
+                source="sandbox_fixture",
                 contribution="open",
-                source_label=lockable.label,
+                source_label=fixture.label,
                 source_kind="fixture",
-                target=lockable.label,
+                target=fixture.label,
             ),
         )
     return None

--- a/engine/src/tangl/mechanics/sandbox/handlers.py
+++ b/engine/src/tangl/mechanics/sandbox/handlers.py
@@ -14,7 +14,7 @@ from tangl.story.concepts.asset import AssetTransactionManager, HasAssets
 from tangl.vm import ResolutionPhase, TraversableNode, VmPhaseCtx, on_provision, on_update
 from tangl.vm.dispatch import on_compose_journal, on_gather_ns
 
-from .facets import LightSourceFacet, SwitchableFacet
+from .facets import ContainerFacet, LightSourceFacet, SwitchableFacet
 from .location import (
     SandboxExit,
     SandboxFixture,
@@ -54,11 +54,13 @@ class SandboxAssetSurface(Protocol):
 
     token_from: str
     name: str
+    traits: set[str]
     portable: bool
     readable: bool
     read_text: str | None
     switchable: SwitchableFacet | None
     light_source: LightSourceFacet | None
+    container: ContainerFacet | None
     lit: bool
     turn_on_text: str | None
     turn_off_text: str | None
@@ -100,6 +102,10 @@ def _asset_is_switchable(asset: SandboxAssetSurface) -> bool:
     return asset.switchable is not None
 
 
+def _asset_is_container(asset: SandboxAssetSurface) -> bool:
+    return asset.container is not None
+
+
 def _asset_illuminates(asset: SandboxAssetSurface) -> bool:
     return bool(
         asset.light_source
@@ -128,6 +134,30 @@ def _asset_take_text(asset: SandboxAssetSurface) -> str:
 
 def _asset_drop_text(asset: SandboxAssetSurface) -> str:
     return asset.drop_text or "Dropped."
+
+
+def _asset_container_open_text(asset: SandboxAssetSurface) -> str:
+    container = asset.container
+    if container and container.open_text:
+        return container.open_text
+    return "Opened."
+
+
+def _asset_container_close_text(asset: SandboxAssetSurface) -> str:
+    container = asset.container
+    if container and container.close_text:
+        return container.close_text
+    return "Closed."
+
+
+def _asset_container_action_text(asset: SandboxAssetSurface) -> str:
+    container = asset.container
+    asset_name = _asset_name(asset)
+    if container and container.is_open:
+        return container.close_action_text or f"Close {asset_name}"
+    if container:
+        return container.open_action_text or f"Open {asset_name}"
+    return f"Open {asset_name}"
 
 
 def _clear_dynamic_sandbox_actions(
@@ -395,6 +425,19 @@ def _fixture_can_close(location: SandboxLocation, label: str) -> bool:
     return bool(fixture and fixture.can_close())
 
 
+def _fixture_can_receive_asset(
+    location: SandboxLocation,
+    fixture_label: str,
+    asset_label: str,
+) -> bool:
+    fixture = _fixture_by_label(location, fixture_label)
+    player_assets = _player_asset_holder(location)
+    if fixture is None or player_assets is None:
+        return False
+    asset = player_assets.get_asset(asset_label)
+    return bool(asset and fixture.can_receive_asset(asset, player_assets))
+
+
 def _player_asset_holder(location: SandboxLocation) -> HasAssets | None:
     for candidate in location.ancestors:
         if isinstance(candidate, SandboxScope):
@@ -503,6 +546,23 @@ def _sandbox_inventory(location: SandboxLocation) -> set[str]:
     return _asset_inventory(_player_asset_holder(location))
 
 
+def _player_asset(location: SandboxLocation, asset_label: str) -> Token | None:
+    player_assets = _player_asset_holder(location)
+    if player_assets is None:
+        return None
+    return player_assets.get_asset(asset_label)
+
+
+def _player_asset_container(
+    location: SandboxLocation,
+    container_label: str,
+) -> ContainerFacet | None:
+    asset = _player_asset(location, container_label)
+    if asset is None:
+        return None
+    return asset.container
+
+
 def _take_asset(location: SandboxLocation, asset_label: str) -> Token:
     player_assets = _player_asset_holder(location)
     if player_assets is None:
@@ -515,6 +575,86 @@ def _drop_asset(location: SandboxLocation, asset_label: str) -> Token:
     if player_assets is None:
         raise ValueError("sandbox location has no player asset holder")
     return AssetTransactionManager().give_asset(player_assets, location, asset_label)
+
+
+def _put_asset_in_fixture(
+    location: SandboxLocation,
+    fixture_label: str,
+    asset_label: str,
+) -> Token:
+    player_assets = _player_asset_holder(location)
+    if player_assets is None:
+        raise ValueError("sandbox location has no player asset holder")
+    fixture = location.fixture_by_label(fixture_label)
+    return AssetTransactionManager().give_asset(player_assets, fixture, asset_label)
+
+
+def _take_asset_from_fixture(
+    location: SandboxLocation,
+    fixture_label: str,
+    asset_label: str,
+) -> Token:
+    player_assets = _player_asset_holder(location)
+    if player_assets is None:
+        raise ValueError("sandbox location has no player asset holder")
+    fixture = location.fixture_by_label(fixture_label)
+    return AssetTransactionManager().give_asset(fixture, player_assets, asset_label)
+
+
+def _asset_container_can_receive(
+    location: SandboxLocation,
+    container_label: str,
+    asset_label: str,
+) -> bool:
+    container = _player_asset_container(location, container_label)
+    asset = _player_asset(location, asset_label)
+    return bool(container and asset and container.can_receive_asset(asset))
+
+
+def _put_asset_in_asset_container(
+    location: SandboxLocation,
+    container_label: str,
+    asset_label: str,
+) -> Token:
+    player_assets = _player_asset_holder(location)
+    if player_assets is None:
+        raise ValueError("sandbox location has no player asset holder")
+    container = _player_asset_container(location, container_label)
+    if container is None:
+        raise ValueError(f"Asset {container_label!r} is not a container")
+    return AssetTransactionManager().give_asset(player_assets, container, asset_label)
+
+
+def _take_asset_from_asset_container(
+    location: SandboxLocation,
+    container_label: str,
+    asset_label: str,
+) -> Token:
+    player_assets = _player_asset_holder(location)
+    if player_assets is None:
+        raise ValueError("sandbox location has no player asset holder")
+    container = _player_asset_container(location, container_label)
+    if container is None:
+        raise ValueError(f"Asset {container_label!r} is not a container")
+    return AssetTransactionManager().give_asset(container, player_assets, asset_label)
+
+
+def _set_asset_container_open(
+    location: SandboxLocation,
+    container_label: str,
+    is_open: bool,
+) -> Token:
+    asset = _player_asset(location, container_label)
+    if asset is None:
+        raise KeyError(container_label)
+    container = asset.container
+    if container is None:
+        raise ValueError(f"Asset {container_label!r} is not a container")
+    if is_open:
+        container.open()
+    else:
+        container.close()
+    return asset
 
 
 def _set_asset_lit(location: SandboxLocation, asset_label: str, lit: bool) -> Token:
@@ -571,8 +711,57 @@ def contribute_sandbox_inventory_helpers(*, caller, ctx, **_kw):
             caller,
             str(label),
         ),
+        "sandbox_fixture_can_receive_asset": (
+            lambda fixture_label, asset_label: _fixture_can_receive_asset(
+                caller,
+                str(fixture_label),
+                str(asset_label),
+            )
+        ),
         "sandbox_take_asset": lambda asset_label: _take_asset(caller, str(asset_label)),
         "sandbox_drop_asset": lambda asset_label: _drop_asset(caller, str(asset_label)),
+        "sandbox_put_asset_in_fixture": (
+            lambda fixture_label, asset_label: _put_asset_in_fixture(
+                caller,
+                str(fixture_label),
+                str(asset_label),
+            )
+        ),
+        "sandbox_take_asset_from_fixture": (
+            lambda fixture_label, asset_label: _take_asset_from_fixture(
+                caller,
+                str(fixture_label),
+                str(asset_label),
+            )
+        ),
+        "sandbox_asset_container_can_receive": (
+            lambda container_label, asset_label: _asset_container_can_receive(
+                caller,
+                str(container_label),
+                str(asset_label),
+            )
+        ),
+        "sandbox_put_asset_in_asset_container": (
+            lambda container_label, asset_label: _put_asset_in_asset_container(
+                caller,
+                str(container_label),
+                str(asset_label),
+            )
+        ),
+        "sandbox_take_asset_from_asset_container": (
+            lambda container_label, asset_label: _take_asset_from_asset_container(
+                caller,
+                str(container_label),
+                str(asset_label),
+            )
+        ),
+        "sandbox_set_asset_container_open": (
+            lambda container_label, is_open: _set_asset_container_open(
+                caller,
+                str(container_label),
+                bool(is_open),
+            )
+        ),
         "sandbox_turn_on_asset": lambda asset_label: _set_asset_lit(
             caller,
             str(asset_label),
@@ -762,6 +951,39 @@ def project_sandbox_asset_actions(*, caller, ctx, **_kw):
                     asset=asset_label,
                 ),
             )
+        if _asset_is_container(asset):
+            is_open = asset.container.is_open
+            Action(
+                registry=graph,
+                label=f"sandbox_container_toggle_{caller.get_label()}_{asset_label}",
+                predecessor_id=caller.uid,
+                successor_id=caller.uid,
+                text=_asset_container_action_text(asset),
+                effects=[
+                    Effect(
+                        expr=(
+                            f"sandbox_set_asset_container_open({asset_label!r}, False)"
+                            if is_open
+                            else f"sandbox_set_asset_container_open({asset_label!r}, True)"
+                        )
+                    )
+                ],
+                journal_text=(
+                    _asset_container_close_text(asset)
+                    if is_open
+                    else _asset_container_open_text(asset)
+                ),
+                tags={"dynamic", "sandbox", "asset", "container"},
+                ui_hints=_sandbox_contribution_hints(
+                    caller,
+                    source="sandbox_asset",
+                    contribution="container",
+                    source_label=asset_label,
+                    source_kind="asset",
+                    verb="close" if is_open else "open",
+                    asset=asset_label,
+                ),
+            )
         if not projection_state.suppress_asset_affordances:
             Action(
                 registry=graph,
@@ -780,6 +1002,165 @@ def project_sandbox_asset_actions(*, caller, ctx, **_kw):
                     source_kind="asset",
                     verb="drop",
                     asset=asset_label,
+                ),
+            )
+    if projection_state.suppress_asset_affordances:
+        return None
+
+    for fixture in caller.fixtures:
+        if fixture.container is None:
+            continue
+        for asset_label, asset in sorted(player_assets.assets.items()):
+            asset_name = _asset_name(asset)
+            Action(
+                registry=graph,
+                label=(
+                    f"sandbox_put_{caller.get_label()}_{asset_label}_"
+                    f"in_{fixture.label}"
+                ),
+                predecessor_id=caller.uid,
+                successor_id=caller.uid,
+                text=f"Put {asset_name} in {fixture.name or fixture.label}",
+                availability=[
+                    Predicate(
+                        expr=(
+                            "sandbox_fixture_can_receive_asset("
+                            f"{fixture.label!r}, {asset_label!r})"
+                        )
+                    )
+                ],
+                effects=[
+                    Effect(
+                        expr=(
+                            f"sandbox_put_asset_in_fixture({fixture.label!r}, "
+                            f"{asset_label!r})"
+                        )
+                    )
+                ],
+                journal_text="Done.",
+                tags={"dynamic", "sandbox", "asset", "container", "put"},
+                ui_hints=_sandbox_contribution_hints(
+                    caller,
+                    source="sandbox_fixture",
+                    contribution="put",
+                    source_label=fixture.label,
+                    source_kind="fixture",
+                    asset=asset_label,
+                    target=fixture.label,
+                ),
+            )
+        if not fixture.container_accessible():
+            continue
+        for asset_label, asset in sorted(fixture.assets.items()):
+            asset_name = _asset_name(asset)
+            Action(
+                registry=graph,
+                label=(
+                    f"sandbox_take_{caller.get_label()}_{asset_label}_"
+                    f"from_{fixture.label}"
+                ),
+                predecessor_id=caller.uid,
+                successor_id=caller.uid,
+                text=f"Take {asset_name} from {fixture.name or fixture.label}",
+                effects=[
+                    Effect(
+                        expr=(
+                            f"sandbox_take_asset_from_fixture({fixture.label!r}, "
+                            f"{asset_label!r})"
+                        )
+                    )
+                ],
+                journal_text=_asset_take_text(asset),
+                tags={"dynamic", "sandbox", "asset", "container", "take"},
+                ui_hints=_sandbox_contribution_hints(
+                    caller,
+                    source="sandbox_fixture",
+                    contribution="take_from_container",
+                    source_label=fixture.label,
+                    source_kind="fixture",
+                    asset=asset_label,
+                    target=fixture.label,
+                ),
+            )
+
+    for container_label, container_asset in sorted(player_assets.assets.items()):
+        container = container_asset.container
+        if container is None:
+            continue
+        for asset_label, asset in sorted(player_assets.assets.items()):
+            if asset_label == container_label:
+                continue
+            asset_name = _asset_name(asset)
+            container_name = _asset_name(container_asset)
+            Action(
+                registry=graph,
+                label=(
+                    f"sandbox_put_{caller.get_label()}_{asset_label}_"
+                    f"in_{container_label}"
+                ),
+                predecessor_id=caller.uid,
+                successor_id=caller.uid,
+                text=f"Put {asset_name} in {container_name}",
+                availability=[
+                    Predicate(
+                        expr=(
+                            "sandbox_asset_container_can_receive("
+                            f"{container_label!r}, {asset_label!r})"
+                        )
+                    )
+                ],
+                effects=[
+                    Effect(
+                        expr=(
+                            "sandbox_put_asset_in_asset_container("
+                            f"{container_label!r}, {asset_label!r})"
+                        )
+                    )
+                ],
+                journal_text="Done.",
+                tags={"dynamic", "sandbox", "asset", "container", "put"},
+                ui_hints=_sandbox_contribution_hints(
+                    caller,
+                    source="sandbox_asset",
+                    contribution="put",
+                    source_label=container_label,
+                    source_kind="asset",
+                    asset=asset_label,
+                    target=container_label,
+                ),
+            )
+        if not container.is_open:
+            continue
+        for asset_label, asset in sorted(container.assets.items()):
+            asset_name = _asset_name(asset)
+            container_name = _asset_name(container_asset)
+            Action(
+                registry=graph,
+                label=(
+                    f"sandbox_take_{caller.get_label()}_{asset_label}_"
+                    f"from_{container_label}"
+                ),
+                predecessor_id=caller.uid,
+                successor_id=caller.uid,
+                text=f"Take {asset_name} from {container_name}",
+                effects=[
+                    Effect(
+                        expr=(
+                            "sandbox_take_asset_from_asset_container("
+                            f"{container_label!r}, {asset_label!r})"
+                        )
+                    )
+                ],
+                journal_text=_asset_take_text(asset),
+                tags={"dynamic", "sandbox", "asset", "container", "take"},
+                ui_hints=_sandbox_contribution_hints(
+                    caller,
+                    source="sandbox_asset",
+                    contribution="take_from_container",
+                    source_label=container_label,
+                    source_kind="asset",
+                    asset=asset_label,
+                    target=container_label,
                 ),
             )
     return None

--- a/engine/src/tangl/mechanics/sandbox/location.py
+++ b/engine/src/tangl/mechanics/sandbox/location.py
@@ -120,12 +120,16 @@ class SandboxFixture(HasAssets):
         """Return whether the fixture can currently lock."""
         if self.lockable is None:
             return False
+        if self.openable is not None and self.openable.is_open:
+            return False
         return self.lockable.can_lock(has_key=has_key)
 
     def lock(self) -> None:
         """Lock the fixture."""
         if self.lockable is None:
             raise ValueError(f"Fixture {self.label!r} is not lockable")
+        if self.openable is not None and self.openable.is_open:
+            raise ValueError(f"Fixture {self.label!r} cannot lock while open")
         self.lockable.lock()
 
     def can_open(self, *, has_key: Callable[[str], bool]) -> bool:

--- a/engine/src/tangl/mechanics/sandbox/location.py
+++ b/engine/src/tangl/mechanics/sandbox/location.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -10,6 +11,7 @@ from tangl.core import contribute_ns
 from tangl.story import MenuBlock
 from tangl.story.concepts.asset import HasAssets
 
+from .facets import LockableFacet, OpenableFacet
 from .schedule import ScheduledEvent
 from .visibility import SandboxVisibilityRule
 
@@ -48,36 +50,107 @@ class SandboxExit(BaseModel):
     through: str | None = None
 
 
-class SandboxLockable(BaseModel):
-    """Minimal lockable local fixture projected into sandbox choices."""
+class SandboxFixture(BaseModel):
+    """Place-bound sandbox fixture composed from typed capability facets."""
 
     label: str
     name: str = ""
-    key: str = "key"
-    locked: bool = True
-    openable: bool = False
-    open: bool = False
-    unlock_text: str = "The key turns with a click. The lock opens."
-    unlock_action_text: str = ""
-    open_text: str = "Opened."
-    close_text: str = "Closed."
-    open_action_text: str = ""
-    close_action_text: str = ""
+    openable: OpenableFacet | None = None
+    lockable: LockableFacet | None = None
+
+    @property
+    def locked(self) -> bool:
+        """Return whether the fixture is currently locked."""
+        return bool(self.lockable and self.lockable.is_locked)
+
+    @property
+    def open(self) -> bool:
+        """Return whether the fixture is currently open."""
+        return bool(self.openable and self.openable.is_open)
+
+    @property
+    def key(self) -> str | None:
+        """Return the key label required by the lock, if any."""
+        if self.lockable is None:
+            return None
+        return self.lockable.key
 
     def action_text(self) -> str:
         """Return player-facing unlock action text."""
         target_name = self.name or self.label
-        return self.unlock_action_text or f"Unlock {target_name}"
+        if self.lockable and self.lockable.unlock_action_text:
+            return self.lockable.unlock_action_text
+        return f"Unlock {target_name}"
 
     def open_text_label(self) -> str:
         """Return player-facing open action text."""
         target_name = self.name or self.label
-        return self.open_action_text or f"Open {target_name}"
+        if self.openable and self.openable.open_action_text:
+            return self.openable.open_action_text
+        return f"Open {target_name}"
 
     def close_text_label(self) -> str:
         """Return player-facing close action text."""
         target_name = self.name or self.label
-        return self.close_action_text or f"Close {target_name}"
+        if self.openable and self.openable.close_action_text:
+            return self.openable.close_action_text
+        return f"Close {target_name}"
+
+    def can_unlock(self, *, has_key: Callable[[str], bool]) -> bool:
+        """Return whether the fixture can currently unlock."""
+        if self.lockable is None:
+            return False
+        return self.lockable.can_unlock(has_key=has_key)
+
+    def unlock(self) -> None:
+        """Unlock the fixture."""
+        if self.lockable is None:
+            raise ValueError(f"Fixture {self.label!r} is not lockable")
+        self.lockable.unlock()
+
+    def can_open(self, *, has_key: Callable[[str], bool]) -> bool:
+        """Return whether the fixture can currently open."""
+        _ = has_key
+        if self.openable is None:
+            return False
+        return self.openable.can_open(locked=self.locked)
+
+    def open_fixture(self) -> None:
+        """Open the fixture."""
+        if self.openable is None:
+            raise ValueError(f"Fixture {self.label!r} is not openable")
+        self.openable.open()
+
+    def can_close(self) -> bool:
+        """Return whether the fixture can currently close."""
+        return bool(self.openable and self.openable.can_close())
+
+    def close(self) -> None:
+        """Close the fixture."""
+        if self.openable is None:
+            raise ValueError(f"Fixture {self.label!r} is not openable")
+        self.openable.close()
+
+    @property
+    def unlock_text(self) -> str:
+        """Return journal text for unlocking."""
+        if self.lockable is None:
+            return ""
+        return self.lockable.unlock_text
+
+    @property
+    def open_text(self) -> str:
+        """Return journal text for opening."""
+        if self.openable is None:
+            return ""
+        return self.openable.open_text
+
+    @property
+    def close_text(self) -> str:
+        """Return journal text for closing."""
+        if self.openable is None:
+            return ""
+        return self.openable.close_text
 
 
 class SandboxLocation(HasAssets, MenuBlock):
@@ -85,7 +158,7 @@ class SandboxLocation(HasAssets, MenuBlock):
 
     links: dict[str, str | SandboxExit] = Field(default_factory=dict)
     scheduled_events: list[ScheduledEvent] = Field(default_factory=list)
-    lockables: list[SandboxLockable] = Field(default_factory=list)
+    fixtures: list[SandboxFixture] = Field(default_factory=list)
     visibility_rules: list[SandboxVisibilityRule] = Field(default_factory=list)
     sandbox_scope: str | None = None
     location_name: str = ""
@@ -95,29 +168,30 @@ class SandboxLocation(HasAssets, MenuBlock):
     wait_text: str | None = None
     wait_turn_delta: int | None = None
 
-    def unlock_lockable(self, label: str) -> SandboxLockable:
-        """Unlock and return the named lockable object."""
-        for lockable in self.lockables:
-            if lockable.label == label:
-                lockable.locked = False
-                return lockable
-        raise KeyError(f"Unknown lockable: {label}")
+    def fixture_by_label(self, label: str) -> SandboxFixture:
+        """Return the named local fixture."""
+        for fixture in self.fixtures:
+            if fixture.label == label:
+                return fixture
+        raise KeyError(f"Unknown fixture: {label}")
 
-    def open_lockable(self, label: str) -> SandboxLockable:
-        """Open and return the named lockable object."""
-        for lockable in self.lockables:
-            if lockable.label == label:
-                lockable.open = True
-                return lockable
-        raise KeyError(f"Unknown lockable: {label}")
+    def unlock_fixture(self, label: str) -> SandboxFixture:
+        """Unlock and return the named fixture."""
+        fixture = self.fixture_by_label(label)
+        fixture.unlock()
+        return fixture
 
-    def close_lockable(self, label: str) -> SandboxLockable:
-        """Close and return the named lockable object."""
-        for lockable in self.lockables:
-            if lockable.label == label:
-                lockable.open = False
-                return lockable
-        raise KeyError(f"Unknown lockable: {label}")
+    def open_fixture(self, label: str) -> SandboxFixture:
+        """Open and return the named fixture."""
+        fixture = self.fixture_by_label(label)
+        fixture.open_fixture()
+        return fixture
+
+    def close_fixture(self, label: str) -> SandboxFixture:
+        """Close and return the named fixture."""
+        fixture = self.fixture_by_label(label)
+        fixture.close()
+        return fixture
 
     @contribute_ns
     def provide_sandbox_location_symbols(self) -> dict[str, Any]:
@@ -126,7 +200,7 @@ class SandboxLocation(HasAssets, MenuBlock):
             "current_location": self,
             "current_location_label": self.get_label(),
             "current_location_name": self.location_name or self.get_label(),
-            "sandbox_lockables": {lockable.label: lockable for lockable in self.lockables},
+            "sandbox_fixtures": {fixture.label: fixture for fixture in self.fixtures},
         }
         if self.sandbox_scope:
             payload["sandbox_scope"] = self.sandbox_scope

--- a/engine/src/tangl/mechanics/sandbox/location.py
+++ b/engine/src/tangl/mechanics/sandbox/location.py
@@ -7,11 +7,11 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
-from tangl.core import contribute_ns
+from tangl.core import Token, contribute_ns
 from tangl.story import MenuBlock
 from tangl.story.concepts.asset import HasAssets
 
-from .facets import LockableFacet, OpenableFacet
+from .facets import ContainerFacet, LockableFacet, OpenableFacet
 from .schedule import ScheduledEvent
 from .visibility import SandboxVisibilityRule
 
@@ -50,13 +50,14 @@ class SandboxExit(BaseModel):
     through: str | None = None
 
 
-class SandboxFixture(BaseModel):
+class SandboxFixture(HasAssets):
     """Place-bound sandbox fixture composed from typed capability facets."""
 
     label: str
     name: str = ""
     openable: OpenableFacet | None = None
     lockable: LockableFacet | None = None
+    container: ContainerFacet | None = None
 
     @property
     def locked(self) -> bool:
@@ -130,6 +131,28 @@ class SandboxFixture(BaseModel):
         if self.openable is None:
             raise ValueError(f"Fixture {self.label!r} is not openable")
         self.openable.close()
+
+    def container_accessible(self) -> bool:
+        """Return whether the fixture's container contents are reachable."""
+        if self.container is None:
+            return False
+        if self.locked:
+            return False
+        if self.openable is not None and not self.open:
+            return False
+        return True
+
+    def can_receive_asset(self, asset: Token, giver: HasAssets | None = None) -> bool:
+        """Return whether this fixture can receive a discrete asset."""
+        _ = giver
+        if self.container is None or not self.container_accessible():
+            return False
+        return self.container.can_accept_asset(asset, current_count=len(self.assets))
+
+    def can_give_asset(self, asset: Token, receiver: HasAssets | None = None) -> bool:
+        """Return whether this fixture can release a discrete asset."""
+        _ = receiver
+        return self.container_accessible() and self.has_asset(asset)
 
     @property
     def unlock_text(self) -> str:

--- a/engine/src/tangl/mechanics/sandbox/location.py
+++ b/engine/src/tangl/mechanics/sandbox/location.py
@@ -83,6 +83,13 @@ class SandboxFixture(HasAssets):
             return self.lockable.unlock_action_text
         return f"Unlock {target_name}"
 
+    def lock_text_label(self) -> str:
+        """Return player-facing lock action text."""
+        target_name = self.name or self.label
+        if self.lockable and self.lockable.lock_action_text:
+            return self.lockable.lock_action_text
+        return f"Lock {target_name}"
+
     def open_text_label(self) -> str:
         """Return player-facing open action text."""
         target_name = self.name or self.label
@@ -109,6 +116,18 @@ class SandboxFixture(HasAssets):
             raise ValueError(f"Fixture {self.label!r} is not lockable")
         self.lockable.unlock()
 
+    def can_lock(self, *, has_key: Callable[[str], bool]) -> bool:
+        """Return whether the fixture can currently lock."""
+        if self.lockable is None:
+            return False
+        return self.lockable.can_lock(has_key=has_key)
+
+    def lock(self) -> None:
+        """Lock the fixture."""
+        if self.lockable is None:
+            raise ValueError(f"Fixture {self.label!r} is not lockable")
+        self.lockable.lock()
+
     def can_open(self, *, has_key: Callable[[str], bool]) -> bool:
         """Return whether the fixture can currently open."""
         _ = has_key
@@ -121,16 +140,20 @@ class SandboxFixture(HasAssets):
         if self.openable is None:
             raise ValueError(f"Fixture {self.label!r} is not openable")
         self.openable.open()
+        if self.container is not None:
+            self.container.open()
 
     def can_close(self) -> bool:
         """Return whether the fixture can currently close."""
         return bool(self.openable and self.openable.can_close())
 
-    def close(self) -> None:
+    def close_fixture(self) -> None:
         """Close the fixture."""
         if self.openable is None:
             raise ValueError(f"Fixture {self.label!r} is not openable")
         self.openable.close()
+        if self.container is not None:
+            self.container.close()
 
     def container_accessible(self) -> bool:
         """Return whether the fixture's container contents are reachable."""
@@ -139,6 +162,8 @@ class SandboxFixture(HasAssets):
         if self.locked:
             return False
         if self.openable is not None and not self.open:
+            return False
+        if self.openable is None and not self.container.is_open:
             return False
         return True
 
@@ -152,7 +177,9 @@ class SandboxFixture(HasAssets):
     def can_give_asset(self, asset: Token, receiver: HasAssets | None = None) -> bool:
         """Return whether this fixture can release a discrete asset."""
         _ = receiver
-        return self.container_accessible() and self.has_asset(asset)
+        if self.container is None or not self.container_accessible():
+            return False
+        return self.has_asset(asset)
 
     @property
     def unlock_text(self) -> str:
@@ -160,6 +187,13 @@ class SandboxFixture(HasAssets):
         if self.lockable is None:
             return ""
         return self.lockable.unlock_text
+
+    @property
+    def lock_text(self) -> str:
+        """Return journal text for locking."""
+        if self.lockable is None:
+            return ""
+        return self.lockable.lock_text
 
     @property
     def open_text(self) -> str:
@@ -204,6 +238,12 @@ class SandboxLocation(HasAssets, MenuBlock):
         fixture.unlock()
         return fixture
 
+    def lock_fixture(self, label: str) -> SandboxFixture:
+        """Lock and return the named fixture."""
+        fixture = self.fixture_by_label(label)
+        fixture.lock()
+        return fixture
+
     def open_fixture(self, label: str) -> SandboxFixture:
         """Open and return the named fixture."""
         fixture = self.fixture_by_label(label)
@@ -213,7 +253,7 @@ class SandboxLocation(HasAssets, MenuBlock):
     def close_fixture(self, label: str) -> SandboxFixture:
         """Close and return the named fixture."""
         fixture = self.fixture_by_label(label)
-        fixture.close()
+        fixture.close_fixture()
         return fixture
 
     @contribute_ns

--- a/engine/src/tangl/story/concepts/asset/ASSET_DESIGN.md
+++ b/engine/src/tangl/story/concepts/asset/ASSET_DESIGN.md
@@ -10,6 +10,8 @@ They are not a separate inventory engine.
 This package currently defines:
 
 - `AssetType`: a singleton definition for tokenizable, lightly stateful assets.
+  It includes a small `traits` set for story/mechanics layers that need
+  semantic acceptance checks.
 - `CountableAsset`: a fungible asset definition tracked by quantity.
 - `AssetWallet`: a compact counter for fungible assets.
 - `HasAssets`: a story-level facet for nodes that hold wallet counts and
@@ -46,6 +48,11 @@ relationship-backed shape is:
 - inventory affordances are projected from the current cursor namespace plus
   ready-at-hand holders such as the player avatar.
 
+The sandbox package currently uses `ContainerFacet` as a mechanics-level
+holder/policy object for first-slice container behavior. That is intentionally
+not the final ownership model; it is a compact way to pressure-test transfer
+preflight before promoting container membership into graph relationships.
+
 The holding relation should be built as a general relationship mechanism, not
 as asset-only code. The old `Associating` and `Connection` scratch designs are
 better prior art for relationship preflight and acceptance than for inventory
@@ -77,9 +84,9 @@ The current slice is intentionally sufficient for sandbox affordance
 experiments, not a complete inventory system.
 
 - `HasAssets.assets` is a holder-local map, not yet a graph-backed ownership
-  subgraph. It is good enough for "player has key" checks, but not enough for
-  full persistence of container membership, room inventories, or ownership
-  history.
+  subgraph. It is good enough for "player has key" checks and first-slice
+  sandbox containers, but not enough for full persistence of room inventories
+  or ownership history.
 - Discrete transfers currently move tokens between holder maps. Slice 2 should
   replace or back this with a first-class holding relation so graph topology is
   the source of truth.

--- a/engine/src/tangl/story/concepts/asset/ASSET_DESIGN.md
+++ b/engine/src/tangl/story/concepts/asset/ASSET_DESIGN.md
@@ -53,6 +53,39 @@ holder/policy object for first-slice container behavior. That is intentionally
 not the final ownership model; it is a compact way to pressure-test transfer
 preflight before promoting container membership into graph relationships.
 
+### ContainerFacet Validation Criteria
+
+Keep `ContainerFacet` as an experimental mechanics-level holder until it proves
+the following against sandbox examples:
+
+- fixture containers and portable asset containers both use the same
+  `AssetTransactionManager` preflight path;
+- closed or locked containers reject receive/release attempts without partial
+  mutation;
+- count capacity, trait acceptance, and the current no-nested-containers rule
+  are expressible without special-case action code;
+- generated affordances can explain source, target, and rejection through
+  ordinary action availability and `ui_hints`;
+- the Adventure cage/chest pressure tests remain deterministic under replay.
+
+### Migration Plan
+
+The target model is a graph-relationship ownership/holding relation. Promote to
+that model once sandbox needs persisted container membership across broader
+graph operations, actor inventories, or nested/ambiguous containment. The
+migration should:
+
+1. Add a general holding relation with preflight/acceptance hooks, not an
+   asset-only edge type.
+2. Move `HasAssets.assets` storage behind that relation while preserving the
+   same `HasAssets` public holder methods.
+3. Teach `AssetTransactionManager` to mutate holding edges instead of holder
+   maps.
+4. Update sandbox container callers to use the relationship-backed holder
+   surface directly.
+5. Remove `ContainerFacet`'s holder-map responsibility, leaving only container
+   policy fields or deleting the facet if the relation owns all needed policy.
+
 The holding relation should be built as a general relationship mechanism, not
 as asset-only code. The old `Associating` and `Connection` scratch designs are
 better prior art for relationship preflight and acceptance than for inventory

--- a/engine/src/tangl/story/concepts/asset/asset_type.py
+++ b/engine/src/tangl/story/concepts/asset/asset_type.py
@@ -18,6 +18,7 @@ class AssetType(InstanceInheritance):
 
     value: float = 0.0
     description: str | None = None
+    traits: set[str] = Field(default_factory=set)
 
     def __init__(
         self,

--- a/engine/tests/mechanics/test_sandbox.py
+++ b/engine/tests/mechanics/test_sandbox.py
@@ -445,6 +445,53 @@ def test_locked_local_object_unlocks_with_carried_key_and_stops_projecting() -> 
     assert cave_entrance.fixtures[0].locked is True
 
 
+def test_open_fixture_cannot_lock_until_closed() -> None:
+    graph = StoryGraph(label="tiny_cave")
+    scope = SandboxScope(label="tiny_cave_scope")
+    cave_entrance = SandboxLocation(
+        label="cave_entrance",
+        location_name="Cave Entrance",
+        fixtures=[
+            SandboxFixture(
+                label="grate",
+                name="grate",
+                openable=OpenableFacet(is_open=True),
+                lockable=LockableFacet(key="keys", is_locked=False),
+            )
+        ],
+    )
+    SandboxItemType(label="keys", name="keys")
+    keys = Token[SandboxItemType](token_from="keys", label="keys")
+    scope.player_assets.add_asset(keys)
+    graph.add(scope)
+    graph.add(cave_entrance)
+    graph.add(keys)
+    scope.add_child(cave_entrance)
+    ctx = PhaseCtx(graph=graph, cursor_id=cave_entrance.uid)
+
+    do_provision(cave_entrance, ctx=ctx)
+
+    lock = _dynamic_sandbox_actions_with_tag(cave_entrance, "lock")[0]
+    fragments = render_block_choices(caller=cave_entrance, ctx=ctx)
+    choices = [fragment for fragment in fragments or [] if isinstance(fragment, ChoiceFragment)]
+    lock_choice = next(choice for choice in choices if choice.text == "Lock grate")
+
+    assert lock_choice.available is False
+    assert cave_entrance.fixtures[0].can_lock(has_key=lambda key: key == "keys") is False
+    with pytest.raises(ValueError, match="Fixture 'grate' cannot lock while open"):
+        cave_entrance.lock_fixture("grate")
+
+    ledger = Ledger.from_graph(graph, entry_id=cave_entrance.uid)
+    close = _dynamic_sandbox_actions_with_tag(cave_entrance, "close")[0]
+    ledger.resolve_choice(close.uid)
+
+    do_provision(cave_entrance, ctx=PhaseCtx(graph=graph, cursor_id=cave_entrance.uid))
+    closed_lock = _dynamic_sandbox_actions_with_tag(cave_entrance, "lock")[0]
+    ledger.resolve_choice(closed_lock.uid)
+
+    assert cave_entrance.fixtures[0].locked is True
+
+
 def test_locked_local_object_unlocks_with_key_asset_in_player_inventory() -> None:
     graph = StoryGraph(label="tiny_cave")
     scope = SandboxScope(label="tiny_cave_scope")

--- a/engine/tests/mechanics/test_sandbox.py
+++ b/engine/tests/mechanics/test_sandbox.py
@@ -438,6 +438,11 @@ def test_locked_local_object_unlocks_with_carried_key_and_stops_projecting() -> 
 
     do_provision(cave_entrance, ctx=PhaseCtx(graph=graph, cursor_id=cave_entrance.uid))
     assert _dynamic_sandbox_actions_with_tag(cave_entrance, "unlock") == []
+    lock = _dynamic_sandbox_actions_with_tag(cave_entrance, "lock")[0]
+
+    ledger.resolve_choice(lock.uid)
+
+    assert cave_entrance.fixtures[0].locked is True
 
 
 def test_locked_local_object_unlocks_with_key_asset_in_player_inventory() -> None:
@@ -549,6 +554,31 @@ def test_location_assets_project_take_read_and_drop_actions() -> None:
     assert not scope.player_assets.has_asset("keys")
 
 
+def test_carried_readable_asset_projects_read_action() -> None:
+    graph = StoryGraph(label="tiny_cave")
+    scope = SandboxScope(label="tiny_cave_scope")
+    building = SandboxLocation(label="building", location_name="Building")
+    SandboxItemType(
+        label="leaflet",
+        name="leaflet",
+        readable=True,
+        read_text="Welcome to Adventure!",
+    )
+    leaflet = Token[SandboxItemType](token_from="leaflet", label="leaflet")
+    scope.player_assets.add_asset(leaflet)
+    graph.add(scope)
+    graph.add(building)
+    graph.add(leaflet)
+    scope.add_child(building)
+    ctx = PhaseCtx(graph=graph, cursor_id=building.uid)
+
+    do_provision(building, ctx=ctx)
+
+    actions = _dynamic_sandbox_actions_with_tag(building, "asset")
+    read = next(action for action in actions if action.text == "Read leaflet")
+    assert read.journal_text == "Welcome to Adventure!"
+
+
 def test_fixture_container_accepts_matching_assets_through_preflight() -> None:
     graph = StoryGraph(label="tiny_cave")
     scope = SandboxScope(label="tiny_cave_scope")
@@ -606,7 +636,7 @@ def test_closed_fixture_container_hides_contents_and_rejects_receive() -> None:
         label="chest",
         name="chest",
         openable=OpenableFacet(is_open=False),
-        container=ContainerFacet(accepts_traits={"tiny"}),
+        container=ContainerFacet(is_open=False, accepts_traits={"tiny"}),
     )
     building = SandboxLocation(
         label="building",
@@ -634,6 +664,30 @@ def test_closed_fixture_container_hides_contents_and_rejects_receive() -> None:
 
     assert put_keys.available is False
     assert "Take coin from chest" not in {action.text for action in actions}
+
+    fixture_actions = _dynamic_sandbox_actions_with_tag(building, "fixture")
+    open_chest = next(action for action in fixture_actions if action.text == "Open chest")
+    ledger = Ledger(graph=graph, cursor_id=building.uid)
+    ledger.resolve_choice(open_chest.uid)
+
+    assert chest.open is True
+    assert chest.container.is_open is True
+
+    do_provision(building, ctx=PhaseCtx(graph=graph, cursor_id=building.uid))
+    opened_actions = _dynamic_sandbox_actions_with_tag(building, "container")
+    fragments = render_block_choices(
+        caller=building,
+        ctx=PhaseCtx(graph=graph, cursor_id=building.uid),
+    )
+    opened_choices = [
+        fragment for fragment in fragments or [] if isinstance(fragment, ChoiceFragment)
+    ]
+    opened_put_keys = next(
+        choice for choice in opened_choices if choice.text == "Put keys in chest"
+    )
+
+    assert opened_put_keys.available is True
+    assert "Take coin from chest" in {action.text for action in opened_actions}
 
 
 def test_portable_container_rejects_nested_container_without_mutation() -> None:
@@ -698,6 +752,55 @@ def test_portable_container_open_state_controls_contained_asset_projection() -> 
     closed_actions = _dynamic_sandbox_actions_with_tag(building, "container")
     assert "Take keys from cage" not in {action.text for action in closed_actions}
     assert "Open cage" in {action.text for action in closed_actions}
+
+
+def test_light_source_inside_carried_container_can_be_reached_in_darkness() -> None:
+    graph = StoryGraph(label="tiny_cave")
+    scope = SandboxScope(
+        label="tiny_cave_scope",
+        visibility_rules=[
+            SandboxVisibilityRule(journal_text="It is now pitch dark.")
+        ],
+    )
+    cave = SandboxLocation(label="dark_cave", location_name="Dark Cave")
+    SandboxItemType(
+        label="bag",
+        name="bag",
+        traits={"container"},
+        container=ContainerFacet(),
+    )
+    SandboxItemType(
+        label="lamp",
+        name="lamp",
+        switchable=SwitchableFacet(),
+        light_source=LightSourceFacet(),
+    )
+    bag = Token[SandboxItemType](token_from="bag", label="bag")
+    lamp = Token[SandboxItemType](token_from="lamp", label="lamp")
+    bag.container.add_asset(lamp)
+    scope.player_assets.add_asset(bag)
+    graph.add(scope)
+    graph.add(cave)
+    graph.add(bag)
+    graph.add(lamp)
+    scope.add_child(cave)
+    ctx = PhaseCtx(graph=graph, cursor_id=cave.uid)
+
+    do_provision(cave, ctx=ctx)
+    actions = _dynamic_sandbox_actions_with_tag(cave, "container")
+
+    assert "Take lamp from bag" in {action.text for action in actions}
+
+    take_lamp = next(action for action in actions if action.text == "Take lamp from bag")
+    ledger = Ledger(graph=graph, cursor_id=cave.uid)
+    ledger.resolve_choice(take_lamp.uid)
+
+    assert scope.player_assets.has_asset("lamp")
+    assert not bag.container.has_asset("lamp")
+
+    do_provision(cave, ctx=PhaseCtx(graph=graph, cursor_id=cave.uid))
+    lit_actions = _dynamic_sandbox_actions_with_tag(cave, "asset")
+    assert "Turn on lamp" in {action.text for action in lit_actions}
 
 
 def test_darkness_rule_substitutes_journal_and_suppresses_local_asset_actions() -> None:

--- a/engine/tests/mechanics/test_sandbox.py
+++ b/engine/tests/mechanics/test_sandbox.py
@@ -8,6 +8,7 @@ from pydantic import Field
 from tangl.core import Graph, Selector, Token
 from tangl.core.runtime_op import Effect, Predicate
 from tangl.mechanics.sandbox import (
+    ContainerFacet,
     LightSourceFacet,
     LockableFacet,
     OpenableFacet,
@@ -28,7 +29,7 @@ from tangl.mechanics.sandbox import (
 )
 from tangl.story import Action, Block, StoryGraph
 from tangl.story.concepts import Actor, Role
-from tangl.story.concepts.asset import AssetType
+from tangl.story.concepts.asset import AssetTransactionManager, AssetType
 from tangl.story.fragments import ChoiceFragment, ContentFragment
 from tangl.story.system_handlers import render_block_choices
 from tangl.vm import Ledger, Requirement
@@ -38,11 +39,16 @@ from tangl.vm.runtime.frame import PhaseCtx
 
 class SandboxItemType(AssetType):
     name: str = ""
+    traits: set[str] = Field(default_factory=set)
     portable: bool = True
     readable: bool = False
     read_text: str | None = None
     switchable: SwitchableFacet | None = None
     light_source: LightSourceFacet | None = None
+    container: ContainerFacet | None = Field(
+        default=None,
+        json_schema_extra={"instance_var": True},
+    )
     lit: bool = Field(default=False, json_schema_extra={"instance_var": True})
     turn_on_text: str | None = None
     turn_off_text: str | None = None
@@ -541,6 +547,157 @@ def test_location_assets_project_take_read_and_drop_actions() -> None:
 
     assert building.has_asset("keys")
     assert not scope.player_assets.has_asset("keys")
+
+
+def test_fixture_container_accepts_matching_assets_through_preflight() -> None:
+    graph = StoryGraph(label="tiny_cave")
+    scope = SandboxScope(label="tiny_cave_scope")
+    building = SandboxLocation(
+        label="building",
+        location_name="Building",
+        fixtures=[
+            SandboxFixture(
+                label="basket",
+                name="basket",
+                container=ContainerFacet(max_items=1, accepts_traits={"tiny"}),
+            )
+        ],
+    )
+    SandboxItemType(label="keys", name="keys", traits={"tiny"})
+    SandboxItemType(label="lamp", name="lamp")
+    keys = Token[SandboxItemType](token_from="keys", label="keys")
+    lamp = Token[SandboxItemType](token_from="lamp", label="lamp")
+    scope.player_assets.add_asset(keys)
+    scope.player_assets.add_asset(lamp)
+    graph.add(scope)
+    graph.add(building)
+    graph.add(keys)
+    graph.add(lamp)
+    scope.add_child(building)
+    ctx = PhaseCtx(graph=graph, cursor_id=building.uid)
+
+    do_provision(building, ctx=ctx)
+    fragments = render_block_choices(caller=building, ctx=ctx)
+    choices = [fragment for fragment in fragments or [] if isinstance(fragment, ChoiceFragment)]
+    put_keys = next(choice for choice in choices if choice.text == "Put keys in basket")
+    put_lamp = next(choice for choice in choices if choice.text == "Put lamp in basket")
+
+    assert put_keys.available is True
+    assert put_lamp.available is False
+
+    ledger = Ledger(graph=graph, cursor_id=building.uid)
+    action = next(
+        action
+        for action in _dynamic_sandbox_actions_with_tag(building, "put")
+        if action.text == "Put keys in basket"
+    )
+    ledger.resolve_choice(action.uid)
+
+    basket = building.fixture_by_label("basket")
+    assert basket.has_asset("keys")
+    assert not scope.player_assets.has_asset("keys")
+    assert scope.player_assets.has_asset("lamp")
+
+
+def test_closed_fixture_container_hides_contents_and_rejects_receive() -> None:
+    graph = StoryGraph(label="tiny_cave")
+    scope = SandboxScope(label="tiny_cave_scope")
+    chest = SandboxFixture(
+        label="chest",
+        name="chest",
+        openable=OpenableFacet(is_open=False),
+        container=ContainerFacet(accepts_traits={"tiny"}),
+    )
+    building = SandboxLocation(
+        label="building",
+        location_name="Building",
+        fixtures=[chest],
+    )
+    SandboxItemType(label="keys", name="keys", traits={"tiny"})
+    SandboxItemType(label="coin", name="coin", traits={"tiny"})
+    keys = Token[SandboxItemType](token_from="keys", label="keys")
+    coin = Token[SandboxItemType](token_from="coin", label="coin")
+    scope.player_assets.add_asset(keys)
+    chest.add_asset(coin)
+    graph.add(scope)
+    graph.add(building)
+    graph.add(keys)
+    graph.add(coin)
+    scope.add_child(building)
+    ctx = PhaseCtx(graph=graph, cursor_id=building.uid)
+
+    do_provision(building, ctx=ctx)
+    actions = _dynamic_sandbox_actions_with_tag(building, "container")
+    fragments = render_block_choices(caller=building, ctx=ctx)
+    choices = [fragment for fragment in fragments or [] if isinstance(fragment, ChoiceFragment)]
+    put_keys = next(choice for choice in choices if choice.text == "Put keys in chest")
+
+    assert put_keys.available is False
+    assert "Take coin from chest" not in {action.text for action in actions}
+
+
+def test_portable_container_rejects_nested_container_without_mutation() -> None:
+    SandboxItemType(
+        label="cage",
+        name="cage",
+        traits={"container"},
+        container=ContainerFacet(),
+    )
+    SandboxItemType(
+        label="bag",
+        name="bag",
+        traits={"container"},
+        container=ContainerFacet(),
+    )
+    cage = Token[SandboxItemType](token_from="cage", label="cage")
+    bag = Token[SandboxItemType](token_from="bag", label="bag")
+    holder = SandboxScope(label="tiny_cave_scope").player_assets
+    holder.add_asset(cage)
+    holder.add_asset(bag)
+
+    result = AssetTransactionManager().can_give_asset(holder, cage.container, "bag")
+
+    assert result.accepted is False
+    assert result.reason == "receiver cannot receive asset"
+    assert holder.has_asset("bag")
+    assert not cage.container.has_asset("bag")
+
+
+def test_portable_container_open_state_controls_contained_asset_projection() -> None:
+    graph = StoryGraph(label="tiny_cave")
+    scope = SandboxScope(label="tiny_cave_scope")
+    building = SandboxLocation(label="building", location_name="Building")
+    SandboxItemType(
+        label="cage",
+        name="cage",
+        traits={"container"},
+        container=ContainerFacet(close_text="The cage snaps shut."),
+    )
+    SandboxItemType(label="keys", name="keys", traits={"tiny"})
+    cage = Token[SandboxItemType](token_from="cage", label="cage")
+    keys = Token[SandboxItemType](token_from="keys", label="keys")
+    cage.container.add_asset(keys)
+    scope.player_assets.add_asset(cage)
+    graph.add(scope)
+    graph.add(building)
+    graph.add(cage)
+    graph.add(keys)
+    scope.add_child(building)
+    ctx = PhaseCtx(graph=graph, cursor_id=building.uid)
+
+    do_provision(building, ctx=ctx)
+    open_actions = _dynamic_sandbox_actions_with_tag(building, "container")
+    assert "Take keys from cage" in {action.text for action in open_actions}
+
+    close_cage = next(action for action in open_actions if action.text == "Close cage")
+    ledger = Ledger(graph=graph, cursor_id=building.uid)
+    ledger.resolve_choice(close_cage.uid)
+
+    assert cage.container.is_open is False
+    do_provision(building, ctx=PhaseCtx(graph=graph, cursor_id=building.uid))
+    closed_actions = _dynamic_sandbox_actions_with_tag(building, "container")
+    assert "Take keys from cage" not in {action.text for action in closed_actions}
+    assert "Open cage" in {action.text for action in closed_actions}
 
 
 def test_darkness_rule_substitutes_journal_and_suppresses_local_asset_actions() -> None:

--- a/engine/tests/mechanics/test_sandbox.py
+++ b/engine/tests/mechanics/test_sandbox.py
@@ -8,15 +8,19 @@ from pydantic import Field
 from tangl.core import Graph, Selector, Token
 from tangl.core.runtime_op import Effect, Predicate
 from tangl.mechanics.sandbox import (
+    LightSourceFacet,
+    LockableFacet,
+    OpenableFacet,
     SandboxExit,
+    SandboxFixture,
     SandboxLocation,
-    SandboxLockable,
     SandboxScope,
     SandboxVisibilityRule,
     Schedule,
     ScheduleEntry,
     ScheduledEvent,
     ScheduledPresence,
+    SwitchableFacet,
     WorldTime,
     advance_world_turn,
     current_world_time,
@@ -37,7 +41,8 @@ class SandboxItemType(AssetType):
     portable: bool = True
     readable: bool = False
     read_text: str | None = None
-    light_source: bool = False
+    switchable: SwitchableFacet | None = None
+    light_source: LightSourceFacet | None = None
     lit: bool = Field(default=False, json_schema_extra={"instance_var": True})
     turn_on_text: str | None = None
     turn_off_text: str | None = None
@@ -353,12 +358,14 @@ def test_scheduled_event_renders_as_normal_choice_fragment() -> None:
 
 def test_locked_local_object_projects_unavailable_unlock_without_key() -> None:
     graph, _road, _building, cave_entrance = _sandbox_graph()
-    cave_entrance.lockables = [
-        SandboxLockable(
+    cave_entrance.fixtures = [
+        SandboxFixture(
             label="grate",
             name="grate",
-            key="keys",
-            unlock_text="The key turns with a click. The grate unlocks.",
+            lockable=LockableFacet(
+                key="keys",
+                unlock_text="The key turns with a click. The grate unlocks.",
+            ),
         )
     ]
     ctx = PhaseCtx(graph=graph, cursor_id=cave_entrance.uid)
@@ -385,12 +392,14 @@ def test_locked_local_object_unlocks_with_carried_key_and_stops_projecting() -> 
         location_name="Cave Entrance",
         content="The grate is {grate_state}.",
         locals={"grate_state": "locked"},
-        lockables=[
-            SandboxLockable(
+        fixtures=[
+            SandboxFixture(
                 label="grate",
                 name="grate",
-                key="keys",
-                unlock_text="The key turns with a click. The grate unlocks.",
+                lockable=LockableFacet(
+                    key="keys",
+                    unlock_text="The key turns with a click. The grate unlocks.",
+                ),
             )
         ],
     )
@@ -409,7 +418,7 @@ def test_locked_local_object_unlocks_with_carried_key_and_stops_projecting() -> 
 
     ledger.resolve_choice(unlock.uid)
 
-    assert cave_entrance.lockables[0].locked is False
+    assert cave_entrance.fixtures[0].locked is False
     assert cave_entrance.locals["grate_state"] == "unlocked"
     content = [
         fragment.content
@@ -431,12 +440,14 @@ def test_locked_local_object_unlocks_with_key_asset_in_player_inventory() -> Non
     cave_entrance = SandboxLocation(
         label="cave_entrance",
         location_name="Cave Entrance",
-        lockables=[
-            SandboxLockable(
+        fixtures=[
+            SandboxFixture(
                 label="grate",
                 name="grate",
-                key="keys",
-                unlock_text="The key turns with a click. The grate unlocks.",
+                lockable=LockableFacet(
+                    key="keys",
+                    unlock_text="The key turns with a click. The grate unlocks.",
+                ),
             )
         ],
     )
@@ -455,6 +466,29 @@ def test_locked_local_object_unlocks_with_key_asset_in_player_inventory() -> Non
     unlock = next(choice for choice in choices if choice.text == "Unlock grate")
 
     assert unlock.available is True
+
+
+def test_openable_fixture_projects_without_lockable_facet() -> None:
+    graph = StoryGraph(label="tiny_cave")
+    cave_entrance = SandboxLocation(
+        label="cave_entrance",
+        location_name="Cave Entrance",
+        fixtures=[
+            SandboxFixture(
+                label="hatch",
+                name="hatch",
+                openable=OpenableFacet(open_text="The hatch swings open."),
+            )
+        ],
+    )
+    graph.add(cave_entrance)
+    ctx = PhaseCtx(graph=graph, cursor_id=cave_entrance.uid)
+
+    do_provision(cave_entrance, ctx=ctx)
+
+    opens = _dynamic_sandbox_actions_with_tag(cave_entrance, "fixture")
+    assert [action.text for action in opens] == ["Open hatch"]
+    assert opens[0].journal_text == "The hatch swings open."
 
 
 def test_location_assets_project_take_read_and_drop_actions() -> None:
@@ -569,7 +603,8 @@ def test_carried_lamp_restores_dark_location_detail_and_asset_affordances() -> N
     SandboxItemType(
         label="lamp",
         name="lamp",
-        light_source=True,
+        switchable=SwitchableFacet(),
+        light_source=LightSourceFacet(),
         turn_on_text="Your lamp is now on.",
     )
     SandboxItemType(label="nugget", name="nugget")

--- a/engine/tests/mechanics/test_sandbox_adventure_slice.py
+++ b/engine/tests/mechanics/test_sandbox_adventure_slice.py
@@ -372,9 +372,63 @@ def test_adventure_slice_compiler_preserves_provenance_inputs() -> None:
     assert isinstance(compiled.materialization, SandboxMaterializationSpec)
     assert isinstance(compiled.mobs["wounded_pirate"], SandboxMob)
     assert compiled.assets["wicker_cage"].container.max_items == 1
+    assert compiled.assets["wicker_cage"].container.accepts_traits == {"tiny"}
     assert compiled.materialization.stable.assets == ["brass_lamp"]
     assert compiled.source_map["source_refs"]["kind"] == "punyinform"
     assert compiled.codec_state["codec_id"] == "compact_sandbox_slice"
+
+
+def test_compiled_openable_fixture_container_opens_embedded_container() -> None:
+    data: dict[str, Any] = {
+        "id": "fixture_container",
+        "scope": {"id": "cave"},
+        "locations": {"building": {"name": "Building", "traits": ["light"]}},
+        "assets": {
+            "keys": {
+                "name": "keys",
+                "traits": ["portable", "tiny"],
+                "initial": {"location": "building"},
+            },
+        },
+        "fixtures": {
+            "chest": {
+                "name": "chest",
+                "traits": ["fixture", "container", "openable"],
+                "initial": {
+                    "locations": ["building"],
+                    "state": {"open": False},
+                },
+                "capacity": {"accepts_traits": ["tiny"]},
+            },
+        },
+    }
+    compiled = SandboxSliceCompiler().compile(data)
+    graph = compiled.graph
+    building = compiled.locations["building"]
+    chest = compiled.fixtures["chest"]
+    keys = compiled.assets["keys"]
+    building.remove_asset(keys)
+    compiled.scope.player_assets.add_asset(keys)
+
+    put_keys = next(
+        choice
+        for choice in _choice_fragments(building, graph)
+        if choice.text == "Put keys in chest"
+    )
+    assert put_keys.available is False
+
+    ledger = Ledger.from_graph(graph, entry_id=building.uid)
+    _choose(ledger, contribution="open", target="chest")
+
+    assert chest.open is True
+    assert chest.container.is_open is True
+
+    opened_put_keys = next(
+        choice
+        for choice in _choice_fragments(building, graph)
+        if choice.text == "Put keys in chest"
+    )
+    assert opened_put_keys.available is True
 
 
 def test_adventure_slice_stable_mob_projects_only_when_present() -> None:

--- a/engine/tests/mechanics/test_sandbox_adventure_slice.py
+++ b/engine/tests/mechanics/test_sandbox_adventure_slice.py
@@ -190,6 +190,21 @@ ADVENTURE_SANDBOX_SLICE: dict[str, Any] = {
             },
             "descriptions": {"examine": "It is a shiny brass lamp."},
         },
+        "wicker_cage": {
+            "name": "wicker cage",
+            "kind": "container",
+            "traits": ["portable", "container"],
+            "initial": {
+                "location": "cobble_crawl",
+                "state": {"open": True},
+            },
+            "capacity": {"max_items": 1, "accepts_traits": ["tiny"]},
+            "descriptions": {
+                "examine": "It's a small wicker cage.",
+                "close": "The cage snaps shut.",
+                "open": "The cage opens.",
+            },
+        },
     },
     "fixtures": {
         "grate": {
@@ -286,6 +301,7 @@ def test_adventure_slice_schema_validates() -> None:
     assert spec.scope.materialization.stable.locations == ["cobble_crawl"]
     assert spec.scope.materialization.stable.mobs == ["wounded_pirate"]
     assert spec.locations["cobble_crawl"].runtime_identity.stable is True
+    assert spec.assets["wicker_cage"].capacity.accepts_traits == ["tiny"]
     assert spec.mobs["wounded_pirate"].initial.location == "cobble_crawl"
     assert spec.mobs["wounded_pirate"].runtime_identity.stable is True
 
@@ -355,6 +371,7 @@ def test_adventure_slice_compiler_preserves_provenance_inputs() -> None:
     assert isinstance(compiled, SandboxCompiledSlice)
     assert isinstance(compiled.materialization, SandboxMaterializationSpec)
     assert isinstance(compiled.mobs["wounded_pirate"], SandboxMob)
+    assert compiled.assets["wicker_cage"].container.max_items == 1
     assert compiled.materialization.stable.assets == ["brass_lamp"]
     assert compiled.source_map["source_refs"]["kind"] == "punyinform"
     assert compiled.codec_state["codec_id"] == "compact_sandbox_slice"


### PR DESCRIPTION
extended sandbox concepts with examples for more sophisticated subtypes such as openable, lockable, containers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fixtures now use composable capability facets: openable, lockable, switchable, light-source, and container.
  * Containers support capacity limits, trait-based acceptance, put/take affordances, and disallow nested portable containers by default.
  * Light sources can require switches and be toggled on/off.
  * Assets expose trait tags used for container compatibility.

* **Documentation**
  * Expanded README and design guidance on facets, container projection, and trait→facet projection.

* **Tests**
  * Expanded end-to-end tests for fixtures, containers, lighting, and trait acceptance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->