### PR TITLE
Route update journal fragments through phase context

### DIFF
--- a/engine/src/tangl/journal/fragments.py
+++ b/engine/src/tangl/journal/fragments.py
@@ -38,7 +38,14 @@ class PresentationHints(BaseModel, extra="allow"):
 
 
 class ContentFragment(BaseFragment):
-    """Canonical content-bearing journal fragment."""
+    """Canonical content-bearing journal fragment.
+
+    ``source_id`` identifies the entity or edge that donated the content.
+    ``origin_id`` records the producer/provenance trail inherited from
+    :class:`BaseFragment`. Handlers that merely transport or defer fragments
+    should preserve both. Compositors that synthesize replacement prose may use
+    the composing cursor or source of the new composite instead.
+    """
 
     fragment_type: str | Enum = "content"
     content: Any = None

--- a/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
+++ b/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
@@ -735,6 +735,14 @@ use this path. Future mob movement notices, queue arrivals, hazards, and
 selected effect narration should use the same context field instead of
 inventing persistent stash keys.
 
+Injected fragments preserve the concept that donated the content. A lamp charge
+warning uses the lamp token as `source_id` and `origin_id`, and an
+incremental-cycle note uses the hosted game node as `source_id` and
+`origin_id`; they are not re-labeled as the active location merely because the
+location is the current cursor. Compositors may replace or synthesize fragments
+under a new source when they intentionally compose new prose, such as replacing
+suppressed location description with a darkness fragment.
+
 ### Projected State As Disclosure
 
 Sandbox projected state is an optional client convenience, not an authority

--- a/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
+++ b/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
@@ -707,46 +707,33 @@ that observer's generic vocabulary to its own mechanics package and keep only
 the sandbox adapter here. The sandbox package should remain the dynamic-hub and
 scoped-time host, not the permanent home for every tick-compatible subsystem.
 
-#### Future RFC: Effect-Phase Content Injection
+#### Effect-Phase Content Injection
 
-The current tick implementation uses a small pragmatic bridge: update-time
-observers return `SandboxTickEvent`s, the sandbox time-advance helper gathers
-them into a result, and journal handlers render the observable events later in
-the same VM pass. Some first-pass adapters temporarily stash those renderable
-events on the active location's `locals`.
+Tick observers may produce journalable facts during UPDATE, before the JOURNAL
+phase has gathered normal node content. These facts must not be stored in
+location or scope `locals`: `locals` is persistent story state, while
+effect-phase journal material is ephemeral and belongs only to the current
+`follow_edge` pass.
 
-That is acceptable as scaffolding, but it is not the right long-term contract.
-`locals` is persistent story state. Phase-local render material is ephemeral and
-may contain objects that should not serialize, replay as state, or become
-visible to predicates as durable world truth.
-
-A cleaner general pattern would give UPDATE a receipt-like content side channel:
+The VM provides `PhaseCtx.injected_journal_fragments` as a receipt-like content
+side channel:
 
 ```text
 UPDATE
   -> selected-edge effects
   -> node/domain effects
-  -> observers append content candidates to ctx or update receipts
+  -> observers append concrete journal fragments to ctx.injected_journal_fragments
 JOURNAL
-  -> gather content candidates
+  -> drain injected fragments
+  -> gather normal node content
   -> enrich/order/filter candidates
   -> compose normal journal fragments
 ```
 
-Possible implementations:
-
-- add an explicit `injected_fragments` or `content_candidates` slot to the
-  runtime context for one `follow_edge` pass;
-- let update handlers return structured receipts that the frame carries into
-  JOURNAL;
-- define a small sandbox-local context wrapper while the pattern is being
-  proven, then promote the generic part once another mechanic needs it.
-
-This would match the existing journal-phase shape, where intermediate gathered
-content can live on the context until composition emits the phase result. It
-would also give charge warnings, incremental cycle notes, mob movement notices,
-queue arrivals, hazards, and selected effect narration one shared path into the
-journal without making each observer invent a persistent stash key.
+Sandbox charge warnings, charge exhaustion notes, and incremental-cycle notes
+use this path. Future mob movement notices, queue arrivals, hazards, and
+selected effect narration should use the same context field instead of
+inventing persistent stash keys.
 
 ### Projected State As Disclosure
 

--- a/engine/src/tangl/mechanics/sandbox/handlers.py
+++ b/engine/src/tangl/mechanics/sandbox/handlers.py
@@ -627,8 +627,16 @@ def _time_owner(location: SandboxLocation) -> Any:
     return location
 
 
-def _record_tick_result(location: SandboxLocation, result: SandboxTickResult) -> None:
-    location.locals["_sandbox_tick_result"] = result
+def _inject_tick_fragments(
+    ctx: VmPhaseCtx,
+    location: SandboxLocation,
+    result: SandboxTickResult,
+) -> None:
+    ctx.injected_journal_fragments.extend(
+        ContentFragment(content=event.text, source_id=location.uid)
+        for event in result.events
+        if event.observable and event.text
+    )
 
 
 def _sandbox_time_advance(
@@ -640,7 +648,6 @@ def _sandbox_time_advance(
     duration = _clock_policy(location).action_duration(cost)
     result = SandboxTickResult(requested=duration)
     if duration == 0:
-        _record_tick_result(location, result)
         return result
 
     time_owner = _time_owner(location)
@@ -656,7 +663,7 @@ def _sandbox_time_advance(
                 charged_assets=charged_assets,
             )
         )
-    _record_tick_result(location, result)
+    _inject_tick_fragments(ctx, location, result)
     return result
 
 
@@ -2293,26 +2300,3 @@ def compose_sandbox_mob_journal(*, caller, ctx, fragments, **_kw):
     if not additions:
         return None
     return [*fragments, *additions]
-
-
-@on_journal(
-    wants_caller_kind=SandboxLocation,
-    wants_exact_kind=False,
-    priority=Priority.LAST,
-)
-def render_sandbox_tick_journal(*, caller, ctx, **_kw):
-    """Render observable sandbox tick events to the journal."""
-    if not isinstance(caller, SandboxLocation):
-        return None
-    result = caller.locals.get("_sandbox_tick_result")
-    if not isinstance(result, SandboxTickResult):
-        return None
-    fragments = [
-        ContentFragment(content=event.text, source_id=caller.uid)
-        for event in result.events
-        if event.observable and event.text
-    ]
-    return fragments or None
-
-
-compose_sandbox_tick_journal = render_sandbox_tick_journal

--- a/engine/src/tangl/mechanics/sandbox/handlers.py
+++ b/engine/src/tangl/mechanics/sandbox/handlers.py
@@ -632,11 +632,17 @@ def _inject_tick_fragments(
     location: SandboxLocation,
     result: SandboxTickResult,
 ) -> None:
-    ctx.injected_journal_fragments.extend(
-        ContentFragment(content=event.text, source_id=location.uid)
-        for event in result.events
-        if event.observable and event.text
-    )
+    for event in result.events:
+        if not event.observable or not event.text:
+            continue
+        source_id = event.source_id or location.uid
+        ctx.injected_journal_fragments.append(
+            ContentFragment(
+                content=event.text,
+                source_id=source_id,
+                origin_id=source_id,
+            )
+        )
 
 
 def _sandbox_time_advance(
@@ -2224,6 +2230,7 @@ def reconcile_charged_sandbox_assets(
                     SandboxTickEvent(
                         kind="charge_warning",
                         source_label=_asset_key(asset),
+                        source_id=asset.uid,
                         text=text,
                         clock_tick=clock_tick,
                     )
@@ -2236,6 +2243,7 @@ def reconcile_charged_sandbox_assets(
                     SandboxTickEvent(
                         kind="charge_exhausted",
                         source_label=_asset_key(asset),
+                        source_id=asset.uid,
                         text=_charge_event_text(asset, charge),
                         clock_tick=clock_tick,
                     )

--- a/engine/src/tangl/mechanics/sandbox/incremental.py
+++ b/engine/src/tangl/mechanics/sandbox/incremental.py
@@ -14,7 +14,7 @@ from tangl.mechanics.games import (
     IncrementalMove,
 )
 from tangl.story import Action, StoryGraph
-from tangl.vm import VmPhaseCtx, on_journal, on_provision, on_update
+from tangl.vm import VmPhaseCtx, on_provision, on_update
 
 from .dispatch import on_sandbox_tick
 from .handlers import sandbox_scopes
@@ -101,12 +101,11 @@ def _latest_fragments(host: HasGame) -> list[ContentFragment]:
 
 
 def _store_incremental_fragments(
-    location: SandboxLocation,
+    ctx: VmPhaseCtx,
     host: HasGame,
 ) -> None:
     fragments = _latest_fragments(host)
-    if fragments:
-        location.locals["_sandbox_incremental_fragments"] = fragments
+    ctx.injected_journal_fragments.extend(fragments)
 
 
 @on_provision(
@@ -182,7 +181,7 @@ def process_sandbox_incremental_game_move(*, caller, ctx, **_kw):
         host.locals["last_round"] = None
         host.locals["round_result"] = None
     host.locals["game_result"] = host.game.result
-    _store_incremental_fragments(caller, host)
+    _store_incremental_fragments(ctx, host)
     return None
 
 
@@ -222,25 +221,8 @@ def reconcile_incremental_games_on_sandbox_tick(*, caller, ctx, clock_tick, **_k
     return events or None
 
 
-@on_journal(
-    wants_caller_kind=SandboxLocation,
-    wants_exact_kind=False,
-    priority=Priority.LATE,
-)
-def render_sandbox_incremental_journal(*, caller, ctx, **_kw):
-    """Append allocation-action journal fragments for hosted incremental games."""
-    if not isinstance(caller, SandboxLocation):
-        return None
-    additions = caller.locals.get("_sandbox_incremental_fragments")
-    if not isinstance(additions, list):
-        return None
-    caller.locals["_sandbox_incremental_fragments"] = []
-    return additions or None
-
-
 __all__ = [
     "process_sandbox_incremental_game_move",
     "project_sandbox_incremental_game_moves",
     "reconcile_incremental_games_on_sandbox_tick",
-    "render_sandbox_incremental_journal",
 ]

--- a/engine/src/tangl/mechanics/sandbox/incremental.py
+++ b/engine/src/tangl/mechanics/sandbox/incremental.py
@@ -105,7 +105,15 @@ def _store_incremental_fragments(
     host: HasGame,
 ) -> None:
     fragments = _latest_fragments(host)
-    ctx.injected_journal_fragments.extend(fragments)
+    ctx.injected_journal_fragments.extend(
+        fragment.model_copy(
+            update={
+                "source_id": fragment.source_id or host.uid,
+                "origin_id": fragment.origin_id or host.uid,
+            }
+        )
+        for fragment in fragments
+    )
 
 
 @on_provision(
@@ -214,6 +222,7 @@ def reconcile_incremental_games_on_sandbox_tick(*, caller, ctx, clock_tick, **_k
                 SandboxTickEvent(
                     kind="incremental_cycle",
                     source_label=host.get_label(),
+                    source_id=host.uid,
                     text=fragment.content,
                     clock_tick=clock_tick,
                 )

--- a/engine/src/tangl/mechanics/sandbox/time.py
+++ b/engine/src/tangl/mechanics/sandbox/time.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 from typing import Any, Protocol
+from uuid import UUID
 
 from pydantic import Field
 
@@ -130,6 +131,7 @@ class SandboxTickEvent(BaseModelPlus):
 
     kind: str
     source_label: str = ""
+    source_id: UUID | None = None
     text: str | None = None
     observable: bool = True
     clock_tick: int | None = None

--- a/engine/src/tangl/vm/VM_DESIGN.md
+++ b/engine/src/tangl/vm/VM_DESIGN.md
@@ -136,6 +136,13 @@ across the parent boundary unless they are intentionally promoted into public
 vocabulary. This is the boundary rule that makes recursive phase refinement useful
 instead of turning the phase bus into a stack of incompatible private runtimes.
 
+`PhaseCtx.injected_journal_fragments` is the promoted side channel for one common
+cross-phase case: UPDATE-time work that needs to emit concrete journal fragments
+during the same `follow_edge` pass. UPDATE handlers may append fragments there;
+`do_journal` drains the list before normal journal rendering and composition.
+Handlers must not put such ephemeral render material in persistent entity
+`locals`.
+
 Domain packages may therefore subdivide a VM phase with their own behavior chain,
 provided the outer VM contract remains intact. For example, a sandbox package may
 invoke `do_sandbox_tick` from an `on_update` handler after normal selected-edge and

--- a/engine/src/tangl/vm/VM_DESIGN.md
+++ b/engine/src/tangl/vm/VM_DESIGN.md
@@ -139,9 +139,12 @@ instead of turning the phase bus into a stack of incompatible private runtimes.
 `PhaseCtx.injected_journal_fragments` is the promoted side channel for one common
 cross-phase case: UPDATE-time work that needs to emit concrete journal fragments
 during the same `follow_edge` pass. UPDATE handlers may append fragments there;
-`do_journal` drains the list before normal journal rendering and composition.
-Handlers must not put such ephemeral render material in persistent entity
-`locals`.
+`do_journal` drains the list before normal journal render results are merged,
+then sends the combined list through composition. This preserves generated order:
+effect narration from UPDATE precedes JOURNAL-time rendering. Handlers must not
+put such ephemeral render material in persistent entity `locals`. Injected
+fragments should preserve the donor `source_id`; use the cursor id only when the
+cursor genuinely composes new replacement prose.
 
 Domain packages may therefore subdivide a VM phase with their own behavior chain,
 provided the outer VM contract remains intact. For example, a sandbox package may

--- a/engine/src/tangl/vm/ctx.py
+++ b/engine/src/tangl/vm/ctx.py
@@ -27,6 +27,7 @@ class VmPhaseCtx(DispatchCtx, Protocol):
     incoming_edge: Any | None
     selected_edge: Any | None
     selected_payload: Any
+    injected_journal_fragments: list[Any]
 
     @property
     def cursor(self) -> Any | None: ...

--- a/engine/src/tangl/vm/dispatch.py
+++ b/engine/src/tangl/vm/dispatch.py
@@ -220,12 +220,23 @@ def do_update(caller, *, ctx, **kwargs) -> None:
 
 
 def do_journal(caller, *, ctx, **kwargs):
+    injected = list(ctx.injected_journal_fragments)
+    ctx.injected_journal_fragments.clear()
     receipts = _run_task("render_journal", caller=caller, ctx=ctx, **kwargs)
     results = CallReceipt.gather_results(*receipts)
-    if not results:
+    if not results and not injected:
         return None
 
     merged: list[Record] = []
+    for value in injected:
+        normalized = _assert_fragment_result(value, task="render_journal")
+        if normalized is None:
+            continue
+        if isinstance(normalized, Record):
+            merged.append(normalized)
+            continue
+        merged.extend(normalized)
+
     for value in results:
         normalized = _assert_fragment_result(value, task="render_journal")
         if normalized is None:

--- a/engine/src/tangl/vm/runtime/frame.py
+++ b/engine/src/tangl/vm/runtime/frame.py
@@ -167,6 +167,7 @@ class PhaseCtx:
     local_authorities: list[BehaviorRegistry] = field(default_factory=list)
     incoming_edge: Any | None = None
     incoming_payload: Any = None
+    injected_journal_fragments: list[Record] = field(default_factory=list)
 
     _ns_cache: dict[UUID, ChainMap[str, Any]] = field(default_factory=dict)
     _ns_inflight: set[UUID] = field(default_factory=set)
@@ -224,6 +225,7 @@ class PhaseCtx:
             "local_authorities": list(self.local_authorities),
             "incoming_edge": self.incoming_edge,
             "incoming_payload": self.incoming_payload,
+            "injected_journal_fragments": self.injected_journal_fragments,
         }
         kwargs.update(field_overrides)
         return PhaseCtx(**kwargs)

--- a/engine/tests/mechanics/test_sandbox.py
+++ b/engine/tests/mechanics/test_sandbox.py
@@ -921,6 +921,7 @@ def test_sandbox_can_host_incremental_allocation_and_tick_cycles() -> None:
         and fragment.content == "You assign a worker to forage."
         for fragment in ledger.get_journal()
     )
+    assert "_sandbox_incremental_fragments" not in hub.locals
 
     do_provision(hub, ctx=PhaseCtx(graph=graph, cursor_id=hub.uid))
     cycle = next(
@@ -942,6 +943,7 @@ def test_sandbox_can_host_incremental_allocation_and_tick_cycles() -> None:
     ]
     assert "Cycle 1 resolves." in journal_text
     assert "Resources: food=2." in journal_text
+    assert "_sandbox_tick_result" not in hub.locals
 
 
 def test_sandbox_incremental_update_rejects_unsupported_move_kind() -> None:

--- a/engine/tests/mechanics/test_sandbox.py
+++ b/engine/tests/mechanics/test_sandbox.py
@@ -919,6 +919,8 @@ def test_sandbox_can_host_incremental_allocation_and_tick_cycles() -> None:
     assert any(
         isinstance(fragment, ContentFragment)
         and fragment.content == "You assign a worker to forage."
+        and fragment.source_id == colony.uid
+        and fragment.origin_id == colony.uid
         for fragment in ledger.get_journal()
     )
     assert "_sandbox_incremental_fragments" not in hub.locals
@@ -1703,6 +1705,52 @@ def test_darkness_rule_substitutes_journal_and_suppresses_local_asset_actions() 
     ]
     assert content == ["It is now pitch dark."]
     assert _dynamic_sandbox_actions_with_tag(cave, "asset") == []
+
+
+def test_tick_fragments_do_not_replace_suppressed_location_description() -> None:
+    graph = StoryGraph(label="tiny_cave")
+    scope = SandboxScope(
+        label="tiny_cave_scope",
+        visibility_rules=[
+            SandboxVisibilityRule(journal_text="It is now pitch dark.")
+        ],
+    )
+    cave = SandboxLocation(
+        label="dark_cave",
+        location_name="Dark Cave",
+        content="A glittering nugget rests here.",
+    )
+    SandboxItemType(
+        label="lamp",
+        name="lamp",
+        switchable=SwitchableFacet(),
+        light_source=LightSourceFacet(),
+        charge=ChargeFacet(current=1, maximum=1),
+    )
+    lamp = Token[SandboxItemType](token_from="lamp", label="lamp", lit=True)
+    scope.player_assets.add_asset(lamp)
+    graph.add(scope)
+    graph.add(cave)
+    graph.add(lamp)
+    scope.add_child(cave)
+
+    do_provision(cave, ctx=PhaseCtx(graph=graph, cursor_id=cave.uid))
+    wait = _dynamic_sandbox_actions_with_tag(cave, "wait")[0]
+    ledger = Ledger(graph=graph, cursor_id=cave.uid)
+    ledger.resolve_choice(wait.uid, choice_payload=wait.payload)
+
+    fragments = [
+        fragment
+        for fragment in ledger.get_journal()
+        if isinstance(fragment, ContentFragment)
+    ]
+    assert [fragment.content for fragment in fragments] == [
+        "The lamp flickers and goes out.",
+        "It is now pitch dark.",
+    ]
+    assert fragments[0].source_id == lamp.uid
+    assert fragments[0].origin_id == lamp.uid
+    assert fragments[1].source_id == cave.uid
 
 
 def test_carried_lamp_restores_dark_location_detail_and_asset_affordances() -> None:

--- a/engine/tests/mechanics/test_sandbox_adventure_slice.py
+++ b/engine/tests/mechanics/test_sandbox_adventure_slice.py
@@ -702,6 +702,7 @@ def test_adventure_lamp_charge_exhausts_during_sandbox_tick() -> None:
         for fragment in ledger.get_journal()
         if isinstance(fragment, ContentFragment)
     )
+    assert "_sandbox_tick_result" not in compiled.locations["building"].locals
 
 
 def test_charged_assets_keep_ticking_when_left_offscreen() -> None:

--- a/engine/tests/vm/conftest.py
+++ b/engine/tests/vm/conftest.py
@@ -93,6 +93,7 @@ def null_ctx() -> SimpleNamespace:
     return SimpleNamespace(
         get_authorities=lambda: [],
         get_inline_behaviors=lambda: [],
+        injected_journal_fragments=[],
     )
 
 

--- a/engine/tests/vm/test_ctx.py
+++ b/engine/tests/vm/test_ctx.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from tangl.core import Graph
 from tangl.core.ctx import CoreCtx
+from tangl.journal.fragments import ContentFragment
 from tangl.vm.ctx import VmPhaseCtx
 from tangl.vm.runtime.frame import PhaseCtx
 from tangl.vm.traversable import TraversableNode
@@ -65,3 +66,16 @@ def test_phase_ctx_isolates_result_pipe_for_subdispatch() -> None:
         assert nested.results == ["inner"]
 
     assert ctx.results == ["outer"]
+
+
+def test_phase_ctx_derive_shares_injected_journal_fragments() -> None:
+    graph = Graph()
+    node = TraversableNode(label="n")
+    graph.add(node)
+    ctx = PhaseCtx(graph=graph, cursor_id=node.uid)
+    fragment = ContentFragment(content="fragment")
+
+    derived = ctx.derive()
+    derived.injected_journal_fragments.append(fragment)
+
+    assert ctx.injected_journal_fragments == [fragment]

--- a/engine/tests/vm/test_dispatch.py
+++ b/engine/tests/vm/test_dispatch.py
@@ -236,6 +236,23 @@ class TestDoJournal:
 
         assert result is fragment
 
+    def test_injected_journal_fragments_are_drained_before_render_results(self) -> None:
+        injected = ContentFragment(content="from update")
+        rendered = ContentFragment(content="from journal")
+        on_journal(lambda *, caller, ctx, **kw: rendered)
+        g = Graph()
+        node = _node(g, label="n")
+        ctx = PhaseCtx(
+            graph=g,
+            cursor_id=node.uid,
+            injected_journal_fragments=[injected],
+        )
+
+        result = do_journal(node, ctx=ctx)
+
+        assert result == [injected, rendered]
+        assert ctx.injected_journal_fragments == []
+
     def test_compose_handler_receives_merged_fragments_and_can_replace_output(self, null_ctx) -> None:
         first = Record(label="first")
         second = Record(label="second")

--- a/engine/tests/vm/test_resolver.py
+++ b/engine/tests/vm/test_resolver.py
@@ -119,6 +119,7 @@ class _ResolverCtx:
         self.incoming_payload = None
         self.selected_edge = None
         self.selected_payload = None
+        self.injected_journal_fragments = []
         self._authorities = list(authorities or [])
         self._rng = rng or Random(0)
         self._location_entity_groups = list(location_entity_groups or [])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal journal composition for sandbox mechanics. Sandbox tick results and incremental game events now use a dedicated side-channel mechanism during game updates, replacing previous persistent storage patterns for cleaner, more consistent event narration composition.

* **Tests**
  * Added contract tests verifying the new journal fragment injection mechanism and its integration with phase execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/derekmerck/storytangl/pull/240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->