### PR TITLE
Sandbox as Queuing Sim/DES

### DIFF
--- a/engine/src/tangl/mechanics/README.md
+++ b/engine/src/tangl/mechanics/README.md
@@ -13,7 +13,9 @@ The top-level package organization stays broad and family-oriented:
 - `assembly`
 - `demographics`
 - `presence`
-- later: `sandbox`, `credentials`, other world- or plugin-provided families
+- `sandbox`
+- `simulation`
+- later: `credentials`, other world- or plugin-provided families
 
 Within each family, the preferred design lens is:
 
@@ -68,6 +70,10 @@ are using it systematically.
   ordinary `MenuBlock`, `Fanout`, `Action`, target availability, journal, ledger,
   and replay machinery rather than a separate traversal subsystem. See
   `sandbox/SANDBOX_DESIGN.md`.
+- **Simulation**: small operational-simulation kernels that attach through
+  ordinary mechanics and VM seams. The first proof is a deterministic queueing
+  model that uses a mutable core `Registry` as a future-event list, `HasGame`
+  for re-entrant actions, and normal journal fragments for observation.
 - **Credentials**: expected to compose game kernels, asset collections, render, and
   writeback rather than porting the legacy package wholesale.
 

--- a/engine/src/tangl/mechanics/sandbox/__init__.py
+++ b/engine/src/tangl/mechanics/sandbox/__init__.py
@@ -73,6 +73,7 @@ from .time import (
     TimePolicy,
     WorldTime,
     advance_world_turn,
+    advance_world_turn_to,
     current_world_time,
     get_world_turn,
 )
@@ -132,6 +133,7 @@ __all__ = [
     "TimePolicy",
     "advance_sandbox_time_on_action",
     "advance_world_turn",
+    "advance_world_turn_to",
     "compose_sandbox_mob_journal",
     "compose_sandbox_visibility_journal",
     "contribute_sandbox_inventory_helpers",

--- a/engine/src/tangl/mechanics/sandbox/time.py
+++ b/engine/src/tangl/mechanics/sandbox/time.py
@@ -174,3 +174,21 @@ def advance_world_turn(source: HasMutableLocals, delta: int = 1) -> int:
     next_turn = int(locals_.get("world_turn", 0)) + delta
     locals_["world_turn"] = next_turn
     return next_turn
+
+
+def advance_world_turn_to(source: HasMutableLocals, target_turn: int) -> int:
+    """Advance ``source.locals['world_turn']`` to ``target_turn``.
+
+    Returns the elapsed normalized turns. Backward jumps are rejected; callers
+    that need rollback or replay should express that through VM history rather
+    than mutating the clock in reverse.
+    """
+    locals_ = source.locals
+    if not isinstance(locals_, dict):
+        raise TypeError("source must expose a mutable locals dict")
+    current_turn = int(locals_.get("world_turn", 0))
+    if target_turn < current_turn:
+        raise ValueError("target_turn must not be earlier than current world_turn")
+    elapsed = target_turn - current_turn
+    advance_world_turn(source, elapsed)
+    return elapsed

--- a/engine/src/tangl/mechanics/simulation/README.md
+++ b/engine/src/tangl/mechanics/simulation/README.md
@@ -1,0 +1,13 @@
+# Simulation Mechanics
+
+`tangl.mechanics.simulation` contains small operational-simulation kernels that
+attach to ordinary StoryTangl runtime seams. The first member is a deterministic
+queueing proof: future events are pending work in a mutable core `Registry`,
+state changes happen through the existing game UPDATE phase, and observations
+are emitted as normal journal fragments.
+
+The package deliberately does not replace sandbox scheduling. Sandbox schedules
+describe availability against a derived `WorldTime`; the simulation event
+calendar stores exact future events and supports next-event advancement. Both
+share normalized integer time and can be bridged later when a sandbox scope wants
+to host a queueing or resource simulation as a tick-compatible observer.

--- a/engine/src/tangl/mechanics/simulation/__init__.py
+++ b/engine/src/tangl/mechanics/simulation/__init__.py
@@ -1,0 +1,28 @@
+"""Operational simulation mechanics."""
+
+from __future__ import annotations
+
+from .calendar import EventCalendar, SimulationEvent
+from .queueing import (
+    QueueMetrics,
+    QueueMove,
+    QueuePatient,
+    QueueSimulation,
+    QueueSimulationHandler,
+    QueueStationSpec,
+    QueueStationState,
+    QueueTraceEvent,
+)
+
+__all__ = [
+    "EventCalendar",
+    "QueueMetrics",
+    "QueueMove",
+    "QueuePatient",
+    "QueueSimulation",
+    "QueueSimulationHandler",
+    "QueueStationSpec",
+    "QueueStationState",
+    "QueueTraceEvent",
+    "SimulationEvent",
+]

--- a/engine/src/tangl/mechanics/simulation/calendar.py
+++ b/engine/src/tangl/mechanics/simulation/calendar.py
@@ -13,7 +13,7 @@ from tangl.core.bases import BaseModelPlus, HasOrder
 class SimulationEvent(HasOrder, Entity):
     """Exact future event ordered by normalized turn and insertion sequence."""
 
-    at_turn: int
+    at_turn: int = Field(ge=0)
     kind: str
     target: str | None = None
     payload: dict[str, Any] = Field(default_factory=dict)

--- a/engine/src/tangl/mechanics/simulation/calendar.py
+++ b/engine/src/tangl/mechanics/simulation/calendar.py
@@ -1,0 +1,71 @@
+"""Mutable future-event list for deterministic simulations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import Field
+
+from tangl.core import Entity, Registry, Selector
+from tangl.core.bases import BaseModelPlus, HasOrder
+
+
+class SimulationEvent(HasOrder, Entity):
+    """Exact future event ordered by normalized turn and insertion sequence."""
+
+    at_turn: int
+    kind: str
+    target: str | None = None
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+    def sort_key(self) -> tuple[int, int]:
+        """Return deterministic future-event-list ordering."""
+        return (self.at_turn, self.seq)
+
+
+class EventCalendar(BaseModelPlus):
+    """Tiny future-event list backed by core `Registry` selection and sorting."""
+
+    registry: Registry[SimulationEvent] = Field(default_factory=Registry)
+
+    def push(self, event: SimulationEvent) -> SimulationEvent:
+        """Add one event and return it for caller bookkeeping."""
+        self.registry.add(event)
+        return event
+
+    def peek_next(self) -> SimulationEvent | None:
+        """Return the next event without mutating the calendar."""
+        return self.registry.find_one(sort_key=lambda event: event.sort_key())
+
+    def pop_next(self) -> SimulationEvent | None:
+        """Remove and return the next event."""
+        event = self.peek_next()
+        if event is None:
+            return None
+        self.registry.remove(event.uid)
+        return event
+
+    def peek_turn(self) -> int | None:
+        """Return the next event turn, or ``None`` when empty."""
+        event = self.peek_next()
+        return event.at_turn if event is not None else None
+
+    def events(self) -> list[SimulationEvent]:
+        """Return pending events in future-event-list order."""
+        return list(self.registry.find_all(sort_key=lambda event: event.sort_key()))
+
+    def __len__(self) -> int:
+        return len(self.registry.members)
+
+    def is_empty(self) -> bool:
+        """Return whether the calendar has no pending events."""
+        return len(self) == 0
+
+    def find_by_kind(self, kind: str) -> list[SimulationEvent]:
+        """Return pending events of one kind in calendar order."""
+        return list(
+            self.registry.find_all(
+                Selector(kind=kind),
+                sort_key=lambda event: event.sort_key(),
+            )
+        )

--- a/engine/src/tangl/mechanics/simulation/queueing.py
+++ b/engine/src/tangl/mechanics/simulation/queueing.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from statistics import mean
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Literal
 
 from pydantic import Field
 
@@ -27,8 +27,8 @@ class QueueMove:
 class QueueStationSpec(BaseModelPlus):
     """Static service-station configuration."""
 
-    capacity: int = 1
-    service_turns: int = 1
+    capacity: int = Field(default=1, ge=1)
+    service_turns: int = Field(default=1, ge=1)
     next_station: str | None = None
 
 
@@ -36,7 +36,7 @@ class QueuePatient(BaseModelPlus):
     """One job moving through the queueing network."""
 
     label: str
-    arrival_turn: int
+    arrival_turn: int = Field(ge=0)
     current_station: str | None = None
     completed: bool = False
     completion_turn: int | None = None
@@ -60,8 +60,8 @@ class QueueStationState(BaseModelPlus):
     """Mutable service-station state."""
 
     label: str
-    capacity: int = 1
-    service_turns: int = 1
+    capacity: int = Field(default=1, ge=1)
+    service_turns: int = Field(default=1, ge=1)
     next_station: str | None = None
     queue: list[str] = Field(default_factory=list)
     in_service: list[str] = Field(default_factory=list)
@@ -101,7 +101,8 @@ class QueueSimulation(Game[QueueMove]):
     patient_arrivals: dict[str, int] = Field(default_factory=dict)
     station_specs: dict[str, QueueStationSpec] = Field(default_factory=dict)
     entry_station: str = "triage"
-    projection_mode: str = "log"
+    projection_mode: Literal["log", "narrative"] = "log"
+    max_run_events: int = Field(default=10_000, ge=1)
 
     locals: dict[str, Any] = Field(
         default_factory=dict,
@@ -156,6 +157,7 @@ class QueueSimulationHandler(GameHandler[QueueSimulation]):
     game_cls: ClassVar[type[Game]] = QueueSimulation
 
     def on_setup(self, game: QueueSimulation) -> None:
+        self._validate_config(game)
         game.locals["world_turn"] = 0
         game.calendar = EventCalendar()
         game.patients = {
@@ -192,7 +194,7 @@ class QueueSimulationHandler(GameHandler[QueueSimulation]):
         if game.metrics is not None:
             return []
         if game.calendar.is_empty():
-            return []
+            return [QueueMove("run_until_complete")]
         return [QueueMove("run_next"), QueueMove("run_until_complete")]
 
     def get_move_label(self, game: QueueSimulation, move: QueueMove) -> str:
@@ -212,8 +214,15 @@ class QueueSimulationHandler(GameHandler[QueueSimulation]):
             latest = self.run_next_event(game)
         elif player_move.kind == "run_until_complete":
             latest = []
+            processed = 0
             while not game.calendar.is_empty():
+                if processed >= game.max_run_events:
+                    raise RuntimeError(
+                        "run_until_complete exceeded max_run_events; "
+                        "check queue topology for non-terminating routes"
+                    )
                 latest.extend(self.run_next_event(game))
+                processed += 1
         else:
             raise ValueError(f"Unsupported queueing move: {player_move.kind!r}")
 
@@ -224,6 +233,28 @@ class QueueSimulationHandler(GameHandler[QueueSimulation]):
 
         game.latest_trace = latest
         return RoundResult.WIN if game.metrics is not None else RoundResult.CONTINUE
+
+    def _validate_config(self, game: QueueSimulation) -> None:
+        if game.entry_station not in game.station_specs:
+            raise ValueError(
+                f"entry_station must reference a known station: {game.entry_station!r}"
+            )
+        for label, arrival_turn in game.patient_arrivals.items():
+            if arrival_turn < 0:
+                raise ValueError(f"patient {label!r} arrival_turn must be non-negative")
+        for label, spec in game.station_specs.items():
+            if spec.next_station is not None and spec.next_station not in game.station_specs:
+                raise ValueError(
+                    f"station {label!r} next_station is unknown: {spec.next_station!r}"
+                )
+
+        seen: set[str] = set()
+        current: str | None = game.entry_station
+        while current is not None:
+            if current in seen:
+                raise ValueError(f"station topology contains a cycle at {current!r}")
+            seen.add(current)
+            current = game.station_specs[current].next_station
 
     def evaluate(self, game: QueueSimulation) -> GameResult:
         if game.metrics is not None:
@@ -310,7 +341,9 @@ class QueueSimulationHandler(GameHandler[QueueSimulation]):
         event: SimulationEvent,
         latest: list[QueueTraceEvent],
     ) -> None:
-        patient = game.patients[event.target or ""]
+        if event.target is None:
+            raise ValueError("arrival event requires a target patient")
+        patient = game.patients[event.target]
         self._enqueue(game, patient, game.entry_station, latest, arrival=True)
         self._try_start_service(game, game.entry_station, latest)
 
@@ -320,8 +353,11 @@ class QueueSimulationHandler(GameHandler[QueueSimulation]):
         event: SimulationEvent,
         latest: list[QueueTraceEvent],
     ) -> None:
-        patient = game.patients[str(event.payload["patient"])]
-        station_label = str(event.payload["station"])
+        patient_label = event.payload["patient"]
+        station_label = event.payload["station"]
+        if not isinstance(patient_label, str) or not isinstance(station_label, str):
+            raise TypeError("service_complete event payload requires patient and station labels")
+        patient = game.patients[patient_label]
         station = game.stations[station_label]
         station.in_service.remove(patient.label)
         station.completed_count += 1

--- a/engine/src/tangl/mechanics/simulation/queueing.py
+++ b/engine/src/tangl/mechanics/simulation/queueing.py
@@ -1,0 +1,476 @@
+"""Deterministic queueing simulation kernel."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import mean
+from typing import Any, ClassVar
+
+from pydantic import Field
+
+from tangl.core.bases import BaseModelPlus
+from tangl.journal.fragments import ContentFragment
+from tangl.mechanics.games import Game, GameHandler
+from tangl.mechanics.games.enums import GameResult, RoundResult
+from tangl.mechanics.sandbox.time import advance_world_turn_to
+
+from .calendar import EventCalendar, SimulationEvent
+
+
+@dataclass(frozen=True)
+class QueueMove:
+    """Move requested by the queueing simulation block."""
+
+    kind: str
+
+
+class QueueStationSpec(BaseModelPlus):
+    """Static service-station configuration."""
+
+    capacity: int = 1
+    service_turns: int = 1
+    next_station: str | None = None
+
+
+class QueuePatient(BaseModelPlus):
+    """One job moving through the queueing network."""
+
+    label: str
+    arrival_turn: int
+    current_station: str | None = None
+    completed: bool = False
+    completion_turn: int | None = None
+    queued_at: dict[str, int] = Field(default_factory=dict)
+    service_start: dict[str, int] = Field(default_factory=dict)
+    service_end: dict[str, int] = Field(default_factory=dict)
+    wait_turns: dict[str, int] = Field(default_factory=dict)
+
+    def total_wait(self) -> int:
+        """Return total time spent waiting across all stations."""
+        return sum(self.wait_turns.values())
+
+    def length_of_stay(self) -> int | None:
+        """Return arrival-to-completion duration when complete."""
+        if self.completion_turn is None:
+            return None
+        return self.completion_turn - self.arrival_turn
+
+
+class QueueStationState(BaseModelPlus):
+    """Mutable service-station state."""
+
+    label: str
+    capacity: int = 1
+    service_turns: int = 1
+    next_station: str | None = None
+    queue: list[str] = Field(default_factory=list)
+    in_service: list[str] = Field(default_factory=list)
+    busy_turns: int = 0
+    max_queue_length: int = 0
+    started_count: int = 0
+    completed_count: int = 0
+
+
+class QueueTraceEvent(BaseModelPlus):
+    """One observed fact from a queueing run."""
+
+    turn: int
+    kind: str
+    text: str
+    patient: str | None = None
+    station: str | None = None
+
+
+class QueueMetrics(BaseModelPlus):
+    """Simple one-run queueing metrics."""
+
+    completed_count: int = 0
+    completed_turn: int = 0
+    mean_length_of_stay: float = 0.0
+    mean_wait: float = 0.0
+    utilization: dict[str, float] = Field(default_factory=dict)
+    bottleneck: str = ""
+
+
+class QueueSimulation(Game[QueueMove]):
+    """Deterministic single-run queueing simulation."""
+
+    scoring_strategy: str = "single_round"
+    opponent_strategy: str | None = None
+
+    patient_arrivals: dict[str, int] = Field(default_factory=dict)
+    station_specs: dict[str, QueueStationSpec] = Field(default_factory=dict)
+    entry_station: str = "triage"
+    projection_mode: str = "log"
+
+    locals: dict[str, Any] = Field(
+        default_factory=dict,
+        json_schema_extra={"reset_field": True},
+    )
+    calendar: EventCalendar = Field(
+        default_factory=EventCalendar,
+        json_schema_extra={"reset_field": True},
+    )
+    patients: dict[str, QueuePatient] = Field(
+        default_factory=dict,
+        json_schema_extra={"reset_field": True},
+    )
+    stations: dict[str, QueueStationState] = Field(
+        default_factory=dict,
+        json_schema_extra={"reset_field": True},
+    )
+    completed: list[str] = Field(
+        default_factory=list,
+        json_schema_extra={"reset_field": True},
+    )
+    trace: list[QueueTraceEvent] = Field(
+        default_factory=list,
+        json_schema_extra={"reset_field": True},
+    )
+    latest_trace: list[QueueTraceEvent] = Field(
+        default_factory=list,
+        json_schema_extra={"reset_field": True},
+    )
+    metrics: QueueMetrics | None = Field(
+        default=None,
+        json_schema_extra={"reset_field": True},
+    )
+
+    def to_namespace(self) -> dict[str, object]:
+        """Expose simulation facts to ordinary predicate evaluation."""
+        namespace = super().to_namespace()
+        namespace.update(
+            {
+                "simulation_turn": int(self.locals.get("world_turn", 0)),
+                "queue_completed_count": len(self.completed),
+                "queue_bottleneck": self.metrics.bottleneck if self.metrics else "",
+                "queue_metrics": self.metrics,
+            }
+        )
+        return namespace
+
+
+class QueueSimulationHandler(GameHandler[QueueSimulation]):
+    """Stateless rules for deterministic queueing simulations."""
+
+    game_cls: ClassVar[type[Game]] = QueueSimulation
+
+    def on_setup(self, game: QueueSimulation) -> None:
+        game.locals["world_turn"] = 0
+        game.calendar = EventCalendar()
+        game.patients = {
+            label: QueuePatient(label=label, arrival_turn=arrival_turn)
+            for label, arrival_turn in sorted(
+                game.patient_arrivals.items(),
+                key=lambda item: item[1],
+            )
+        }
+        game.stations = {
+            label: QueueStationState(
+                label=label,
+                capacity=spec.capacity,
+                service_turns=spec.service_turns,
+                next_station=spec.next_station,
+            )
+            for label, spec in game.station_specs.items()
+        }
+        game.completed = []
+        game.trace = []
+        game.latest_trace = []
+        game.metrics = None
+        for patient in game.patients.values():
+            game.calendar.push(
+                SimulationEvent(
+                    label=f"arrival_{patient.label}",
+                    at_turn=patient.arrival_turn,
+                    kind="arrival",
+                    target=patient.label,
+                )
+            )
+
+    def get_available_moves(self, game: QueueSimulation) -> list[QueueMove]:
+        if game.metrics is not None:
+            return []
+        if game.calendar.is_empty():
+            return []
+        return [QueueMove("run_next"), QueueMove("run_until_complete")]
+
+    def get_move_label(self, game: QueueSimulation, move: QueueMove) -> str:
+        if move.kind == "run_next":
+            return "Run next event"
+        if move.kind == "run_until_complete":
+            return "Run until complete"
+        return super().get_move_label(game, move)
+
+    def resolve_round(
+        self,
+        game: QueueSimulation,
+        player_move: QueueMove,
+        opponent_move: QueueMove | None,
+    ) -> RoundResult:
+        if player_move.kind == "run_next":
+            latest = self.run_next_event(game)
+        elif player_move.kind == "run_until_complete":
+            latest = []
+            while not game.calendar.is_empty():
+                latest.extend(self.run_next_event(game))
+        else:
+            raise ValueError(f"Unsupported queueing move: {player_move.kind!r}")
+
+        if game.calendar.is_empty():
+            game.metrics = self.compute_metrics(game)
+            latest.append(self._summary_event(game))
+            game.score["player"] = 1
+
+        game.latest_trace = latest
+        return RoundResult.WIN if game.metrics is not None else RoundResult.CONTINUE
+
+    def evaluate(self, game: QueueSimulation) -> GameResult:
+        if game.metrics is not None:
+            return GameResult.WIN
+        return GameResult.IN_PROCESS
+
+    def build_round_notes(
+        self,
+        game: QueueSimulation,
+        player_move: QueueMove,
+        opponent_move: QueueMove | None,
+        round_result: RoundResult,
+    ) -> dict[str, Any] | None:
+        return {
+            "action": player_move.kind,
+            "round_result": round_result.value,
+            "latest_trace": [event.model_dump() for event in game.latest_trace],
+            "metrics": game.metrics.model_dump() if game.metrics is not None else None,
+        }
+
+    def get_journal_fragments(self, game: QueueSimulation) -> list[ContentFragment] | None:
+        return [
+            ContentFragment(content=self.render_trace_event(game, event))
+            for event in game.latest_trace
+        ]
+
+    def run_next_event(self, game: QueueSimulation) -> list[QueueTraceEvent]:
+        """Pop and process the next future event."""
+        event = game.calendar.pop_next()
+        if event is None:
+            return []
+
+        advance_world_turn_to(game, event.at_turn)
+        latest: list[QueueTraceEvent] = []
+        if event.kind == "arrival":
+            self._handle_arrival(game, event, latest)
+        elif event.kind == "service_complete":
+            self._handle_service_complete(game, event, latest)
+        else:
+            raise ValueError(f"Unsupported simulation event kind: {event.kind!r}")
+        game.trace.extend(latest)
+        return latest
+
+    def compute_metrics(self, game: QueueSimulation) -> QueueMetrics:
+        """Compute one-run metrics from completed state."""
+        completed_patients = [game.patients[label] for label in game.completed]
+        stays = [
+            stay
+            for patient in completed_patients
+            if (stay := patient.length_of_stay()) is not None
+        ]
+        waits = [patient.total_wait() for patient in completed_patients]
+        completed_turn = max(
+            (patient.completion_turn or 0 for patient in completed_patients),
+            default=0,
+        )
+        utilization = {
+            label: (
+                station.busy_turns / (completed_turn * station.capacity)
+                if completed_turn and station.capacity
+                else 0.0
+            )
+            for label, station in game.stations.items()
+        }
+        bottleneck = max(utilization, key=utilization.get) if utilization else ""
+        return QueueMetrics(
+            completed_count=len(completed_patients),
+            completed_turn=completed_turn,
+            mean_length_of_stay=mean(stays) if stays else 0.0,
+            mean_wait=mean(waits) if waits else 0.0,
+            utilization=utilization,
+            bottleneck=bottleneck,
+        )
+
+    def render_trace_event(self, game: QueueSimulation, event: QueueTraceEvent) -> str:
+        """Render one trace fact in the configured projection mode."""
+        if game.projection_mode == "narrative":
+            return self._narrative_text(event)
+        return f"{self._clock_label(event.turn)} — {event.text}"
+
+    def _handle_arrival(
+        self,
+        game: QueueSimulation,
+        event: SimulationEvent,
+        latest: list[QueueTraceEvent],
+    ) -> None:
+        patient = game.patients[event.target or ""]
+        self._enqueue(game, patient, game.entry_station, latest, arrival=True)
+        self._try_start_service(game, game.entry_station, latest)
+
+    def _handle_service_complete(
+        self,
+        game: QueueSimulation,
+        event: SimulationEvent,
+        latest: list[QueueTraceEvent],
+    ) -> None:
+        patient = game.patients[str(event.payload["patient"])]
+        station_label = str(event.payload["station"])
+        station = game.stations[station_label]
+        station.in_service.remove(patient.label)
+        station.completed_count += 1
+        patient.service_end[station_label] = event.at_turn
+        latest.append(
+            self._trace(
+                game,
+                "service_complete",
+                f"{patient.label} completes {station_label}.",
+                patient=patient.label,
+                station=station_label,
+            )
+        )
+
+        next_station = station.next_station
+        if next_station is None:
+            patient.completed = True
+            patient.completion_turn = event.at_turn
+            patient.current_station = None
+            game.completed.append(patient.label)
+            latest.append(
+                self._trace(
+                    game,
+                    "complete",
+                    f"{patient.label} is discharged.",
+                    patient=patient.label,
+                )
+            )
+        else:
+            self._enqueue(game, patient, next_station, latest)
+
+        self._try_start_service(game, station_label, latest)
+        if next_station is not None:
+            self._try_start_service(game, next_station, latest)
+
+    def _enqueue(
+        self,
+        game: QueueSimulation,
+        patient: QueuePatient,
+        station_label: str,
+        latest: list[QueueTraceEvent],
+        *,
+        arrival: bool = False,
+    ) -> None:
+        station = game.stations[station_label]
+        patient.current_station = station_label
+        patient.queued_at[station_label] = int(game.locals["world_turn"])
+        station.queue.append(patient.label)
+        station.max_queue_length = max(station.max_queue_length, len(station.queue))
+        if arrival:
+            text = f"{patient.label} arrives and enters {station_label}."
+            kind = "arrival"
+        else:
+            text = f"{patient.label} waits for {station_label}."
+            kind = "queued"
+        latest.append(
+            self._trace(
+                game,
+                kind,
+                text,
+                patient=patient.label,
+                station=station_label,
+            )
+        )
+
+    def _try_start_service(
+        self,
+        game: QueueSimulation,
+        station_label: str,
+        latest: list[QueueTraceEvent],
+    ) -> None:
+        station = game.stations[station_label]
+        while station.queue and len(station.in_service) < station.capacity:
+            patient = game.patients[station.queue.pop(0)]
+            now = int(game.locals["world_turn"])
+            station.in_service.append(patient.label)
+            station.started_count += 1
+            station.busy_turns += station.service_turns
+            patient.service_start[station_label] = now
+            patient.wait_turns[station_label] = now - patient.queued_at[station_label]
+            game.calendar.push(
+                SimulationEvent(
+                    label=f"complete_{patient.label}_{station_label}_{now}",
+                    at_turn=now + station.service_turns,
+                    kind="service_complete",
+                    target=station_label,
+                    payload={
+                        "patient": patient.label,
+                        "station": station_label,
+                    },
+                )
+            )
+            latest.append(
+                self._trace(
+                    game,
+                    "service_start",
+                    f"{patient.label} starts {station_label}.",
+                    patient=patient.label,
+                    station=station_label,
+                )
+            )
+
+    def _summary_event(self, game: QueueSimulation) -> QueueTraceEvent:
+        metrics = game.metrics
+        if metrics is None:
+            raise ValueError("Cannot summarize incomplete queue simulation")
+        return self._trace(
+            game,
+            "summary",
+            (
+                f"Summary: completed={metrics.completed_count}; "
+                f"mean_los={metrics.mean_length_of_stay:.1f}; "
+                f"mean_wait={metrics.mean_wait:.1f}; "
+                f"bottleneck={metrics.bottleneck}."
+            ),
+        )
+
+    def _trace(
+        self,
+        game: QueueSimulation,
+        kind: str,
+        text: str,
+        *,
+        patient: str | None = None,
+        station: str | None = None,
+    ) -> QueueTraceEvent:
+        return QueueTraceEvent(
+            turn=int(game.locals["world_turn"]),
+            kind=kind,
+            text=text,
+            patient=patient,
+            station=station,
+        )
+
+    def _narrative_text(self, event: QueueTraceEvent) -> str:
+        clock = self._clock_label(event.turn)
+        if event.kind == "arrival":
+            return f"{clock}: the doors open for {event.patient}."
+        if event.kind == "queued":
+            return f"{clock}: {event.patient} joins the wait for {event.station}."
+        if event.kind == "service_start":
+            return f"{clock}: {event.station} takes {event.patient} into service."
+        if event.kind == "service_complete":
+            return f"{clock}: {event.patient} clears {event.station}."
+        if event.kind == "complete":
+            return f"{clock}: {event.patient} leaves the department."
+        if event.kind == "summary":
+            return f"{clock}: the run settles; {event.text}"
+        return f"{clock}: {event.text}"
+
+    def _clock_label(self, turn: int) -> str:
+        return f"{turn:02d}:00"

--- a/engine/tests/loaders/test_ed_queue_demo_world.py
+++ b/engine/tests/loaders/test_ed_queue_demo_world.py
@@ -1,0 +1,67 @@
+"""Tests for the ED queueing simulation demo world bundle."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tangl.core import Selector
+from tangl.loaders import WorldBundle
+from tangl.loaders.compiler import WorldCompiler
+from tangl.service.world_registry import WorldRegistry
+from tangl.story import Action, InitMode
+from tangl.vm import Ledger
+
+
+def _repo_worlds_dir() -> Path:
+    return Path(__file__).resolve().parents[3] / "worlds"
+
+
+def _ed_queue_root() -> Path:
+    return _repo_worlds_dir() / "ed_queue_demo"
+
+
+def _actions(ledger: Ledger) -> list[Action]:
+    return list(ledger.cursor.edges_out(Selector(has_kind=Action, trigger_phase=None)))
+
+
+class TestEdQueueDemoWorld:
+    """Tests for the ED queueing simulation demo."""
+
+    def test_world_registry_discovers_ed_queue_demo(self) -> None:
+        registry = WorldRegistry([_repo_worlds_dir()])
+
+        assert "ed_queue_demo" in registry.bundles
+        bundle = registry.bundles["ed_queue_demo"]
+        assert bundle.manifest.label == "ed_queue_demo"
+        assert bundle.manifest.metadata["title"] == "ED Queue Demo"
+
+    def test_ed_queue_demo_compiles_and_runs_to_summary(self) -> None:
+        bundle = WorldBundle.load(_ed_queue_root())
+        world = WorldCompiler().compile(bundle)
+
+        assert "EdQueueBlock" in world.class_registry
+
+        result = world.create_story("ed_queue_demo", init_mode=InitMode.EAGER)
+        ledger = Ledger.from_graph(result.graph, entry_id=result.graph.initial_cursor_id)
+
+        assert ledger.cursor.label == "entrance"
+        ledger.resolve_choice(_actions(ledger)[0].uid)
+
+        assert ledger.cursor.label == "simulation"
+        run_until_complete = next(
+            action
+            for action in _actions(ledger)
+            if action.label == "Run until complete"
+        )
+        ledger.resolve_choice(
+            run_until_complete.uid,
+            choice_payload=run_until_complete.payload,
+        )
+
+        assert ledger.cursor.label == "summary"
+        content = " ".join(
+            getattr(fragment, "content", "")
+            for fragment in ledger.get_journal()
+        )
+        assert "mean_los=14.0" in content
+        assert "bottleneck=imaging" in content

--- a/engine/tests/loaders/test_ed_queue_demo_world.py
+++ b/engine/tests/loaders/test_ed_queue_demo_world.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from tangl.core import Selector
+from tangl.journal.fragments import ContentFragment
 from tangl.loaders import WorldBundle
 from tangl.loaders.compiler import WorldCompiler
 from tangl.service.world_registry import WorldRegistry
@@ -60,8 +61,9 @@ class TestEdQueueDemoWorld:
 
         assert ledger.cursor.label == "summary"
         content = " ".join(
-            getattr(fragment, "content", "")
+            fragment.content
             for fragment in ledger.get_journal()
+            if isinstance(fragment, ContentFragment)
         )
         assert "mean_los=14.0" in content
         assert "bottleneck=imaging" in content

--- a/engine/tests/mechanics/simulation/test_queueing.py
+++ b/engine/tests/mechanics/simulation/test_queueing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from pydantic import Field
 
 from tangl.core import Graph
@@ -79,12 +80,8 @@ def test_advance_world_turn_to_advances_and_rejects_backwards() -> None:
     assert source.locals["world_turn"] == 5
     assert advance_world_turn_to(source, 5) == 0
 
-    try:
+    with pytest.raises(ValueError, match="target_turn"):
         advance_world_turn_to(source, 4)
-    except ValueError as exc:
-        assert "target_turn" in str(exc)
-    else:
-        raise AssertionError("backward clock jumps should fail")
 
 
 def test_event_calendar_peeks_and_pops_by_turn_then_sequence() -> None:
@@ -118,6 +115,37 @@ def test_queueing_run_processes_events_in_order_and_completes_patients() -> None
         "imaging": 0.8,
         "disposition": 0.32,
     }
+
+
+def test_queueing_empty_run_can_complete() -> None:
+    game = QueueSimulation(
+        station_specs={"triage": QueueStationSpec()},
+        entry_station="triage",
+    )
+    handler = QueueSimulationHandler()
+    handler.setup(game)
+
+    assert [move.kind for move in handler.get_available_moves(game)] == ["run_until_complete"]
+
+    handler.receive_move(game, QueueMove("run_until_complete"))
+
+    assert game.metrics is not None
+    assert game.metrics.completed_count == 0
+    assert game.metrics.completed_turn == 0
+
+
+def test_queueing_rejects_non_terminating_topology() -> None:
+    game = QueueSimulation(
+        patient_arrivals={"P1": 0},
+        station_specs={
+            "triage": QueueStationSpec(next_station="imaging"),
+            "imaging": QueueStationSpec(next_station="triage"),
+        },
+        entry_station="triage",
+    )
+
+    with pytest.raises(ValueError, match="cycle"):
+        QueueSimulationHandler().setup(game)
 
 
 def test_queueing_capacity_and_fifo_order_are_respected() -> None:

--- a/engine/tests/mechanics/simulation/test_queueing.py
+++ b/engine/tests/mechanics/simulation/test_queueing.py
@@ -1,0 +1,203 @@
+"""Tests for deterministic simulation and queueing mechanics."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from tangl.core import Graph
+from tangl.core.bases import BaseModelPlus
+from tangl.journal.fragments import ContentFragment
+from tangl.mechanics.games import HasGame
+from tangl.mechanics.games.handlers import provision_game_moves
+from tangl.mechanics.sandbox.time import advance_world_turn_to
+from tangl.mechanics.simulation import (
+    EventCalendar,
+    QueueMove,
+    QueueSimulation,
+    QueueSimulationHandler,
+    QueueStationSpec,
+    SimulationEvent,
+)
+from tangl.story import Action, Block
+from tangl.vm import Frame, Ledger, TraversableEdge as ChoiceEdge
+
+
+class ClockSource(BaseModelPlus):
+    """Minimal locals-bearing object for clock helper tests."""
+
+    locals: dict[str, object] = Field(default_factory=dict)
+
+
+class QueueBlock(HasGame, Block):
+    """Test block embedding the queue simulation."""
+
+    _game_class = QueueSimulation
+    _game_handler_class = QueueSimulationHandler
+
+
+def _ed_game(*, projection_mode: str = "log") -> QueueSimulation:
+    return QueueSimulation(
+        patient_arrivals={
+            "P1": 0,
+            "P2": 2,
+            "P3": 4,
+            "P4": 8,
+        },
+        station_specs={
+            "triage": QueueStationSpec(
+                capacity=1,
+                service_turns=3,
+                next_station="imaging",
+            ),
+            "imaging": QueueStationSpec(
+                capacity=1,
+                service_turns=5,
+                next_station="disposition",
+            ),
+            "disposition": QueueStationSpec(
+                capacity=1,
+                service_turns=2,
+                next_station=None,
+            ),
+        },
+        entry_station="triage",
+        projection_mode=projection_mode,
+    )
+
+
+def _run_to_completion(game: QueueSimulation) -> QueueSimulationHandler:
+    handler = QueueSimulationHandler()
+    handler.setup(game)
+    handler.receive_move(game, QueueMove("run_until_complete"))
+    return handler
+
+
+def test_advance_world_turn_to_advances_and_rejects_backwards() -> None:
+    source = ClockSource(locals={"world_turn": 2})
+
+    assert advance_world_turn_to(source, 5) == 3
+    assert source.locals["world_turn"] == 5
+    assert advance_world_turn_to(source, 5) == 0
+
+    try:
+        advance_world_turn_to(source, 4)
+    except ValueError as exc:
+        assert "target_turn" in str(exc)
+    else:
+        raise AssertionError("backward clock jumps should fail")
+
+
+def test_event_calendar_peeks_and_pops_by_turn_then_sequence() -> None:
+    calendar = EventCalendar()
+    later = calendar.push(SimulationEvent(label="later", at_turn=3, kind="x"))
+    first = calendar.push(SimulationEvent(label="first", at_turn=1, kind="x"))
+    second = calendar.push(SimulationEvent(label="second", at_turn=1, kind="x"))
+
+    assert calendar.peek_next() is first
+    assert len(calendar) == 3
+    assert calendar.pop_next() is first
+    assert calendar.pop_next() is second
+    assert calendar.pop_next() is later
+    assert calendar.pop_next() is None
+
+
+def test_queueing_run_processes_events_in_order_and_completes_patients() -> None:
+    game = _ed_game()
+    _run_to_completion(game)
+
+    assert [event.turn for event in game.trace] == sorted(event.turn for event in game.trace)
+    assert game.completed == ["P1", "P2", "P3", "P4"]
+    assert game.metrics is not None
+    assert game.metrics.completed_count == 4
+    assert game.metrics.completed_turn == 25
+    assert game.metrics.mean_length_of_stay == 14.0
+    assert game.metrics.mean_wait == 4.0
+    assert game.metrics.bottleneck == "imaging"
+    assert game.metrics.utilization == {
+        "triage": 0.48,
+        "imaging": 0.8,
+        "disposition": 0.32,
+    }
+
+
+def test_queueing_capacity_and_fifo_order_are_respected() -> None:
+    game = _ed_game()
+    _run_to_completion(game)
+
+    for station_label, station in game.stations.items():
+        boundaries: list[tuple[int, int]] = []
+        for patient in game.patients.values():
+            if station_label not in patient.service_start:
+                continue
+            boundaries.append((patient.service_start[station_label], 1))
+            boundaries.append((patient.service_end[station_label], -1))
+        active = 0
+        for _, delta in sorted(boundaries):
+            active += delta
+            assert active <= station.capacity
+
+    assert [
+        patient.label
+        for patient in sorted(
+            game.patients.values(),
+            key=lambda patient: patient.service_start["triage"],
+        )
+    ] == ["P1", "P2", "P3", "P4"]
+
+
+def test_queueing_log_and_narrative_projection_share_trace() -> None:
+    log_game = _ed_game(projection_mode="log")
+    narrative_game = _ed_game(projection_mode="narrative")
+    log_handler = _run_to_completion(log_game)
+    narrative_handler = _run_to_completion(narrative_game)
+
+    assert [event.model_dump() for event in log_game.latest_trace] == [
+        event.model_dump() for event in narrative_game.latest_trace
+    ]
+    log_fragments = log_handler.get_journal_fragments(log_game)
+    narrative_fragments = narrative_handler.get_journal_fragments(narrative_game)
+    assert log_fragments is not None
+    assert narrative_fragments is not None
+    assert isinstance(log_fragments[0], ContentFragment)
+    assert "—" in log_fragments[0].content
+    assert "the doors open" in narrative_fragments[0].content
+
+
+def test_queueing_hasgame_provisions_self_loop_and_journals_fragments() -> None:
+    graph = Graph(label="queueing_flow")
+    intro = graph.add_node(kind=Block, label="intro")
+    block = graph.add_node(kind=QueueBlock, label="queue")
+    block._game = _ed_game()
+    ChoiceEdge(
+        graph=graph,
+        predecessor_id=intro.uid,
+        successor_id=block.uid,
+        label="Run queue",
+    )
+
+    ledger = Ledger.from_graph(graph=graph, entry_id=intro.uid)
+    enter = next(edge for edge in ledger.cursor.edges_out() if edge.label == "Run queue")
+    ledger.resolve_choice(enter.uid)
+
+    frame = Frame(graph=graph, cursor=ledger.cursor)
+    ctx = frame._make_ctx()
+    object.__setattr__(ctx, "_frame", frame)
+    actions = provision_game_moves(ledger.cursor, ctx=ctx)
+    labels = {action.label for action in actions}
+    assert labels == {"Run next event", "Run until complete"}
+
+    run_next = next(
+        action
+        for action in ledger.cursor.edges_out()
+        if isinstance(action, Action) and action.label == "Run next event"
+    )
+    ledger.resolve_choice(run_next.uid, choice_payload=run_next.payload)
+
+    assert ledger.cursor_id == block.uid
+    content = [
+        fragment.content
+        for fragment in ledger.get_journal()
+        if isinstance(fragment, ContentFragment)
+    ]
+    assert any("P1 arrives and enters triage" in item for item in content)
+    assert any("P1 starts triage" in item for item in content)

--- a/worlds/ed_queue_demo/ed_queue_demo/__init__.py
+++ b/worlds/ed_queue_demo/ed_queue_demo/__init__.py
@@ -1,0 +1,1 @@
+"""ED queueing simulation demo world."""

--- a/worlds/ed_queue_demo/ed_queue_demo/domain.py
+++ b/worlds/ed_queue_demo/ed_queue_demo/domain.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from uuid import UUID
 
+from pydantic import Field
+
 from tangl.mechanics.games import HasGame
 from tangl.mechanics.simulation import QueueSimulation, QueueSimulationHandler, QueueStationSpec
 from tangl.story import Block
@@ -10,17 +12,25 @@ from tangl.story import Block
 class EdQueueSimulation(QueueSimulation):
     """Deterministic ED queue configuration for the demo world."""
 
-    patient_arrivals: dict[str, int] = {
-        "P1": 0,
-        "P2": 2,
-        "P3": 4,
-        "P4": 8,
-    }
-    station_specs: dict[str, QueueStationSpec] = {
-        "triage": QueueStationSpec(capacity=1, service_turns=3, next_station="imaging"),
-        "imaging": QueueStationSpec(capacity=1, service_turns=5, next_station="disposition"),
-        "disposition": QueueStationSpec(capacity=1, service_turns=2, next_station=None),
-    }
+    patient_arrivals: dict[str, int] = Field(
+        default_factory=lambda: {
+            "P1": 0,
+            "P2": 2,
+            "P3": 4,
+            "P4": 8,
+        }
+    )
+    station_specs: dict[str, QueueStationSpec] = Field(
+        default_factory=lambda: {
+            "triage": QueueStationSpec(capacity=1, service_turns=3, next_station="imaging"),
+            "imaging": QueueStationSpec(
+                capacity=1,
+                service_turns=5,
+                next_station="disposition",
+            ),
+            "disposition": QueueStationSpec(capacity=1, service_turns=2, next_station=None),
+        }
+    )
     entry_station: str = "triage"
 
 

--- a/worlds/ed_queue_demo/ed_queue_demo/domain.py
+++ b/worlds/ed_queue_demo/ed_queue_demo/domain.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from tangl.mechanics.games import HasGame
+from tangl.mechanics.simulation import QueueSimulation, QueueSimulationHandler, QueueStationSpec
+from tangl.story import Block
+
+
+class EdQueueSimulation(QueueSimulation):
+    """Deterministic ED queue configuration for the demo world."""
+
+    patient_arrivals: dict[str, int] = {
+        "P1": 0,
+        "P2": 2,
+        "P3": 4,
+        "P4": 8,
+    }
+    station_specs: dict[str, QueueStationSpec] = {
+        "triage": QueueStationSpec(capacity=1, service_turns=3, next_station="imaging"),
+        "imaging": QueueStationSpec(capacity=1, service_turns=5, next_station="disposition"),
+        "disposition": QueueStationSpec(capacity=1, service_turns=2, next_station=None),
+    }
+    entry_station: str = "triage"
+
+
+class EdQueueBlock(HasGame, Block):
+    """Story block hosting the ED queueing simulation."""
+
+    _game_class = EdQueueSimulation
+    _game_handler_class = QueueSimulationHandler
+
+
+EdQueueBlock.model_rebuild(_types_namespace={"UUID": UUID})

--- a/worlds/ed_queue_demo/script.yaml
+++ b/worlds/ed_queue_demo/script.yaml
@@ -1,0 +1,36 @@
+label: ed_queue_demo
+
+metadata:
+  title: "ED Queue Demo"
+  description: "A deterministic queueing simulation proof."
+  start_at: ed_queue.entrance
+
+scenes:
+  ed_queue:
+    title: "ED Queue Demo"
+    blocks:
+      entrance:
+        content: |
+          The department is quiet enough to study: four arrivals, three
+          stations, one obvious bottleneck waiting to reveal itself.
+        actions:
+          - text: "Open the event list"
+            successor: simulation
+
+      simulation:
+        kind: "ed_queue_demo.domain.EdQueueBlock"
+        content: |
+          The board is ready. Triage, imaging, and disposition will run from
+          the same deterministic future-event list.
+        continues:
+          - successor: summary
+            trigger: last
+            predicate: game_won
+
+      summary:
+        content: |
+          The trace is complete. The journal has already shown the run; the
+          ledger can now be mined for the queueing metrics.
+        actions:
+          - text: "Run it again"
+            successor: entrance

--- a/worlds/ed_queue_demo/world.yaml
+++ b/worlds/ed_queue_demo/world.yaml
@@ -1,0 +1,6 @@
+label: ed_queue_demo
+scripts: script.yaml
+domain_module: ed_queue_demo.domain
+metadata:
+  title: "ED Queue Demo"
+  description: "A deterministic queueing simulation proof."


### PR DESCRIPTION
## Summary
- Add a small simulation-oriented sandbox/time module and queueing primitives under `tangl.mechanics`
- Wire up calendar and queueing support for the ED demo world scaffold
- Add README notes plus loader and simulation tests to cover the new spike path

## Testing
- Added unit coverage for queueing behavior in `engine/tests/mechanics/simulation/test_queueing.py`
- Added loader coverage for the ED queue demo world in `engine/tests/loaders/test_ed_queue_demo_world.py`
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added deterministic event scheduling system for simulations with calendar-based event management.
  * Introduced queueing simulation mechanics supporting operational scenarios with patient flow, station capacity, and performance metrics.
  * New "ED Queue Demo" world demonstrating an emergency department queueing simulation with triage, imaging, and disposition stations.

* **Documentation**
  * Updated mechanics documentation to include the new Simulation and Sandbox families.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/derekmerck/storytangl/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->