### PR TITLE
Complex entry and re-entry patterns

### DIFF
--- a/engine/src/tangl/mechanics/sandbox/README.md
+++ b/engine/src/tangl/mechanics/sandbox/README.md
@@ -207,12 +207,15 @@ object declarations as semantic facts like `portable`, `lockable`,
 Those traits are authoring compression: the compiler lowers them into typed
 runtime facets, and handlers project ordinary StoryTangl actions from the
 facets.
-The first executable slice lives in
-`engine/tests/mechanics/test_sandbox_adventure_slice.py` and now runs through
-`SandboxSliceCompiler`. This compiler is intentionally below the full loader
-stack: future codecs can decode source formats into the compact slice schema,
-and later world-bundle integration can decide how much of this should become a
-shared story/world compiler layer.
+The compact compiler pressure test lives in
+`engine/tests/mechanics/test_sandbox_adventure_slice.py` and runs through
+`SandboxSliceCompiler`. A playable world-bundle version lives in
+`worlds/adventure_sandbox_slice`; it declares the map as ordinary near-native
+world blocks and uses a small domain setup handler to attach the shared scope,
+assets, fixtures, and pirate. The compiler is intentionally below the full
+loader stack: future codecs can decode source formats into the compact slice
+schema, and later world-bundle integration can decide how much of this should
+become a shared story/world compiler layer.
 
 The compact schema can also declare materialization policy. The current sandbox
 slice compiler is allowed to be fully eager: declared locations, assets, and

--- a/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
+++ b/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
@@ -131,11 +131,37 @@ The current v38 architecture already has most of the sandbox substrate:
   which gives generated choices their own activation conditions and mutations.
 - `TraversableEdge.return_phase` supports jump-and-return interactions.
 - Target-node availability expresses entry gating.
+- VM container entry projection lets a sandbox hub, questline, or board-like
+  scope re-enter through a remembered or conditional child without creating a
+  sandbox cursor.
 - Namespace gathering exposes caller, ancestor, role, setting, graph, and world
   locals to predicates and render.
 
 The sandbox package should add reusable rules and schedule/time vocabulary, not
 a second VM.
+
+### Re-entrant Hubs And Board-like Scopes
+
+Sandbox hubs are ordinary traversable containers that happen to project
+location-centered affordances. When a hub needs to resume somewhere other than
+its default source, it should use the VM's `resolve_entry(ctx)` / `enter(ctx)`
+contract rather than a sandbox-specific traversal path. A town hub can resume a
+tavern questline, a castle escape, or a local board-game phase by changing the
+container's continuation target; the VM still follows one cursor through one
+ordinary descent edge at a time.
+
+Board-game and track interactions fit this same model. The board or track can
+be a constrained sandbox-like scope whose active entry is the current phase or
+space. Token positions, score, supplies, dice state, and turn counters remain
+scope-local state or assets, not VM cursors. `HasGame` may wrap that scope when
+the rules want a game facade, but the underlying traversal remains normal VM
+container entry projection.
+
+Dynamic sandbox affordances remain ephemeral. Each projector clears only the
+actions it previously generated for the active owner node, then rebuilds from
+current location, inventory, mobs, schedule, and scope state. This is the same
+refresh pattern used by game move projection: re-entering a hub means
+recomputing the visible frontier, not trusting stale generated edges.
 
 ### Architectural Legitimacy Guardrail
 

--- a/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
+++ b/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
@@ -707,6 +707,47 @@ that observer's generic vocabulary to its own mechanics package and keep only
 the sandbox adapter here. The sandbox package should remain the dynamic-hub and
 scoped-time host, not the permanent home for every tick-compatible subsystem.
 
+##### Future Work: Timed Process / Counter Vocabulary
+
+`ChargeFacet` and queueing service completions are probably two projections of a
+smaller shared mechanic: a normalized counter or timed process with a progress
+policy and a completion event.
+
+They should not be unified by making triage service time pretend to be lamp oil.
+`ChargeFacet` is useful story vocabulary for batteries, lamp fuel, oxygen,
+ammunition drip, cooldowns, fatigue, and other resources that deplete or refill.
+Queue service time is better modeled as work in progress that schedules or
+emits a completion. The reusable layer underneath both is closer to:
+
+```text
+normalized counter + consumption/progress predicate + warning/completion policy
+```
+
+Examples:
+
+- lamp charge decreases while lit and emits exhaustion when it reaches zero;
+- queue service completes after a normalized duration and emits
+  `service_complete`;
+- a deadline expires at a normalized turn and emits a failure or warning;
+- a build, research, recovery, or cooldown timer progresses while its enabling
+  conditions hold and emits a completion affordance/event.
+
+The queueing proof currently uses the event-calendar path because DES wants
+next-event advancement: when service starts, it schedules completion at
+`now + service_turns`. The lamp proof currently uses the sandbox tick path
+because visible/offscreen depletion is easiest to reason about one normalized
+tick at a time. A future `TimedProcessFacet`, `CountdownFacet`, or similarly
+named mechanics-level type could expose both adapters:
+
+- sandbox tick adapter: observe each normalized tick and mutate the counter;
+- simulation calendar adapter: schedule the next completion directly;
+- journal/story-info adapter: project warnings, exhaustion, completion, and
+  remaining-time summaries.
+
+That promotion should happen only after one more non-lamp and non-queue use case
+proves the common shape. Until then, keep `ChargeFacet` domain-specific and keep
+queue service completion in the simulation package.
+
 #### Effect-Phase Content Injection
 
 Tick observers may produce journalable facts during UPDATE, before the JOURNAL

--- a/engine/src/tangl/mechanics/simulation/README.md
+++ b/engine/src/tangl/mechanics/simulation/README.md
@@ -11,3 +11,10 @@ describe availability against a derived `WorldTime`; the simulation event
 calendar stores exact future events and supports next-event advancement. Both
 share normalized integer time and can be bridged later when a sandbox scope wants
 to host a queueing or resource simulation as a tick-compatible observer.
+
+Future work should explore a shared timed-process/counter vocabulary under both
+`ChargeFacet` and queue service completions. The queueing demo should keep using
+calendar-scheduled `service_complete` events for now; lamp charge should keep
+using sandbox tick depletion. If another timer-like mechanic proves the same
+shape, promote the common counter/progress/completion surface into a small
+mechanics-level type and leave charge and queueing as domain-specific adapters.

--- a/engine/src/tangl/story/system_handlers.py
+++ b/engine/src/tangl/story/system_handlers.py
@@ -24,6 +24,7 @@ from tangl.vm import (
     Affordance,
     Dependency,
     Resolver,
+    TraversableNode,
     do_compose_journal,
     on_provision,
 )
@@ -220,6 +221,11 @@ def _choice_unavailable_reason(*, edge: Action, ctx) -> str | None:
             return None
         return "missing_successor"
 
+    if isinstance(edge.successor, TraversableNode) and edge.successor.is_container:
+        preview = Resolver.from_ctx(ctx).preview_frontier_node(edge.successor, _ctx=ctx)
+        if not preview.viable:
+            return "missing_dependency"
+
     # Hard unresolved dependencies block choice availability regardless of guard predicates.
     if _hard_unresolved_dependencies(edge=edge):
         return "missing_dependency"
@@ -254,6 +260,13 @@ def _choice_blockers(*, edge: Action, ctx) -> list[dict[str, Any]]:
             if preview_blockers:
                 return preview_blockers
         return [{"type": "edge", "reason": "missing_successor"}]
+
+    if isinstance(edge.successor, TraversableNode) and edge.successor.is_container:
+        preview = Resolver.from_ctx(ctx).preview_frontier_node(edge.successor, _ctx=ctx)
+        if not preview.viable:
+            return _preview_blockers(preview) or [
+                {"type": "provision", "reason": "container_entry_unavailable"}
+            ]
 
     blockers = [_dependency_blocker(dep) for dep in _hard_unresolved_dependencies(edge=edge)]
     if blockers:

--- a/engine/src/tangl/vm/VM_DESIGN.md
+++ b/engine/src/tangl/vm/VM_DESIGN.md
@@ -200,12 +200,12 @@ terminal path. Runtime enterability only asks whether the active entry can be en
 under ordinary VM rules; provisioning continues through the normal PLANNING path after
 the descent commits.
 
-**Provisionability preview is future work.** Current delegated enterability checks
-boundary availability and resolved-entry availability. It does not perform a
-non-mutating preview of the resolved entry's hard dependency satisfaction before the
-container is offered. A future resolver preview surface should be able to ask whether
-`ctx.derive(cursor_id=resolved_entry.uid)` has satisfied or provisionable hard
-requirements without committing bindings, dynamic edges, or graph mutations.
+**Provisionability preview is dependency-only and non-mutating.** During PLANNING,
+container frontier viability delegates to the resolved entry target and asks whether
+that target's open hard dependencies are already satisfied or have admissible offers
+under `ctx.derive(cursor_id=resolved_entry.uid)`. This preview does not bind providers,
+materialize templates, create dynamic edges, or prove full route solvability. Committed
+traversal still provisions normally after PREREQS descent reaches the resolved entry.
 
 **LCA-based movement.** Every cursor movement is `goto(target)` whose context
 implications are determined by the lowest common ancestor (LCA) of source and target in
@@ -537,6 +537,12 @@ materialize the provider.
 entity), `CREATE` (clone/mint a new one), `STUB` (debug/preview fallback, only when
 stubs are allowed), `TOKEN` (specifically a singleton token). Requirements can restrict
 which policies are acceptable.
+
+`Resolver.preview_requirement()` and `Resolver.preview_frontier_node()` expose the
+non-mutating side of the same contract. They gather and filter admissible offers, then
+report viability without invoking offer callbacks, binding dependency providers, or
+creating topology. Container entry projection uses this path to hide an entry whose
+active child has unsatisfied hard requirements that cannot currently be provisioned.
 
 **Selected-path runtime materialization.** When a CREATE or CLONE offer is
 accepted for a traversable requirement, resolver may need to build missing

--- a/engine/src/tangl/vm/VM_DESIGN.md
+++ b/engine/src/tangl/vm/VM_DESIGN.md
@@ -200,6 +200,13 @@ terminal path. Runtime enterability only asks whether the active entry can be en
 under ordinary VM rules; provisioning continues through the normal PLANNING path after
 the descent commits.
 
+**Provisionability preview is future work.** Current delegated enterability checks
+boundary availability and resolved-entry availability. It does not perform a
+non-mutating preview of the resolved entry's hard dependency satisfaction before the
+container is offered. A future resolver preview surface should be able to ask whether
+`ctx.derive(cursor_id=resolved_entry.uid)` has satisfied or provisionable hard
+requirements without committing bindings, dynamic edges, or graph mutations.
+
 **LCA-based movement.** Every cursor movement is `goto(target)` whose context
 implications are determined by the lowest common ancestor (LCA) of source and target in
 the hierarchy. The ancestor chain at any cursor position defines the complete resource

--- a/engine/src/tangl/vm/VM_DESIGN.md
+++ b/engine/src/tangl/vm/VM_DESIGN.md
@@ -178,6 +178,28 @@ the graph. Unlike the legacy `TraversableSubgraph` which created hidden `__SOURC
 `__SINK` nodes, v38 designates existing members as source and sink. Edges into the
 container target the container itself; edges out of the container originate from the sink.
 
+**Container entry projection.** `source_id` is the default entry, not the only possible
+entry. A container may opt into re-entry policy by overriding `resolve_entry(ctx)`;
+the built-in `HasContainerEntryProjection` surface supports a remembered `resume_id`
+and ordered conditional entry rules. PREREQS descent calls `enter(ctx)`, which resolves
+the active child and returns an ordinary `AnonymousEdge` to that child. This is still
+one VM cursor: the bookmark is a continuation target, not a second cursor.
+
+**Delegated enterability.** An edge targeting a container first checks the edge's own
+availability, then the container boundary, then the resolved child's availability in a
+derived context for that child. If a remembered resume target exists but is currently
+unavailable, the container is unavailable; it does not silently fall back to an entry
+rule or `source_id`. Malformed targets such as missing nodes or nodes outside the
+container fail loudly at point of use.
+
+**Sink reachability is analysis, not runtime availability.** `has_forward_progress()`
+remains useful for static checks, tests, and authoring diagnostics, but live container
+entry does not prove that the sink is reachable. Sandboxes, board tracks, games, and
+re-entrant story hubs may intentionally loop, wait on schedules, or have no immediate
+terminal path. Runtime enterability only asks whether the active entry can be entered
+under ordinary VM rules; provisioning continues through the normal PLANNING path after
+the descent commits.
+
 **LCA-based movement.** Every cursor movement is `goto(target)` whose context
 implications are determined by the lowest common ancestor (LCA) of source and target in
 the hierarchy. The ancestor chain at any cursor position defines the complete resource
@@ -609,10 +631,18 @@ UPDATE effects fire on arrival. FINALIZE effects fire on departure/commit. The
 `trigger_phase` field on `TraversableEffect` determines which handler fires it.
 
 **Container descent is a PREREQS handler.** When the cursor arrives at a container node
-(`is_container=True`), the system PREREQS handler calls `node.enter()` and returns the
-resulting `AnonymousEdge`. The frame's PREREQS aggregation is `first_result`, so this
-redirect is followed and the pipeline re-runs at the source node. Nested containers
-descend recursively through normal pipeline execution.
+(`is_container=True`), the system PREREQS handler calls `node.enter(ctx)` and returns
+the resulting `AnonymousEdge`. The frame's PREREQS aggregation is `first_result`, so
+this redirect is followed and the pipeline re-runs at the resolved entry node. Nested
+containers descend recursively through normal pipeline execution, each resolving its
+own active entry.
+
+**Dynamic frontier refresh.** Domain packages that project dynamic choices during
+PLANNING must treat those edges as ephemeral affordances. Before rebuilding, a provider
+clears only the previous dynamic edges it generated for that owner node, using tags or
+provenance narrow enough not to delete another provider's work. Re-entering a hub,
+game, or sandbox location therefore recomputes the local frontier from current state
+instead of relying on stale generated paths.
 
 
 ---

--- a/engine/src/tangl/vm/__init__.py
+++ b/engine/src/tangl/vm/__init__.py
@@ -70,6 +70,8 @@ from .provision import (
 # Provides:
 # - cursor traversal rules
 from .traversable import (
+    ContainerEntryRule,
+    HasContainerEntryProjection,
     TraversableEdge,
     TraversableNode,
     AnonymousEdge,
@@ -142,6 +144,8 @@ __all__ = [
     "UpdateCloneProvisioner",
     "ViabilityResult",
     "CloneProvisioner",
+    "ContainerEntryRule",
+    "HasContainerEntryProjection",
     "TraversableEdge",
     "TraversableGraph",
     "TraversableGraphFactory",

--- a/engine/src/tangl/vm/provision/resolver.py
+++ b/engine/src/tangl/vm/provision/resolver.py
@@ -1655,10 +1655,7 @@ class Resolver:
         # Whole-container route-to-sink analysis is a static-analysis concern,
         # not a runtime availability gate.
         if isinstance(node, TraversableNode) and node.is_container:
-            try:
-                if not node.enterable(ctx=_ctx):
-                    return False
-            except (RuntimeError, TypeError, ValueError):
+            if not node.enterable(ctx=_ctx):
                 return False
 
         return True

--- a/engine/src/tangl/vm/provision/resolver.py
+++ b/engine/src/tangl/vm/provision/resolver.py
@@ -1282,6 +1282,75 @@ class Resolver:
         blockers = self._diagnose_blockers(requirement=requirement, _ctx=_ctx)
         return ViabilityResult(viable=False, chain=[], scope_distance=0, blockers=blockers)
 
+    @staticmethod
+    def _dependency_blocker(
+        dependency: Dependency,
+        *,
+        preview: ViabilityResult,
+    ) -> Blocker:
+        return Blocker(
+            reason="dependency_unprovisionable",
+            context={
+                "dependency_id": str(dependency.uid),
+                "requirement": repr(dependency.requirement),
+                "blockers": [
+                    {
+                        "reason": blocker.reason,
+                        "context": dict(blocker.context),
+                    }
+                    for blocker in preview.blockers
+                ],
+            },
+        )
+
+    def preview_frontier_node(
+        self,
+        node: Node,
+        *,
+        allow_stubs: bool = False,
+        _ctx: VmPhaseCtx | None = None,
+    ) -> ViabilityResult:
+        """Return non-mutating provisionability for one frontier node."""
+        for dependency in node.edges_out(Selector(has_kind=Dependency)):
+            if dependency.satisfied:
+                continue
+            if not dependency.requirement.hard_requirement:
+                continue
+            preview = self.preview_requirement(
+                dependency.requirement,
+                allow_stubs=allow_stubs,
+                _ctx=_ctx,
+            )
+            if not preview.viable:
+                return ViabilityResult(
+                    viable=False,
+                    chain=list(preview.chain),
+                    scope_distance=preview.scope_distance,
+                    blockers=[self._dependency_blocker(dependency, preview=preview)],
+                )
+
+        if isinstance(node, TraversableNode) and node.is_container:
+            if not node.enterable(ctx=_ctx):
+                return ViabilityResult(
+                    viable=False,
+                    blockers=[
+                        Blocker(
+                            reason="entry_unavailable",
+                            context={"node_id": str(node.uid)},
+                        )
+                    ],
+                )
+            target = node.resolve_entry(ctx=_ctx)
+            target_ctx = _ctx.derive(cursor_id=target.uid) if _ctx is not None else None
+            target_resolver = Resolver.from_ctx(target_ctx) if target_ctx is not None else self
+            return target_resolver.preview_frontier_node(
+                target,
+                allow_stubs=allow_stubs,
+                _ctx=target_ctx,
+            )
+
+        return ViabilityResult(viable=True)
+
     def _preview_viable_offer(
         self,
         *,
@@ -1656,6 +1725,16 @@ class Resolver:
         # not a runtime availability gate.
         if isinstance(node, TraversableNode) and node.is_container:
             if not node.enterable(ctx=_ctx):
+                return False
+            target = node.resolve_entry(ctx=_ctx)
+            target_ctx = _ctx.derive(cursor_id=target.uid) if _ctx is not None else None
+            target_resolver = Resolver.from_ctx(target_ctx) if target_ctx is not None else self
+            preview = target_resolver.preview_frontier_node(
+                target,
+                allow_stubs=allow_stubs,
+                _ctx=target_ctx,
+            )
+            if not preview.viable:
                 return False
 
         return True

--- a/engine/src/tangl/vm/provision/resolver.py
+++ b/engine/src/tangl/vm/provision/resolver.py
@@ -1651,16 +1651,14 @@ class Resolver:
         if next(unsatisfied_deps, None) is not None:
             return False
 
-        # Containers must have a reachable sink from their source.
+        # Container frontier viability delegates to the active entry target.
+        # Whole-container route-to-sink analysis is a static-analysis concern,
+        # not a runtime availability gate.
         if isinstance(node, TraversableNode) and node.is_container:
-            source = node.source
-            sink = node.sink
-            if source is None or sink is None:
-                return False
-            ns = None
-            if _ctx is not None and hasattr(_ctx, "get_ns"):
-                ns = dict(_ctx.get_ns(source))
-            if not node.has_forward_progress(source, ns=ns):
+            try:
+                if not node.enterable(ctx=_ctx):
+                    return False
+            except (RuntimeError, TypeError, ValueError):
                 return False
 
         return True

--- a/engine/src/tangl/vm/system_handlers.py
+++ b/engine/src/tangl/vm/system_handlers.py
@@ -317,11 +317,11 @@ def validate_successor_exists(*, caller, ctx, **kw):
 
 @on_prereqs
 def descend_into_container(*, caller, ctx, **kw):
-    """If the cursor is a container, redirect to its source member.
+    """If the cursor is a container, redirect to its active entry member.
 
     This is the only special traversal logic in the whole system.  Everything
     else is generic pipeline execution.  Container descent chains naturally:
-    if the source is also a container, its own PREREQS will fire
+    if the entry is also a container, its own PREREQS will fire
     ``descend_into_container`` again, descending further.
 
     Priority: EARLY-ish — should fire before triggered edge checks, because
@@ -330,8 +330,13 @@ def descend_into_container(*, caller, ctx, **kw):
     not entries).
     """
     if isinstance(caller, TraversableNode) and caller.is_container:
-        logger.debug("Container descent: %s → %s", caller.get_label(), caller.source.get_label())
-        return caller.enter()
+        edge = caller.enter(ctx=ctx)
+        logger.debug(
+            "Container descent: %s → %s",
+            caller.get_label(),
+            edge.successor.get_label(),
+        )
+        return edge
     return None
 
 

--- a/engine/src/tangl/vm/system_handlers.py
+++ b/engine/src/tangl/vm/system_handlers.py
@@ -82,6 +82,7 @@ from .dispatch import (
 )
 from .resolution_phase import ResolutionPhase
 from .traversal import get_visit_count, is_first_visit, steps_since_last_visit
+from .runtime.causality import CausalityMode
 from .traversable import HasEffects, TraversableNode, TraversableEdge, AnonymousEdge
 
 if TYPE_CHECKING:
@@ -304,7 +305,18 @@ def validate_successor_exists(*, caller, ctx, **kw):
     if successor is None:
         return False
     if hasattr(caller, "available"):
-        return bool(caller.available(ctx=ctx))
+        if not bool(caller.available(ctx=ctx)):
+            return False
+        if isinstance(successor, TraversableNode) and successor.is_container:
+            from .provision import Resolver
+
+            preview = Resolver.from_ctx(ctx).preview_frontier_node(
+                successor,
+                allow_stubs=ctx.causality_mode == CausalityMode.HARD_DIRTY,
+                _ctx=ctx,
+            )
+            return preview.viable
+        return True
     if hasattr(successor, "available"):
         ns = ctx.get_ns(successor) if ctx is not None and hasattr(ctx, "get_ns") else None
         return bool(successor.available(ns=ns))

--- a/engine/src/tangl/vm/traversable.py
+++ b/engine/src/tangl/vm/traversable.py
@@ -44,6 +44,7 @@ from tangl.core import Edge, Graph, HierarchicalNode, Node, Selector
 from tangl.core.bases import BaseModelPlus, HasState
 from tangl.core.runtime_op import Effect, Predicate
 from tangl.type_hints import StringMap
+from .ctx import VmPhaseCtx
 from .resolution_phase import ResolutionPhase
 
 
@@ -259,7 +260,12 @@ class ContainerEntryRule(BaseModelPlus):
     label: str | None = None
     """Optional diagnostic label for authoring and tests."""
 
-    def available_for(self, container: object, *, ctx: Any = None) -> bool:
+    def available_for(
+        self,
+        container: TraversableNode,
+        *,
+        ctx: VmPhaseCtx | None = None,
+    ) -> bool:
         """Return whether this rule matches the current container context."""
         if not self.availability:
             return True
@@ -288,7 +294,7 @@ class HasContainerEntryProjection(BaseModelPlus):
     entry_rules: list[ContainerEntryRule] = Field(default_factory=list)
     """Ordered conditional entry rules evaluated when no resume target exists."""
 
-    def resolve_entry(self, *, ctx: Any = None) -> TraversableNode:
+    def resolve_entry(self, *, ctx: VmPhaseCtx | None = None) -> TraversableNode:
         """Resolve the active entry target for this container."""
         if self.resume_id is not None:
             return self._resolve_entry_target(self.resume_id, field_name="resume_id")
@@ -588,7 +594,7 @@ class TraversableNode(HasAvailability, HasEffects, HasState, HierarchicalNode):
             )
         return target
 
-    def resolve_entry(self, *, ctx: Any = None) -> TraversableNode:
+    def resolve_entry(self, *, ctx: VmPhaseCtx | None = None) -> TraversableNode:
         """Resolve the active entry target for this container.
 
         Plain containers always enter through ``source_id``. Re-entrant
@@ -601,22 +607,40 @@ class TraversableNode(HasAvailability, HasEffects, HasState, HierarchicalNode):
             raise RuntimeError(f"{self!r} source_id is missing")
         return self._resolve_entry_target(self.source_id, field_name="source_id")
 
-    def enterable(self, *, ctx: Any = None) -> bool:
+    def enterable(
+        self,
+        *,
+        ctx: VmPhaseCtx | None = None,
+        ns: Mapping[str, Any] | None = None,
+    ) -> bool:
         """Return whether this container's active entry is currently available."""
         if not self.is_container:
-            return self.available(ctx=ctx)
+            return self.available(ns=ns, ctx=ctx)
 
-        ns = ctx.get_ns(self) if ctx is not None else None
-        rand = _resolve_rand(rand=None, ctx=ctx)
-        if not HasAvailability.available(self, ns=ns, ctx=ctx, rand=rand):
+        explicit_ns = ns
+        container_ns = explicit_ns
+        if container_ns is None and ctx is not None:
+            container_ns = ctx.get_ns(self)
+        container_rand = _resolve_rand(rand=None, ctx=ctx)
+        if not HasAvailability.available(
+            self,
+            ns=container_ns,
+            ctx=ctx,
+            rand=container_rand,
+        ):
             return False
 
         target = self.resolve_entry(ctx=ctx)
         target_ctx = ctx.derive(cursor_id=target.uid) if ctx is not None else None
-        target_ns = target_ctx.get_ns(target) if target_ctx is not None else None
-        return target.available(ns=target_ns, ctx=target_ctx, rand=rand)
+        target_ns = explicit_ns
+        if target_ns is None and target_ctx is not None:
+            target_ns = target_ctx.get_ns(target)
+        if target.is_container:
+            return target.enterable(ctx=target_ctx, ns=explicit_ns)
+        target_rand = _resolve_rand(rand=None, ctx=target_ctx)
+        return target.available(ns=target_ns, ctx=target_ctx, rand=target_rand)
 
-    def enter(self, *, ctx: Any = None) -> AnonymousEdge:
+    def enter(self, *, ctx: VmPhaseCtx | None = None) -> AnonymousEdge:
         """Produce the descent edge from this container to its active entry.
 
         Called by the system-level prereq handler when the cursor arrives at a
@@ -861,7 +885,7 @@ class TraversableEdge(HasAvailability, HasEffects, Edge):
             successor_ns = ctx.get_ns(successor)
 
         if isinstance(successor, TraversableNode) and successor.is_container:
-            return successor.enterable(ctx=ctx)
+            return successor.enterable(ctx=ctx, ns=ns)
 
         if not hasattr(successor, "available"):
             return True
@@ -965,13 +989,14 @@ class AnonymousEdge:
         if self.successor is None:
             return False
         rand = _resolve_rand(rand=None, ctx=ctx)
+        explicit_ns = ns
         if ns is None and ctx is not None and hasattr(ctx, "get_ns"):
             ns = ctx.get_ns(self.successor)
         if (
             isinstance(self.successor, TraversableNode)
             and self.successor.is_container
         ):
-            return self.successor.enterable(ctx=ctx)
+            return self.successor.enterable(ctx=ctx, ns=explicit_ns)
         if not hasattr(self.successor, "available"):
             return True
         return self.successor.available(ns=ns, ctx=ctx, rand=rand)

--- a/engine/src/tangl/vm/traversable.py
+++ b/engine/src/tangl/vm/traversable.py
@@ -51,6 +51,8 @@ __all__ = [
     "TraversableEffect",
     "HasAvailability",
     "HasEffects",
+    "ContainerEntryRule",
+    "HasContainerEntryProjection",
     "TraversableNode",
     "TraversableEdge",
     "AnonymousEdge",
@@ -243,6 +245,60 @@ class HasEffects(BaseModelPlus):
             effect.apply(target_ns, rand=resolved_rand)
         self._sync_target_locals(other, target_ns)
         return target_ns
+
+
+class ContainerEntryRule(BaseModelPlus):
+    """Ordered conditional entry target for a re-entrant container."""
+
+    target_id: UUID
+    """Container member to enter when this rule matches."""
+
+    availability: list[Predicate] = Field(default_factory=list)
+    """Predicates evaluated against the container namespace."""
+
+    label: str | None = None
+    """Optional diagnostic label for authoring and tests."""
+
+    def available_for(self, container: object, *, ctx: Any = None) -> bool:
+        """Return whether this rule matches the current container context."""
+        if not self.availability:
+            return True
+        if ctx is None:
+            return False
+        ns = ctx.get_ns(container)
+        rand = _resolve_rand(rand=None, ctx=ctx)
+        return all(
+            predicate.satisfied_by(ns, rand=rand)
+            for predicate in self.availability
+        )
+
+
+class HasContainerEntryProjection(BaseModelPlus):
+    """Opt-in re-entry policy for traversable containers.
+
+    This mixin carries continuation state so plain ``TraversableNode`` instances
+    do not grow re-entry fields they do not use. Classes that need resumable
+    container behavior should inherit it before ``TraversableNode`` so this
+    ``resolve_entry`` method wins in the MRO.
+    """
+
+    resume_id: Optional[UUID] = None
+    """Remembered continuation target inside the container."""
+
+    entry_rules: list[ContainerEntryRule] = Field(default_factory=list)
+    """Ordered conditional entry rules evaluated when no resume target exists."""
+
+    def resolve_entry(self, *, ctx: Any = None) -> TraversableNode:
+        """Resolve the active entry target for this container."""
+        if self.resume_id is not None:
+            return self._resolve_entry_target(self.resume_id, field_name="resume_id")
+
+        for rule in self.entry_rules:
+            if rule.available_for(self, ctx=ctx):
+                label = rule.label or "entry_rules"
+                return self._resolve_entry_target(rule.target_id, field_name=label)
+
+        return super().resolve_entry(ctx=ctx)
 
 
 # ---------------------------------------------------------------------------
@@ -508,25 +564,77 @@ class TraversableNode(HasAvailability, HasEffects, HasState, HierarchicalNode):
         """
         return self.source_id is not None
 
-    def enter(self) -> AnonymousEdge:
-        """Produce the descent edge from this container to its source member.
+    def _resolve_entry_target(
+        self,
+        target_id: UUID,
+        *,
+        field_name: str,
+    ) -> TraversableNode:
+        """Resolve and validate a container entry target."""
+        target = self.graph.get(target_id)
+        if target is None:
+            raise RuntimeError(
+                f"{self!r} {field_name}={target_id} not found in graph"
+            )
+        if not isinstance(target, TraversableNode):
+            raise TypeError(
+                f"{self!r} {field_name}={target_id} resolved to non-traversable "
+                f"{type(target)!r}"
+            )
+        if not self.has_member(target):
+            raise ValueError(
+                f"{self!r} {field_name} target {target!r} is not a member/child "
+                "of container"
+            )
+        return target
+
+    def resolve_entry(self, *, ctx: Any = None) -> TraversableNode:
+        """Resolve the active entry target for this container.
+
+        Plain containers always enter through ``source_id``. Re-entrant
+        containers opt into richer policy by overriding this method, usually
+        through :class:`HasContainerEntryProjection`.
+        """
+        if not self.is_container:
+            raise ValueError(f"{self!r} is not a container (source_id is None)")
+        if self.source_id is None:
+            raise RuntimeError(f"{self!r} source_id is missing")
+        return self._resolve_entry_target(self.source_id, field_name="source_id")
+
+    def enterable(self, *, ctx: Any = None) -> bool:
+        """Return whether this container's active entry is currently available."""
+        if not self.is_container:
+            return self.available(ctx=ctx)
+
+        ns = ctx.get_ns(self) if ctx is not None else None
+        rand = _resolve_rand(rand=None, ctx=ctx)
+        if not HasAvailability.available(self, ns=ns, ctx=ctx, rand=rand):
+            return False
+
+        target = self.resolve_entry(ctx=ctx)
+        target_ctx = ctx.derive(cursor_id=target.uid) if ctx is not None else None
+        target_ns = target_ctx.get_ns(target) if target_ctx is not None else None
+        return target.available(ns=target_ns, ctx=target_ctx, rand=rand)
+
+    def enter(self, *, ctx: Any = None) -> AnonymousEdge:
+        """Produce the descent edge from this container to its active entry.
 
         Called by the system-level prereq handler when the cursor arrives at a
-        container.  The returned edge, when followed by the frame, moves the
-        cursor to the source and runs the full pipeline — which may itself
-        trigger further descent if the source is also a container.
+        container. The returned edge, when followed by the frame, moves the
+        cursor to the resolved entry and runs the full pipeline — which may
+        itself trigger further descent if the entry is also a container.
 
         Raises
         ------
         ValueError
             If this node is not a container (``source_id is None``).
         RuntimeError
-            If the source member cannot be resolved from the graph.
+            If the entry member cannot be resolved from the graph.
 
         Returns
         -------
         AnonymousEdge
-            A lightweight edge from ``self`` to ``self.source``.
+            A lightweight edge from ``self`` to the active entry target.
 
         >>> from tangl.core import Graph
         >>> g = Graph()
@@ -539,14 +647,7 @@ class TraversableNode(HasAvailability, HasEffects, HasState, HierarchicalNode):
         >>> assert edge.predecessor is scene
         >>> assert edge.entry_phase is None
         """
-        if not self.is_container:
-            raise ValueError(f"{self!r} is not a container (source_id is None)")
-        source = self.source
-        if source is None:
-            raise RuntimeError(
-                f"{self!r} source_id={self.source_id} not found in graph"
-            )
-        return AnonymousEdge(predecessor=self, successor=source)
+        return AnonymousEdge(predecessor=self, successor=self.resolve_entry(ctx=ctx))
 
     def has_forward_progress(
         self,
@@ -759,6 +860,9 @@ class TraversableEdge(HasAvailability, HasEffects, Edge):
         if successor_ns is None and ctx is not None and hasattr(ctx, "get_ns"):
             successor_ns = ctx.get_ns(successor)
 
+        if isinstance(successor, TraversableNode) and successor.is_container:
+            return successor.enterable(ctx=ctx)
+
         if not hasattr(successor, "available"):
             return True
         return successor.available(ns=successor_ns, ctx=ctx, rand=rand)
@@ -863,6 +967,11 @@ class AnonymousEdge:
         rand = _resolve_rand(rand=None, ctx=ctx)
         if ns is None and ctx is not None and hasattr(ctx, "get_ns"):
             ns = ctx.get_ns(self.successor)
+        if (
+            isinstance(self.successor, TraversableNode)
+            and self.successor.is_container
+        ):
+            return self.successor.enterable(ctx=ctx)
         if not hasattr(self.successor, "available"):
             return True
         return self.successor.available(ns=ns, ctx=ctx, rand=rand)
@@ -896,6 +1005,8 @@ def validate_traversal_contracts(graph: Graph) -> list[str]:
     - ``source_id`` resolves but is not a child/member of the container.
     - ``sink_id`` is set but does not resolve in the graph.
     - ``sink_id`` resolves but is not a child/member of the container.
+    - resumable entry targets resolve to members when their owning container
+      opts into :class:`HasContainerEntryProjection`.
 
     Returns
     -------
@@ -930,6 +1041,30 @@ def validate_traversal_contracts(graph: Graph) -> list[str]:
                 )
             if node.source_id is None:
                 issues.append(f"{node!r}: sink_id is set but source_id is missing")
+
+        if isinstance(node, HasContainerEntryProjection):
+            entry_targets: list[tuple[str, UUID]] = []
+            if node.resume_id is not None:
+                entry_targets.append(("resume_id", node.resume_id))
+            for index, rule in enumerate(node.entry_rules):
+                label = rule.label or f"entry_rules[{index}]"
+                entry_targets.append((label, rule.target_id))
+            for label, target_id in entry_targets:
+                target = graph.get(target_id)
+                if target is None:
+                    issues.append(
+                        f"{node!r}: {label}={target_id} does not resolve in graph"
+                    )
+                elif not isinstance(target, TraversableNode):
+                    issues.append(
+                        f"{node!r}: {label}={target_id} does not resolve to a "
+                        "TraversableNode"
+                    )
+                elif not node.has_member(target):
+                    issues.append(
+                        f"{node!r}: {label} target {target!r} is not a "
+                        "member/child of container"
+                    )
 
     return issues
 

--- a/engine/tests/loaders/test_adventure_sandbox_world.py
+++ b/engine/tests/loaders/test_adventure_sandbox_world.py
@@ -1,0 +1,101 @@
+"""Tests for the Adventure-style sandbox demo world bundle."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tangl.core import Selector
+from tangl.journal.fragments import ContentFragment
+from tangl.loaders import WorldBundle
+from tangl.loaders.compiler import WorldCompiler
+from tangl.mechanics.sandbox import SandboxLocation
+from tangl.service.world_registry import WorldRegistry
+from tangl.story import Action, InitMode
+from tangl.vm import Ledger
+from tangl.vm.dispatch import do_provision
+from tangl.vm.runtime.frame import PhaseCtx
+
+
+def _repo_worlds_dir() -> Path:
+    return Path(__file__).resolve().parents[3] / "worlds"
+
+
+def _adventure_root() -> Path:
+    return _repo_worlds_dir() / "adventure_sandbox_slice"
+
+
+def _provision_sandbox_actions(ledger: Ledger) -> list[Action]:
+    assert isinstance(ledger.cursor, SandboxLocation)
+    do_provision(
+        ledger.cursor,
+        ctx=PhaseCtx(graph=ledger.graph, cursor_id=ledger.cursor.uid),
+    )
+    return [
+        edge
+        for edge in ledger.cursor.edges_out(Selector(has_kind=Action))
+        if {"dynamic", "sandbox"}.issubset(edge.tags)
+    ]
+
+
+def _choose(ledger: Ledger, **hints: str) -> Action:
+    for action in _provision_sandbox_actions(ledger):
+        if all(action.ui_hints.get(key) == value for key, value in hints.items()):
+            ledger.resolve_choice(action.uid, choice_payload=action.payload)
+            return action
+    raise AssertionError(f"No sandbox action at {ledger.cursor.label!r} matched {hints!r}")
+
+
+class TestAdventureSandboxWorld:
+    """Tests for the real Adventure-style sandbox demo world."""
+
+    def test_world_registry_discovers_adventure_sandbox_slice(self) -> None:
+        registry = WorldRegistry([_repo_worlds_dir()])
+
+        assert "adventure_sandbox_slice" in registry.bundles
+        bundle = registry.bundles["adventure_sandbox_slice"]
+        assert bundle.manifest.label == "adventure_sandbox_slice"
+        assert bundle.manifest.metadata["title"] == "Adventure Sandbox Slice"
+
+    def test_adventure_sandbox_world_runs_core_walkthrough(self) -> None:
+        bundle = WorldBundle.load(_adventure_root())
+        world = WorldCompiler().compile(bundle)
+
+        assert "AdventureSandboxLocation" in world.class_registry
+
+        result = world.create_story("adventure_sandbox_slice", init_mode=InitMode.EAGER)
+        ledger = Ledger.from_graph(result.graph, entry_id=result.graph.initial_cursor_id)
+
+        enter = next(
+            edge
+            for edge in ledger.cursor.edges_out()
+            if edge.label == "action_entrance_0"
+        )
+        ledger.resolve_choice(enter.uid)
+
+        assert ledger.cursor.label == "road"
+
+        _choose(ledger, contribution="movement", direction="east")
+        _choose(ledger, contribution="take", asset="keys")
+        _choose(ledger, contribution="take", asset="brass_lamp")
+        _choose(ledger, contribution="light", asset="brass_lamp", verb="turn_on")
+        _choose(ledger, contribution="movement", direction="west")
+        _choose(ledger, contribution="movement", direction="south")
+        _choose(ledger, contribution="movement", direction="south")
+        _choose(ledger, contribution="movement", direction="south")
+        _choose(ledger, contribution="unlock", target="grate")
+        _choose(ledger, contribution="open", target="grate")
+        _choose(ledger, contribution="movement", direction="down")
+        _choose(ledger, contribution="movement", direction="west")
+
+        assert ledger.cursor.label == "cobble_crawl"
+
+        _choose(ledger, contribution="mob", mob="wounded_pirate", action="help")
+
+        content = [
+            fragment.content
+            for fragment in ledger.get_journal()
+            if isinstance(fragment, ContentFragment)
+        ]
+        assert "The key turns with a click. The grate unlocks." in content
+        assert "A wounded pirate leans against the wall, watching you." in content
+        assert "The pirate eyes you suspiciously, but accepts your help." in content

--- a/engine/tests/loaders/test_adventure_sandbox_world.py
+++ b/engine/tests/loaders/test_adventure_sandbox_world.py
@@ -68,7 +68,8 @@ class TestAdventureSandboxWorld:
         enter = next(
             edge
             for edge in ledger.cursor.edges_out()
-            if edge.label == "action_entrance_0"
+            if isinstance(edge, Action)
+            and edge.text == "Stand at the end of the road"
         )
         ledger.resolve_choice(enter.uid)
 

--- a/engine/tests/vm/test_phase_integration.py
+++ b/engine/tests/vm/test_phase_integration.py
@@ -34,10 +34,12 @@ from typing import Callable, Iterator
 import pytest
 
 from tangl.core import Graph
+from tangl.core.runtime_op import Predicate
 from tangl.journal.fragments import ContentFragment
 from tangl.vm.dispatch import (
     dispatch as vm_dispatch,
     on_journal,
+    on_provision,
     on_update,
     on_validate,
 )
@@ -47,10 +49,15 @@ from tangl.vm.runtime.ledger import Ledger
 from tangl.vm.replay import StepRecord
 from tangl.vm.traversable import (
     AnonymousEdge,
+    HasContainerEntryProjection,
     TraversableEdge,
     TraversableNode,
 )
 import tangl.vm.system_handlers  # side-effect: register default handlers
+
+
+class ResumableNode(HasContainerEntryProjection, TraversableNode):
+    """Test node with re-entrant container entry projection."""
 
 
 # ---------------------------------------------------------------------------
@@ -60,6 +67,12 @@ import tangl.vm.system_handlers  # side-effect: register default handlers
 
 def _node(graph: Graph, **kwargs) -> TraversableNode:
     node = TraversableNode(**kwargs)
+    graph.add(node)
+    return node
+
+
+def _resumable_node(graph: Graph, **kwargs) -> ResumableNode:
+    node = ResumableNode(**kwargs)
     graph.add(node)
     return node
 
@@ -263,6 +276,151 @@ class TestPrereqsRedirect:
         frame.resolve_choice(edge_to_container)
         # After descent the cursor should be inside the container
         assert frame.cursor in (container, source)
+
+    def test_container_descent_follows_resume_target(self) -> None:
+        g = Graph()
+        outer = _node(g, label="outer")
+        container = _resumable_node(g, label="container")
+        source = _node(g, label="entry")
+        resumed = _node(g, label="resumed")
+        sink = _node(g, label="exit")
+        for member in (source, resumed, sink):
+            container.add_child(member)
+        container.source_id = source.uid
+        container.sink_id = sink.uid
+        container.resume_id = resumed.uid
+        edge_to_container = _edge(g, predecessor_id=outer.uid, successor_id=container.uid)
+
+        frame = Frame(graph=g, cursor=outer)
+        frame.resolve_choice(edge_to_container)
+
+        assert frame.cursor is resumed
+
+    def test_container_edge_validation_uses_resolved_entry(self) -> None:
+        g = Graph()
+        outer = _node(g, label="outer")
+        container = _resumable_node(g, label="container")
+        source = _node(g, label="entry")
+        resumed = _node(
+            g,
+            label="resumed",
+            availability=[Predicate(expr="resume_open")],
+        )
+        sink = _node(g, label="exit")
+        for member in (source, resumed, sink):
+            container.add_child(member)
+        container.source_id = source.uid
+        container.sink_id = sink.uid
+        container.resume_id = resumed.uid
+        resumed.locals["resume_open"] = False
+        edge_to_container = _edge(g, predecessor_id=outer.uid, successor_id=container.uid)
+
+        frame = Frame(graph=g, cursor=outer)
+        with pytest.raises(ValueError, match="Edge validation failed"):
+            frame.resolve_choice(edge_to_container)
+
+    def test_incoming_edge_availability_applies_before_container_entry(self) -> None:
+        g = Graph()
+        outer = _node(g, label="outer")
+        container = _resumable_node(g, label="container")
+        source = _node(g, label="entry")
+        resumed = _node(g, label="resumed")
+        sink = _node(g, label="exit")
+        for member in (source, resumed, sink):
+            container.add_child(member)
+        container.source_id = source.uid
+        container.sink_id = sink.uid
+        container.resume_id = resumed.uid
+        outer.locals["gate_open"] = False
+        edge_to_container = _edge(
+            g,
+            predecessor_id=outer.uid,
+            successor_id=container.uid,
+            availability=[Predicate(expr="gate_open")],
+        )
+
+        frame = Frame(graph=g, cursor=outer)
+        with pytest.raises(ValueError, match="Edge validation failed"):
+            frame.resolve_choice(edge_to_container)
+
+    def test_committed_container_entry_runs_planning_for_resolved_entry(self) -> None:
+        g = Graph()
+        outer = _node(g, label="outer")
+        container = _resumable_node(g, label="container")
+        source = _node(g, label="entry")
+        resumed = _node(g, label="resumed")
+        sink = _node(g, label="exit")
+        for member in (source, resumed, sink):
+            container.add_child(member)
+        container.source_id = source.uid
+        container.sink_id = sink.uid
+        container.resume_id = resumed.uid
+        edge_to_container = _edge(g, predecessor_id=outer.uid, successor_id=container.uid)
+        provisioned: list[TraversableNode] = []
+
+        @on_provision
+        def record_provision(caller, *, ctx, **kw):
+            _ = (ctx, kw)
+            if isinstance(caller, TraversableNode):
+                provisioned.append(caller)
+            return None
+
+        frame = Frame(graph=g, cursor=outer)
+        with _cleanup_behaviors(record_provision):
+            frame.resolve_choice(edge_to_container)
+
+        assert resumed in provisioned
+        assert frame.cursor is resumed
+
+    def test_nested_container_descent_resolves_each_active_entry(self) -> None:
+        g = Graph()
+        outer = _node(g, label="outer")
+        parent = _resumable_node(g, label="parent")
+        parent_source = _node(g, label="parent_entry")
+        child = _resumable_node(g, label="child")
+        child_source = _node(g, label="child_entry")
+        child_resume = _node(g, label="child_resume")
+        child_sink = _node(g, label="child_exit")
+        parent_sink = _node(g, label="parent_exit")
+        for member in (child_source, child_resume, child_sink):
+            child.add_child(member)
+        child.source_id = child_source.uid
+        child.sink_id = child_sink.uid
+        child.resume_id = child_resume.uid
+        for member in (parent_source, child, parent_sink):
+            parent.add_child(member)
+        parent.source_id = parent_source.uid
+        parent.sink_id = parent_sink.uid
+        parent.resume_id = child.uid
+        edge_to_parent = _edge(g, predecessor_id=outer.uid, successor_id=parent.uid)
+
+        frame = Frame(graph=g, cursor=outer)
+        frame.resolve_choice(edge_to_parent)
+
+        assert frame.cursor is child_resume
+
+    def test_board_like_container_resumes_current_phase(self) -> None:
+        g = Graph()
+        outer = _node(g, label="outer")
+        board = _resumable_node(g, label="board")
+        roll = _node(g, label="roll")
+        move = _node(g, label="move")
+        resolve = _node(g, label="resolve")
+        for member in (roll, move, resolve):
+            board.add_child(member)
+        board.source_id = roll.uid
+        board.sink_id = resolve.uid
+        board.locals["token_space"] = "space_3"
+        board.locals["score"] = 7
+        board.resume_id = move.uid
+        edge_to_board = _edge(g, predecessor_id=outer.uid, successor_id=board.uid)
+
+        frame = Frame(graph=g, cursor=outer)
+        frame.resolve_choice(edge_to_board)
+
+        assert frame.cursor is move
+        assert board.locals["token_space"] == "space_3"
+        assert board.locals["score"] == 7
 
 
 # ---------------------------------------------------------------------------

--- a/engine/tests/vm/test_phase_integration.py
+++ b/engine/tests/vm/test_phase_integration.py
@@ -43,6 +43,7 @@ from tangl.vm.dispatch import (
     on_update,
     on_validate,
 )
+from tangl.vm.provision import Dependency, ProvisionPolicy, Requirement
 from tangl.vm.resolution_phase import ResolutionPhase
 from tangl.vm.runtime.frame import Frame
 from tangl.vm.runtime.ledger import Ledger
@@ -214,6 +215,32 @@ class TestValidateGate:
         edge = AnonymousEdge(predecessor=a, successor=orphan)
         frame = Frame(graph=g, cursor=a)
         with pytest.raises(Exception):
+            frame.follow_edge(edge)
+
+    def test_container_target_validation_previews_active_entry_dependencies(self) -> None:
+        g = Graph()
+        start = _node(g, label="start")
+        container = _resumable_node(g, label="scene")
+        entry = _node(g, label="entry")
+        resumed = _node(g, label="resumed")
+        sink = _node(g, label="exit")
+        for member in (entry, resumed, sink):
+            container.add_child(member)
+        container.source_id = entry.uid
+        container.sink_id = sink.uid
+        container.resume_id = resumed.uid
+        Dependency(
+            registry=g,
+            predecessor_id=resumed.uid,
+            requirement=Requirement(
+                has_identifier="missing",
+                provision_policy=ProvisionPolicy.EXISTING,
+            ),
+        )
+        edge = _edge(g, predecessor_id=start.uid, successor_id=container.uid)
+
+        frame = Frame(graph=g, cursor=start)
+        with pytest.raises(ValueError, match="validation failed"):
             frame.follow_edge(edge)
 
 

--- a/engine/tests/vm/test_resolver.py
+++ b/engine/tests/vm/test_resolver.py
@@ -1406,6 +1406,23 @@ class TestResolverFrontierNode:
         resolver = Resolver(entity_groups=[])
         assert resolver.resolve_frontier_node(container, _ctx=ctx) is False
 
+    def test_malformed_container_entry_target_raises(self) -> None:
+        g = Graph()
+        container = _resumable_node(g, label="scene")
+        source = _node(g, label="entry")
+        sink = _node(g, label="exit")
+        elsewhere = _node(g, label="elsewhere")
+        for member in (source, sink):
+            container.add_child(member)
+        container.source_id = source.uid
+        container.sink_id = sink.uid
+        container.resume_id = elsewhere.uid
+        ctx = PhaseCtx(graph=g, cursor_id=container.uid)
+
+        resolver = Resolver(entity_groups=[])
+        with pytest.raises(ValueError, match="not a member"):
+            resolver.resolve_frontier_node(container, _ctx=ctx)
+
     def test_node_with_empty_fanout_still_resolves_true(self) -> None:
         g = Graph()
         node = _node(g, label="hub")

--- a/engine/tests/vm/test_resolver.py
+++ b/engine/tests/vm/test_resolver.py
@@ -29,6 +29,7 @@ from tangl.core import (
     Token,
     TokenCatalog,
 )
+from tangl.core.runtime_op import Predicate
 from tangl.media.media_creators.svg_forge.vector_spec import VectorSpec
 from tangl.media.media_resource import (
     MediaInventory,
@@ -53,7 +54,7 @@ from tangl.vm.provision.matching import annotate_offer_specificity
 from tangl.vm.resolution_phase import ResolutionPhase
 from tangl.vm.runtime.causality import CausalityMode
 from tangl.vm.runtime.frame import PhaseCtx
-from tangl.vm.traversable import TraversableNode
+from tangl.vm.traversable import HasContainerEntryProjection, TraversableNode
 
 
 class FinalizableContainer(TraversableNode):
@@ -69,8 +70,18 @@ class FinalizableContainer(TraversableNode):
                 self.sink_id = children[-1].uid
 
 
+class ResumableNode(HasContainerEntryProjection, TraversableNode):
+    """Test container that opts into re-entrant entry projection."""
+
+
 def _node(graph: Graph, **kwargs) -> TraversableNode:
     node = TraversableNode(**kwargs)
+    graph.add(node)
+    return node
+
+
+def _resumable_node(graph: Graph, **kwargs) -> ResumableNode:
+    node = ResumableNode(**kwargs)
     graph.add(node)
     return node
 
@@ -1362,7 +1373,7 @@ class TestResolverFrontierNode:
         result = resolver.resolve_frontier_node(node)
         assert result is False
 
-    def test_container_without_progress_is_not_viable(self) -> None:
+    def test_container_without_progress_is_runtime_viable(self) -> None:
         g = Graph()
         container = _node(g, label="scene")
         source = _node(g, label="entry")
@@ -1372,7 +1383,28 @@ class TestResolverFrontierNode:
         container.source_id = source.uid
         container.sink_id = sink.uid
         resolver = Resolver(entity_groups=[])
-        assert resolver.resolve_frontier_node(container) is False
+        assert resolver.resolve_frontier_node(container) is True
+
+    def test_container_with_unavailable_resolved_entry_is_not_viable(self) -> None:
+        g = Graph()
+        container = _resumable_node(g, label="scene")
+        source = _node(g, label="entry")
+        resumed = _node(
+            g,
+            label="resumed",
+            availability=[Predicate(expr="resume_open")],
+        )
+        sink = _node(g, label="exit")
+        for member in (source, resumed, sink):
+            container.add_child(member)
+        container.source_id = source.uid
+        container.sink_id = sink.uid
+        container.resume_id = resumed.uid
+        resumed.locals["resume_open"] = False
+        ctx = PhaseCtx(graph=g, cursor_id=container.uid)
+
+        resolver = Resolver(entity_groups=[])
+        assert resolver.resolve_frontier_node(container, _ctx=ctx) is False
 
     def test_node_with_empty_fanout_still_resolves_true(self) -> None:
         g = Graph()

--- a/engine/tests/vm/test_resolver.py
+++ b/engine/tests/vm/test_resolver.py
@@ -1406,6 +1406,61 @@ class TestResolverFrontierNode:
         resolver = Resolver(entity_groups=[])
         assert resolver.resolve_frontier_node(container, _ctx=ctx) is False
 
+    def test_container_entry_dependency_preview_blocks_unprovisionable_entry(self) -> None:
+        g = Graph()
+        container = _resumable_node(g, label="scene")
+        source = _node(g, label="entry")
+        resumed = _node(g, label="resumed")
+        sink = _node(g, label="exit")
+        for member in (source, resumed, sink):
+            container.add_child(member)
+        container.source_id = source.uid
+        container.sink_id = sink.uid
+        container.resume_id = resumed.uid
+        dep = _dependency(
+            g,
+            predecessor_id=resumed.uid,
+            requirement=Requirement(
+                has_identifier="missing",
+                provision_policy=ProvisionPolicy.EXISTING,
+            ),
+        )
+        ctx = PhaseCtx(graph=g, cursor_id=container.uid)
+
+        resolver = Resolver(entity_groups=[])
+
+        assert resolver.resolve_frontier_node(container, _ctx=ctx) is False
+        assert dep.satisfied is False
+        assert dep.provider is None
+
+    def test_container_entry_dependency_preview_does_not_bind_provider(self) -> None:
+        g = Graph()
+        container = _resumable_node(g, label="scene")
+        source = _node(g, label="entry")
+        resumed = _node(g, label="resumed")
+        sink = _node(g, label="exit")
+        key = _node(g, label="key")
+        for member in (source, resumed, sink):
+            container.add_child(member)
+        container.source_id = source.uid
+        container.sink_id = sink.uid
+        container.resume_id = resumed.uid
+        dep = _dependency(
+            g,
+            predecessor_id=resumed.uid,
+            requirement=Requirement(
+                has_identifier="key",
+                provision_policy=ProvisionPolicy.EXISTING,
+            ),
+        )
+        ctx = PhaseCtx(graph=g, cursor_id=container.uid)
+
+        resolver = Resolver(entity_groups=[[key]])
+
+        assert resolver.resolve_frontier_node(container, _ctx=ctx) is True
+        assert dep.satisfied is False
+        assert dep.provider is None
+
     def test_malformed_container_entry_target_raises(self) -> None:
         g = Graph()
         container = _resumable_node(g, label="scene")

--- a/engine/tests/vm/test_traversable.py
+++ b/engine/tests/vm/test_traversable.py
@@ -20,9 +20,12 @@ import tangl.vm.traversable as traversable_module
 from tangl.core import Graph
 from tangl.core.runtime_op import Predicate
 from tangl.vm.resolution_phase import ResolutionPhase
+from tangl.vm.runtime.frame import PhaseCtx
 from tangl.vm.traversable import (
     AnonymousEdge,
     AnyTraversableEdge,
+    ContainerEntryRule,
+    HasContainerEntryProjection,
     TraversableEffect,
     TraversableEdge,
     TraversableNode,
@@ -33,8 +36,18 @@ from tangl.vm.traversable import (
 )
 
 
+class ResumableNode(HasContainerEntryProjection, TraversableNode):
+    """Test container that opts into re-entrant entry projection."""
+
+
 def _node(graph: Graph, **kwargs) -> TraversableNode:
     node = TraversableNode(**kwargs)
+    graph.add(node)
+    return node
+
+
+def _resumable_node(graph: Graph, **kwargs) -> ResumableNode:
+    node = ResumableNode(**kwargs)
     graph.add(node)
     return node
 
@@ -216,6 +229,99 @@ class TestTraversableNodeContainer:
         assert isinstance(edge, AnonymousEdge)
         assert edge.predecessor is container
         assert edge.successor is entry
+
+    def test_resumable_container_enters_resume_target(self) -> None:
+        g = Graph()
+        container = _resumable_node(g, label="scene")
+        entry = _node(g, label="entry")
+        resumed = _node(g, label="resumed")
+        container.add_child(entry)
+        container.add_child(resumed)
+        container.source_id = entry.uid
+        container.resume_id = resumed.uid
+
+        edge = container.enter()
+        assert edge.successor is resumed
+
+    def test_resumable_container_without_resume_uses_source(self) -> None:
+        g = Graph()
+        container = _resumable_node(g, label="scene")
+        entry = _node(g, label="entry")
+        container.add_child(entry)
+        container.source_id = entry.uid
+
+        assert container.enter().successor is entry
+
+    def test_entry_rule_selects_matching_target(self) -> None:
+        g = Graph()
+        container = _resumable_node(g, label="scene")
+        entry = _node(g, label="entry")
+        strider_entry = _node(g, label="strider_entry")
+        container.add_child(entry)
+        container.add_child(strider_entry)
+        container.source_id = entry.uid
+        container.locals["befriended_strider"] = True
+        container.entry_rules = [
+            ContainerEntryRule(
+                target_id=strider_entry.uid,
+                availability=[Predicate(expr="befriended_strider")],
+            )
+        ]
+        ctx = PhaseCtx(graph=g, cursor_id=container.uid)
+
+        edge = container.enter(ctx=ctx)
+        assert edge.successor is strider_entry
+
+    def test_resume_overrides_matching_entry_rule(self) -> None:
+        g = Graph()
+        container = _resumable_node(g, label="scene")
+        entry = _node(g, label="entry")
+        rule_entry = _node(g, label="rule_entry")
+        resumed = _node(g, label="resumed")
+        for member in (entry, rule_entry, resumed):
+            container.add_child(member)
+        container.source_id = entry.uid
+        container.resume_id = resumed.uid
+        container.locals["rule_matches"] = True
+        container.entry_rules = [
+            ContainerEntryRule(
+                target_id=rule_entry.uid,
+                availability=[Predicate(expr="rule_matches")],
+            )
+        ]
+        ctx = PhaseCtx(graph=g, cursor_id=container.uid)
+
+        assert container.enter(ctx=ctx).successor is resumed
+
+    def test_resume_target_outside_container_fails_loudly(self) -> None:
+        g = Graph()
+        container = _resumable_node(g, label="scene")
+        entry = _node(g, label="entry")
+        elsewhere = _node(g, label="elsewhere")
+        container.add_child(entry)
+        container.source_id = entry.uid
+        container.resume_id = elsewhere.uid
+
+        with pytest.raises(ValueError, match="not a member"):
+            container.enter()
+
+    def test_unavailable_resume_target_makes_container_unenterable(self) -> None:
+        g = Graph()
+        container = _resumable_node(g, label="scene")
+        entry = _node(g, label="entry")
+        resumed = _node(
+            g,
+            label="resumed",
+            availability=[Predicate(expr="resume_open")],
+        )
+        container.add_child(entry)
+        container.add_child(resumed)
+        container.source_id = entry.uid
+        container.resume_id = resumed.uid
+        resumed.locals["resume_open"] = False
+        ctx = PhaseCtx(graph=g, cursor_id=container.uid)
+
+        assert container.enterable(ctx=ctx) is False
 
     def test_sink_property(self) -> None:
         g = Graph()
@@ -670,6 +776,21 @@ class TestTraversalContractValidation:
 
         issues = validate_traversal_contracts(g)
         assert any("source_id is set but sink_id is missing" in issue for issue in issues)
+
+    def test_resume_target_not_member_reports_issue(self) -> None:
+        g = Graph()
+        container = _resumable_node(g, label="scene")
+        source = _node(g, label="entry")
+        sink = _node(g, label="exit")
+        elsewhere = _node(g, label="elsewhere")
+        container.add_child(source)
+        container.add_child(sink)
+        container.source_id = source.uid
+        container.sink_id = sink.uid
+        container.resume_id = elsewhere.uid
+
+        issues = validate_traversal_contracts(g)
+        assert any("resume_id" in issue and "not a member" in issue for issue in issues)
 
     def test_sink_without_source_reports_issue(self) -> None:
         g = Graph()

--- a/engine/tests/vm/test_traversable.py
+++ b/engine/tests/vm/test_traversable.py
@@ -323,6 +323,50 @@ class TestTraversableNodeContainer:
 
         assert container.enterable(ctx=ctx) is False
 
+    def test_nested_unavailable_resume_makes_parent_unenterable(self) -> None:
+        g = Graph()
+        parent = _resumable_node(g, label="parent")
+        child = _resumable_node(g, label="child")
+        parent_entry = _node(g, label="parent_entry")
+        parent_exit = _node(g, label="parent_exit")
+        child_entry = _node(g, label="child_entry")
+        child_resume = _node(
+            g,
+            label="child_resume",
+            availability=[Predicate(expr="child_open")],
+        )
+        child_exit = _node(g, label="child_exit")
+        for member in (child_entry, child_resume, child_exit):
+            child.add_child(member)
+        child.source_id = child_entry.uid
+        child.sink_id = child_exit.uid
+        child.resume_id = child_resume.uid
+        child_resume.locals["child_open"] = False
+        for member in (parent_entry, child, parent_exit):
+            parent.add_child(member)
+        parent.source_id = parent_entry.uid
+        parent.sink_id = parent_exit.uid
+        parent.resume_id = child.uid
+        ctx = PhaseCtx(graph=g, cursor_id=parent.uid)
+
+        assert parent.enterable(ctx=ctx) is False
+
+    def test_container_successor_preserves_explicit_namespace(self) -> None:
+        g = Graph()
+        source = _node(g, label="source")
+        container = _resumable_node(g, label="container")
+        entry = _node(
+            g,
+            label="entry",
+            availability=[Predicate(expr="entry_open")],
+        )
+        container.add_child(entry)
+        container.source_id = entry.uid
+        edge = _edge(g, predecessor_id=source.uid, successor_id=container.uid)
+
+        assert edge.available(ns={"entry_open": True}) is True
+        assert edge.available(ns={"entry_open": False}) is False
+
     def test_sink_property(self) -> None:
         g = Graph()
         container = _node(g, label="scene")

--- a/worlds/README.md
+++ b/worlds/README.md
@@ -19,6 +19,15 @@ See [logic_demo/README.md](logic_demo/README.md) for details.
 **Twine Logic Demo** - The same state-machine idea authored in Twee/Twine and
 decoded through the built-in Twine codec.
 
+### adventure_sandbox_slice/
+**Adventure Sandbox Slice** - A compact Colossal Cave-style sandbox mechanics
+demo with location links, inventory, a lamp, a lockable grate, darkness, and a
+present mob interaction.
+
+### ed_queue_demo/
+**ED Queue Demo** - A deterministic queueing/DES mechanics proof rendered
+through normal StoryTangl journal fragments.
+
 ## Creating a New World
 
 ### Quick Start

--- a/worlds/adventure_sandbox_slice/adventure_sandbox_slice/__init__.py
+++ b/worlds/adventure_sandbox_slice/adventure_sandbox_slice/__init__.py
@@ -1,0 +1,1 @@
+"""Adventure-style sandbox demo world domain."""

--- a/worlds/adventure_sandbox_slice/adventure_sandbox_slice/domain.py
+++ b/worlds/adventure_sandbox_slice/adventure_sandbox_slice/domain.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from tangl.core import Priority, Selector, Token
+from tangl.core import Graph, Priority, Selector, Token
 from tangl.mechanics.sandbox import (
     ChargeFacet,
     ContainerFacet,
@@ -18,28 +18,34 @@ from tangl.mechanics.sandbox import (
     SandboxVisibilityRule,
     SwitchableFacet,
 )
-from tangl.vm import on_prereqs
+from tangl.vm import on_provision
+from tangl.vm.ctx import VmPhaseCtx
 
 
 class AdventureSandboxLocation(SandboxLocation):
     """A demo Adventure-like location using the generic sandbox handlers."""
 
 
-def _location(graph, label: str) -> AdventureSandboxLocation:
+def _location(graph: Graph, label: str) -> AdventureSandboxLocation:
     location = graph.find_one(Selector.from_identifier(label))
     if not isinstance(location, AdventureSandboxLocation):
         raise ValueError(f"Adventure sandbox location {label!r} is missing")
     return location
 
 
-def _asset_type(label: str, **values) -> SandboxCompiledAssetType:
+def _asset_type(label: str, **values: object) -> SandboxCompiledAssetType:
     existing = SandboxCompiledAssetType.get_instance(label)
     if existing is not None:
         return existing
     return SandboxCompiledAssetType(label=label, **values)
 
 
-def _add_asset(graph, label: str, location: AdventureSandboxLocation, **values) -> Token:
+def _add_asset(
+    graph: Graph,
+    label: str,
+    location: AdventureSandboxLocation,
+    **values: object,
+) -> Token[SandboxCompiledAssetType]:
     asset_type = _asset_type(label, **values)
     asset = Token[SandboxCompiledAssetType](token_from=label, label=label)
     graph.add(asset)
@@ -47,7 +53,7 @@ def _add_asset(graph, label: str, location: AdventureSandboxLocation, **values) 
     return asset
 
 
-def _ensure_adventure_sandbox(graph) -> None:
+def _ensure_adventure_sandbox(graph: Graph) -> None:
     if graph.find_one(Selector.from_identifier("cave")) is not None:
         return
 
@@ -171,16 +177,20 @@ def _ensure_adventure_sandbox(graph) -> None:
     scope.mobs.append(pirate)
 
 
-@on_prereqs(
+@on_provision(
     wants_caller_kind=AdventureSandboxLocation,
     wants_exact_kind=False,
     priority=Priority.FIRST,
 )
-def setup_adventure_sandbox(*, caller, ctx, **_kw):
+def setup_adventure_sandbox(
+    *,
+    caller: AdventureSandboxLocation,
+    ctx: VmPhaseCtx,
+    **_kw: object,
+) -> None:
     """Attach the demo's shared sandbox state before location planning."""
 
-    if not isinstance(caller, AdventureSandboxLocation):
-        return None
+    _ = ctx
     _ensure_adventure_sandbox(caller.graph)
     return None
 

--- a/worlds/adventure_sandbox_slice/adventure_sandbox_slice/domain.py
+++ b/worlds/adventure_sandbox_slice/adventure_sandbox_slice/domain.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from tangl.core import Priority, Selector, Token
+from tangl.mechanics.sandbox import (
+    ChargeFacet,
+    ContainerFacet,
+    LightSourceFacet,
+    LockableFacet,
+    OpenableFacet,
+    SandboxCompiledAssetType,
+    SandboxFixture,
+    SandboxLocation,
+    SandboxMob,
+    SandboxMobAffordance,
+    SandboxScope,
+    SandboxVisibilityRule,
+    SwitchableFacet,
+)
+from tangl.vm import on_prereqs
+
+
+class AdventureSandboxLocation(SandboxLocation):
+    """A demo Adventure-like location using the generic sandbox handlers."""
+
+
+def _location(graph, label: str) -> AdventureSandboxLocation:
+    location = graph.find_one(Selector.from_identifier(label))
+    if not isinstance(location, AdventureSandboxLocation):
+        raise ValueError(f"Adventure sandbox location {label!r} is missing")
+    return location
+
+
+def _asset_type(label: str, **values) -> SandboxCompiledAssetType:
+    existing = SandboxCompiledAssetType.get_instance(label)
+    if existing is not None:
+        return existing
+    return SandboxCompiledAssetType(label=label, **values)
+
+
+def _add_asset(graph, label: str, location: AdventureSandboxLocation, **values) -> Token:
+    asset_type = _asset_type(label, **values)
+    asset = Token[SandboxCompiledAssetType](token_from=label, label=label)
+    graph.add(asset)
+    location.add_asset(asset)
+    return asset
+
+
+def _ensure_adventure_sandbox(graph) -> None:
+    if graph.find_one(Selector.from_identifier("cave")) is not None:
+        return
+
+    scope = SandboxScope(
+        label="cave",
+        locals={"world_turn": 0},
+        visibility_rules=[
+            SandboxVisibilityRule(
+                journal_text=(
+                    "It is now pitch dark. If you proceed you will likely fall "
+                    "into a pit."
+                )
+            )
+        ],
+        wait_enabled=True,
+        wait_text="Wait",
+        wait_turn_delta=1,
+    )
+    graph.add(scope)
+
+    locations = [
+        location
+        for location in graph.find_all(Selector(has_kind=AdventureSandboxLocation))
+    ]
+    for location in locations:
+        location.sandbox_scope = "cave"
+        scope.add_child(location)
+
+    building = _location(graph, "building")
+    outside_grate = _location(graph, "outside_grate")
+    below_grate = _location(graph, "below_grate")
+    cobble_crawl = _location(graph, "cobble_crawl")
+
+    _add_asset(
+        graph,
+        "keys",
+        building,
+        name="set of keys",
+        kind="keyring",
+        traits={"portable", "tiny"},
+        portable=True,
+        read_text="It's just a normal-looking set of keys.",
+        take_text="Taken.",
+        drop_text="Dropped.",
+    )
+    _add_asset(
+        graph,
+        "brass_lamp",
+        building,
+        name="brass lantern",
+        kind="lamp",
+        traits={"portable", "switchable", "provides_light", "requires_charge"},
+        portable=True,
+        switchable=SwitchableFacet(),
+        light_source=LightSourceFacet(requires_switch=True),
+        lit=False,
+        charge=ChargeFacet(current=330, maximum=330, charge_name="oil"),
+        read_text="It is a shiny brass lamp.",
+        turn_on_text="Your lamp is now on.",
+        turn_off_text="Your lamp is now off.",
+        take_text="Taken.",
+        drop_text="Dropped.",
+    )
+    _add_asset(
+        graph,
+        "wicker_cage",
+        cobble_crawl,
+        name="wicker cage",
+        kind="container",
+        traits={"portable", "container"},
+        portable=True,
+        container=ContainerFacet(
+            is_open=True,
+            max_items=1,
+            accepts_traits={"tiny"},
+            open_text="The cage opens.",
+            close_text="The cage snaps shut.",
+        ),
+        read_text="It's a small wicker cage.",
+        take_text="Taken.",
+        drop_text="Dropped.",
+    )
+
+    grate = SandboxFixture(
+        label="grate",
+        name="steel grate",
+        lockable=LockableFacet(
+            key="keys",
+            is_locked=True,
+            unlock_text="The key turns with a click. The grate unlocks.",
+        ),
+        openable=OpenableFacet(
+            is_open=False,
+            open_text="The grate opens.",
+            close_text="The grate closes.",
+        ),
+    )
+    outside_grate.fixtures.append(grate)
+    below_grate.fixtures.append(grate)
+
+    pirate = SandboxMob(
+        label="wounded_pirate",
+        name="wounded pirate",
+        kind="mobile_actor",
+        traits={"mobile", "audible_nearby", "can_carry"},
+        location="cobble_crawl",
+        state={"hp": 3, "injured": True, "hostile": False},
+        present_text="A wounded pirate leans against the wall, watching you.",
+        nearby_text="You hear someone breathing raggedly nearby.",
+        affordances=[
+            SandboxMobAffordance(
+                label="help",
+                text="Make sure the wounded pirate is okay",
+                journal_text="The pirate eyes you suspiciously, but accepts your help.",
+                state_effects={"helped": True, "hostile": False},
+            )
+        ],
+    )
+    graph.add(pirate)
+    scope.add_child(pirate)
+    scope.mobs.append(pirate)
+
+
+@on_prereqs(
+    wants_caller_kind=AdventureSandboxLocation,
+    wants_exact_kind=False,
+    priority=Priority.FIRST,
+)
+def setup_adventure_sandbox(*, caller, ctx, **_kw):
+    """Attach the demo's shared sandbox state before location planning."""
+
+    if not isinstance(caller, AdventureSandboxLocation):
+        return None
+    _ensure_adventure_sandbox(caller.graph)
+    return None
+
+
+AdventureSandboxLocation.model_rebuild(_types_namespace={"UUID": UUID})

--- a/worlds/adventure_sandbox_slice/script.yaml
+++ b/worlds/adventure_sandbox_slice/script.yaml
@@ -1,0 +1,111 @@
+label: adventure_sandbox_slice
+
+metadata:
+  title: "Adventure Sandbox Slice"
+  description: "A compact Adventure-like sandbox demo."
+  start_at: adventure.entrance
+
+scenes:
+  adventure:
+    title: "Adventure Sandbox Slice"
+    blocks:
+      entrance:
+        content: |
+          This is not a preservation port. It is a small semantic-compression
+          demo: locations, assets, a lockable grate, a lamp, darkness, and one
+          wounded pirate, all projected through ordinary StoryTangl choices.
+        actions:
+          - text: "Stand at the end of the road"
+            successor: road
+
+      road:
+        kind: "adventure_sandbox_slice.domain.AdventureSandboxLocation"
+        location_name: "End of Road"
+        light: true
+        content: |
+          You are standing at the end of a road before a small brick building.
+          Around you is a forest. A small stream flows out of the building and
+          down a gully.
+        links:
+          east: building
+          south: valley
+          down: valley
+          in: building
+
+      building:
+        kind: "adventure_sandbox_slice.domain.AdventureSandboxLocation"
+        location_name: "Inside Building"
+        light: true
+        content: |
+          You are inside a building, a well house for a large spring.
+        links:
+          west: road
+          out: road
+          in:
+            kind: message
+            journal: "The pipes are too small."
+
+      valley:
+        kind: "adventure_sandbox_slice.domain.AdventureSandboxLocation"
+        location_name: "In A Valley"
+        light: true
+        content: |
+          You are in a valley beside a stream tumbling along a rocky bed.
+        links:
+          north: road
+          up: road
+          south: slit_streambed
+          down: slit_streambed
+
+      slit_streambed:
+        kind: "adventure_sandbox_slice.domain.AdventureSandboxLocation"
+        location_name: "At Slit in Streambed"
+        light: true
+        content: |
+          At your feet all the water of the stream splashes into a 2-inch slit
+          in the rock. Downstream the streambed is bare rock.
+        links:
+          north: valley
+          up: valley
+          south: outside_grate
+          down:
+            kind: message
+            journal: "You don't fit through a two-inch slit!"
+
+      outside_grate:
+        kind: "adventure_sandbox_slice.domain.AdventureSandboxLocation"
+        location_name: "Outside Grate"
+        light: true
+        content: |
+          You are in a 20-foot depression floored with bare dirt. Set into the
+          dirt is a strong steel grate mounted in concrete.
+        links:
+          north: slit_streambed
+          down:
+            through: grate
+            target: below_grate
+
+      below_grate:
+        kind: "adventure_sandbox_slice.domain.AdventureSandboxLocation"
+        location_name: "Below the Grate"
+        content: |
+          You are in a small chamber beneath a 3x3 steel grate to the surface.
+          A low crawl over cobbles leads inward to the west.
+        dark_text: |
+          It is now pitch dark. If you proceed you will likely fall into a pit.
+        links:
+          up:
+            through: grate
+            target: outside_grate
+          west: cobble_crawl
+
+      cobble_crawl:
+        kind: "adventure_sandbox_slice.domain.AdventureSandboxLocation"
+        location_name: "In Cobble Crawl"
+        content: |
+          You are crawling over cobbles in a low passage. There is a dim light
+          at the east end of the passage.
+        dark_text: |
+          It is now pitch dark. If you proceed you will likely fall into a pit.
+        links:
+          east: below_grate

--- a/worlds/adventure_sandbox_slice/world.yaml
+++ b/worlds/adventure_sandbox_slice/world.yaml
@@ -1,0 +1,8 @@
+label: adventure_sandbox_slice
+scripts: script.yaml
+domain_module: adventure_sandbox_slice.domain
+
+metadata:
+  title: "Adventure Sandbox Slice"
+  description: "A feel-preserving Colossal Cave-style sandbox mechanics demo."
+  start_at: adventure.entrance


### PR DESCRIPTION
1. enable conditional entry points to episode containers, validate and provision specifically against the preview node
2. track and respect container bookmarks for re-entering a container that has been exited
3. invalidate pre-provisioned frontier edges when re-entering a node and re-validate and provision them to determine currently valid paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Adventure Sandbox Slice" world demo featuring interactive sandbox mechanics with items, mobs, and fixtures
  * Implemented container re-entry mechanism enabling sandboxes and board-like scopes to resume from saved positions

* **Documentation**
  * Enhanced sandbox design documentation on re-entrant container semantics and ephemeral affordances
  * Updated VM design notes clarifying container traversal and entry resolution mechanics

* **Tests**
  * Added integration tests for adventure sandbox world bundle
  * Expanded VM test coverage for container re-entry, resumable nodes, and nested descent scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/derekmerck/storytangl/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->