### PR TITLE
Credentials: roster shift + Phase A (derive, factory, sampling)

### DIFF
--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -429,6 +429,54 @@ PNG/JPG LFS rules.
 
 ---
 
+## Generality: one engine, many skins
+
+The credentials engine is **theme-neutral**. A world supplies only *data* -- the
+restriction map (rules), the permit/credential catalog, the indication
+vocabulary, and the candidate extras -- while the runtime (roster of extras +
+procedurally generated packets + inspect/decide + derived disposition) is
+identical across themes. This is the same reuse the other `mechanics.games`
+kernels already follow (Bag-RPS in `colony_loop`, etc.), and it is a concrete
+*second use case*, which is what justifies generalizing the vocabulary now.
+
+Build Phase A accordingly: **no border/travel nouns baked into the kernel.**
+`Indication`, `RestrictionLevel`, and the permit catalog are per-world data; only
+the abstract chain (Indication -> RestrictionLevel -> Presentation -> Outcome)
+and the generator live in the engine.
+
+### Worked second skin: Steam-Automata Chop Shop
+
+A notes-rich world concept (an underground robot fencing / modification ring)
+reskins the mechanic onto robot legality. Its data lives in a *sibling checkout*,
+not this repo:
+`/Users/derek/dev/storytangl/scratch/old/worlds/chopshop/resources/`
+(`automata_credential_types.yaml`, `automata_parts_list.yaml`,
+`automata_upgrades.yaml`, `scene_notes.yaml`).
+
+- `automata_credential_types.yaml` is `default_credential_types.yaml` reskinned:
+  anonymous "activation stamps" (`valid_period: 0`, no id) and id-bound
+  "inspection / waiver tags" (`valid_period: 100`), over indications
+  work / skilled / luxury (purpose) and passing / weapons / thinking
+  (contraband), with origins CoD / CMG / black-market mapping onto `Region`.
+- A unit's **components and upgrades determine its true indications**: a milspec
+  chassis grants combat (needs a weapon waiver), a simulacrum chassis grants
+  `passing` (needs a passing waiver), and illegal mods like `thinking` or
+  `cloaking` are contraband (deny / arrest). Same Indication -> ... -> Outcome
+  derivation, with candidate truth *computed from config* rather than authored
+  directly.
+
+### Direction: assess -> remediate (legalize) loop
+
+Chop shop also inverts the gatekeeper framing. The disposition is not terminal:
+it **feeds an outer shop loop** (buy / repair / legalize). The player can
+*remediate* a unit to change its legality -- part it out, or forge / procure the
+right stamps -- which is the degrade / generate machinery applied from the player
+side (inspect -> assess -> remediate -> re-assess). That is a composite loop
+(shell = shop economy, spike = legality assessment), noted as a future direction
+(not v1 scope) and a natural wing of the unified showcase world.
+
+---
+
 ## Scratch disposition: keep / adapt / drop
 
 - **Keep as canonical narrative:** `README.md` (the encounter spec) and

--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -268,6 +268,76 @@ Five properties keep Phases A/B/C as extensions rather than entangled rewrites:
 
 ---
 
+## The rule and failure-mode model
+
+The mechanic runs on a few axes. Stating them precisely here so Phases A/B/C
+implement the same model.
+
+### The restriction axis (and rule deltas)
+
+Each indication sits on one ordered axis, most to least restrictive:
+
+```
+forbidden  ->  allowed with permit (req id)  ->  allowed with id  ->  allowed (anonymous)
+```
+
+`req_id` is a *property of the level*: the two id-bound levels (permit, id)
+require checking the bearer id; the anonymous level does not. A day's authored
+rule change is a **delta along this axis** for some indication ("work moves from
+allowed-with-id to allowed-with-permit today"). Which failure modes are reachable
+follows from where each indication currently sits (see "Rules are an authored
+story lever", A.5).
+
+### Which rule applies (candidate -> bin)
+
+A candidate is mapped to a restriction bin by three factors:
+
+- **origin** (region),
+- **purpose** (the intent indication: travel / work / emigrate / ...),
+- **possessions** (contraband indications: weapon / drugs / secrets / ...).
+
+origin + purpose + each possession select the level(s) that candidate must
+satisfy.
+
+### Two error surfaces per permit
+
+A permitted indication needs a permit *and* verification of the permit against
+the bearer id -- so there are **two independent places to introduce an error**:
+the permit document itself (missing / bad / forged) and the id linkage (the
+permit's holder reference vs. the presented id). Generation and inspection both
+treat these as distinct surfaces.
+
+### Mitigatable infractions vs. crimes
+
+The disposition split turns on whether an error is *fixable in the moment*:
+
+| Error                            | Class       | Fix (mediation)           | Unfixed |
+| -------------------------------- | ----------- | ------------------------- | ------- |
+| Missing document                 | mitigatable | produce it                | deny    |
+| Missing seal                     | mitigatable | return to the signer      | deny    |
+| Openly declared contraband       | mitigatable | hand it over (relinquish) | deny    |
+| Forged seal                      | crime       | --                        | arrest  |
+| Fake id / fake papers (knowing)  | crime       | --                        | arrest  |
+| Concealed contraband             | crime       | (a search reveals it)     | arrest  |
+
+Mitigatable errors are the Phase B mediation moves: a successful fix clears the
+infraction (-> allow); refusal or inability escalates (-> deny). Crimes are not
+clearable; a search is a *detection* move (it exposes concealment), not a fix.
+
+### Origin bends severity (Phase C)
+
+Origin is not only a bin selector -- it modulates outcome severity *after* the
+base disposition is derived:
+
+- a **privileged** origin can have a crime overlooked (arrest -> deny / allow);
+- an **out-of-favor** origin can have a minor infraction charged up
+  (deny -> arrest).
+
+This is the nuanced form of whitelist / blacklist: not a binary pass/arrest, but
+a shift along the severity scale.
+
+---
+
 ## Phase A: derived disposition and generated packets
 
 The scratch package under `scratch/mechanics/credentials/` already designed this

--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -1,8 +1,8 @@
 # Credentials Loop Design
 
-**Status:** v1 LANDED (candidate-roster shift, 2026-05-21); Phase A.1 LANDED
-(rules-derived dispositions, 2026-05-22); Phase A.2 LANDED (candidate factory,
-2026-05-22); Phases A.3/B/C/D designed below as overlays  
+**Status:** v1 LANDED (candidate-roster shift, 2026-05-21); Phase A LANDED
+(A.1 rules-derived dispositions, A.2 candidate factory, A.3 day-spec sampling +
+lazy offer roster, 2026-05-22); Phases B/C/D designed below as overlays  
 **Scope:** the credentials / checkpoint interaction as a stacked picking-game
 composition inside `tangl.mechanics.games`  
 **Background sources:** `docs/src/notes/CREDENTIALS_INTERACTION.md`,
@@ -455,7 +455,20 @@ A.1's structured truth is exactly the target this builds and mutates, and the
 **round-trip invariant** test pins it: `derive(degrade(build_valid(intent,
 rules), mode)) == expected_for(mode)`.
 
-### A.4 Day spec, lazy offers, and editable roster (the A.3 increment)
+### A.4 Day spec, lazy offers, and editable roster (the A.3 increment, LANDED)
+
+**Landed (2026-05-22)** in `credentials_roster.py` (compact form): `ShiftSpec`
+(rules + origin distribution + disposition-class distribution + encounters +
+purpose pool + pinned + seed); `generate_roster` samples origin + target then
+picks a *feasible, verified* failure mode (so the linchpin holds by
+construction); `ScenarioOffer` is the unmaterialized promise; `materialize(offer,
+rules)` builds the packet deterministically; `CredentialsGame.offers` +
+`active_case` materialize each candidate **on arrival** (cached in
+`materialized`, a reset field). `render_narrative` (in the factory) projects the
+inspect-loop strings from the structured truth so generated cases are playable.
+Pinned whitelisted encounters (the "John Smith" case) work. Multi-day shifts and
+live roster editing are deliberately left as repeated generation / ordinary list
+edits -- no extra machinery.
 
 This is the larger increment. It is authored at the **shift/day** level and
 materializes candidates lazily.

--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -1,6 +1,7 @@
 # Credentials Loop Design
 
-**Status:** PROMOTED FAMILY NOTE  
+**Status:** v1 LANDED (candidate-roster shift, 2026-05-21); Phases A/B/C/D
+designed below as overlays  
 **Scope:** the credentials / checkpoint interaction as a stacked picking-game
 composition inside `tangl.mechanics.games`  
 **Background sources:** `docs/src/notes/CREDENTIALS_INTERACTION.md`,
@@ -218,3 +219,196 @@ If the credentials family is expanded next, the live design should aim for:
 That should preserve the best lessons from the old *Papers, Please*
 deconstruction without forcing the first implementation to solve everything at
 once.
+
+---
+
+## v1 Landed (2026-05-21): the candidate-roster shift
+
+The first live expansion is implemented in `credentials_game.py` and demoed by
+`worlds/credential_gate`. A single `CredentialsGame` hosts a **roster** of
+`CredentialCase`s walked by one re-entrant `HasGame` block: each disposition keeps
+the game `READY` and re-provisions moves for the next candidate, so there are no
+nested game blocks and no per-candidate story edges. The game reports terminal
+only once the final candidate is decided, at which point the existing
+`game_won` / `game_lost` POSTREQS exits route to a shift summary.
+
+What shipped:
+
+- **`CredentialCase`** -- the single source of truth for per-candidate authored
+  data (documents, hidden facts, packet facts, `correct_disposition`), with
+  reserved seams for Phase A (`region`/`purpose`/`contraband`) and Phase C
+  (`whitelist`/`blacklist`/`bribe_offer`).
+- **`CredentialCaseResult`** -- an auditable record per disposition (chosen vs.
+  expected, correct, findings).
+- **`shift_complete` + `evaluate()`** own shift terminality; `advance_case()`
+  resets only per-case working state; `pass_threshold` defaults to strict
+  all-correct.
+- **`expected_disposition(case)`** -- the single correctness chokepoint, today
+  returning the authored answer (bent by whitelist/blacklist context).
+
+Dispositions are authored per case, and the interaction is inspect -> packet ->
+disposition only. Everything below layers onto this spine.
+
+---
+
+## Implementation Seams (how later phases stay overlays)
+
+Five properties keep Phases A/B/C as extensions rather than entangled rewrites:
+
+1. **`CredentialCase` is pure data.** Every phase adds *fields*; the loop never
+   special-cases them.
+2. **`expected_disposition(case)` is the single correctness chokepoint.** Nothing
+   else decides right vs. wrong.
+3. **Move dispatch is by `move.kind`** in the picking kernel. New interactions are
+   new kinds, not new control flow.
+4. **Shift state is additive** (`case_results` today; `reputation`/`finding_status`
+   later), reset on setup, exported via `to_namespace`.
+5. **Consequences route through namespace + authored POSTREQS edges** in YAML, not
+   hardcoded branches.
+
+---
+
+## Phase A: derived disposition and generated packets
+
+The scratch package under `scratch/mechanics/credentials/` already designed this
+end to end. The work is **port-and-reconcile**, not new invention.
+
+### A.1 Derivation vocabulary (port)
+
+The conceptual core is a chain:
+
+```
+Indication --(restriction map)--> RestrictionLevel --> Presentation --> Outcome
+```
+
+- `credentials-2/enums.py` is the cleanest source: `Indication`,
+  `RestrictionLevel`, `RestrictionMap`, `RegionalRestrictionMaps` (with worked
+  LOCAL / FOREIGN_EAST / FOREIGN_WEST example maps), and a `Presentation` enum
+  whose members are grouped by `Outcome` via `presentations_for_outcome`.
+- Top-level `enums.py` is the complementary richer version: the **Flag `Outcome`
+  severity hierarchy** (CRIME > DENY > ACCEPT, with specific members such as
+  `FORGED_CREDENTIAL`, `MISSING_PERMIT`, `POSSIBLE_*`) plus the full `Move` set
+  and `Move.appropriate_for(outcome)`.
+- `tests/test_outcomes.py` locks the presentation -> outcome mapping; port it as
+  the spec for the canonical vocabulary (reconcile the two enum files into one).
+
+### A.2 derive_disposition
+
+Swap the body of `expected_disposition(case)` from `return case.correct_disposition`
+to a derivation against the shift's `restriction_map`, returning the
+**most-severe applicable Outcome** (the Flag hierarchy encodes that precedence).
+Keep authored `correct_disposition` as an explicit override so v1 cases and pinned
+encounters keep working unchanged.
+
+### A.3 Candidate factory: one pipeline, three entry points
+
+```
+disposition --sample--> failure mode(s) --construct--> packet (CredentialCase)
+   (Tier 3)               (Tier 2)                       (Tier 1)
+```
+
+Each tier supplies data from that point down; it is one funnel, not three paths.
+Tier 1 = explicit packet (v1 today). Tier 2 = declare a failure mode (or none)
+and build it against the current rules; disposition is then derived. Tier 3 =
+declare a disposition and sample an appropriate failure mode.
+
+The construction primitive is **start correct, then degrade**:
+
+```
+case = degrade(build_valid(intent, restriction_map), failure_modes)
+```
+
+`credentialed.py::generate_credentials()` is the worked blueprint: build a proper
+packet from the rules, then apply crime / invalidation / mediation mutators
+(`_forged_credential`, `_wrong_id_holder`, `_hidden_contraband`,
+`_bad_credential`, `_missing_credential`, `_possible_*`), with `outcome.specify()`
+sampling a specific failure within a category. Its doctrine -- *credentials are
+never tested against restrictions; they are created to pass or violate them* --
+is what makes generation tractable. Failure modes compose (multiple corruptions
+on one packet); a correct candidate is `degrade(..., [])`.
+
+### A.4 RosterSpec and pinned encounters
+
+`generate_roster(spec, restriction_map, rng)` returns `list[CredentialCase]` from
+a disposition distribution plus pinned cases. Port the shape from
+`credential_script_models.py` (`outcomes_distribution` /
+`expected_disposition_ratio` per region, `num_encounters`) and
+`credentials-2/cred_check_scene.py` (`sample_outcomes()`, pinned `extras`). This
+realizes "day 1 = 2 accept / 1 deny / 1 arrest, or pin known encounters." It is
+generation-side only; the runtime loop never learns whether a case was authored
+or sampled.
+
+### A.5 Packet-as-tokens (when structure is needed)
+
+When narrative-string findings are no longer enough, the structured packet model
+is `credentials-2/credential.py`: `CredentialType` as a YAML-loaded Singleton
+wrapped by `WrappedSingleton`, with `credential_status` as an overlay flag and
+computed `seal` (`seal.py::Seal.type_for`), issue, and expiry. It deliberately
+mirrors the **Wearable / Outfit-manager** pattern -- the credential packet is to
+the candidate what an outfit is to an actor. `default_credential_types.yaml` is
+the catalog (ticket, asylum, work permit, etc.). This becomes
+`CredentialCase.packet`; the degrade mutators set `credential_status` overlays
+rather than rebuilding tokens.
+
+---
+
+## Phase B: mediation moves
+
+Add a `"mediate"` move kind (`request_document` / `request_search` /
+`verify_id`). Override two methods in `CredentialsGameHandler`:
+`get_available_moves` (super + mediation targets) and `resolve_round` (handle
+`"mediate"`, else `super()`); the picking base is untouched. Add a per-case
+`finding_status` working dict (possible -> cleared / confirmed) reset by
+`advance_case`, which `derive_disposition` reads (e.g. a declined search becomes a
+deny). Port the move set and the discrepancy / mediation table from top-level
+`enums.py` and `notes.md`.
+
+**Optional enabling refactor:** before Phase B, change
+`PickingGameHandler.resolve_round` from `if inspect / elif decide / else raise`
+to dispatch through a `dict[str, resolver]` (or a `resolve_move_kind` hook with
+inspect/decide defaults). This turns "add a move kind" into a registration for
+*any* picking game, keeping B and C as true overlays.
+
+---
+
+## Phase C: context and haggling
+
+Whitelist / blacklist are already wired through `expected_disposition` and
+`_packet_finding`; Phase C only needs authored cases that set the flags plus
+journal flavor. Bribe / threat is another move kind (`accept_bribe` /
+`refuse_bribe`) plus additive shift tallies (`reputation`, `coin`) updated in
+resolution and exported to namespace; richer endings are then authored as extra
+POSTREQS edges keyed on `credential_*` predicates -- no engine change. The
+`ScreeningRound` narrative-override idea from the (dropped) `screening.py`
+(`on_invalid_seal`, `on_allow`, ...) is worth reviving as per-finding journal
+flavor.
+
+---
+
+## Phase D: media (deferred)
+
+The media layer is specced in `credential_forge/credforge.py`,
+`credential_forge/credforge_configs.yaml`, and `credentials-2/journal_models.py`
+(forge for ticket / id-card / permit images, seal images, holder portraits, and
+`JournalCredential` media items). Keep these as the eventual design, but defer
+until the interaction is proven, and use **SVG only** per the repository's
+PNG/JPG LFS rules.
+
+---
+
+## Scratch disposition: keep / adapt / drop
+
+- **Keep / port:** `credentials-2/enums.py` (derivation chain), top-level
+  `enums.py` (Flag severity + `Move` set), `credentials-2/credential.py` +
+  `seal.py` + `default_credential_types.yaml` (token packet model),
+  `credentialed.py::generate_credentials` (degrade-from-correct algorithm),
+  `credential_script_models.py` + `credentials-2/cred_check_scene.py` (roster
+  distribution + pinned extras), `tests/test_outcomes.py` +
+  `tests/test_credential_types.py` (specs).
+- **Keep as deferred:** `credential_forge/*`, `credentials-2/journal_models.py`
+  (media), `outcomes_graph.py` (optional derivation-graph validation tool).
+- **Drop (superseded by v38 Block/HasGame):** `screening.py` (old Challenge/Scene
+  scaffolding -- but salvage the narrative-override hook idea),
+  `papers_please_example.py`, and the empty stubs `credential_check.py`,
+  `candidate.py`, `credentials.py`, `credentials-2/cred_check_*.py`,
+  `id_card.py`, `enums_1.py`, `id_mint.py`, `utils.py`.

--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -1,7 +1,8 @@
 # Credentials Loop Design
 
-**Status:** v1 LANDED (candidate-roster shift, 2026-05-21); Phases A/B/C/D
-designed below as overlays  
+**Status:** v1 LANDED (candidate-roster shift, 2026-05-21); Phase A.1 LANDED
+(rules-derived dispositions, 2026-05-22); Phases A.2+/B/C/D designed below as
+overlays  
 **Scope:** the credentials / checkpoint interaction as a stacked picking-game
 composition inside `tangl.mechanics.games`  
 **Background sources:** `docs/src/notes/CREDENTIALS_INTERACTION.md`,
@@ -359,6 +360,18 @@ discrepancies present are the intended ones, and it is what makes the
 specification funnel (A.3) possible at all. Do not reintroduce a packet-validator
 to compute dispositions; dispositions are an *input* to generation, derived for
 scoring only via `expected_disposition`.
+
+**A.1 landed (2026-05-22).** `credentials_enums.py` holds the vocabulary
+(`Region`, `Indication`, `RestrictionLevel`, `CredentialStatus`) and the lean
+packet types (`CredentialToken`, `ContrabandItem`); `derive_disposition` reads a
+case only through its **discovery API** (`get_region` / `get_purpose` /
+`id_status` / `credential_for` / `get_contraband`) so the packet's internals stay
+opaque and swappable. `expected_disposition` derives unless an authored
+`correct_disposition` override is set; `credential_gate` now derives all three
+dispositions. Rules are stored as a flat `Restrictions` model (a rule list with
+`level_for` + a `from_map` authoring constructor) rather than an enum-keyed dict,
+because the VM hashes node state with `json.dumps` and enum dict-keys are not
+JSON-serializable. A.2+ below is still pending.
 
 ### A.1 Derivation vocabulary (port)
 

--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -392,15 +392,16 @@ Indication --(restriction map)--> RestrictionLevel --> Presentation --> Outcome
 - `tests/test_outcomes.py` locks the presentation -> outcome mapping; port it as
   the spec for the canonical vocabulary (reconcile the two enum files into one).
 
-### A.2 derive_disposition
+### A.2 derive_disposition (landed with A.1)
 
-Swap the body of `expected_disposition(case)` from `return case.correct_disposition`
-to a derivation against the shift's `restriction_map`, returning the
-**most-severe applicable Outcome** (the Flag hierarchy encodes that precedence).
-Keep authored `correct_disposition` as an explicit override so v1 cases and pinned
-encounters keep working unchanged.
+`expected_disposition(case)` derives against the shift's `restriction_map`,
+returning the **most-severe applicable disposition** (an explicit
+`ARREST > DENY > PASS` severity order on `CredentialDisposition`). Authored
+`correct_disposition` stays an explicit override so v1 cases and pinned
+encounters keep working unchanged. (The two design subsections A.1 and A.2 were
+implemented together as the "A.1 derivation spine" increment.)
 
-### A.3 Candidate factory: one pipeline, three entry points
+### A.3 Candidate factory: one pipeline, three entry points (the A.2 increment)
 
 ```
 disposition --sample--> failure mode(s) --construct--> packet (CredentialCase)
@@ -427,16 +428,72 @@ never tested against restrictions; they are created to pass or violate them* --
 is what makes generation tractable. Failure modes compose (multiple corruptions
 on one packet); a correct candidate is `degrade(..., [])`.
 
-### A.4 RosterSpec and pinned encounters
+**Failure-mode catalog.** `degrade` is driven by an explicit `FailureMode` set,
+and the same catalog is what A.3's sampler draws from. Each mode carries:
 
-`generate_roster(spec, restriction_map, rng)` returns `list[CredentialCase]` from
-a disposition distribution plus pinned cases. Port the shape from
-`credential_script_models.py` (`outcomes_distribution` /
-`expected_disposition_ratio` per region, `num_encounters`) and
-`credentials-2/cred_check_scene.py` (`sample_outcomes()`, pinned `extras`). This
-realizes "day 1 = 2 accept / 1 deny / 1 arrest, or pin known encounters." It is
-generation-side only; the runtime loop never learns whether a case was authored
-or sampled.
+- a **class** -- *mitigatable* (-> deny if unfixed) vs *crime* (-> arrest), matching
+  `CredentialStatus.is_crime` and the concealed-contraband case from A.1;
+- the **mutation** it applies (which token/id status it sets, or contraband it
+  conceals); and
+- an **applicability** predicate: which modes a given indication can even exhibit
+  at its current restriction level (you can only "miss a permit" where a permit is
+  required; only "forge a seal" where a credential exists; only conceal contraband
+  where contraband is present). This is the A.5 "rules shape the failure space"
+  point made concrete -- the sampler asks the catalog which modes are reachable
+  for an (indication, level) before choosing one.
+
+A.1's structured truth is exactly the target this builds and mutates, and the
+**round-trip invariant** test pins it: `derive(degrade(build_valid(intent,
+rules), mode)) == expected_for(mode)`.
+
+### A.4 Day spec, lazy offers, and editable roster (the A.3 increment)
+
+This is the larger increment. It is authored at the **shift/day** level and
+materializes candidates lazily.
+
+**Day/shift spec (authored).** A `ShiftSpec` carries everything a day needs:
+
+- the day's **rules** (a `Restrictions`; rules change between days -- "foreign-west
+  is now allied: anonymous transit, no id; foreign-east is now work-permit-with-id
+  only");
+- an **origin distribution** set by the gate/location ("at the western gate: 50%
+  foreign-west, 30% local, 20% foreign-east");
+- a **disposition-class distribution** ("40% valid->allow, 30% mitigatable->deny,
+  30% illegal->arrest");
+- **encounters per day** and **number of days** ("5/day for 3 days");
+- **pinned offers** -- scripted encounters that must appear ("John Smith arrives
+  with an invalid political clearance, but he's whitelisted -> allow"). A pinned
+  offer can fix any subset (origin, packet specifics, context override) and the
+  rest is filled by sampling.
+
+**Two-stage sampling.** For each non-pinned slot: (1) sample an origin from the
+origin distribution and a disposition class from the class distribution; (2) ask
+the failure-mode catalog (A.3) for the modes of that class **reachable** for this
+origin under the day's rules, and sample one (or a composition). PASS = no mode;
+deny = a mitigatable mode {bad/missing seal, missing doc, declared-unpermitted
+contraband...}; arrest = a crime mode {forgery, fake id, concealment...}.
+
+**Roster = offers, materialized on arrival.** The roster holds **scenario offers**
+(origin + target class + chosen failure mode + any pins/overrides), *not* concrete
+packets. The actual `CredentialCase` (the credential tokens) is built on demand --
+via `build_valid` + `degrade` -- only when that candidate arrives in the story.
+Until then an offer is just a promise of a scenario, so the roster can be
+**pre-empted, edited, reordered, or inserted into** (drop in John Smith, retune a
+day) before materialization. This unifies the three tiers: every roster entry is
+an offer, fully-specified (Tier 1), failure-specified (Tier 2), or
+disposition-specified (Tier 3), and materialization resolves it down the funnel.
+
+The lazy hook fits the existing loop cleanly: materialize the next offer into the
+active case at `advance_case` / setup time. The runtime loop still never learns
+whether a case was authored or sampled. Port the distribution shape from
+`credential_script_models.py` (`expected_disposition_ratio` per region,
+`num_encounters`) and `credentials-2/cred_check_scene.py` (`sample_outcomes()`,
+pinned `extras`).
+
+**Tests** (the linchpin): every materialized offer derives to the disposition
+class it was generated for; the origin/class distributions are hit under a seed;
+pinned offers appear (and honor context overrides like John Smith's whitelist);
+editing/pre-empting the roster before arrival changes who shows up.
 
 ### A.5 Rules are an authored story lever
 

--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -1,8 +1,8 @@
 # Credentials Loop Design
 
 **Status:** v1 LANDED (candidate-roster shift, 2026-05-21); Phase A.1 LANDED
-(rules-derived dispositions, 2026-05-22); Phases A.2+/B/C/D designed below as
-overlays  
+(rules-derived dispositions, 2026-05-22); Phase A.2 LANDED (candidate factory,
+2026-05-22); Phases A.3/B/C/D designed below as overlays  
 **Scope:** the credentials / checkpoint interaction as a stacked picking-game
 composition inside `tangl.mechanics.games`  
 **Background sources:** `docs/src/notes/CREDENTIALS_INTERACTION.md`,
@@ -401,7 +401,16 @@ returning the **most-severe applicable disposition** (an explicit
 encounters keep working unchanged. (The two design subsections A.1 and A.2 were
 implemented together as the "A.1 derivation spine" increment.)
 
-### A.3 Candidate factory: one pipeline, three entry points (the A.2 increment)
+### A.3 Candidate factory: one pipeline, three entry points (the A.2 increment, LANDED)
+
+**Landed (2026-05-22)** in `credentials_factory.py`: `build_valid(region, purpose,
+rules, *, contraband)` produces a valid packet (derives PASS); `degrade(case,
+modes)` / `apply_failure` corrupt it per the `FailureMode` catalog;
+`make_case(...)` is the Tier 2 entry; `applicable_modes(case, class)` and
+`sample_failure_mode(case, class, rng)` expose the reachable modes for sampling.
+The round-trip invariant is tested: every mode derives to its class disposition,
+and composition takes the worst. Tier 3 sampling / day spec / lazy roster is A.4
+below (the A.3 increment), still pending.
 
 ```
 disposition --sample--> failure mode(s) --construct--> packet (CredentialCase)

--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -278,7 +278,7 @@ implement the same model.
 
 Each indication sits on one ordered axis, most to least restrictive:
 
-```
+```text
 forbidden  ->  allowed with permit (req id)  ->  allowed with id  ->  allowed (anonymous)
 ```
 
@@ -377,7 +377,7 @@ JSON-serializable. A.2+ below is still pending.
 
 The conceptual core is a chain:
 
-```
+```text
 Indication --(restriction map)--> RestrictionLevel --> Presentation --> Outcome
 ```
 
@@ -412,7 +412,7 @@ The round-trip invariant is tested: every mode derives to its class disposition,
 and composition takes the worst. Tier 3 sampling / day spec / lazy roster is A.4
 below (the A.3 increment), still pending.
 
-```
+```text
 disposition --sample--> failure mode(s) --construct--> packet (CredentialCase)
    (Tier 3)               (Tier 2)                       (Tier 1)
 ```
@@ -424,7 +424,7 @@ declare a disposition and sample an appropriate failure mode.
 
 The construction primitive is **start correct, then degrade**:
 
-```
+```text
 case = degrade(build_valid(intent, restriction_map), failure_modes)
 ```
 

--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -271,7 +271,24 @@ Five properties keep Phases A/B/C as extensions rather than entangled rewrites:
 ## Phase A: derived disposition and generated packets
 
 The scratch package under `scratch/mechanics/credentials/` already designed this
-end to end. The work is **port-and-reconcile**, not new invention.
+end to end. The work is **port-and-reconcile**, not new invention. Its
+`README.md` is the canonical encounter spec (rules-per-indication, candidate
+truth vs. presentation, derived expected disposition, blacklist/whitelist, and
+the haggling twist where a candidate may bribe for a *denial*).
+
+### A.0 Why generate, not validate (the central lesson)
+
+The scratch work first tried to **algorithmically validate** an author-produced
+packet -- inspect the documents, compare against the rules, and *infer* the
+correct disposition. That path is a trap: it forces the engine to re-derive
+intent from artifacts, and every new failure type needs new validation logic.
+
+The decisive pivot was to **build the packet to match the intended disposition**
+instead. Generation is strictly easier than inference, it guarantees the only
+discrepancies present are the intended ones, and it is what makes the
+specification funnel (A.3) possible at all. Do not reintroduce a packet-validator
+to compute dispositions; dispositions are an *input* to generation, derived for
+scoring only via `expected_disposition`.
 
 ### A.1 Derivation vocabulary (port)
 
@@ -338,7 +355,23 @@ realizes "day 1 = 2 accept / 1 deny / 1 arrest, or pin known encounters." It is
 generation-side only; the runtime loop never learns whether a case was authored
 or sampled.
 
-### A.5 Packet-as-tokens (when structure is needed)
+### A.5 Rules are an authored story lever
+
+The `restriction_map` is not engine configuration -- it is a **story knob the
+author sets per day** ("no asylum from the east today"; "no weapons permits from
+the west"). Changing the rules changes *which failure modes can even exist*: a
+forbidden indication cannot be cleared by any permit, an allowed one cannot
+produce a missing-permit failure, and so on. So the available failure-mode space
+is **derived from the current rules**, and generation (A.3) samples only from
+that derived space.
+
+`outcomes_graph.py` exists for exactly this: it visualizes the
+`Indication -> RestrictionLevel -> Presentation -> Outcome` graph under a given
+rule set, so an author can *see* which dispositions and failure modes are
+reachable today before committing a day's rules. It is an authoring/validation
+aid for rule sets, not a runtime component.
+
+### A.6 Packet-as-tokens (when structure is needed)
 
 When narrative-string findings are no longer enough, the structured packet model
 is `credentials-2/credential.py`: `CredentialType` as a YAML-loaded Singleton
@@ -398,6 +431,9 @@ PNG/JPG LFS rules.
 
 ## Scratch disposition: keep / adapt / drop
 
+- **Keep as canonical narrative:** `README.md` (the encounter spec) and
+  `notes.md` (the discrepancy / mediation taxonomy). These are the design of
+  record for the mechanic, not just background.
 - **Keep / port:** `credentials-2/enums.py` (derivation chain), top-level
   `enums.py` (Flag severity + `Move` set), `credentials-2/credential.py` +
   `seal.py` + `default_credential_types.yaml` (token packet model),
@@ -406,7 +442,10 @@ PNG/JPG LFS rules.
   distribution + pinned extras), `tests/test_outcomes.py` +
   `tests/test_credential_types.py` (specs).
 - **Keep as deferred:** `credential_forge/*`, `credentials-2/journal_models.py`
-  (media), `outcomes_graph.py` (optional derivation-graph validation tool).
+  (media).
+- **Keep as an authoring aid:** `outcomes_graph.py` -- visualizes the reachable
+  failure-mode / disposition space under a given rule set (see A.5), for vetting
+  a day's authored rules. Not a runtime component.
 - **Drop (superseded by v38 Block/HasGame):** `screening.py` (old Challenge/Scene
   scaffolding -- but salvage the narrative-override hook idea),
   `papers_please_example.py`, and the empty stubs `credential_check.py`,

--- a/engine/src/tangl/mechanics/games/__init__.py
+++ b/engine/src/tangl/mechanics/games/__init__.py
@@ -94,11 +94,26 @@ from .corridor_game import CorridorGame, CorridorGameHandler, CorridorMove, Twen
 from .siege_rps_game import SiegeRpsGame, SiegeRpsGameHandler
 from .picking_game import PickingGame, PickingGameHandler, PickingMove
 from .kim_game import KimGame, KimGameHandler, KimMove
+from .credentials_enums import (
+    ContrabandItem,
+    CredentialStatus,
+    CredentialToken,
+    DEFAULT_RESTRICTIONS,
+    Indication,
+    Region,
+    RestrictionLevel,
+    RestrictionMap,
+    RestrictionRule,
+    Restrictions,
+)
 from .credentials_game import (
+    CredentialCase,
+    CredentialCaseResult,
     CredentialDisposition,
     CredentialsGame,
     CredentialsGameHandler,
     CredentialsMove,
+    derive_disposition,
 )
 
 
@@ -152,6 +167,19 @@ __all__ = [
     "CredentialsGameHandler",
     "CredentialsMove",
     "CredentialDisposition",
+    "CredentialCase",
+    "CredentialCaseResult",
+    "derive_disposition",
+    "ContrabandItem",
+    "CredentialStatus",
+    "CredentialToken",
+    "Indication",
+    "Region",
+    "RestrictionLevel",
+    "RestrictionMap",
+    "RestrictionRule",
+    "Restrictions",
+    "DEFAULT_RESTRICTIONS",
     # Dispatch
     "HasGame",
     "generate_game_journal",

--- a/engine/src/tangl/mechanics/games/__init__.py
+++ b/engine/src/tangl/mechanics/games/__init__.py
@@ -99,6 +99,8 @@ from .credentials_enums import (
     CredentialStatus,
     CredentialToken,
     DEFAULT_RESTRICTIONS,
+    FailureClass,
+    FailureMode,
     Indication,
     Region,
     RestrictionLevel,
@@ -114,6 +116,14 @@ from .credentials_game import (
     CredentialsGameHandler,
     CredentialsMove,
     derive_disposition,
+)
+from .credentials_factory import (
+    applicable_modes,
+    apply_failure,
+    build_valid,
+    degrade,
+    make_case,
+    sample_failure_mode,
 )
 
 
@@ -180,6 +190,14 @@ __all__ = [
     "RestrictionRule",
     "Restrictions",
     "DEFAULT_RESTRICTIONS",
+    "FailureClass",
+    "FailureMode",
+    "build_valid",
+    "degrade",
+    "make_case",
+    "apply_failure",
+    "applicable_modes",
+    "sample_failure_mode",
     # Dispatch
     "HasGame",
     "generate_game_journal",

--- a/engine/src/tangl/mechanics/games/__init__.py
+++ b/engine/src/tangl/mechanics/games/__init__.py
@@ -123,7 +123,15 @@ from .credentials_factory import (
     build_valid,
     degrade,
     make_case,
+    render_narrative,
     sample_failure_mode,
+)
+from .credentials_roster import (
+    ScenarioOffer,
+    ShiftSpec,
+    generate_roster,
+    make_offer,
+    materialize,
 )
 
 
@@ -195,9 +203,15 @@ __all__ = [
     "build_valid",
     "degrade",
     "make_case",
+    "render_narrative",
     "apply_failure",
     "applicable_modes",
     "sample_failure_mode",
+    "ScenarioOffer",
+    "ShiftSpec",
+    "generate_roster",
+    "make_offer",
+    "materialize",
     # Dispatch
     "HasGame",
     "generate_game_journal",

--- a/engine/src/tangl/mechanics/games/credentials_enums.py
+++ b/engine/src/tangl/mechanics/games/credentials_enums.py
@@ -101,6 +101,48 @@ class CredentialStatus(Enum):
         return self in (CredentialStatus.FORGED, CredentialStatus.WRONG_HOLDER)
 
 
+class FailureClass(Enum):
+    """How severe a packet failure is, and therefore the disposition it forces."""
+
+    MITIGATABLE = "mitigatable"  # fixable in the moment -> deny if unfixed
+    CRIME = "crime"              # -> arrest
+
+
+class FailureMode(Enum):
+    """A single way a packet can be degraded away from valid.
+
+    Used by the candidate factory's ``degrade`` (Phase A.2) and, later, sampled
+    by the roster generator (A.3). ``failure_class`` splits the modes that a
+    mediation could clear (-> deny) from outright crimes (-> arrest).
+    """
+
+    # mitigatable
+    MISSING_PERMIT = "missing_permit"
+    UNSEALED_PERMIT = "unsealed_permit"
+    MISSING_ID = "missing_id"
+    EXPIRED_ID = "expired_id"
+    UNPERMITTED_CONTRABAND = "unpermitted_contraband"
+    # crimes
+    FORGED_PERMIT = "forged_permit"
+    FAKE_ID = "fake_id"
+    WRONG_HOLDER_PERMIT = "wrong_holder_permit"
+    CONCEALED_CONTRABAND = "concealed_contraband"
+
+    @property
+    def failure_class(self) -> FailureClass:
+        return FailureClass.CRIME if self in _CRIME_MODES else FailureClass.MITIGATABLE
+
+
+_CRIME_MODES = frozenset(
+    {
+        FailureMode.FORGED_PERMIT,
+        FailureMode.FAKE_ID,
+        FailureMode.WRONG_HOLDER_PERMIT,
+        FailureMode.CONCEALED_CONTRABAND,
+    }
+)
+
+
 class CredentialToken(BaseModelPlus):
     """A single presented credential.
 

--- a/engine/src/tangl/mechanics/games/credentials_enums.py
+++ b/engine/src/tangl/mechanics/games/credentials_enums.py
@@ -1,0 +1,211 @@
+"""
+Credentials domain vocabulary and the opaque packet representation.
+
+This module holds the theme-neutral derivation vocabulary -- ``Region``,
+``Indication``, ``RestrictionLevel``, ``CredentialStatus`` -- and the lean value
+types that back a candidate's credential packet (``CredentialToken``,
+``ContrabandItem``).
+
+The packet is meant to be **opaque to the game loop**: the loop and
+``derive_disposition`` ask the candidate questions through a small discovery API
+(see :class:`~tangl.mechanics.games.credentials_game.CredentialCase`) about
+content, declared intent, and validity. Whether those answers are backed by
+these flat enums (today) or by a richer Singleton token catalog with per-roster
+media (later, see ``CREDENTIALS_LOOP_DESIGN.md`` A.6) is an implementation detail
+behind that surface.
+
+See also: ``CREDENTIALS_LOOP_DESIGN.md`` -- "The rule and failure-mode model".
+"""
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import Field
+
+from tangl.core.bases import BaseModelPlus
+
+
+class Region(Enum):
+    """Candidate origin; selects which restriction map applies."""
+
+    LOCAL = "local"
+    FOREIGN_EAST = "foreign_east"  # typically allied
+    FOREIGN_WEST = "foreign_west"  # typically hostile
+
+
+class Indication(Enum):
+    """A reason a candidate may require a credential.
+
+    Purpose indications (every candidate has one) and contraband indications
+    (optional possessions) share one enum so the restriction map keys are
+    uniform.
+    """
+
+    # purpose
+    TRAVEL = "travel"
+    WORK = "work"
+    EMIGRATE = "emigrate"
+    # contraband
+    WEAPON = "weapon"
+    DRUGS = "drugs"
+    SECRETS = "secrets"
+
+
+PURPOSES = frozenset({Indication.TRAVEL, Indication.WORK, Indication.EMIGRATE})
+CONTRABAND = frozenset({Indication.WEAPON, Indication.DRUGS, Indication.SECRETS})
+
+
+class RestrictionLevel(Enum):
+    """How permissive the rule is for an indication, most to least restrictive.
+
+    ``forbidden -> with_permit (req id) -> with_id -> anonymous``. A day's
+    authored rule change is a delta along this axis for some indication.
+    """
+
+    FORBIDDEN = "forbidden"        # never; no valid credential exists
+    WITH_PERMIT = "with_permit"    # requires a permit (which itself requires id)
+    WITH_ID = "with_id"            # requires a valid bearer id
+    ANONYMOUS = "anonymous"        # always allowed; no document needed
+
+    @property
+    def requires_permit(self) -> bool:
+        return self is RestrictionLevel.WITH_PERMIT
+
+    @property
+    def requires_id(self) -> bool:
+        return self in (RestrictionLevel.WITH_PERMIT, RestrictionLevel.WITH_ID)
+
+
+class CredentialStatus(Enum):
+    """Validity of a single presented credential (document or id).
+
+    The split between *mitigatable* infractions (fixable in the moment -> deny if
+    unfixed) and *crimes* (-> arrest) drives the derived disposition.
+    """
+
+    VALID = "valid"
+    # mitigatable infractions
+    MISSING_SEAL = "missing_seal"
+    BAD_DATE = "bad_date"
+    EXPIRED = "expired"
+    # crimes
+    FORGED = "forged"            # bad / fake seal
+    WRONG_HOLDER = "wrong_holder"  # fake or mismatched id
+
+    @property
+    def is_valid(self) -> bool:
+        return self is CredentialStatus.VALID
+
+    @property
+    def is_crime(self) -> bool:
+        return self in (CredentialStatus.FORGED, CredentialStatus.WRONG_HOLDER)
+
+
+class CredentialToken(BaseModelPlus):
+    """A single presented credential.
+
+    ``holder_matches`` models the id-linkage surface for permits: a permit may be
+    intrinsically valid yet reference a different bearer than the presented id (a
+    crime), independent of the permit's own ``status``.
+    """
+
+    indication: Indication
+    status: CredentialStatus = CredentialStatus.VALID
+    requires_id: bool = False
+    holder_matches: bool = True
+
+
+class ContrabandItem(BaseModelPlus):
+    """A possession that may need a waiver, be relinquished, or be concealed."""
+
+    indication: Indication
+    concealed: bool = False
+    permit: CredentialToken | None = None
+
+
+# Authored as a nested map for convenience...
+RestrictionMap = dict[Indication, RestrictionLevel]
+
+
+class RestrictionRule(BaseModelPlus):
+    """One rule: indication X from region R sits at restriction level L."""
+
+    region: Region
+    indication: Indication
+    level: RestrictionLevel
+
+
+class Restrictions(BaseModelPlus):
+    """The day's rules, stored as a flat rule list.
+
+    A flat list (rather than a ``dict[Region, dict[Indication, RestrictionLevel]]``)
+    keeps the persisted game state JSON-serializable -- enum *dict keys* are not,
+    and the VM hashes node state with ``json.dumps``. Author via :meth:`from_map`
+    for the convenient nested-dict form; look rules up via :meth:`level_for`.
+    """
+
+    rules: list[RestrictionRule] = Field(default_factory=list)
+    default_level: RestrictionLevel = RestrictionLevel.ANONYMOUS
+
+    def level_for(
+        self,
+        region: Region,
+        indication: Indication,
+        default: RestrictionLevel | None = None,
+    ) -> RestrictionLevel:
+        for rule in self.rules:
+            if rule.region is region and rule.indication is indication:
+                return rule.level
+        return default if default is not None else self.default_level
+
+    @classmethod
+    def from_map(
+        cls,
+        mapping: dict[Region, RestrictionMap],
+        *,
+        default_level: RestrictionLevel = RestrictionLevel.ANONYMOUS,
+    ) -> Restrictions:
+        return cls(
+            rules=[
+                RestrictionRule(region=region, indication=indication, level=level)
+                for region, sub in mapping.items()
+                for indication, level in sub.items()
+            ],
+            default_level=default_level,
+        )
+
+
+COMMON_LOCAL_RESTRICTIONS: RestrictionMap = {
+    Indication.TRAVEL: RestrictionLevel.WITH_ID,
+    Indication.WORK: RestrictionLevel.WITH_PERMIT,
+    Indication.EMIGRATE: RestrictionLevel.WITH_PERMIT,
+    Indication.WEAPON: RestrictionLevel.WITH_PERMIT,
+    Indication.DRUGS: RestrictionLevel.FORBIDDEN,
+    Indication.SECRETS: RestrictionLevel.FORBIDDEN,
+}
+
+COMMON_ALLIED_RESTRICTIONS: RestrictionMap = {
+    Indication.TRAVEL: RestrictionLevel.WITH_ID,
+    Indication.WORK: RestrictionLevel.WITH_PERMIT,
+    Indication.EMIGRATE: RestrictionLevel.WITH_PERMIT,
+    Indication.WEAPON: RestrictionLevel.WITH_PERMIT,
+    Indication.DRUGS: RestrictionLevel.FORBIDDEN,
+    Indication.SECRETS: RestrictionLevel.WITH_PERMIT,
+}
+
+COMMON_HOSTILE_RESTRICTIONS: RestrictionMap = {
+    Indication.TRAVEL: RestrictionLevel.WITH_PERMIT,
+    Indication.WORK: RestrictionLevel.FORBIDDEN,
+    Indication.EMIGRATE: RestrictionLevel.ANONYMOUS,  # asylum seekers
+    Indication.WEAPON: RestrictionLevel.FORBIDDEN,
+    Indication.DRUGS: RestrictionLevel.FORBIDDEN,
+    Indication.SECRETS: RestrictionLevel.WITH_PERMIT,
+}
+
+DEFAULT_RESTRICTIONS: Restrictions = Restrictions.from_map(
+    {
+        Region.LOCAL: COMMON_LOCAL_RESTRICTIONS,
+        Region.FOREIGN_EAST: COMMON_ALLIED_RESTRICTIONS,
+        Region.FOREIGN_WEST: COMMON_HOSTILE_RESTRICTIONS,
+    }
+)

--- a/engine/src/tangl/mechanics/games/credentials_factory.py
+++ b/engine/src/tangl/mechanics/games/credentials_factory.py
@@ -1,0 +1,196 @@
+"""
+Procedural candidate factory (Phase A.2).
+
+Builds a fully valid credential packet for an intent against the day's rules,
+then degrades it with explicit failure modes. Generation is **start correct,
+then degrade**: every candidate begins from a valid packet, and corruptions are
+applied only as the chosen failure modes dictate, so the only discrepancies
+present are the intended ones (the doctrine from the scratch
+``credentialed.py::generate_credentials``).
+
+These functions are pure and on-demand -- they just materialize ``CredentialCase``
+data and validate against :func:`~tangl.mechanics.games.credentials_game.derive_disposition`.
+The day spec, origin/disposition sampling, and lazy roster of *offers* are Phase
+A.3 and live elsewhere; this module is only the case factory the sampler will
+call.
+"""
+from __future__ import annotations
+
+import random
+from collections.abc import Iterable, Sequence
+
+from .credentials_enums import (
+    ContrabandItem,
+    CredentialStatus,
+    CredentialToken,
+    FailureClass,
+    FailureMode,
+    Indication,
+    Region,
+    RestrictionLevel,
+    Restrictions,
+)
+from .credentials_game import CredentialCase
+
+# Contraband used by smuggling / relinquish failures when the intent itself
+# carries none. Weapons are permit-gated (not anonymous) in the usual rule sets,
+# so a declared one with no permit reads as a mitigatable infraction.
+_DEFAULT_CONTRABAND = Indication.WEAPON
+
+
+def build_valid(
+    region: Region,
+    purpose: Indication,
+    restrictions: Restrictions,
+    *,
+    candidate_name: str = "Traveler",
+    contraband: Sequence[Indication] = (),
+) -> CredentialCase:
+    """Assemble a fully valid packet for ``purpose`` (+ declared contraband).
+
+    The result derives to PASS under ``restrictions``. Declared contraband should
+    be permittable (a forbidden possession cannot be made valid).
+    """
+
+    case = CredentialCase(
+        candidate_name=candidate_name,
+        region=region,
+        purpose=purpose,
+        presented_documents={},
+        hidden_facts={},
+        packet_hidden_facts={},
+    )
+    level = restrictions.level_for(region, purpose, RestrictionLevel.ANONYMOUS)
+    if level.requires_id:
+        case.id_card = CredentialToken(indication=purpose, status=CredentialStatus.VALID)
+    if level.requires_permit:
+        case.packet.append(
+            CredentialToken(
+                indication=purpose,
+                status=CredentialStatus.VALID,
+                requires_id=True,
+                holder_matches=True,
+            )
+        )
+
+    for c_ind in contraband:
+        c_level = restrictions.level_for(region, c_ind, RestrictionLevel.FORBIDDEN)
+        if c_level.requires_permit:
+            case.packet.append(
+                CredentialToken(
+                    indication=c_ind,
+                    status=CredentialStatus.VALID,
+                    requires_id=True,
+                    holder_matches=True,
+                )
+            )
+        case.possessions.append(ContrabandItem(indication=c_ind, concealed=False))
+
+    return case
+
+
+def _purpose_permit(case: CredentialCase) -> CredentialToken | None:
+    return case.credential_for(case.get_purpose())
+
+
+def applies_to(mode: FailureMode, case: CredentialCase) -> bool:
+    """Whether ``mode`` can be applied to ``case`` (something exists to corrupt)."""
+
+    match mode:
+        case (
+            FailureMode.MISSING_PERMIT
+            | FailureMode.UNSEALED_PERMIT
+            | FailureMode.FORGED_PERMIT
+            | FailureMode.WRONG_HOLDER_PERMIT
+        ):
+            return _purpose_permit(case) is not None
+        case FailureMode.MISSING_ID | FailureMode.EXPIRED_ID | FailureMode.FAKE_ID:
+            return case.id_card is not None
+        case FailureMode.UNPERMITTED_CONTRABAND | FailureMode.CONCEALED_CONTRABAND:
+            return True
+    return False
+
+
+def apply_failure(mode: FailureMode, case: CredentialCase) -> None:
+    """Mutate ``case`` in place to exhibit ``mode``. No-op if not applicable."""
+
+    permit = _purpose_permit(case)
+    match mode:
+        case FailureMode.MISSING_PERMIT:
+            if permit is not None:
+                case.packet.remove(permit)
+        case FailureMode.UNSEALED_PERMIT:
+            if permit is not None:
+                permit.status = CredentialStatus.MISSING_SEAL
+        case FailureMode.FORGED_PERMIT:
+            if permit is not None:
+                permit.status = CredentialStatus.FORGED
+        case FailureMode.WRONG_HOLDER_PERMIT:
+            if permit is not None:
+                permit.holder_matches = False
+        case FailureMode.MISSING_ID:
+            case.id_card = None
+        case FailureMode.EXPIRED_ID:
+            if case.id_card is not None:
+                case.id_card.status = CredentialStatus.EXPIRED
+        case FailureMode.FAKE_ID:
+            if case.id_card is not None:
+                case.id_card.status = CredentialStatus.WRONG_HOLDER
+        case FailureMode.UNPERMITTED_CONTRABAND:
+            case.possessions.append(
+                ContrabandItem(indication=_DEFAULT_CONTRABAND, concealed=False)
+            )
+        case FailureMode.CONCEALED_CONTRABAND:
+            case.possessions.append(
+                ContrabandItem(indication=_DEFAULT_CONTRABAND, concealed=True)
+            )
+
+
+def degrade(case: CredentialCase, modes: Iterable[FailureMode]) -> CredentialCase:
+    """Apply each failure mode to ``case`` in place and return it."""
+
+    for mode in modes:
+        apply_failure(mode, case)
+    return case
+
+
+def make_case(
+    region: Region,
+    purpose: Indication,
+    restrictions: Restrictions,
+    *,
+    failure_modes: Sequence[FailureMode] = (),
+    candidate_name: str = "Traveler",
+    contraband: Sequence[Indication] = (),
+) -> CredentialCase:
+    """Tier 2 entry: build a valid packet, then degrade it with ``failure_modes``."""
+
+    case = build_valid(
+        region, purpose, restrictions, candidate_name=candidate_name, contraband=contraband
+    )
+    return degrade(case, failure_modes)
+
+
+def applicable_modes(
+    case: CredentialCase,
+    failure_class: FailureClass | None = None,
+) -> list[FailureMode]:
+    """Failure modes that can be applied to ``case``, optionally filtered by class."""
+
+    modes = [mode for mode in FailureMode if applies_to(mode, case)]
+    if failure_class is not None:
+        modes = [mode for mode in modes if mode.failure_class is failure_class]
+    return modes
+
+
+def sample_failure_mode(
+    case: CredentialCase,
+    failure_class: FailureClass,
+    rng: random.Random | None = None,
+) -> FailureMode | None:
+    """Pick an applicable failure mode of ``failure_class`` for ``case``, if any."""
+
+    choices = applicable_modes(case, failure_class)
+    if not choices:
+        return None
+    return (rng or random.Random()).choice(choices)

--- a/engine/src/tangl/mechanics/games/credentials_factory.py
+++ b/engine/src/tangl/mechanics/games/credentials_factory.py
@@ -154,6 +154,55 @@ def degrade(case: CredentialCase, modes: Iterable[FailureMode]) -> CredentialCas
     return case
 
 
+_STATUS_FINDINGS = {
+    CredentialStatus.MISSING_SEAL: "The issuing seal is missing.",
+    CredentialStatus.BAD_DATE: "The issue date is wrong.",
+    CredentialStatus.EXPIRED: "The credential has expired.",
+    CredentialStatus.FORGED: "The seal is a forgery.",
+    CredentialStatus.WRONG_HOLDER: "The holder does not match this document.",
+}
+
+
+def render_narrative(case: CredentialCase) -> CredentialCase:
+    """Populate the inspect-loop strings from the structured truth, in place.
+
+    Gives a generated case the ``presented_documents`` / ``hidden_facts`` /
+    ``packet_hidden_facts`` the v1 inspect loop needs. Document-level infractions
+    (bad/forged seal, holder mismatch) surface here; missing documents and
+    concealed contraband are detected by Phase B follow-up moves, not by plain
+    inspection, so they are not rendered as findings.
+    """
+
+    documents: dict[str, str] = {}
+    findings: dict[str, str] = {}
+
+    if case.id_card is not None:
+        documents["passport"] = "An identity document."
+        if not case.id_card.status.is_valid:
+            findings["passport"] = _STATUS_FINDINGS[case.id_card.status]
+
+    for token in case.packet:
+        label = f"{token.indication.value} permit"
+        documents[label] = f"A {token.indication.value} permit."
+        if not token.status.is_valid:
+            findings[label] = _STATUS_FINDINGS[token.status]
+        elif not token.holder_matches:
+            findings[label] = "The permit's holder does not match the bearer id."
+
+    for item in case.possessions:
+        if not item.concealed:
+            documents[f"declared {item.indication.value}"] = f"Openly declared {item.indication.value}."
+
+    case.presented_documents = documents
+    case.hidden_facts = findings
+    case.packet_hidden_facts = (
+        {"packet consistency": "The packet does not satisfy the checkpoint rules as presented."}
+        if findings
+        else {}
+    )
+    return case
+
+
 def make_case(
     region: Region,
     purpose: Indication,
@@ -163,12 +212,13 @@ def make_case(
     candidate_name: str = "Traveler",
     contraband: Sequence[Indication] = (),
 ) -> CredentialCase:
-    """Tier 2 entry: build a valid packet, then degrade it with ``failure_modes``."""
+    """Tier 2 entry: build a valid packet, degrade it, and render its narrative."""
 
     case = build_valid(
         region, purpose, restrictions, candidate_name=candidate_name, contraband=contraband
     )
-    return degrade(case, failure_modes)
+    degrade(case, failure_modes)
+    return render_narrative(case)
 
 
 def applicable_modes(

--- a/engine/src/tangl/mechanics/games/credentials_factory.py
+++ b/engine/src/tangl/mechanics/games/credentials_factory.py
@@ -48,8 +48,9 @@ def build_valid(
 ) -> CredentialCase:
     """Assemble a fully valid packet for ``purpose`` (+ declared contraband).
 
-    The result derives to PASS under ``restrictions``. Declared contraband should
-    be permittable (a forbidden possession cannot be made valid).
+    The result derives to PASS under ``restrictions``. Declared contraband must be
+    permittable; requesting a FORBIDDEN possession raises, since no valid packet
+    can carry it (fail loud rather than return a non-valid case).
     """
 
     case = CredentialCase(
@@ -75,6 +76,11 @@ def build_valid(
 
     for c_ind in contraband:
         c_level = restrictions.level_for(region, c_ind, RestrictionLevel.FORBIDDEN)
+        if c_level is RestrictionLevel.FORBIDDEN:
+            raise ValueError(
+                f"Cannot build a valid case with forbidden contraband: "
+                f"{c_ind.value} in {region.value}."
+            )
         if c_level.requires_permit:
             case.packet.append(
                 CredentialToken(

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -13,9 +13,12 @@ next candidate after every disposition until the game reports terminal.
 from __future__ import annotations
 
 from enum import Enum
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 from pydantic import Field
+
+if TYPE_CHECKING:
+    from .credentials_roster import ScenarioOffer
 
 from tangl.core.bases import BaseModelPlus
 from tangl.journal.fragments import ContentFragment
@@ -250,6 +253,10 @@ class CredentialsGame(PickingGame):
 
     # --- Shift configuration (authored; never reset between candidates) ------
     roster: list[CredentialCase] = Field(default_factory=_default_roster)
+    # Optional lazy roster: when set, candidates are sampled offers materialized
+    # on arrival (Phase A.3), and `offers` is the source of truth instead of
+    # `roster`. See credentials_roster.py.
+    offers: list["ScenarioOffer"] = Field(default_factory=list)
     checkpoint_rules: list[str] = Field(
         default_factory=lambda: [
             "Travelers need a valid passport.",
@@ -289,11 +296,29 @@ class CredentialsGame(PickingGame):
         default=False,
         json_schema_extra={"reset_field": True},
     )
+    # Lazy cache of materialized offers (cleared on setup; rebuilt on arrival).
+    materialized: list[CredentialCase] = Field(
+        default_factory=list,
+        json_schema_extra={"reset_field": True},
+    )
 
     # ----- active case access ----------------------------------------------
+    def _total_cases(self) -> int:
+        """Number of candidates this shift: sampled offers if any, else roster."""
+
+        return len(self.offers) if self.offers else len(self.roster)
+
     @property
     def active_case(self) -> CredentialCase:
-        return self.roster[self.case_index]
+        if not self.offers:
+            return self.roster[self.case_index]
+        # Lazy: materialize each offer's packet only when the candidate arrives.
+        from .credentials_roster import materialize
+
+        while len(self.materialized) <= self.case_index:
+            offer = self.offers[len(self.materialized)]
+            self.materialized.append(materialize(offer, self.restriction_map))
+        return self.materialized[self.case_index]
 
     @property
     def candidate_name(self) -> str:
@@ -343,7 +368,7 @@ class CredentialsGame(PickingGame):
     def required_correct(self) -> int:
         if self.pass_threshold is not None:
             return self.pass_threshold
-        return len(self.roster)
+        return self._total_cases()
 
     # ----- picking-kernel surface (reads the active case) -------------------
     def get_visible_items(self) -> list[str]:
@@ -397,7 +422,7 @@ class CredentialsGame(PickingGame):
         :meth:`CredentialsGameHandler.evaluate` owns shift terminality.
         """
 
-        if self.case_index + 1 < len(self.roster):
+        if self.case_index + 1 < self._total_cases():
             self.case_index += 1
         else:
             self.shift_complete = True
@@ -430,8 +455,8 @@ class CredentialsGame(PickingGame):
                 # Shift / roster progress
                 "credential_case_index": self.case_index,
                 "credential_case_number": self.case_index + 1,
-                "credential_roster_size": len(self.roster),
-                "credential_cases_remaining": len(self.roster) - len(self.case_results),
+                "credential_roster_size": self._total_cases(),
+                "credential_cases_remaining": self._total_cases() - len(self.case_results),
                 "credential_correct_count": self.correct_count,
                 "credential_shift_score": dict(self.score),
                 "credential_shift_complete": self.shift_complete,

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -575,10 +575,19 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         round_result: RoundResult,
     ) -> dict[str, object] | None:
         detail = dict(super().build_round_notes(game, player_move, opponent_move, round_result) or {})
-        detail["discovered_findings"] = dict(game.revealed_findings)
-        detail["packet_findings"] = dict(game.packet_findings)
+        # A decision runs advance_case(), which resets the per-case working state,
+        # so read the just-decided case's findings/index from its recorded result
+        # rather than the (already reset) live game state.
+        if detail.get("action") == "decide" and game.case_results:
+            last = game.case_results[-1]
+            detail["discovered_findings"] = dict(last.discovered_findings)
+            detail["packet_findings"] = dict(last.packet_findings)
+            detail["case_index"] = len(game.case_results) - 1
+        else:
+            detail["discovered_findings"] = dict(game.revealed_findings)
+            detail["packet_findings"] = dict(game.packet_findings)
+            detail["case_index"] = game.case_index
         detail.setdefault("credential_stage", game.current_stage)
-        detail["case_index"] = game.case_index
         detail["correct_count"] = game.correct_count
         detail["shift_complete"] = game.shift_complete
         return detail
@@ -588,8 +597,9 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         if last_round is None:
             return []
 
-        action = last_round.player_move.kind
-        target = last_round.player_move.target
+        move = self._normalize_move(last_round.player_move)
+        action = move.kind
+        target = move.target
         notes = last_round.notes or {}
 
         if action == "inspect":
@@ -620,7 +630,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             fragments.append(
                 ContentFragment(
                     content=(
-                        f"Shift complete: {game.correct_count} of {len(game.roster)} "
+                        f"Shift complete: {game.correct_count} of {game._total_cases()} "
                         "calls correct."
                     )
                 )

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -20,6 +20,16 @@ from pydantic import Field
 from tangl.core.bases import BaseModelPlus
 from tangl.journal.fragments import ContentFragment
 
+from .credentials_enums import (
+    DEFAULT_RESTRICTIONS,
+    ContrabandItem,
+    CredentialStatus,
+    CredentialToken,
+    Indication,
+    Region,
+    Restrictions,
+    RestrictionLevel,
+)
 from .enums import GameResult, RoundResult
 from .game import Game
 from .picking_game import PickingGame, PickingGameHandler, PickingMove
@@ -37,16 +47,23 @@ CredentialsMove = PickingMove
 
 
 class CredentialCase(BaseModelPlus):
-    """Authored data for one candidate -- the single source of truth per case.
+    """One candidate, with an opaque credential packet behind a discovery API.
 
-    Working state (what the player has inspected, revealed, or decided) lives on
-    :class:`CredentialsGame`; this model is only the static case definition. The
-    Phase A and Phase C fields are reserved seams: they carry no behavior in v1
-    but let later layers swap authored answers for derived ones without
-    reshaping the roster.
+    The narrative strings (``presented_documents`` / ``hidden_facts`` /
+    ``packet_hidden_facts``) drive the v1 inspect loop. The *structured truth*
+    (``region`` / ``purpose`` / ``id_card`` / ``packet`` / ``possessions``) is
+    what :func:`derive_disposition` reads -- but only through the discovery
+    methods below, never by reaching into the fields. That keeps the internal
+    representation swappable (flat tokens today; a Singleton catalog with media
+    later, see ``CREDENTIALS_LOOP_DESIGN.md`` A.6) behind one stable surface.
+
+    ``correct_disposition`` is an optional authored *override*: when set it wins,
+    otherwise the disposition is derived from the rules.
     """
 
     candidate_name: str = "Traveler"
+
+    # --- Narrative surface for the (v1) inspect loop -------------------------
     required_documents: list[str] = Field(
         default_factory=lambda: ["passport", "travel permit"]
     )
@@ -67,17 +84,44 @@ class CredentialCase(BaseModelPlus):
             "packet consistency": "The packet does not satisfy the checkpoint rules as presented.",
         }
     )
-    correct_disposition: CredentialDisposition = CredentialDisposition.DENY
 
-    # --- Phase A seams (candidate truth -> derive_disposition); unused in v1 --
-    region: str | None = None
-    purpose: str | None = None
-    contraband: str | None = None
+    # --- Structured truth (read only via the discovery API below) ------------
+    region: Region = Region.LOCAL
+    purpose: Indication = Indication.TRAVEL
+    id_card: CredentialToken | None = None
+    packet: list[CredentialToken] = Field(default_factory=list)
+    possessions: list[ContrabandItem] = Field(default_factory=list)
 
-    # --- Phase C seams (context overrides / haggling); unused in v1 ----------
+    # Authored override; None means "derive from the rules".
+    correct_disposition: CredentialDisposition | None = None
+
+    # --- Phase C seams (context overrides / haggling) -----------------------
     whitelist: bool = False
     blacklist: bool = False
     bribe_offer: int = 0
+
+    # ----- Discovery API ----------------------------------------------------
+    # The only surface the game loop and derive_disposition may use to ask the
+    # packet about its content, declared intent, and validity.
+
+    def get_region(self) -> Region:
+        return self.region
+
+    def get_purpose(self) -> Indication:
+        return self.purpose
+
+    def id_status(self) -> CredentialStatus | None:
+        """Status of the bearer id, or ``None`` if no id was presented."""
+
+        return self.id_card.status if self.id_card is not None else None
+
+    def credential_for(self, indication: Indication) -> CredentialToken | None:
+        """The presented credential satisfying ``indication``, if any."""
+
+        return next((c for c in self.packet if c.indication is indication), None)
+
+    def get_contraband(self) -> list[ContrabandItem]:
+        return list(self.possessions)
 
 
 class CredentialCaseResult(BaseModelPlus):
@@ -95,7 +139,7 @@ def _default_roster() -> list[CredentialCase]:
     """A two-candidate shift so a bare game is playable and demonstrable."""
 
     return [
-        CredentialCase(),  # blurred seal -> DENY
+        CredentialCase(correct_disposition=CredentialDisposition.DENY),
         CredentialCase(
             candidate_name="Tomas Vey",
             presented_documents={
@@ -107,6 +151,98 @@ def _default_roster() -> list[CredentialCase]:
             correct_disposition=CredentialDisposition.PASS,
         ),
     ]
+
+
+# --- Disposition derivation (reads cases only via the discovery API) --------
+
+_DISPOSITION_SEVERITY: dict[CredentialDisposition, int] = {
+    CredentialDisposition.PASS: 0,
+    CredentialDisposition.DENY: 1,
+    CredentialDisposition.ARREST: 2,
+}
+
+
+def _worse(a: CredentialDisposition, b: CredentialDisposition) -> CredentialDisposition:
+    return a if _DISPOSITION_SEVERITY[a] >= _DISPOSITION_SEVERITY[b] else b
+
+
+def _assess_credential(token: CredentialToken | None) -> CredentialDisposition:
+    if token is None:
+        return CredentialDisposition.DENY  # missing -> produce it (mitigatable)
+    if token.status.is_valid:
+        return CredentialDisposition.PASS
+    if token.status.is_crime:
+        return CredentialDisposition.ARREST  # forged
+    return CredentialDisposition.DENY  # missing seal / bad date / expired
+
+
+def _assess_id(case: CredentialCase) -> CredentialDisposition:
+    status = case.id_status()
+    if status is None:
+        return CredentialDisposition.DENY  # missing id -> produce it (mitigatable)
+    if status.is_valid:
+        return CredentialDisposition.PASS
+    if status.is_crime:
+        return CredentialDisposition.ARREST  # fake / wrong-holder id
+    return CredentialDisposition.DENY
+
+
+def _assess_requirement(
+    case: CredentialCase,
+    indication: Indication,
+    level: RestrictionLevel,
+) -> CredentialDisposition:
+    """Assess one indication against its required level (the two error surfaces)."""
+
+    worst = CredentialDisposition.PASS
+    if level.requires_permit:
+        permit = case.credential_for(indication)
+        worst = _worse(worst, _assess_credential(permit))
+        if permit is not None and not permit.holder_matches:
+            worst = _worse(worst, CredentialDisposition.ARREST)  # permit/id mismatch
+    if level.requires_id:
+        worst = _worse(worst, _assess_id(case))
+    return worst
+
+
+def _assess_contraband(
+    case: CredentialCase,
+    item: ContrabandItem,
+    level: RestrictionLevel,
+) -> CredentialDisposition:
+    if item.concealed:
+        return CredentialDisposition.ARREST  # concealment is a crime
+    if level is RestrictionLevel.FORBIDDEN:
+        return CredentialDisposition.DENY  # declared but forbidden -> relinquish
+    return _assess_requirement(case, item.indication, level)
+
+
+def derive_disposition(
+    case: CredentialCase,
+    restrictions: Restrictions,
+) -> CredentialDisposition:
+    """Derive the correct disposition from the rules and the candidate's packet.
+
+    Reads the candidate only through its discovery API, so the packet's internal
+    representation stays opaque. Returns the most-severe applicable outcome
+    (ARREST > DENY > PASS).
+    """
+
+    region = case.get_region()
+    worst = CredentialDisposition.PASS
+
+    purpose = case.get_purpose()
+    level = restrictions.level_for(region, purpose, RestrictionLevel.ANONYMOUS)
+    if level is RestrictionLevel.FORBIDDEN:
+        worst = _worse(worst, CredentialDisposition.DENY)  # purpose not allowed
+    else:
+        worst = _worse(worst, _assess_requirement(case, purpose, level))
+
+    for item in case.get_contraband():
+        level = restrictions.level_for(region, item.indication, RestrictionLevel.FORBIDDEN)
+        worst = _worse(worst, _assess_contraband(case, item, level))
+
+    return worst
 
 
 class CredentialsGame(PickingGame):
@@ -123,6 +259,11 @@ class CredentialsGame(PickingGame):
     allow_arrest: bool = True
     # ``None`` means "every candidate must be correct" (the strict default).
     pass_threshold: int | None = None
+    # The day's rules. Cases derive their disposition against this unless they
+    # carry an authored ``correct_disposition`` override.
+    restriction_map: Restrictions = Field(
+        default_factory=lambda: DEFAULT_RESTRICTIONS.model_copy(deep=True)
+    )
 
     # --- Per-case working state (reset by advance_case) ----------------------
     case_index: int = Field(default=0, json_schema_extra={"reset_field": True})
@@ -229,9 +370,9 @@ class CredentialsGame(PickingGame):
     def expected_disposition(self, case: CredentialCase) -> CredentialDisposition:
         """Resolve the correct disposition for ``case``.
 
-        v1 returns the authored answer (bent by whitelist/blacklist context).
-        Phase A will replace the body with ``derive_disposition(case,
-        restriction_map)`` while keeping this call site stable.
+        Context overrides (whitelist/blacklist) win first; then an authored
+        ``correct_disposition`` override if present; otherwise the disposition is
+        derived from the day's rules via :func:`derive_disposition`.
         """
 
         if case.whitelist:
@@ -242,7 +383,9 @@ class CredentialsGame(PickingGame):
                 if self.allow_arrest
                 else CredentialDisposition.DENY
             )
-        return case.correct_disposition
+        if case.correct_disposition is not None:
+            return case.correct_disposition
+        return derive_disposition(case, self.restriction_map)
 
     # ----- roster advancement ----------------------------------------------
     def advance_case(self) -> None:

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -1,8 +1,14 @@
 """
-Credential check contest built on the same inspect-and-commit loop.
+Credential checkpoint shift built on the inspect-and-commit picking loop.
 
-This is intentionally the small outer game block only: inspect evidence, reveal
-findings, then choose a disposition.
+A single :class:`CredentialsGame` hosts a *roster* of candidates. Each candidate
+is evaluated through the same staged virtual subloop -- inspect documents,
+review the packet, then choose a disposition -- and the shift ends only when the
+final candidate has been dispositioned. This is the "one outer game with staged
+virtual subgames" shape recommended in ``CREDENTIALS_LOOP_DESIGN.md``: no nested
+game blocks and no extra story edges. The loop lives inside the game; the hosting
+:class:`~tangl.mechanics.games.has_game.HasGame` block re-provisions moves for the
+next candidate after every disposition until the game reports terminal.
 """
 from __future__ import annotations
 
@@ -11,15 +17,16 @@ from typing import ClassVar
 
 from pydantic import Field
 
+from tangl.core.bases import BaseModelPlus
 from tangl.journal.fragments import ContentFragment
 
-from .enums import RoundResult
+from .enums import GameResult, RoundResult
 from .game import Game
 from .picking_game import PickingGame, PickingGameHandler, PickingMove
 
 
 class CredentialDisposition(Enum):
-    """Terminal credential dispositions."""
+    """Terminal disposition for a single candidate."""
 
     PASS = "pass"
     DENY = "deny"
@@ -29,14 +36,17 @@ class CredentialDisposition(Enum):
 CredentialsMove = PickingMove
 
 
-class CredentialsGame(PickingGame):
-    """State for a compact credential inspection loop."""
+class CredentialCase(BaseModelPlus):
+    """Authored data for one candidate -- the single source of truth per case.
+
+    Working state (what the player has inspected, revealed, or decided) lives on
+    :class:`CredentialsGame`; this model is only the static case definition. The
+    Phase A and Phase C fields are reserved seams: they carry no behavior in v1
+    but let later layers swap authored answers for derived ones without
+    reshaping the roster.
+    """
 
     candidate_name: str = "Traveler"
-    current_stage: str = Field(
-        default="documents",
-        json_schema_extra={"reset_field": True},
-    )
     required_documents: list[str] = Field(
         default_factory=lambda: ["passport", "travel permit"]
     )
@@ -57,18 +67,69 @@ class CredentialsGame(PickingGame):
             "packet consistency": "The packet does not satisfy the checkpoint rules as presented.",
         }
     )
+    correct_disposition: CredentialDisposition = CredentialDisposition.DENY
+
+    # --- Phase A seams (candidate truth -> derive_disposition); unused in v1 --
+    region: str | None = None
+    purpose: str | None = None
+    contraband: str | None = None
+
+    # --- Phase C seams (context overrides / haggling); unused in v1 ----------
+    whitelist: bool = False
+    blacklist: bool = False
+    bribe_offer: int = 0
+
+
+class CredentialCaseResult(BaseModelPlus):
+    """Auditable record of one dispositioned candidate."""
+
+    candidate_name: str
+    chosen_disposition: CredentialDisposition
+    expected_disposition: CredentialDisposition
+    correct: bool
+    discovered_findings: dict[str, str] = Field(default_factory=dict)
+    packet_findings: dict[str, str] = Field(default_factory=dict)
+
+
+def _default_roster() -> list[CredentialCase]:
+    """A two-candidate shift so a bare game is playable and demonstrable."""
+
+    return [
+        CredentialCase(),  # blurred seal -> DENY
+        CredentialCase(
+            candidate_name="Tomas Vey",
+            presented_documents={
+                "passport": "A crisp passport, its seal sharp and current.",
+                "travel permit": "A permit stamped for this very week.",
+            },
+            hidden_facts={},
+            packet_hidden_facts={},
+            correct_disposition=CredentialDisposition.PASS,
+        ),
+    ]
+
+
+class CredentialsGame(PickingGame):
+    """A checkpoint shift: a roster of candidates inspected one at a time."""
+
+    # --- Shift configuration (authored; never reset between candidates) ------
+    roster: list[CredentialCase] = Field(default_factory=_default_roster)
     checkpoint_rules: list[str] = Field(
         default_factory=lambda: [
             "Travelers need a valid passport.",
             "This route also requires a travel permit.",
         ]
     )
-    whitelist_status: bool = False
-    blacklist_status: bool = False
-    bribe_offer: int = 0
-    prior_encounters: list[str] = Field(default_factory=list)
-    correct_disposition: CredentialDisposition = CredentialDisposition.DENY
     allow_arrest: bool = True
+    # ``None`` means "every candidate must be correct" (the strict default).
+    pass_threshold: int | None = None
+
+    # --- Per-case working state (reset by advance_case) ----------------------
+    case_index: int = Field(default=0, json_schema_extra={"reset_field": True})
+    current_stage: str = Field(
+        default="documents",
+        json_schema_extra={"reset_field": True},
+    )
     inspected_packet_targets: list[str] = Field(
         default_factory=list,
         json_schema_extra={"reset_field": True},
@@ -78,24 +139,72 @@ class CredentialsGame(PickingGame):
         json_schema_extra={"reset_field": True},
     )
 
+    # --- Shift-level outcome state (reset only on full setup) ----------------
+    case_results: list[CredentialCaseResult] = Field(
+        default_factory=list,
+        json_schema_extra={"reset_field": True},
+    )
+    shift_complete: bool = Field(
+        default=False,
+        json_schema_extra={"reset_field": True},
+    )
+
+    # ----- active case access ----------------------------------------------
+    @property
+    def active_case(self) -> CredentialCase:
+        return self.roster[self.case_index]
+
+    @property
+    def candidate_name(self) -> str:
+        return self.active_case.candidate_name
+
+    @property
+    def presented_documents(self) -> dict[str, str]:
+        return self.active_case.presented_documents
+
+    @property
+    def packet_hidden_facts(self) -> dict[str, str]:
+        return self.active_case.packet_hidden_facts
+
+    @property
+    def required_documents(self) -> list[str]:
+        return self.active_case.required_documents
+
+    @property
+    def hidden_findings(self) -> dict[str, str]:
+        return self.active_case.hidden_facts
+
     @property
     def inspected_documents(self) -> list[str]:
-        return [target for target in self.inspected_targets if target in self.presented_documents]
+        return [t for t in self.inspected_targets if t in self.presented_documents]
 
     @property
     def discovered_findings(self) -> dict[str, str]:
         return self.revealed_findings
 
     @property
-    def hidden_findings(self) -> dict[str, str]:
-        return self.hidden_facts
+    def disposition(self) -> CredentialDisposition | None:
+        """The disposition committed for the *current* case, or ``None``.
+
+        Per-case, not game-terminal: ``advance_case`` clears it so the next
+        candidate starts undecided.
+        """
+
+        if self.committed_decision is None:
+            return None
+        return CredentialDisposition(self.committed_decision)
 
     @property
-    def disposition(self) -> CredentialDisposition | None:
-        if self.terminal_decision is None:
-            return None
-        return CredentialDisposition(self.terminal_decision)
+    def correct_count(self) -> int:
+        return sum(1 for result in self.case_results if result.correct)
 
+    @property
+    def required_correct(self) -> int:
+        if self.pass_threshold is not None:
+            return self.pass_threshold
+        return len(self.roster)
+
+    # ----- picking-kernel surface (reads the active case) -------------------
     def get_visible_items(self) -> list[str]:
         return list(self.presented_documents)
 
@@ -116,10 +225,52 @@ class CredentialsGame(PickingGame):
             options.append(CredentialDisposition.ARREST.value)
         return options
 
+    # ----- disposition policy ----------------------------------------------
+    def expected_disposition(self, case: CredentialCase) -> CredentialDisposition:
+        """Resolve the correct disposition for ``case``.
+
+        v1 returns the authored answer (bent by whitelist/blacklist context).
+        Phase A will replace the body with ``derive_disposition(case,
+        restriction_map)`` while keeping this call site stable.
+        """
+
+        if case.whitelist:
+            return CredentialDisposition.PASS
+        if case.blacklist:
+            return (
+                CredentialDisposition.ARREST
+                if self.allow_arrest
+                else CredentialDisposition.DENY
+            )
+        return case.correct_disposition
+
+    # ----- roster advancement ----------------------------------------------
+    def advance_case(self) -> None:
+        """Reset per-case working state and step to the next candidate.
+
+        Never touches roster, checkpoint rules, threshold, score, or
+        ``case_results``. Sets ``shift_complete`` instead of letting
+        ``case_index`` run past the roster, so
+        :meth:`CredentialsGameHandler.evaluate` owns shift terminality.
+        """
+
+        if self.case_index + 1 < len(self.roster):
+            self.case_index += 1
+        else:
+            self.shift_complete = True
+
+        self.current_stage = "documents"
+        self.inspected_targets = []
+        self.revealed_findings = {}
+        self.inspected_packet_targets = []
+        self.packet_findings = {}
+        self.committed_decision = None
+
     def to_namespace(self) -> dict[str, object]:
         namespace = super().to_namespace()
         namespace.update(
             {
+                # Active candidate / case progress
                 "credential_candidate_name": self.candidate_name,
                 "credential_required_documents": list(self.required_documents),
                 "credential_inspected_documents": list(self.inspected_documents),
@@ -129,39 +280,44 @@ class CredentialsGame(PickingGame):
                 "credential_packet_findings": dict(self.packet_findings),
                 "credential_num_packet_findings": len(self.packet_findings),
                 "credential_checkpoint_rules": list(self.checkpoint_rules),
-                "credential_whitelist_status": self.whitelist_status,
-                "credential_blacklist_status": self.blacklist_status,
-                "credential_bribe_offer": self.bribe_offer,
-                "credential_prior_encounters": list(self.prior_encounters),
                 "credential_allow_arrest": self.allow_arrest,
                 "credential_disposition": (
                     self.disposition.value if self.disposition is not None else None
                 ),
+                # Shift / roster progress
+                "credential_case_index": self.case_index,
+                "credential_case_number": self.case_index + 1,
+                "credential_roster_size": len(self.roster),
+                "credential_cases_remaining": len(self.roster) - len(self.case_results),
+                "credential_correct_count": self.correct_count,
+                "credential_shift_score": dict(self.score),
+                "credential_shift_complete": self.shift_complete,
             }
         )
         return namespace
 
 
 class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
-    """Handler for inspect-and-dispose credential checks."""
+    """Handler for an inspect-and-dispose checkpoint shift."""
 
     game_cls: ClassVar[type[Game]] = CredentialsGame
 
     def get_available_inspect_targets(self, game: CredentialsGame) -> list[str]:
+        case = game.active_case
         targets = [
-            name for name in game.presented_documents if name not in game.inspected_documents
+            name for name in case.presented_documents if name not in game.inspected_documents
         ]
         if game.current_stage != "documents":
             targets.extend(
                 target
-                for target in game.packet_hidden_facts
+                for target in case.packet_hidden_facts
                 if target not in game.inspected_packet_targets
             )
         return targets
 
     def get_move_label(self, game: CredentialsGame, move: CredentialsMove) -> str:
         if move.kind == "inspect":
-            if move.target in game.packet_hidden_facts:
+            if move.target in game.active_case.packet_hidden_facts:
                 return f"Review {move.target}"
             return f"Inspect {move.target}"
         return f"Choose {move.target}"
@@ -172,7 +328,9 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         target: str,
         detail: dict[str, object],
     ) -> RoundResult:
-        if target in game.packet_hidden_facts:
+        case = game.active_case
+
+        if target in case.packet_hidden_facts:
             game.inspected_packet_targets.append(target)
             finding = self._packet_finding(game, target)
             if finding is not None:
@@ -185,7 +343,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             game.current_stage = "packet"
             return RoundResult.CONTINUE
 
-        finding = game.hidden_findings.get(target)
+        finding = case.hidden_facts.get(target)
         if finding is not None:
             game.revealed_findings[target] = finding
             detail["finding"] = finding
@@ -202,16 +360,44 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         target: str,
         detail: dict[str, object],
     ) -> RoundResult:
-        expected = self._expected_disposition(game)
-        if game.disposition == expected:
-            game.score["player"] = 1
-            detail["outcome"] = "correct_disposition"
-            return RoundResult.WIN
+        case = game.active_case
+        chosen = CredentialDisposition(target)
+        expected = game.expected_disposition(case)
+        correct = chosen == expected
 
-        game.score["opponent"] = 1
-        detail["outcome"] = "wrong_disposition"
-        detail["correct_disposition"] = expected.value
-        return RoundResult.LOSE
+        game.case_results.append(
+            CredentialCaseResult(
+                candidate_name=case.candidate_name,
+                chosen_disposition=chosen,
+                expected_disposition=expected,
+                correct=correct,
+                discovered_findings=dict(game.revealed_findings),
+                packet_findings=dict(game.packet_findings),
+            )
+        )
+
+        detail["candidate"] = case.candidate_name
+        detail["credential_stage"] = game.current_stage
+        if correct:
+            game.score["player"] = game.score.get("player", 0) + 1
+            detail["outcome"] = "correct_disposition"
+        else:
+            game.score["opponent"] = game.score.get("opponent", 0) + 1
+            detail["outcome"] = "wrong_disposition"
+            detail["correct_disposition"] = expected.value
+
+        round_result = RoundResult.WIN if correct else RoundResult.LOSE
+        game.advance_case()
+        return round_result
+
+    def evaluate(self, game: CredentialsGame) -> GameResult:
+        """Own shift terminality: in process until the final candidate is decided."""
+
+        if not game.shift_complete:
+            return GameResult.IN_PROCESS
+        if game.correct_count >= game.required_correct:
+            return GameResult.WIN
+        return GameResult.LOSE
 
     def build_round_notes(
         self,
@@ -221,9 +407,12 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         round_result: RoundResult,
     ) -> dict[str, object] | None:
         detail = dict(super().build_round_notes(game, player_move, opponent_move, round_result) or {})
-        detail["discovered_findings"] = dict(game.discovered_findings)
+        detail["discovered_findings"] = dict(game.revealed_findings)
         detail["packet_findings"] = dict(game.packet_findings)
-        detail["credential_stage"] = game.current_stage
+        detail.setdefault("credential_stage", game.current_stage)
+        detail["case_index"] = game.case_index
+        detail["correct_count"] = game.correct_count
+        detail["shift_complete"] = game.shift_complete
         return detail
 
     def get_journal_fragments(self, game: CredentialsGame) -> list[ContentFragment] | None:
@@ -236,7 +425,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         notes = last_round.notes or {}
 
         if action == "inspect":
-            if target in game.packet_hidden_facts:
+            if str(notes.get("outcome", "")).startswith("packet"):
                 return [
                     ContentFragment(content=f"You review {target}."),
                     ContentFragment(content=str(notes.get("finding", "No new contradiction appears."))),
@@ -246,36 +435,45 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                 ContentFragment(content=str(notes.get("finding", "Nothing new emerges."))),
             ]
 
-        outcome_line = (
-            f"{game.candidate_name} absorbs the ruling without protest."
-            if last_round.result == RoundResult.WIN
-            else (
-                f"The room turns uneasy. The right call was "
-                f"{notes.get('correct_disposition', game.correct_disposition.value)}."
+        candidate = notes.get("candidate", "the traveler")
+        if last_round.result == RoundResult.WIN:
+            outcome_line = f"{candidate} absorbs the ruling without protest."
+        else:
+            outcome_line = (
+                f"The room turns uneasy. The right call for {candidate} was "
+                f"{notes.get('correct_disposition', 'a different ruling')}."
             )
-        )
-        return [
+
+        fragments = [
             ContentFragment(content=f"You choose to {target}."),
             ContentFragment(content=outcome_line),
         ]
-
-    def _expected_disposition(self, game: CredentialsGame) -> CredentialDisposition:
-        if game.whitelist_status:
-            return CredentialDisposition.PASS
-        if game.blacklist_status:
-            return CredentialDisposition.ARREST if game.allow_arrest else CredentialDisposition.DENY
-        return game.correct_disposition
+        if game.shift_complete:
+            fragments.append(
+                ContentFragment(
+                    content=(
+                        f"Shift complete: {game.correct_count} of {len(game.roster)} "
+                        "calls correct."
+                    )
+                )
+            )
+        else:
+            fragments.append(
+                ContentFragment(content="The next traveler steps up to the counter.")
+            )
+        return fragments
 
     def _packet_finding(self, game: CredentialsGame, target: str) -> str | None:
-        if target not in game.packet_hidden_facts:
+        case = game.active_case
+        if target not in case.packet_hidden_facts:
             return None
-        if game.whitelist_status:
+        if case.whitelist:
             return "The whitelist seal overrides the usual packet mismatch."
-        if game.blacklist_status:
+        if case.blacklist:
             return "The packet matches a standing blacklist notice at this checkpoint."
-        if game.bribe_offer > 0:
+        if case.bribe_offer > 0:
             return (
-                f"The packet comes with a quiet offer of {game.bribe_offer} in side payment. "
-                f"{game.packet_hidden_facts[target]}"
+                f"The packet comes with a quiet offer of {case.bribe_offer} in side payment. "
+                f"{case.packet_hidden_facts[target]}"
             )
-        return game.packet_hidden_facts[target]
+        return case.packet_hidden_facts[target]

--- a/engine/src/tangl/mechanics/games/credentials_roster.py
+++ b/engine/src/tangl/mechanics/games/credentials_roster.py
@@ -1,0 +1,211 @@
+"""
+Roster sampling and lazy offer materialization (Phase A.3, compact).
+
+A shift is authored as a :class:`ShiftSpec` (rules + an origin distribution + a
+disposition-class distribution + a few pinned encounters). :func:`generate_roster`
+does all the sampling once and returns a list of :class:`ScenarioOffer` -- a
+*promise* of an encounter (origin, purpose, target disposition, and the verified
+failure mode that realizes it). The concrete candidate packet is built only when
+the encounter arrives, via :func:`materialize`.
+
+This is the compact exercise of the legacy procedural-candidate strategy: sample
+by origin / pace, pick an appropriate failure mode per sample, and don't
+materialize until called. Multi-day shifts and live roster editing are just
+repeated generation and ordinary list edits on the offers; no extra machinery.
+"""
+from __future__ import annotations
+
+import random
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+from pydantic import Field
+
+from tangl.core.bases import BaseModelPlus
+
+from .credentials_enums import (
+    FailureClass,
+    FailureMode,
+    Indication,
+    PURPOSES,
+    Region,
+    RestrictionLevel,
+    Restrictions,
+)
+from .credentials_factory import applicable_modes, build_valid, degrade, render_narrative
+from .credentials_game import (
+    CredentialCase,
+    CredentialDisposition,
+    CredentialsGame,
+    derive_disposition,
+)
+
+# A target disposition is just a CredentialDisposition: PASS = allow,
+# DENY = invalid-but-mitigatable, ARREST = invalid-illegal.
+_DEFAULT_DISPOSITIONS = {
+    CredentialDisposition.PASS: 0.4,
+    CredentialDisposition.DENY: 0.3,
+    CredentialDisposition.ARREST: 0.3,
+}
+
+
+class ScenarioOffer(BaseModelPlus):
+    """A promised encounter -- enough to materialize a candidate on arrival.
+
+    Sampling (origin / disposition / failure mode) happens once at roster
+    generation; the packet is built lazily by :func:`materialize`. A ``pinned_case``
+    is a fully-authored Tier 1 candidate that materializes verbatim.
+    """
+
+    target_disposition: CredentialDisposition = CredentialDisposition.PASS
+    region: Region = Region.LOCAL
+    purpose: Indication = Indication.TRAVEL
+    candidate_name: str = "Traveler"
+    contraband: list[Indication] = Field(default_factory=list)
+    failure_modes: list[FailureMode] = Field(default_factory=list)
+    whitelist: bool = False
+    blacklist: bool = False
+    pinned_case: CredentialCase | None = None
+
+
+@dataclass(frozen=True)
+class ShiftSpec:
+    """Generation-time recipe for one shift's roster (not persisted game state)."""
+
+    rules: Restrictions
+    encounters: int = 5
+    origin_distribution: dict[Region, float] = field(
+        default_factory=lambda: {Region.LOCAL: 1.0}
+    )
+    disposition_distribution: dict[CredentialDisposition, float] = field(
+        default_factory=lambda: dict(_DEFAULT_DISPOSITIONS)
+    )
+    purpose_pool: Sequence[Indication] = tuple(sorted(PURPOSES, key=lambda i: i.value))
+    pinned: Sequence[ScenarioOffer] = ()
+    seed: int | None = None
+
+
+def _weighted_choice(distribution: dict, rng: random.Random):
+    return rng.choices(list(distribution.keys()), weights=list(distribution.values()), k=1)[0]
+
+
+def _verified_offer(
+    region: Region,
+    purpose: Indication,
+    target: CredentialDisposition,
+    rules: Restrictions,
+    rng: random.Random,
+) -> ScenarioOffer | None:
+    """Build an offer for ``(region, purpose)`` that derives to ``target``, or None.
+
+    Returns None when the combination cannot reach the target -- e.g. PASS for a
+    purpose that is FORBIDDEN in this region (an inherent infraction no packet can
+    clear). Verifies against :func:`derive_disposition`, so the linchpin invariant
+    holds by construction.
+    """
+
+    base = build_valid(region, purpose, rules)
+    base_disposition = derive_disposition(base, rules)
+
+    if target is base_disposition:
+        # Already at the target with no failure (e.g. a forbidden purpose -> deny).
+        return ScenarioOffer(target_disposition=target, region=region, purpose=purpose)
+    if target is CredentialDisposition.PASS:
+        return None
+
+    failure_class = (
+        FailureClass.MITIGATABLE if target is CredentialDisposition.DENY else FailureClass.CRIME
+    )
+    candidates = applicable_modes(base, failure_class)
+    rng.shuffle(candidates)
+    for mode in candidates:
+        trial = degrade(build_valid(region, purpose, rules), [mode])
+        if derive_disposition(trial, rules) is target:
+            return ScenarioOffer(
+                target_disposition=target,
+                region=region,
+                purpose=purpose,
+                failure_modes=[mode],
+            )
+    return None
+
+
+def make_offer(
+    region: Region,
+    purpose: Indication,
+    target: CredentialDisposition,
+    rules: Restrictions,
+    rng: random.Random | None = None,
+) -> ScenarioOffer:
+    """A verified offer for ``target``, or a best-effort offer at this purpose's
+    inherent disposition if ``target`` is unreachable here."""
+
+    rng = rng or random.Random()
+    offer = _verified_offer(region, purpose, target, rules, rng)
+    if offer is not None:
+        return offer
+    base = build_valid(region, purpose, rules)
+    return ScenarioOffer(
+        target_disposition=derive_disposition(base, rules), region=region, purpose=purpose
+    )
+
+
+def generate_roster(spec: ShiftSpec, rng: random.Random | None = None) -> list[ScenarioOffer]:
+    """Sample a shift's worth of offers, inserting pinned encounters at random spots.
+
+    For each slot: sample an origin and a target disposition, then pick the first
+    purpose (shuffled) that can actually reach that target in that region.
+    """
+
+    rng = rng or random.Random(spec.seed)
+    pinned = list(spec.pinned)
+    sampled_count = max(spec.encounters - len(pinned), 0)
+
+    roster: list[ScenarioOffer] = []
+    for _ in range(sampled_count):
+        region = _weighted_choice(spec.origin_distribution, rng)
+        target = _weighted_choice(spec.disposition_distribution, rng)
+        purposes = list(spec.purpose_pool)
+        rng.shuffle(purposes)
+
+        offer = None
+        for purpose in purposes:
+            offer = _verified_offer(region, purpose, target, spec.rules, rng)
+            if offer is not None:
+                break
+        roster.append(offer or make_offer(region, purposes[0], target, spec.rules, rng))
+
+    for offer in pinned:
+        roster.insert(rng.randint(0, len(roster)), offer)
+    return roster
+
+
+def materialize(offer: ScenarioOffer, rules: Restrictions) -> CredentialCase:
+    """Build the concrete candidate for ``offer`` (deterministic).
+
+    Replays the offer's verified failure modes onto a fresh valid packet, so the
+    materialized case derives to the offer's ``target_disposition`` (context
+    overrides like whitelist are applied for the game's ``expected_disposition``).
+    """
+
+    if offer.pinned_case is not None:
+        return offer.pinned_case
+
+    case = build_valid(
+        offer.region,
+        offer.purpose,
+        rules,
+        candidate_name=offer.candidate_name,
+        contraband=list(offer.contraband),
+    )
+    degrade(case, offer.failure_modes)
+    render_narrative(case)
+    case.whitelist = offer.whitelist
+    case.blacklist = offer.blacklist
+    return case
+
+
+# Resolve the ``offers: list["ScenarioOffer"]`` forward reference on the game now
+# that ScenarioOffer exists. credentials_game cannot import this module at load
+# time (it would cycle through derive_disposition), so the rebuild lives here.
+CredentialsGame.model_rebuild(_types_namespace={"ScenarioOffer": ScenarioOffer})

--- a/engine/src/tangl/mechanics/games/picking_game.py
+++ b/engine/src/tangl/mechanics/games/picking_game.py
@@ -47,7 +47,7 @@ class PickingGame(Game[PickingMove]):
         default_factory=dict,
         json_schema_extra={"reset_field": True},
     )
-    terminal_decision: str | None = Field(
+    committed_decision: str | None = Field(
         default=None,
         json_schema_extra={"reset_field": True},
     )
@@ -96,7 +96,7 @@ class PickingGame(Game[PickingMove]):
                 "picking_inspected_targets": list(self.inspected_targets),
                 "picking_revealed_findings": dict(self.revealed_findings),
                 "picking_num_findings": len(self.revealed_findings),
-                "picking_terminal_decision": self.terminal_decision,
+                "picking_committed_decision": self.committed_decision,
                 "picking_decision_options": self.get_decision_targets(),
             }
         )
@@ -174,7 +174,7 @@ class PickingGameHandler(GameHandler[PickingGameT]):
             game.inspected_targets.append(player_move.target)
             result = self.resolve_inspection(game, player_move.target, detail)
         elif player_move.kind == "decide":
-            game.terminal_decision = player_move.target
+            game.committed_decision = player_move.target
             result = self.resolve_decision(game, player_move.target, detail)
         else:
             raise ValueError(f"Unknown picking move kind: {player_move.kind}")
@@ -215,7 +215,7 @@ class PickingGameHandler(GameHandler[PickingGameT]):
         detail["round_result"] = round_result.value
         detail["inspected_targets"] = list(game.inspected_targets)
         detail["revealed_findings"] = dict(game.revealed_findings)
-        detail["terminal_decision"] = game.terminal_decision
+        detail["committed_decision"] = game.committed_decision
         return detail
 
     def get_journal_fragments(self, game: PickingGameT) -> list[ContentFragment] | None:

--- a/engine/tests/loaders/test_credential_gate_world.py
+++ b/engine/tests/loaders/test_credential_gate_world.py
@@ -47,17 +47,24 @@ class TestCredentialGateWorld:
         assert ledger.cursor.label == "entrance"
 
         ledger.resolve_choice(_actions(ledger)[0].uid)
-
         assert ledger.cursor.label == "challenge"
-        inspect = next(action for action in _actions(ledger) if action.label == "Inspect passport")
-        ledger.resolve_choice(inspect.uid, choice_payload=inspect.payload)
 
-        packet = next(action for action in _actions(ledger) if action.label == "Review packet consistency")
-        ledger.resolve_choice(packet.uid, choice_payload=packet.payload)
+        def choose(label: str) -> None:
+            action = next(a for a in _actions(ledger) if a.label == label)
+            ledger.resolve_choice(action.uid, choice_payload=action.payload)
 
-        deny = next(action for action in _actions(ledger) if action.label == "Choose deny")
-        ledger.resolve_choice(deny.uid, choice_payload=deny.payload)
+        # The authored roster: Tomas (pass), Edda (deny), Goran (arrest).
+        choose("Inspect passport")
+        choose("Choose pass")
+        assert ledger.cursor.label == "challenge"  # still mid-shift
+
+        choose("Inspect passport")
+        choose("Choose deny")
+        assert ledger.cursor.label == "challenge"
+
+        choose("Inspect passport")
+        choose("Choose arrest")
 
         assert ledger.cursor.label == "victory"
         content = " ".join(getattr(fragment, "content", "") for fragment in ledger.get_journal())
-        assert "choose to deny" in content.lower()
+        assert "shift complete" in content.lower()

--- a/engine/tests/mechanics/games/test_credentials_derive.py
+++ b/engine/tests/mechanics/games/test_credentials_derive.py
@@ -19,29 +19,29 @@ from tangl.mechanics.games import (
 
 D = CredentialDisposition
 S = CredentialStatus
-I = Indication
+IND = Indication
 L = RestrictionLevel
 
 # A compact local rule set used across the matrix tests.
 LOCAL_RULES = Restrictions.from_map(
     {
         Region.LOCAL: {
-            I.TRAVEL: L.WITH_ID,
-            I.WORK: L.WITH_PERMIT,
-            I.EMIGRATE: L.ANONYMOUS,
-            I.WEAPON: L.WITH_PERMIT,
-            I.DRUGS: L.FORBIDDEN,
-            I.SECRETS: L.FORBIDDEN,
+            IND.TRAVEL: L.WITH_ID,
+            IND.WORK: L.WITH_PERMIT,
+            IND.EMIGRATE: L.ANONYMOUS,
+            IND.WEAPON: L.WITH_PERMIT,
+            IND.DRUGS: L.FORBIDDEN,
+            IND.SECRETS: L.FORBIDDEN,
         }
     }
 )
 
 
 def _id(status: S) -> CredentialToken:
-    return CredentialToken(indication=I.TRAVEL, status=status)
+    return CredentialToken(indication=IND.TRAVEL, status=status)
 
 
-def _permit(indication: I, status: S = S.VALID, holder_matches: bool = True) -> CredentialToken:
+def _permit(indication: IND, status: S = S.VALID, holder_matches: bool = True) -> CredentialToken:
     return CredentialToken(
         indication=indication, status=status, requires_id=True, holder_matches=holder_matches
     )
@@ -53,54 +53,54 @@ def _derive(case: CredentialCase) -> CredentialDisposition:
 
 class TestAnonymousAndId:
     def test_anonymous_purpose_passes_without_documents(self) -> None:
-        case = CredentialCase(purpose=I.EMIGRATE)  # ANONYMOUS locally
+        case = CredentialCase(purpose=IND.EMIGRATE)  # ANONYMOUS locally
         assert _derive(case) is D.PASS
 
     def test_with_id_valid_passes(self) -> None:
-        case = CredentialCase(purpose=I.TRAVEL, id_card=_id(S.VALID))
+        case = CredentialCase(purpose=IND.TRAVEL, id_card=_id(S.VALID))
         assert _derive(case) is D.PASS
 
     def test_with_id_missing_denies(self) -> None:
-        case = CredentialCase(purpose=I.TRAVEL, id_card=None)
+        case = CredentialCase(purpose=IND.TRAVEL, id_card=None)
         assert _derive(case) is D.DENY
 
     def test_with_id_expired_denies(self) -> None:
-        case = CredentialCase(purpose=I.TRAVEL, id_card=_id(S.EXPIRED))
+        case = CredentialCase(purpose=IND.TRAVEL, id_card=_id(S.EXPIRED))
         assert _derive(case) is D.DENY
 
     def test_with_id_fake_arrests(self) -> None:
-        case = CredentialCase(purpose=I.TRAVEL, id_card=_id(S.WRONG_HOLDER))
+        case = CredentialCase(purpose=IND.TRAVEL, id_card=_id(S.WRONG_HOLDER))
         assert _derive(case) is D.ARREST
 
 
 class TestPermit:
     def test_valid_permit_and_id_passes(self) -> None:
         case = CredentialCase(
-            purpose=I.WORK, id_card=_id(S.VALID), packet=[_permit(I.WORK)]
+            purpose=IND.WORK, id_card=_id(S.VALID), packet=[_permit(IND.WORK)]
         )
         assert _derive(case) is D.PASS
 
     def test_missing_permit_denies(self) -> None:
-        case = CredentialCase(purpose=I.WORK, id_card=_id(S.VALID), packet=[])
+        case = CredentialCase(purpose=IND.WORK, id_card=_id(S.VALID), packet=[])
         assert _derive(case) is D.DENY
 
     def test_missing_seal_permit_denies(self) -> None:
         case = CredentialCase(
-            purpose=I.WORK, id_card=_id(S.VALID), packet=[_permit(I.WORK, S.MISSING_SEAL)]
+            purpose=IND.WORK, id_card=_id(S.VALID), packet=[_permit(IND.WORK, S.MISSING_SEAL)]
         )
         assert _derive(case) is D.DENY
 
     def test_forged_permit_arrests(self) -> None:
         case = CredentialCase(
-            purpose=I.WORK, id_card=_id(S.VALID), packet=[_permit(I.WORK, S.FORGED)]
+            purpose=IND.WORK, id_card=_id(S.VALID), packet=[_permit(IND.WORK, S.FORGED)]
         )
         assert _derive(case) is D.ARREST
 
     def test_permit_holder_mismatch_arrests(self) -> None:
         case = CredentialCase(
-            purpose=I.WORK,
+            purpose=IND.WORK,
             id_card=_id(S.VALID),
-            packet=[_permit(I.WORK, S.VALID, holder_matches=False)],
+            packet=[_permit(IND.WORK, S.VALID, holder_matches=False)],
         )
         assert _derive(case) is D.ARREST
 
@@ -110,13 +110,13 @@ class TestTwoErrorSurfaces:
 
     def test_valid_permit_but_fake_id_arrests(self) -> None:
         case = CredentialCase(
-            purpose=I.WORK, id_card=_id(S.WRONG_HOLDER), packet=[_permit(I.WORK)]
+            purpose=IND.WORK, id_card=_id(S.WRONG_HOLDER), packet=[_permit(IND.WORK)]
         )
         assert _derive(case) is D.ARREST
 
     def test_forged_permit_but_valid_id_arrests(self) -> None:
         case = CredentialCase(
-            purpose=I.WORK, id_card=_id(S.VALID), packet=[_permit(I.WORK, S.FORGED)]
+            purpose=IND.WORK, id_card=_id(S.VALID), packet=[_permit(IND.WORK, S.FORGED)]
         )
         assert _derive(case) is D.ARREST
 
@@ -125,42 +125,42 @@ class TestSeverityAndForbidden:
     def test_severity_takes_the_worst(self) -> None:
         # A mitigatable permit (deny) plus concealed contraband (arrest) -> arrest.
         case = CredentialCase(
-            purpose=I.WORK,
+            purpose=IND.WORK,
             id_card=_id(S.VALID),
-            packet=[_permit(I.WORK, S.MISSING_SEAL)],
-            possessions=[ContrabandItem(indication=I.WEAPON, concealed=True)],
+            packet=[_permit(IND.WORK, S.MISSING_SEAL)],
+            possessions=[ContrabandItem(indication=IND.WEAPON, concealed=True)],
         )
         assert _derive(case) is D.ARREST
 
     def test_forbidden_purpose_denies(self) -> None:
-        rules = Restrictions.from_map({Region.LOCAL: {I.WORK: L.FORBIDDEN}})
-        case = CredentialCase(purpose=I.WORK, id_card=_id(S.VALID))
+        rules = Restrictions.from_map({Region.LOCAL: {IND.WORK: L.FORBIDDEN}})
+        case = CredentialCase(purpose=IND.WORK, id_card=_id(S.VALID))
         assert derive_disposition(case, rules) is D.DENY
 
 
 class TestContraband:
     def test_concealed_contraband_arrests(self) -> None:
         case = CredentialCase(
-            purpose=I.TRAVEL,
+            purpose=IND.TRAVEL,
             id_card=_id(S.VALID),
-            possessions=[ContrabandItem(indication=I.DRUGS, concealed=True)],
+            possessions=[ContrabandItem(indication=IND.DRUGS, concealed=True)],
         )
         assert _derive(case) is D.ARREST
 
     def test_declared_forbidden_contraband_denies(self) -> None:
         case = CredentialCase(
-            purpose=I.TRAVEL,
+            purpose=IND.TRAVEL,
             id_card=_id(S.VALID),
-            possessions=[ContrabandItem(indication=I.DRUGS, concealed=False)],
+            possessions=[ContrabandItem(indication=IND.DRUGS, concealed=False)],
         )
         assert _derive(case) is D.DENY
 
     def test_declared_permitted_contraband_with_permit_passes(self) -> None:
         case = CredentialCase(
-            purpose=I.TRAVEL,
+            purpose=IND.TRAVEL,
             id_card=_id(S.VALID),
-            packet=[_permit(I.WEAPON)],
-            possessions=[ContrabandItem(indication=I.WEAPON, concealed=False)],
+            packet=[_permit(IND.WEAPON)],
+            possessions=[ContrabandItem(indication=IND.WEAPON, concealed=False)],
         )
         assert _derive(case) is D.PASS
 
@@ -169,10 +169,10 @@ class TestRegionalSelection:
     def test_same_purpose_differs_by_region(self) -> None:
         # Work is permit-gated locally but forbidden from the hostile west.
         local = CredentialCase(
-            region=Region.LOCAL, purpose=I.WORK, id_card=_id(S.VALID), packet=[_permit(I.WORK)]
+            region=Region.LOCAL, purpose=IND.WORK, id_card=_id(S.VALID), packet=[_permit(IND.WORK)]
         )
         hostile = CredentialCase(
-            region=Region.FOREIGN_WEST, purpose=I.WORK, id_card=_id(S.VALID), packet=[_permit(I.WORK)]
+            region=Region.FOREIGN_WEST, purpose=IND.WORK, id_card=_id(S.VALID), packet=[_permit(IND.WORK)]
         )
         assert derive_disposition(local, DEFAULT_RESTRICTIONS) is D.PASS
         assert derive_disposition(hostile, DEFAULT_RESTRICTIONS) is D.DENY
@@ -180,16 +180,16 @@ class TestRegionalSelection:
 
 class TestExpectedDispositionWiring:
     def test_derives_when_no_authored_override(self) -> None:
-        case = CredentialCase(purpose=I.WORK, id_card=_id(S.VALID), packet=[_permit(I.WORK, S.FORGED)])
+        case = CredentialCase(purpose=IND.WORK, id_card=_id(S.VALID), packet=[_permit(IND.WORK, S.FORGED)])
         game = CredentialsGame(roster=[case], restriction_map=LOCAL_RULES)
         assert game.expected_disposition(case) is D.ARREST
 
     def test_authored_override_wins_over_derivation(self) -> None:
         # Would derive ARREST, but the author pins PASS.
         case = CredentialCase(
-            purpose=I.WORK,
+            purpose=IND.WORK,
             id_card=_id(S.VALID),
-            packet=[_permit(I.WORK, S.FORGED)],
+            packet=[_permit(IND.WORK, S.FORGED)],
             correct_disposition=D.PASS,
         )
         game = CredentialsGame(roster=[case], restriction_map=LOCAL_RULES)

--- a/engine/tests/mechanics/games/test_credentials_derive.py
+++ b/engine/tests/mechanics/games/test_credentials_derive.py
@@ -1,0 +1,196 @@
+"""Tests for rules-based disposition derivation (Phase A.1)."""
+
+from __future__ import annotations
+
+from tangl.mechanics.games import (
+    ContrabandItem,
+    CredentialCase,
+    CredentialDisposition,
+    CredentialStatus,
+    CredentialToken,
+    CredentialsGame,
+    DEFAULT_RESTRICTIONS,
+    Indication,
+    Region,
+    Restrictions,
+    RestrictionLevel,
+    derive_disposition,
+)
+
+D = CredentialDisposition
+S = CredentialStatus
+I = Indication
+L = RestrictionLevel
+
+# A compact local rule set used across the matrix tests.
+LOCAL_RULES = Restrictions.from_map(
+    {
+        Region.LOCAL: {
+            I.TRAVEL: L.WITH_ID,
+            I.WORK: L.WITH_PERMIT,
+            I.EMIGRATE: L.ANONYMOUS,
+            I.WEAPON: L.WITH_PERMIT,
+            I.DRUGS: L.FORBIDDEN,
+            I.SECRETS: L.FORBIDDEN,
+        }
+    }
+)
+
+
+def _id(status: S) -> CredentialToken:
+    return CredentialToken(indication=I.TRAVEL, status=status)
+
+
+def _permit(indication: I, status: S = S.VALID, holder_matches: bool = True) -> CredentialToken:
+    return CredentialToken(
+        indication=indication, status=status, requires_id=True, holder_matches=holder_matches
+    )
+
+
+def _derive(case: CredentialCase) -> CredentialDisposition:
+    return derive_disposition(case, LOCAL_RULES)
+
+
+class TestAnonymousAndId:
+    def test_anonymous_purpose_passes_without_documents(self) -> None:
+        case = CredentialCase(purpose=I.EMIGRATE)  # ANONYMOUS locally
+        assert _derive(case) is D.PASS
+
+    def test_with_id_valid_passes(self) -> None:
+        case = CredentialCase(purpose=I.TRAVEL, id_card=_id(S.VALID))
+        assert _derive(case) is D.PASS
+
+    def test_with_id_missing_denies(self) -> None:
+        case = CredentialCase(purpose=I.TRAVEL, id_card=None)
+        assert _derive(case) is D.DENY
+
+    def test_with_id_expired_denies(self) -> None:
+        case = CredentialCase(purpose=I.TRAVEL, id_card=_id(S.EXPIRED))
+        assert _derive(case) is D.DENY
+
+    def test_with_id_fake_arrests(self) -> None:
+        case = CredentialCase(purpose=I.TRAVEL, id_card=_id(S.WRONG_HOLDER))
+        assert _derive(case) is D.ARREST
+
+
+class TestPermit:
+    def test_valid_permit_and_id_passes(self) -> None:
+        case = CredentialCase(
+            purpose=I.WORK, id_card=_id(S.VALID), packet=[_permit(I.WORK)]
+        )
+        assert _derive(case) is D.PASS
+
+    def test_missing_permit_denies(self) -> None:
+        case = CredentialCase(purpose=I.WORK, id_card=_id(S.VALID), packet=[])
+        assert _derive(case) is D.DENY
+
+    def test_missing_seal_permit_denies(self) -> None:
+        case = CredentialCase(
+            purpose=I.WORK, id_card=_id(S.VALID), packet=[_permit(I.WORK, S.MISSING_SEAL)]
+        )
+        assert _derive(case) is D.DENY
+
+    def test_forged_permit_arrests(self) -> None:
+        case = CredentialCase(
+            purpose=I.WORK, id_card=_id(S.VALID), packet=[_permit(I.WORK, S.FORGED)]
+        )
+        assert _derive(case) is D.ARREST
+
+    def test_permit_holder_mismatch_arrests(self) -> None:
+        case = CredentialCase(
+            purpose=I.WORK,
+            id_card=_id(S.VALID),
+            packet=[_permit(I.WORK, S.VALID, holder_matches=False)],
+        )
+        assert _derive(case) is D.ARREST
+
+
+class TestTwoErrorSurfaces:
+    """The permit document and the id linkage are independent error surfaces."""
+
+    def test_valid_permit_but_fake_id_arrests(self) -> None:
+        case = CredentialCase(
+            purpose=I.WORK, id_card=_id(S.WRONG_HOLDER), packet=[_permit(I.WORK)]
+        )
+        assert _derive(case) is D.ARREST
+
+    def test_forged_permit_but_valid_id_arrests(self) -> None:
+        case = CredentialCase(
+            purpose=I.WORK, id_card=_id(S.VALID), packet=[_permit(I.WORK, S.FORGED)]
+        )
+        assert _derive(case) is D.ARREST
+
+
+class TestSeverityAndForbidden:
+    def test_severity_takes_the_worst(self) -> None:
+        # A mitigatable permit (deny) plus concealed contraband (arrest) -> arrest.
+        case = CredentialCase(
+            purpose=I.WORK,
+            id_card=_id(S.VALID),
+            packet=[_permit(I.WORK, S.MISSING_SEAL)],
+            possessions=[ContrabandItem(indication=I.WEAPON, concealed=True)],
+        )
+        assert _derive(case) is D.ARREST
+
+    def test_forbidden_purpose_denies(self) -> None:
+        rules = Restrictions.from_map({Region.LOCAL: {I.WORK: L.FORBIDDEN}})
+        case = CredentialCase(purpose=I.WORK, id_card=_id(S.VALID))
+        assert derive_disposition(case, rules) is D.DENY
+
+
+class TestContraband:
+    def test_concealed_contraband_arrests(self) -> None:
+        case = CredentialCase(
+            purpose=I.TRAVEL,
+            id_card=_id(S.VALID),
+            possessions=[ContrabandItem(indication=I.DRUGS, concealed=True)],
+        )
+        assert _derive(case) is D.ARREST
+
+    def test_declared_forbidden_contraband_denies(self) -> None:
+        case = CredentialCase(
+            purpose=I.TRAVEL,
+            id_card=_id(S.VALID),
+            possessions=[ContrabandItem(indication=I.DRUGS, concealed=False)],
+        )
+        assert _derive(case) is D.DENY
+
+    def test_declared_permitted_contraband_with_permit_passes(self) -> None:
+        case = CredentialCase(
+            purpose=I.TRAVEL,
+            id_card=_id(S.VALID),
+            packet=[_permit(I.WEAPON)],
+            possessions=[ContrabandItem(indication=I.WEAPON, concealed=False)],
+        )
+        assert _derive(case) is D.PASS
+
+
+class TestRegionalSelection:
+    def test_same_purpose_differs_by_region(self) -> None:
+        # Work is permit-gated locally but forbidden from the hostile west.
+        local = CredentialCase(
+            region=Region.LOCAL, purpose=I.WORK, id_card=_id(S.VALID), packet=[_permit(I.WORK)]
+        )
+        hostile = CredentialCase(
+            region=Region.FOREIGN_WEST, purpose=I.WORK, id_card=_id(S.VALID), packet=[_permit(I.WORK)]
+        )
+        assert derive_disposition(local, DEFAULT_RESTRICTIONS) is D.PASS
+        assert derive_disposition(hostile, DEFAULT_RESTRICTIONS) is D.DENY
+
+
+class TestExpectedDispositionWiring:
+    def test_derives_when_no_authored_override(self) -> None:
+        case = CredentialCase(purpose=I.WORK, id_card=_id(S.VALID), packet=[_permit(I.WORK, S.FORGED)])
+        game = CredentialsGame(roster=[case], restriction_map=LOCAL_RULES)
+        assert game.expected_disposition(case) is D.ARREST
+
+    def test_authored_override_wins_over_derivation(self) -> None:
+        # Would derive ARREST, but the author pins PASS.
+        case = CredentialCase(
+            purpose=I.WORK,
+            id_card=_id(S.VALID),
+            packet=[_permit(I.WORK, S.FORGED)],
+            correct_disposition=D.PASS,
+        )
+        game = CredentialsGame(roster=[case], restriction_map=LOCAL_RULES)
+        assert game.expected_disposition(case) is D.PASS

--- a/engine/tests/mechanics/games/test_credentials_factory.py
+++ b/engine/tests/mechanics/games/test_credentials_factory.py
@@ -1,0 +1,112 @@
+"""Tests for the procedural candidate factory (Phase A.2)."""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from tangl.mechanics.games import (
+    CredentialDisposition,
+    FailureClass,
+    FailureMode,
+    Indication,
+    Region,
+    Restrictions,
+    RestrictionLevel,
+    applicable_modes,
+    build_valid,
+    degrade,
+    derive_disposition,
+    make_case,
+    sample_failure_mode,
+)
+
+D = CredentialDisposition
+I = Indication
+L = RestrictionLevel
+
+RULES = Restrictions.from_map(
+    {
+        Region.LOCAL: {
+            I.TRAVEL: L.WITH_ID,
+            I.WORK: L.WITH_PERMIT,
+            I.WEAPON: L.WITH_PERMIT,
+            I.DRUGS: L.FORBIDDEN,
+        }
+    }
+)
+
+EXPECTED_CLASS_DISPOSITION = {
+    FailureClass.MITIGATABLE: D.DENY,
+    FailureClass.CRIME: D.ARREST,
+}
+
+
+def _derive(case) -> CredentialDisposition:
+    return derive_disposition(case, RULES)
+
+
+class TestBuildValid:
+    def test_work_candidate_passes(self) -> None:
+        assert _derive(build_valid(Region.LOCAL, I.WORK, RULES)) is D.PASS
+
+    def test_travel_candidate_passes(self) -> None:
+        assert _derive(build_valid(Region.LOCAL, I.TRAVEL, RULES)) is D.PASS
+
+    def test_with_permittable_contraband_passes(self) -> None:
+        case = build_valid(Region.LOCAL, I.WORK, RULES, contraband=[I.WEAPON])
+        assert _derive(case) is D.PASS
+
+
+class TestRoundTripInvariant:
+    """degrade(build_valid(...), mode) derives to the mode's class disposition."""
+
+    @pytest.mark.parametrize("mode", list(FailureMode))
+    def test_single_mode_derives_to_its_class(self, mode: FailureMode) -> None:
+        # Use a WORK candidate so permit and id surfaces both exist.
+        case = make_case(Region.LOCAL, I.WORK, RULES, failure_modes=[mode])
+        assert _derive(case) is EXPECTED_CLASS_DISPOSITION[mode.failure_class]
+
+    def test_composition_takes_the_worst(self) -> None:
+        # A mitigatable permit flaw plus a smuggling crime -> arrest.
+        case = make_case(
+            Region.LOCAL,
+            I.WORK,
+            RULES,
+            failure_modes=[FailureMode.UNSEALED_PERMIT, FailureMode.CONCEALED_CONTRABAND],
+        )
+        assert _derive(case) is D.ARREST
+
+
+class TestApplicability:
+    def test_work_candidate_exposes_permit_and_id_modes(self) -> None:
+        modes = applicable_modes(build_valid(Region.LOCAL, I.WORK, RULES))
+        assert FailureMode.FORGED_PERMIT in modes
+        assert FailureMode.FAKE_ID in modes
+
+    def test_travel_candidate_has_no_permit_modes(self) -> None:
+        # Travel is id-only locally: no permit exists to forge.
+        modes = applicable_modes(build_valid(Region.LOCAL, I.TRAVEL, RULES))
+        assert FailureMode.FORGED_PERMIT not in modes
+        assert FailureMode.MISSING_PERMIT not in modes
+        assert FailureMode.FAKE_ID in modes
+
+    def test_filter_by_class(self) -> None:
+        case = build_valid(Region.LOCAL, I.WORK, RULES)
+        crimes = applicable_modes(case, FailureClass.CRIME)
+        assert crimes
+        assert all(m.failure_class is FailureClass.CRIME for m in crimes)
+
+
+class TestSampling:
+    @pytest.mark.parametrize("failure_class", [FailureClass.MITIGATABLE, FailureClass.CRIME])
+    def test_sampled_mode_derives_to_target_class(self, failure_class: FailureClass) -> None:
+        rng = random.Random(1234)
+        for _ in range(20):
+            case = build_valid(Region.LOCAL, I.WORK, RULES)
+            mode = sample_failure_mode(case, failure_class, rng)
+            assert mode is not None
+            assert mode.failure_class is failure_class
+            degrade(case, [mode])
+            assert _derive(case) is EXPECTED_CLASS_DISPOSITION[failure_class]

--- a/engine/tests/mechanics/games/test_credentials_factory.py
+++ b/engine/tests/mechanics/games/test_credentials_factory.py
@@ -7,6 +7,7 @@ import random
 import pytest
 
 from tangl.mechanics.games import (
+    CredentialCase,
     CredentialDisposition,
     FailureClass,
     FailureMode,
@@ -23,16 +24,16 @@ from tangl.mechanics.games import (
 )
 
 D = CredentialDisposition
-I = Indication
+IND = Indication
 L = RestrictionLevel
 
 RULES = Restrictions.from_map(
     {
         Region.LOCAL: {
-            I.TRAVEL: L.WITH_ID,
-            I.WORK: L.WITH_PERMIT,
-            I.WEAPON: L.WITH_PERMIT,
-            I.DRUGS: L.FORBIDDEN,
+            IND.TRAVEL: L.WITH_ID,
+            IND.WORK: L.WITH_PERMIT,
+            IND.WEAPON: L.WITH_PERMIT,
+            IND.DRUGS: L.FORBIDDEN,
         }
     }
 )
@@ -43,20 +44,25 @@ EXPECTED_CLASS_DISPOSITION = {
 }
 
 
-def _derive(case) -> CredentialDisposition:
+def _derive(case: CredentialCase) -> CredentialDisposition:
     return derive_disposition(case, RULES)
 
 
 class TestBuildValid:
     def test_work_candidate_passes(self) -> None:
-        assert _derive(build_valid(Region.LOCAL, I.WORK, RULES)) is D.PASS
+        assert _derive(build_valid(Region.LOCAL, IND.WORK, RULES)) is D.PASS
 
     def test_travel_candidate_passes(self) -> None:
-        assert _derive(build_valid(Region.LOCAL, I.TRAVEL, RULES)) is D.PASS
+        assert _derive(build_valid(Region.LOCAL, IND.TRAVEL, RULES)) is D.PASS
 
     def test_with_permittable_contraband_passes(self) -> None:
-        case = build_valid(Region.LOCAL, I.WORK, RULES, contraband=[I.WEAPON])
+        case = build_valid(Region.LOCAL, IND.WORK, RULES, contraband=[IND.WEAPON])
         assert _derive(case) is D.PASS
+
+    def test_rejects_forbidden_contraband(self) -> None:
+        # Drugs are forbidden locally: no valid packet can carry them.
+        with pytest.raises(ValueError):
+            build_valid(Region.LOCAL, IND.TRAVEL, RULES, contraband=[IND.DRUGS])
 
 
 class TestRoundTripInvariant:
@@ -65,14 +71,14 @@ class TestRoundTripInvariant:
     @pytest.mark.parametrize("mode", list(FailureMode))
     def test_single_mode_derives_to_its_class(self, mode: FailureMode) -> None:
         # Use a WORK candidate so permit and id surfaces both exist.
-        case = make_case(Region.LOCAL, I.WORK, RULES, failure_modes=[mode])
+        case = make_case(Region.LOCAL, IND.WORK, RULES, failure_modes=[mode])
         assert _derive(case) is EXPECTED_CLASS_DISPOSITION[mode.failure_class]
 
     def test_composition_takes_the_worst(self) -> None:
         # A mitigatable permit flaw plus a smuggling crime -> arrest.
         case = make_case(
             Region.LOCAL,
-            I.WORK,
+            IND.WORK,
             RULES,
             failure_modes=[FailureMode.UNSEALED_PERMIT, FailureMode.CONCEALED_CONTRABAND],
         )
@@ -81,19 +87,19 @@ class TestRoundTripInvariant:
 
 class TestApplicability:
     def test_work_candidate_exposes_permit_and_id_modes(self) -> None:
-        modes = applicable_modes(build_valid(Region.LOCAL, I.WORK, RULES))
+        modes = applicable_modes(build_valid(Region.LOCAL, IND.WORK, RULES))
         assert FailureMode.FORGED_PERMIT in modes
         assert FailureMode.FAKE_ID in modes
 
     def test_travel_candidate_has_no_permit_modes(self) -> None:
         # Travel is id-only locally: no permit exists to forge.
-        modes = applicable_modes(build_valid(Region.LOCAL, I.TRAVEL, RULES))
+        modes = applicable_modes(build_valid(Region.LOCAL, IND.TRAVEL, RULES))
         assert FailureMode.FORGED_PERMIT not in modes
         assert FailureMode.MISSING_PERMIT not in modes
         assert FailureMode.FAKE_ID in modes
 
     def test_filter_by_class(self) -> None:
-        case = build_valid(Region.LOCAL, I.WORK, RULES)
+        case = build_valid(Region.LOCAL, IND.WORK, RULES)
         crimes = applicable_modes(case, FailureClass.CRIME)
         assert crimes
         assert all(m.failure_class is FailureClass.CRIME for m in crimes)
@@ -104,7 +110,7 @@ class TestSampling:
     def test_sampled_mode_derives_to_target_class(self, failure_class: FailureClass) -> None:
         rng = random.Random(1234)
         for _ in range(20):
-            case = build_valid(Region.LOCAL, I.WORK, RULES)
+            case = build_valid(Region.LOCAL, IND.WORK, RULES)
             mode = sample_failure_mode(case, failure_class, rng)
             assert mode is not None
             assert mode.failure_class is failure_class

--- a/engine/tests/mechanics/games/test_credentials_game.py
+++ b/engine/tests/mechanics/games/test_credentials_game.py
@@ -1,10 +1,11 @@
-"""Tests for credential inspection mechanics."""
+"""Tests for the credential checkpoint-shift mechanic."""
 
 from __future__ import annotations
 
 from tangl.core import Graph
-from tangl.mechanics.games import HasGame
+from tangl.mechanics.games import GameResult, HasGame
 from tangl.mechanics.games.credentials_game import (
+    CredentialCase,
     CredentialDisposition,
     CredentialsGame,
     CredentialsGameHandler,
@@ -14,48 +15,63 @@ from tangl.story import Action, Block
 from tangl.vm import Ledger, TraversableEdge as ChoiceEdge
 
 
+def _two_case_roster() -> list[CredentialCase]:
+    """A deny-then-pass shift, with case 0 carrying an extra 'baggage' document."""
+
+    return [
+        CredentialCase(
+            candidate_name="Edda Marrow",
+            presented_documents={
+                "passport": "A worn passport with a blurred seal.",
+                "travel permit": "A permit stamped for this week.",
+                "baggage": "A lacquered case with a stubborn clasp.",
+            },
+            hidden_facts={"passport": "The seal impression is wrong for this border."},
+            packet_hidden_facts={
+                "packet consistency": "The documents do not satisfy the rules.",
+            },
+            correct_disposition=CredentialDisposition.DENY,
+        ),
+        CredentialCase(
+            candidate_name="Tomas Vey",
+            presented_documents={
+                "passport": "A crisp passport, seal sharp and current.",
+                "travel permit": "A permit stamped for this very week.",
+            },
+            hidden_facts={},
+            packet_hidden_facts={},
+            correct_disposition=CredentialDisposition.PASS,
+        ),
+    ]
+
+
+def _ready_game(**overrides) -> tuple[CredentialsGame, CredentialsGameHandler]:
+    game = CredentialsGame(roster=_two_case_roster(), **overrides)
+    handler = CredentialsGameHandler()
+    handler.setup(game)
+    return game, handler
+
+
 class CredentialsBlock(HasGame, Block):
-    """Test block embedding credential inspection."""
+    """Test block embedding the credential shift."""
 
     _game_class = CredentialsGame
     _game_handler_class = CredentialsGameHandler
 
 
 class TestCredentialsCore:
-    """Core credential game behavior tests."""
+    """Core shift behavior without the VM."""
 
     def test_inspect_reveals_hidden_finding(self) -> None:
-        game = CredentialsGame()
-        handler = CredentialsGameHandler()
-        handler.setup(game)
+        game, handler = _ready_game()
 
         result = handler.receive_move(game, ("inspect", "passport"))
 
         assert result.name == "CONTINUE"
         assert "passport" in game.discovered_findings
 
-    def test_correct_disposition_wins(self) -> None:
-        game = CredentialsGame(correct_disposition=CredentialDisposition.DENY)
-        handler = CredentialsGameHandler()
-        handler.setup(game)
-        handler.receive_move(game, ("inspect", "passport"))
-
-        result = handler.receive_move(game, ("decide", "deny"))
-
-        assert result.name == "WIN"
-        assert game.result.name == "WIN"
-
-    def test_arrest_move_can_be_disabled(self) -> None:
-        game = CredentialsGame(allow_arrest=False)
-        handler = CredentialsGameHandler()
-        handler.setup(game)
-
-        assert ("decide", "arrest") not in handler.get_available_moves(game)
-
     def test_packet_review_records_packet_finding(self) -> None:
-        game = CredentialsGame()
-        handler = CredentialsGameHandler()
-        handler.setup(game)
+        game, handler = _ready_game()
         handler.receive_move(game, ("inspect", "passport"))
 
         result = handler.receive_move(game, ("inspect", "packet consistency"))
@@ -63,23 +79,140 @@ class TestCredentialsCore:
         assert result.name == "CONTINUE"
         assert "packet consistency" in game.packet_findings
 
-    def test_blacklist_context_can_force_arrest_disposition(self) -> None:
-        game = CredentialsGame(blacklist_status=True)
-        handler = CredentialsGameHandler()
-        handler.setup(game)
+    def test_arrest_move_can_be_disabled(self) -> None:
+        game, handler = _ready_game(allow_arrest=False)
         handler.receive_move(game, ("inspect", "passport"))
 
-        result = handler.receive_move(game, ("decide", "arrest"))
+        assert ("decide", "arrest") not in handler.get_available_moves(game)
+
+    def test_correct_disposition_advances_without_terminal(self) -> None:
+        game, handler = _ready_game()
+        handler.receive_move(game, ("inspect", "passport"))
+
+        result = handler.receive_move(game, ("decide", "deny"))
 
         assert result.name == "WIN"
-        assert game.result.name == "WIN"
+        # Game is not over: a second candidate remains.
+        assert game.result is GameResult.IN_PROCESS
+        assert not game.is_terminal
+        assert game.case_index == 1
+
+    def test_advance_resets_only_per_case_state(self) -> None:
+        game, handler = _ready_game()
+        handler.receive_move(game, ("inspect", "passport"))
+        handler.receive_move(game, ("inspect", "packet consistency"))
+        handler.receive_move(game, ("decide", "deny"))
+
+        # Per-case working state is wiped for the next candidate...
+        assert game.inspected_targets == []
+        assert game.revealed_findings == {}
+        assert game.inspected_packet_targets == []
+        assert game.packet_findings == {}
+        assert game.committed_decision is None
+        assert game.current_stage == "documents"
+        # ...but shift-level state persists.
+        assert len(game.case_results) == 1
+        assert game.case_results[0].candidate_name == "Edda Marrow"
+        assert game.case_results[0].correct is True
+        assert game.score == {"player": 1, "opponent": 0}
+
+    def test_full_roster_traversal_wins(self) -> None:
+        game, handler = _ready_game()
+
+        handler.receive_move(game, ("inspect", "passport"))
+        handler.receive_move(game, ("decide", "deny"))
+        assert not game.is_terminal  # terminal only after the final case
+
+        handler.receive_move(game, ("inspect", "passport"))
+        handler.receive_move(game, ("decide", "pass"))
+
+        assert game.shift_complete is True
+        assert game.is_terminal
+        assert game.result is GameResult.WIN
+        assert game.correct_count == 2
+        assert [r.correct for r in game.case_results] == [True, True]
+
+    def test_one_wrong_call_fails_shift_under_strict_default(self) -> None:
+        game, handler = _ready_game()
+
+        # Wrong call on the first candidate (pass instead of deny).
+        handler.receive_move(game, ("inspect", "passport"))
+        handler.receive_move(game, ("decide", "pass"))
+        # Correct call on the second.
+        handler.receive_move(game, ("inspect", "passport"))
+        handler.receive_move(game, ("decide", "pass"))
+
+        assert game.is_terminal
+        assert game.result is GameResult.LOSE
+        assert game.correct_count == 1
+
+    def test_pass_threshold_allows_a_miss(self) -> None:
+        game, handler = _ready_game(pass_threshold=1)
+
+        handler.receive_move(game, ("inspect", "passport"))
+        handler.receive_move(game, ("decide", "pass"))  # wrong
+        handler.receive_move(game, ("inspect", "passport"))
+        handler.receive_move(game, ("decide", "pass"))  # correct
+
+        assert game.result is GameResult.WIN
+        assert game.correct_count == 1
+
+    def test_terminal_routing_only_after_final_case(self) -> None:
+        game, handler = _ready_game()
+        handler.receive_move(game, ("inspect", "passport"))
+        handler.receive_move(game, ("decide", "deny"))
+
+        # Mid-shift: still in process, awaiting the next candidate.
+        assert game.result is GameResult.IN_PROCESS
+        assert game.is_ready
+
+    def test_expected_disposition_context_seams(self) -> None:
+        game = CredentialsGame(
+            roster=[
+                CredentialCase(correct_disposition=CredentialDisposition.PASS, blacklist=True),
+                CredentialCase(correct_disposition=CredentialDisposition.DENY, whitelist=True),
+            ]
+        )
+
+        assert game.expected_disposition(game.roster[0]) is CredentialDisposition.ARREST
+        assert game.expected_disposition(game.roster[1]) is CredentialDisposition.PASS
+
+    def test_namespace_exposes_shift_progress(self) -> None:
+        game, handler = _ready_game()
+
+        opening = game.to_namespace()
+        assert opening["credential_roster_size"] == 2
+        assert opening["credential_case_number"] == 1
+        assert opening["credential_cases_remaining"] == 2
+        assert opening["credential_correct_count"] == 0
+        assert opening["credential_shift_complete"] is False
+        assert opening["credential_shift_score"] == {"player": 0, "opponent": 0}
+
+        handler.receive_move(game, ("inspect", "passport"))
+        handler.receive_move(game, ("decide", "deny"))
+
+        mid = game.to_namespace()
+        assert mid["credential_case_number"] == 2
+        assert mid["credential_cases_remaining"] == 1
+        assert mid["credential_correct_count"] == 1
+        assert mid["credential_candidate_name"] == "Tomas Vey"
 
 
 class TestCredentialsIntegration:
-    """VM and HasGame integration tests for credentials."""
+    """VM and HasGame integration across a full roster."""
 
-    def test_credentials_can_inspect_then_deny_to_victory(self) -> None:
-        graph = Graph(label="credential_flow")
+    def _actions(self, ledger: Ledger) -> list[Action]:
+        return [a for a in ledger.cursor.edges_out() if isinstance(a, Action)]
+
+    def _labels(self, ledger: Ledger) -> set[str]:
+        return {a.label for a in self._actions(ledger)}
+
+    def _choose(self, ledger: Ledger, label: str) -> None:
+        action = next(a for a in self._actions(ledger) if a.label == label)
+        ledger.resolve_choice(action.uid, choice_payload=action.payload)
+
+    def test_walk_full_roster_to_victory(self) -> None:
+        graph = Graph(label="credential_shift")
         intro = graph.add_node(kind=Block, label="intro")
         victory = graph.add_node(kind=Block, label="victory")
         defeat = graph.add_node(kind=Block, label="defeat")
@@ -92,40 +225,41 @@ class TestCredentialsIntegration:
             defeat_dest=defeat,
             label="checkpoint",
         )
-        block.game.correct_disposition = CredentialDisposition.DENY
+        block.game.roster = _two_case_roster()
         block.game_handler.setup(block.game)
 
         intro_to_checkpoint = ChoiceEdge(
             graph=graph,
             predecessor_id=intro.uid,
             successor_id=block.uid,
-            label="Open the checkpoint ledger",
+            label="Open the gate ledger",
         )
-
         ledger = Ledger.from_graph(graph=graph, entry_id=intro.uid)
         ledger.resolve_choice(intro_to_checkpoint.uid)
 
-        inspect = next(
-            action
-            for action in ledger.cursor.edges_out()
-            if isinstance(action, Action) and action.label == "Inspect passport"
-        )
-        ledger.resolve_choice(inspect.uid, choice_payload=inspect.payload)
+        # Candidate 1 (Edda) -> deny.
+        self._choose(ledger, "Inspect passport")
+        self._choose(ledger, "Choose deny")
 
-        deny = next(
-            action
-            for action in ledger.cursor.edges_out()
-            if isinstance(action, Action) and action.label == "Choose deny"
-        )
-        ledger.resolve_choice(deny.uid, choice_payload=deny.payload)
+        # Stale move cleanup: the desk now shows candidate 2's documents only.
+        labels = self._labels(ledger)
+        assert "Inspect passport" in labels
+        assert "Inspect baggage" not in labels  # belonged to candidate 1
+        assert not any(label.startswith("Choose ") for label in labels)  # must inspect first
+        assert ledger.cursor_id == block.uid  # still mid-shift
+
+        # Candidate 2 (Tomas) -> pass, completing the shift.
+        self._choose(ledger, "Inspect passport")
+        self._choose(ledger, "Choose pass")
 
         assert ledger.cursor_id == victory.uid
-        content = " ".join(getattr(fragment, "content", "") for fragment in ledger.get_journal())
-        assert "choose to deny" in content.lower()
+        content = " ".join(getattr(f, "content", "") for f in ledger.get_journal())
+        assert "shift complete" in content.lower()
 
     def test_context_exports_discovered_findings(self) -> None:
         graph = Graph(label="credential_context")
         block = graph.add_node(kind=CredentialsBlock, label="checkpoint")
+        block.game.roster = _two_case_roster()
         block.game_handler.setup(block.game)
         block.game_handler.receive_move(block.game, ("inspect", "passport"))
 
@@ -138,3 +272,4 @@ class TestCredentialsIntegration:
         assert namespace["credential_num_findings"] == 1
         assert "passport" in namespace["credential_discovered_findings"]
         assert namespace["credential_stage"] == "packet"
+        assert namespace["credential_roster_size"] == 2

--- a/engine/tests/mechanics/games/test_credentials_roster.py
+++ b/engine/tests/mechanics/games/test_credentials_roster.py
@@ -1,0 +1,149 @@
+"""Tests for roster sampling and lazy offer materialization (Phase A.3)."""
+
+from __future__ import annotations
+
+import random
+
+from tangl.mechanics.games import (
+    CredentialCase,
+    CredentialDisposition,
+    CredentialStatus,
+    CredentialToken,
+    CredentialsGame,
+    CredentialsGameHandler,
+    FailureMode,
+    Indication,
+    Region,
+    Restrictions,
+    RestrictionLevel,
+    ScenarioOffer,
+    ShiftSpec,
+    derive_disposition,
+    generate_roster,
+    materialize,
+)
+
+D = CredentialDisposition
+I = Indication
+L = RestrictionLevel
+
+RULES = Restrictions.from_map(
+    {
+        Region.LOCAL: {I.TRAVEL: L.WITH_ID, I.WORK: L.WITH_PERMIT, I.WEAPON: L.WITH_PERMIT},
+        Region.FOREIGN_WEST: {I.TRAVEL: L.WITH_PERMIT, I.WORK: L.FORBIDDEN, I.WEAPON: L.FORBIDDEN},
+    }
+)
+
+
+def _spec(**overrides) -> ShiftSpec:
+    base = dict(rules=RULES, encounters=6, seed=42)
+    base.update(overrides)
+    return ShiftSpec(**base)
+
+
+class TestGenerateRoster:
+    def test_roster_has_requested_size(self) -> None:
+        assert len(generate_roster(_spec(encounters=6))) == 6
+
+    def test_pinned_offers_are_included(self) -> None:
+        pin = ScenarioOffer(candidate_name="John Smith", target_disposition=D.PASS)
+        roster = generate_roster(_spec(encounters=5, pinned=[pin]))
+        assert len(roster) == 5
+        assert any(o.candidate_name == "John Smith" for o in roster)
+
+    def test_origin_distribution_is_honored(self) -> None:
+        roster = generate_roster(_spec(origin_distribution={Region.FOREIGN_WEST: 1.0}))
+        assert all(offer.region is Region.FOREIGN_WEST for offer in roster)
+
+    def test_disposition_distribution_is_honored(self) -> None:
+        roster = generate_roster(_spec(disposition_distribution={D.ARREST: 1.0}))
+        assert all(offer.target_disposition is D.ARREST for offer in roster)
+
+    def test_seed_is_reproducible(self) -> None:
+        a = generate_roster(_spec(seed=7))
+        b = generate_roster(_spec(seed=7))
+        assert [o.model_dump() for o in a] == [o.model_dump() for o in b]
+
+
+class TestLinchpinInvariant:
+    """Every materialized offer derives to the disposition it was generated for."""
+
+    def test_mixed_distribution_round_trips(self) -> None:
+        spec = _spec(
+            encounters=30,
+            origin_distribution={Region.LOCAL: 0.6, Region.FOREIGN_WEST: 0.4},
+            disposition_distribution={D.PASS: 0.4, D.DENY: 0.3, D.ARREST: 0.3},
+            seed=99,
+        )
+        for offer in generate_roster(spec):
+            case = materialize(offer, RULES)
+            assert derive_disposition(case, RULES) is offer.target_disposition
+
+
+class TestMaterialize:
+    def test_is_deterministic(self) -> None:
+        offer = generate_roster(_spec(disposition_distribution={D.DENY: 1.0}))[0]
+        first = materialize(offer, RULES)
+        second = materialize(offer, RULES)
+        assert first.model_dump() == second.model_dump()
+
+    def test_materialized_case_is_inspectable(self) -> None:
+        offer = ScenarioOffer(region=Region.LOCAL, purpose=I.WORK, target_disposition=D.PASS)
+        case = materialize(offer, RULES)
+        # A work candidate presents a passport and a work permit to inspect.
+        assert "passport" in case.presented_documents
+        assert any("permit" in label for label in case.presented_documents)
+
+    def test_pinned_case_materializes_verbatim(self) -> None:
+        authored = CredentialCase(candidate_name="Pinned", purpose=I.TRAVEL)
+        offer = ScenarioOffer(candidate_name="Pinned", pinned_case=authored)
+        assert materialize(offer, RULES) is authored
+
+
+class TestWhitelistedPin:
+    """John Smith: an invalid packet that is waved through by a whitelist override."""
+
+    def test_whitelist_override_beats_derivation(self) -> None:
+        offer = ScenarioOffer(
+            candidate_name="John Smith",
+            region=Region.LOCAL,
+            purpose=I.WORK,
+            target_disposition=D.ARREST,
+            failure_modes=[FailureMode.FORGED_PERMIT],
+            whitelist=True,
+        )
+        case = materialize(offer, RULES)
+        game = CredentialsGame(offers=[offer], restriction_map=RULES)
+        # The packet itself is criminal...
+        assert derive_disposition(case, RULES) is D.ARREST
+        # ...but the whitelist override makes the *expected* call an allow.
+        assert game.expected_disposition(case) is D.PASS
+
+
+class TestGameWalksOffers:
+    def test_lazy_shift_completes_with_correct_calls(self) -> None:
+        # An all-deny shift of work candidates with inspectable permit flaws.
+        spec = _spec(
+            encounters=3,
+            origin_distribution={Region.LOCAL: 1.0},
+            purpose_pool=[I.WORK],
+            disposition_distribution={D.DENY: 1.0},
+            seed=5,
+        )
+        offers = generate_roster(spec)
+        game = CredentialsGame(offers=offers, restriction_map=RULES)
+        handler = CredentialsGameHandler()
+        handler.setup(game)
+
+        assert game.materialized == []  # nothing materialized until arrival
+        assert game._total_cases() == 3
+
+        for _ in range(3):
+            game.active_case  # arrival materializes this candidate
+            inspect = handler.get_available_inspect_targets(game)[0]
+            handler.receive_move(game, ("inspect", inspect))
+            handler.receive_move(game, ("decide", "deny"))
+
+        assert game.shift_complete
+        assert game.result.name == "WIN"
+        assert game.correct_count == 3

--- a/engine/tests/mechanics/games/test_credentials_roster.py
+++ b/engine/tests/mechanics/games/test_credentials_roster.py
@@ -24,13 +24,13 @@ from tangl.mechanics.games import (
 )
 
 D = CredentialDisposition
-I = Indication
+IND = Indication
 L = RestrictionLevel
 
 RULES = Restrictions.from_map(
     {
-        Region.LOCAL: {I.TRAVEL: L.WITH_ID, I.WORK: L.WITH_PERMIT, I.WEAPON: L.WITH_PERMIT},
-        Region.FOREIGN_WEST: {I.TRAVEL: L.WITH_PERMIT, I.WORK: L.FORBIDDEN, I.WEAPON: L.FORBIDDEN},
+        Region.LOCAL: {IND.TRAVEL: L.WITH_ID, IND.WORK: L.WITH_PERMIT, IND.WEAPON: L.WITH_PERMIT},
+        Region.FOREIGN_WEST: {IND.TRAVEL: L.WITH_PERMIT, IND.WORK: L.FORBIDDEN, IND.WEAPON: L.FORBIDDEN},
     }
 )
 
@@ -88,14 +88,14 @@ class TestMaterialize:
         assert first.model_dump() == second.model_dump()
 
     def test_materialized_case_is_inspectable(self) -> None:
-        offer = ScenarioOffer(region=Region.LOCAL, purpose=I.WORK, target_disposition=D.PASS)
+        offer = ScenarioOffer(region=Region.LOCAL, purpose=IND.WORK, target_disposition=D.PASS)
         case = materialize(offer, RULES)
         # A work candidate presents a passport and a work permit to inspect.
         assert "passport" in case.presented_documents
         assert any("permit" in label for label in case.presented_documents)
 
     def test_pinned_case_materializes_verbatim(self) -> None:
-        authored = CredentialCase(candidate_name="Pinned", purpose=I.TRAVEL)
+        authored = CredentialCase(candidate_name="Pinned", purpose=IND.TRAVEL)
         offer = ScenarioOffer(candidate_name="Pinned", pinned_case=authored)
         assert materialize(offer, RULES) is authored
 
@@ -107,7 +107,7 @@ class TestWhitelistedPin:
         offer = ScenarioOffer(
             candidate_name="John Smith",
             region=Region.LOCAL,
-            purpose=I.WORK,
+            purpose=IND.WORK,
             target_disposition=D.ARREST,
             failure_modes=[FailureMode.FORGED_PERMIT],
             whitelist=True,
@@ -126,7 +126,7 @@ class TestGameWalksOffers:
         spec = _spec(
             encounters=3,
             origin_distribution={Region.LOCAL: 1.0},
-            purpose_pool=[I.WORK],
+            purpose_pool=[IND.WORK],
             disposition_distribution={D.DENY: 1.0},
             seed=5,
         )
@@ -139,7 +139,7 @@ class TestGameWalksOffers:
         assert game._total_cases() == 3
 
         for _ in range(3):
-            game.active_case  # arrival materializes this candidate
+            _ = game.active_case  # arrival materializes this candidate
             inspect = handler.get_available_inspect_targets(game)[0]
             handler.receive_move(game, ("inspect", inspect))
             handler.receive_move(game, ("decide", "deny"))
@@ -147,3 +147,7 @@ class TestGameWalksOffers:
         assert game.shift_complete
         assert game.result.name == "WIN"
         assert game.correct_count == 3
+
+        # The shift summary counts the offers (3), not the default roster (2).
+        summary = " ".join(f.content for f in handler.get_journal_fragments(game))
+        assert "of 3" in summary

--- a/worlds/credential_gate/credential_gate/domain.py
+++ b/worlds/credential_gate/credential_gate/domain.py
@@ -5,71 +5,124 @@ from uuid import UUID
 from pydantic import Field
 
 from tangl.mechanics.games import HasGame
+from tangl.mechanics.games.credentials_enums import (
+    CredentialStatus,
+    CredentialToken,
+    Indication,
+    Region,
+    Restrictions,
+    RestrictionLevel,
+)
 from tangl.mechanics.games.credentials_game import (
     CredentialCase,
-    CredentialDisposition,
     CredentialsGame,
     CredentialsGameHandler,
 )
 from tangl.story import Block
 
 
-def _gate_roster() -> list[CredentialCase]:
-    """A three-candidate shift spanning each disposition.
+# The day's rules for this checkpoint. Travel needs a valid id; work needs a
+# permit (which also needs id). The candidates' dispositions are *derived* from
+# these rules and each packet's structured truth -- not authored.
+GATE_RULES = {
+    Region.LOCAL: {
+        Indication.TRAVEL: RestrictionLevel.WITH_ID,
+        Indication.WORK: RestrictionLevel.WITH_PERMIT,
+        Indication.EMIGRATE: RestrictionLevel.WITH_PERMIT,
+        Indication.WEAPON: RestrictionLevel.WITH_PERMIT,
+        Indication.DRUGS: RestrictionLevel.FORBIDDEN,
+        Indication.SECRETS: RestrictionLevel.FORBIDDEN,
+    },
+}
 
-    One clean traveler (pass), one whose seal is wrong (deny), and one whose
-    packet is fabricated (arrest). The correct answers are authored per case;
-    Phase A will later derive them from a restriction map.
+
+def _gate_roster() -> list[CredentialCase]:
+    """Three candidates whose dispositions derive to pass / deny / arrest.
+
+    The narrative strings drive the inspect loop; the structured truth (region,
+    purpose, id_card, packet) is what ``derive_disposition`` reads against
+    ``GATE_RULES``.
     """
 
     return [
+        # Tomas: travelling with a valid id -> derives PASS.
         CredentialCase(
             candidate_name="Tomas Vey",
             presented_documents={
                 "passport": "A crisp passport, its seal sharp and current.",
-                "travel permit": "A permit stamped for this very week.",
             },
             hidden_facts={},
             packet_hidden_facts={},
-            correct_disposition=CredentialDisposition.PASS,
+            region=Region.LOCAL,
+            purpose=Indication.TRAVEL,
+            id_card=CredentialToken(
+                indication=Indication.TRAVEL, status=CredentialStatus.VALID
+            ),
         ),
+        # Edda: here to work, valid id, but the work permit's seal is missing
+        # (a mitigatable infraction) -> derives DENY.
         CredentialCase(
             candidate_name="Edda Marrow",
             presented_documents={
-                "passport": "A worn passport with a blurred seal.",
-                "travel permit": "A permit stamped for this week.",
+                "passport": "A worn passport with a current seal.",
+                "work permit": "A work permit -- but where is the issuing seal?",
                 "baggage": "A lacquered case with a stubborn clasp.",
             },
             hidden_facts={
-                "passport": "The seal impression is wrong for this border.",
+                "work permit": "The work permit was never sealed by the issuer.",
             },
             packet_hidden_facts={
-                "packet consistency": "The documents do not satisfy this checkpoint's rules.",
+                "packet consistency": "An unsealed permit does not satisfy the work rule.",
             },
-            correct_disposition=CredentialDisposition.DENY,
+            region=Region.LOCAL,
+            purpose=Indication.WORK,
+            id_card=CredentialToken(
+                indication=Indication.WORK, status=CredentialStatus.VALID
+            ),
+            packet=[
+                CredentialToken(
+                    indication=Indication.WORK,
+                    status=CredentialStatus.MISSING_SEAL,
+                    requires_id=True,
+                ),
+            ],
         ),
+        # Goran: here to work with a forged work permit -> derives ARREST.
         CredentialCase(
             candidate_name="Goran Siv",
             presented_documents={
                 "passport": "A passport whose photograph sits oddly on the page.",
-                "travel permit": "A permit from an issuing office that closed years ago.",
+                "work permit": "A work permit with an over-bright, wrong-toned seal.",
             },
             hidden_facts={
-                "passport": "The lamination has been lifted and re-set; the photo is swapped.",
-                "travel permit": "The issuing seal belongs to a defunct authority -- a forgery.",
+                "work permit": "The seal is a forgery -- the impression is fake.",
             },
             packet_hidden_facts={
-                "packet consistency": "Two forged documents in one packet: this is fabricated.",
+                "packet consistency": "A forged permit is fabrication, not a clerical slip.",
             },
-            correct_disposition=CredentialDisposition.ARREST,
+            region=Region.LOCAL,
+            purpose=Indication.WORK,
+            id_card=CredentialToken(
+                indication=Indication.WORK, status=CredentialStatus.VALID
+            ),
+            packet=[
+                CredentialToken(
+                    indication=Indication.WORK,
+                    status=CredentialStatus.FORGED,
+                    requires_id=True,
+                ),
+            ],
         ),
     ]
 
 
 class GateCredentialsGame(CredentialsGame):
-    """Authored checkpoint shift for the demo world."""
+    """Authored checkpoint shift for the demo world (dispositions derived)."""
 
     roster: list[CredentialCase] = Field(default_factory=_gate_roster)
+    restriction_map: Restrictions = Field(
+        default_factory=lambda: Restrictions.from_map(GATE_RULES)
+    )
 
 
 class CredentialGateBlock(HasGame, Block):

--- a/worlds/credential_gate/credential_gate/domain.py
+++ b/worlds/credential_gate/credential_gate/domain.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from uuid import UUID
 
+from pydantic import Field
+
 from tangl.mechanics.games import HasGame
 from tangl.mechanics.games.credentials_game import (
+    CredentialCase,
     CredentialDisposition,
     CredentialsGame,
     CredentialsGameHandler,
@@ -11,14 +14,66 @@ from tangl.mechanics.games.credentials_game import (
 from tangl.story import Block
 
 
-class GateCredentialsGame(CredentialsGame):
-    """Deterministic credentials setup for the demo world."""
+def _gate_roster() -> list[CredentialCase]:
+    """A three-candidate shift spanning each disposition.
 
-    correct_disposition: CredentialDisposition = CredentialDisposition.DENY
+    One clean traveler (pass), one whose seal is wrong (deny), and one whose
+    packet is fabricated (arrest). The correct answers are authored per case;
+    Phase A will later derive them from a restriction map.
+    """
+
+    return [
+        CredentialCase(
+            candidate_name="Tomas Vey",
+            presented_documents={
+                "passport": "A crisp passport, its seal sharp and current.",
+                "travel permit": "A permit stamped for this very week.",
+            },
+            hidden_facts={},
+            packet_hidden_facts={},
+            correct_disposition=CredentialDisposition.PASS,
+        ),
+        CredentialCase(
+            candidate_name="Edda Marrow",
+            presented_documents={
+                "passport": "A worn passport with a blurred seal.",
+                "travel permit": "A permit stamped for this week.",
+                "baggage": "A lacquered case with a stubborn clasp.",
+            },
+            hidden_facts={
+                "passport": "The seal impression is wrong for this border.",
+            },
+            packet_hidden_facts={
+                "packet consistency": "The documents do not satisfy this checkpoint's rules.",
+            },
+            correct_disposition=CredentialDisposition.DENY,
+        ),
+        CredentialCase(
+            candidate_name="Goran Siv",
+            presented_documents={
+                "passport": "A passport whose photograph sits oddly on the page.",
+                "travel permit": "A permit from an issuing office that closed years ago.",
+            },
+            hidden_facts={
+                "passport": "The lamination has been lifted and re-set; the photo is swapped.",
+                "travel permit": "The issuing seal belongs to a defunct authority -- a forgery.",
+            },
+            packet_hidden_facts={
+                "packet consistency": "Two forged documents in one packet: this is fabricated.",
+            },
+            correct_disposition=CredentialDisposition.ARREST,
+        ),
+    ]
+
+
+class GateCredentialsGame(CredentialsGame):
+    """Authored checkpoint shift for the demo world."""
+
+    roster: list[CredentialCase] = Field(default_factory=_gate_roster)
 
 
 class CredentialGateBlock(HasGame, Block):
-    """Story block hosting the staged credentials proof."""
+    """Story block hosting the staged credential shift."""
 
     _game_class = GateCredentialsGame
     _game_handler_class = CredentialsGameHandler

--- a/worlds/credential_gate/script.yaml
+++ b/worlds/credential_gate/script.yaml
@@ -2,17 +2,21 @@ label: credential_gate
 
 metadata:
   title: "Credential Gate"
-  description: "Inspect a traveler, review the packet, and choose a disposition."
+  description: "Work a checkpoint shift: inspect each traveler's packet and rule on a disposition."
   start_at: gate.entrance
 
+# One re-entrant HasGame block walks the whole roster: each disposition keeps the
+# game READY and re-provisions moves for the next traveler, so no per-candidate
+# story edges are needed. The game only reports terminal once the final candidate
+# is ruled on, at which point the game_won / game_lost exits route to the summary.
 scenes:
   gate:
     title: "Credential Gate"
     blocks:
       entrance:
         content: |
-          The checkpoint shutters rattle in the wind while the next traveler
-          sets a thin packet on the counter.
+          The checkpoint shutters rattle in the wind. A line of travelers waits,
+          packets in hand, while the first sets a thin sheaf on the counter.
         actions:
           - text: "Open the gate ledger"
             successor: challenge
@@ -20,8 +24,8 @@ scenes:
       challenge:
         kind: "credential_gate.domain.CredentialGateBlock"
         content: |
-          The packet looks almost correct at first glance, which is exactly what
-          makes it worth a closer review.
+          Each packet looks almost correct at first glance, which is exactly what
+          makes the line worth a closer review. Work them one at a time.
         continues:
           - successor: victory
             trigger: last
@@ -32,14 +36,10 @@ scenes:
 
       victory:
         content: |
-          The ruling lands cleanly, and the gate line lurches forward around it.
-        actions:
-          - text: "Reset the desk"
-            successor: entrance
+          The last traveler clears the counter. Every call held up, and the line
+          moves on behind you without complaint.
 
       defeat:
         content: |
-          The desk feels suddenly smaller when the wrong call reaches it.
-        actions:
-          - text: "Try again"
-            successor: entrance
+          The shift ends short. At least one ruling was wrong, and the desk feels
+          smaller for it when the tally is read back.

--- a/worlds/credential_gate/world.yaml
+++ b/worlds/credential_gate/world.yaml
@@ -3,4 +3,4 @@ scripts: script.yaml
 domain_module: credential_gate.domain
 metadata:
   title: "Credential Gate"
-  description: "A staged checkpoint proof for the credentials loop."
+  description: "A checkpoint shift: inspect a roster of travelers and rule on each disposition."


### PR DESCRIPTION
## Summary

Expands the credentials mechanic from a thin point-at-the-flaw demo into a full
candidate-evaluation system, delivered as the multi-phase plan's **Phase 1**:
the candidate-roster shift (v1) plus **Phase A** (rules-derived dispositions +
procedural candidate generation).

- **v1 — candidate-roster shift.** `CredentialsGame` now hosts a roster walked
  by one re-entrant `HasGame` block: inspect each traveler, choose a disposition
  (pass/deny/arrest), and the shift ends only after the last candidate, routing
  to a summary. `CredentialCase` is the per-candidate source of truth;
  `CredentialCaseResult` records each ruling. (Also renamed the picking kernel's
  `terminal_decision` → `committed_decision`, since it's per-commit, not
  game-terminal.)
- **A.1 — rules-derived dispositions.** `derive_disposition(case, rules)` reads a
  candidate only through a small **discovery API**, so the packet stays opaque to
  the loop. Vocabulary (`Region`/`Indication`/`RestrictionLevel`/
  `CredentialStatus`) + a flat, JSON-safe `Restrictions` model. `credential_gate`
  now derives all three dispositions instead of hard-coding them.
- **A.2 — candidate factory.** `build_valid` then `degrade` (start-correct-then-
  degrade) over an explicit `FailureMode` catalog (mitigatable → deny, crime →
  arrest), with the round-trip invariant tested.
- **A.3 — day-spec sampling + lazy offer roster.** `ShiftSpec` (origin +
  disposition-class distributions, encounters, pinned), `generate_roster`
  (two-stage sampling that verifies a reachable failure mode per offer), and
  `ScenarioOffer`s materialized into packets **only on arrival**. Pinned
  whitelisted encounters (the "John Smith" case) supported.

Full design and the remaining-phase plan live in
`engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md`.

The engine stays theme-neutral (rules + permit catalog are data); see the doc's
"one engine, many skins" note and the Steam-Automata Chop Shop reskin.

## What's left

Tracked in #246 — Phases B (mediation moves), C (context + bribe/threat),
D (media), plus the `credential_gate` standard-vs-sampled menu demo and a few
deferred A-extras.

## Test plan

- [x] `engine/tests/mechanics/games` + `engine/tests/loaders`: 282 passed, 6 skipped
- [x] New: `test_credentials_derive.py`, `test_credentials_factory.py`,
      `test_credentials_roster.py` (incl. the round-trip and linchpin invariants)
- [x] Existing `test_credentials_game.py` + `test_credential_gate_world.py` updated and passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented a multi-candidate checkpoint shift where players inspect travelers' credentials one at a time and rule on each disposition sequentially.
  * Added rule-based disposition logic that evaluates credentials against restriction rules.
  * Included configurable pass threshold for shift outcomes.

* **Documentation**
  * Expanded credentials game design documentation with comprehensive implementation phases and architecture details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/derekmerck/storytangl/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->