### PR TITLE
credential_gate: scheduled/randomized menu (Phase A.3 demo)

### DIFF
--- a/engine/tests/loaders/test_credential_gate_world.py
+++ b/engine/tests/loaders/test_credential_gate_world.py
@@ -24,6 +24,17 @@ def _actions(ledger: Ledger) -> list[Action]:
     return list(ledger.cursor.edges_out(Selector(has_kind=Action, trigger_phase=None)))
 
 
+def _choose(ledger: Ledger, label: str) -> None:
+    # Story-authored actions surface their display string as ``text``;
+    # game-provisioned actions surface it as ``label`` (from get_move_label).
+    action = next(
+        a
+        for a in _actions(ledger)
+        if a.label == label or getattr(a, "text", None) == label
+    )
+    ledger.resolve_choice(action.uid, choice_payload=action.payload)
+
+
 class TestCredentialGateWorld:
     """Tests for the staged credentials demo world."""
 
@@ -35,7 +46,7 @@ class TestCredentialGateWorld:
         assert bundle.manifest.label == "credential_gate"
         assert bundle.manifest.metadata["title"] == "Credential Gate"
 
-    def test_credential_gate_compiles_and_routes_to_victory(self) -> None:
+    def test_scheduled_shift_routes_to_victory(self) -> None:
         bundle = WorldBundle.load(_credential_gate_root())
         world = WorldCompiler().compile(bundle)
 
@@ -45,26 +56,55 @@ class TestCredentialGateWorld:
         ledger = Ledger.from_graph(result.graph, entry_id=result.graph.initial_cursor_id)
 
         assert ledger.cursor.label == "entrance"
-
-        ledger.resolve_choice(_actions(ledger)[0].uid)
-        assert ledger.cursor.label == "challenge"
-
-        def choose(label: str) -> None:
-            action = next(a for a in _actions(ledger) if a.label == label)
-            ledger.resolve_choice(action.uid, choice_payload=action.payload)
+        _choose(ledger, "Work the scheduled shift")
+        assert ledger.cursor.label == "standard_challenge"
 
         # The authored roster: Tomas (pass), Edda (deny), Goran (arrest).
-        choose("Inspect passport")
-        choose("Choose pass")
-        assert ledger.cursor.label == "challenge"  # still mid-shift
+        _choose(ledger, "Inspect passport")
+        _choose(ledger, "Choose pass")
+        assert ledger.cursor.label == "standard_challenge"  # still mid-shift
 
-        choose("Inspect passport")
-        choose("Choose deny")
-        assert ledger.cursor.label == "challenge"
+        _choose(ledger, "Inspect passport")
+        _choose(ledger, "Choose deny")
+        assert ledger.cursor.label == "standard_challenge"
 
-        choose("Inspect passport")
-        choose("Choose arrest")
+        _choose(ledger, "Inspect passport")
+        _choose(ledger, "Choose arrest")
 
         assert ledger.cursor.label == "victory"
         content = " ".join(getattr(fragment, "content", "") for fragment in ledger.get_journal())
         assert "shift complete" in content.lower()
+
+    def test_randomized_shift_materializes_lazily_and_routes_to_victory(self) -> None:
+        """The sampled path materializes each candidate on arrival and, played
+        correctly, routes to the same victory ending."""
+
+        bundle = WorldBundle.load(_credential_gate_root())
+        world = WorldCompiler().compile(bundle)
+
+        assert "SampledGateBlock" in world.class_registry
+
+        result = world.create_story("credential_gate_demo", init_mode=InitMode.EAGER)
+        ledger = Ledger.from_graph(result.graph, entry_id=result.graph.initial_cursor_id)
+
+        _choose(ledger, "Work a randomized shift")
+        assert ledger.cursor.label == "sampled_challenge"
+
+        game = ledger.cursor.game
+        total = game._total_cases()
+        assert total > 1
+        # Lazy: only the active arrival has materialized; the rest still pending.
+        assert len(game.materialized) == 1
+
+        for _ in range(total):
+            target = game.expected_disposition(game.active_case).value
+            inspect = next(
+                a for a in _actions(ledger) if a.label.startswith(("Inspect", "Review"))
+            )
+            ledger.resolve_choice(inspect.uid, choice_payload=inspect.payload)
+            _choose(ledger, f"Choose {target}")
+
+        assert ledger.cursor.label == "victory"
+        content = " ".join(getattr(fragment, "content", "") for fragment in ledger.get_journal())
+        assert "shift complete" in content.lower()
+        assert f"of {total}" in content

--- a/engine/tests/loaders/test_credential_gate_world.py
+++ b/engine/tests/loaders/test_credential_gate_world.py
@@ -25,12 +25,12 @@ def _actions(ledger: Ledger) -> list[Action]:
 
 
 def _choose(ledger: Ledger, label: str) -> None:
-    # Story-authored actions surface their display string as ``text``;
-    # game-provisioned actions surface it as ``label`` (from get_move_label).
+    # Story-authored actions surface their display string as ``text`` (a typed
+    # ``str``, defaults to ``""``); game-provisioned actions surface it as
+    # ``label`` (from get_move_label). Both fields are declared, so equality
+    # checks are safe even when one side is the unused default.
     action = next(
-        a
-        for a in _actions(ledger)
-        if a.label == label or getattr(a, "text", None) == label
+        a for a in _actions(ledger) if a.label == label or a.text == label
     )
     ledger.resolve_choice(action.uid, choice_payload=action.payload)
 
@@ -98,8 +98,13 @@ class TestCredentialGateWorld:
 
         for _ in range(total):
             target = game.expected_disposition(game.active_case).value
+            # Action.label is Optional[str] (story-authored actions can have
+            # label=None and surface their text via .text instead); guard the
+            # None case before .startswith.
             inspect = next(
-                a for a in _actions(ledger) if a.label.startswith(("Inspect", "Review"))
+                a
+                for a in _actions(ledger)
+                if a.label and a.label.startswith(("Inspect", "Review"))
             )
             ledger.resolve_choice(inspect.uid, choice_payload=inspect.payload)
             _choose(ledger, f"Choose {target}")

--- a/worlds/credential_gate/credential_gate/domain.py
+++ b/worlds/credential_gate/credential_gate/domain.py
@@ -15,8 +15,14 @@ from tangl.mechanics.games.credentials_enums import (
 )
 from tangl.mechanics.games.credentials_game import (
     CredentialCase,
+    CredentialDisposition,
     CredentialsGame,
     CredentialsGameHandler,
+)
+from tangl.mechanics.games.credentials_roster import (
+    ScenarioOffer,
+    ShiftSpec,
+    generate_roster,
 )
 from tangl.story import Block
 
@@ -132,4 +138,51 @@ class CredentialGateBlock(HasGame, Block):
     _game_handler_class = CredentialsGameHandler
 
 
+# --- Sampled (procedurally generated) variant ---------------------------------
+
+
+def _sampled_offers() -> list[ScenarioOffer]:
+    """A deterministic, demo-sized procedural shift drawn from a ShiftSpec.
+
+    Fixed seed so the demo plays the same line each time. Purpose pool is
+    limited to travel/work so every candidate has an inspectable passport (and
+    sometimes a work permit), keeping the inspect surface usable end-to-end.
+    """
+
+    spec = ShiftSpec(
+        rules=Restrictions.from_map(GATE_RULES),
+        encounters=4,
+        origin_distribution={Region.LOCAL: 1.0},
+        disposition_distribution={
+            CredentialDisposition.PASS: 0.5,
+            CredentialDisposition.DENY: 0.25,
+            CredentialDisposition.ARREST: 0.25,
+        },
+        purpose_pool=(Indication.TRAVEL, Indication.WORK),
+        seed=20260522,
+    )
+    return generate_roster(spec)
+
+
+class SampledGateGame(CredentialsGame):
+    """A procedurally sampled shift drawn from a fixed ShiftSpec.
+
+    Candidates are not authored: they are sampled offers whose packets are
+    materialized lazily as each traveler reaches the counter (Phase A.3).
+    """
+
+    offers: list[ScenarioOffer] = Field(default_factory=_sampled_offers)
+    restriction_map: Restrictions = Field(
+        default_factory=lambda: Restrictions.from_map(GATE_RULES)
+    )
+
+
+class SampledGateBlock(HasGame, Block):
+    """Story block hosting the procedurally sampled shift."""
+
+    _game_class = SampledGateGame
+    _game_handler_class = CredentialsGameHandler
+
+
 CredentialGateBlock.model_rebuild(_types_namespace={"UUID": UUID})
+SampledGateBlock.model_rebuild(_types_namespace={"UUID": UUID})

--- a/worlds/credential_gate/script.yaml
+++ b/worlds/credential_gate/script.yaml
@@ -5,27 +5,43 @@ metadata:
   description: "Work a checkpoint shift: inspect each traveler's packet and rule on a disposition."
   start_at: gate.entrance
 
-# One re-entrant HasGame block walks the whole roster: each disposition keeps the
-# game READY and re-provisions moves for the next traveler, so no per-candidate
-# story edges are needed. The game only reports terminal once the final candidate
-# is ruled on, at which point the game_won / game_lost exits route to the summary.
+# Two ways to work the gate today: a hand-authored line (CredentialGateBlock,
+# Phase A.1's authored cases) or a randomized line (SampledGateBlock, Phase A.3's
+# offers generator). Both block kinds are one re-entrant HasGame block that
+# walks its roster until terminal, so each disposition stays on the block until
+# the game's POSTREQS game_won / game_lost exits route to the shared summary.
 scenes:
   gate:
     title: "Credential Gate"
     blocks:
       entrance:
         content: |
-          The checkpoint shutters rattle in the wind. A line of travelers waits,
-          packets in hand, while the first sets a thin sheaf on the counter.
+          The checkpoint shutters rattle in the wind. You can work today's
+          scheduled line of known travelers, or take a randomized shift drawn
+          from the day's quota.
         actions:
-          - text: "Open the gate ledger"
-            successor: challenge
+          - text: "Work the scheduled shift"
+            successor: standard_challenge
+          - text: "Work a randomized shift"
+            successor: sampled_challenge
 
-      challenge:
+      standard_challenge:
         kind: "credential_gate.domain.CredentialGateBlock"
         content: |
-          Each packet looks almost correct at first glance, which is exactly what
-          makes the line worth a closer review. Work them one at a time.
+          A short, hand-picked line: three travelers, each almost in order.
+        continues:
+          - successor: victory
+            trigger: last
+            predicate: game_won
+          - successor: defeat
+            trigger: last
+            predicate: game_lost
+
+      sampled_challenge:
+        kind: "credential_gate.domain.SampledGateBlock"
+        content: |
+          A randomized line drawn from today's quota; you won't know each
+          traveler's mix until they reach the counter.
         continues:
           - successor: victory
             trigger: last
@@ -36,10 +52,10 @@ scenes:
 
       victory:
         content: |
-          The last traveler clears the counter. Every call held up, and the line
-          moves on behind you without complaint.
+          The last traveler clears the counter. Every call held up, and the
+          line moves on behind you without complaint.
 
       defeat:
         content: |
-          The shift ends short. At least one ruling was wrong, and the desk feels
-          smaller for it when the tally is read back.
+          The shift ends short. At least one ruling was wrong, and the desk
+          feels smaller for it when the tally is read back.


### PR DESCRIPTION
## Summary

Demo wiring from #246: the `credential_gate` entrance now offers two ways to work the gate, exercising both the authored and procedural credentials paths in one world.

- **"Work the scheduled shift"** → `CredentialGateBlock` (Phase A.1's hand-picked Tomas/Edda/Goran on derived dispositions).
- **"Work a randomized shift"** → new `SampledGateBlock` whose offers are generated from a fixed-seed `ShiftSpec` (Phase A.3). Candidates materialize lazily as each traveler reaches the counter; both block kinds share the same victory/defeat endings.

Tiny incidental: the world-test choice helper now matches actions by either `.label` (game-provisioned moves) or `.text` (story-authored choices), so one helper drives both menu picks and game moves.

## Test plan

- [x] `engine/tests/loaders/test_credential_gate_world.py` — the existing scheduled-path walk plus a new sampled-path walk that:
  - asserts lazy materialization (only the active arrival has materialized after entering the block),
  - drives each round by querying `game.expected_disposition(active_case)` (i.e. plays correctly),
  - asserts routing to `victory` and a "shift complete... of N" summary that reflects the offers count.
- [x] Full `engine/tests/mechanics/games` + `engine/tests/loaders` suite: 184 passed, 4 skipped locally.
- [ ] CI green.

Refs #246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The credential gate entrance now offers two distinct paths: a scheduled (standard) shift and a randomized (sampled) shift, each following its own challenge flow and endings.

* **Tests**
  * Added and refactored tests to cover both scheduled and randomized shift flows, verifying successful victory outcomes and expected journal messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/derekmerck/storytangl/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->