### PR TITLE
Adventure sandbox treasure, magic word, and movement hazard slice

### DIFF
--- a/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
+++ b/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
@@ -987,12 +987,15 @@ The point is not that the schema is final. The point is to keep an executable
 pressure fixture while negotiating which schema choices are authoring sugar,
 which are generic sandbox traits, and which require world-specific authorities.
 
-One small Adventure-flavored follow-up worth preserving is magic-word
-teleportation, such as `XYZZY`. It is charming, but architecturally it should be
-just another sponsored interaction or parser-facing choice: a scoped/world
-authority recognizes the word, projects the teleport affordance when appropriate,
-and resolves it through ordinary traversal/effects rather than giving parser
-input special semantic power.
+The demo world now also carries a small Adventure authority slice over the
+generic sandbox surface: a treasure asset can be deposited at a location marked
+as a deposit site, location-authored magic-word anchors project `Say XYZZY` as
+ordinary actions, and a first movement hazard rewrites an `up` movement into a
+self-looping blocked climb while the player carries the gold nugget. These are
+intentionally domain-owned policies over normal actions, assets, and journal
+fragments. A later compact-IR compiler can lower `magic_words`, treasure
+scoring, and `movement_hazards` sections into the same surfaces once the schema
+is stable.
 
 `SandboxSliceCompiler` is the current mechanics-level compiler boundary for
 that pressure fixture. It mirrors the broader compiler split in miniature:

--- a/engine/src/tangl/mechanics/sandbox/compiler.py
+++ b/engine/src/tangl/mechanics/sandbox/compiler.py
@@ -52,6 +52,8 @@ class SandboxCompiledAssetType(AssetType):
     turn_off_text: str | None = None
     take_text: str | None = None
     drop_text: str | None = None
+    treasure_score: int = 0
+    treasure_loss_penalty: int = 0
     interactions: list[SandboxInteraction] = Field(default_factory=list)
     scheduled_events: list[ScheduledEvent] = Field(default_factory=list)
 

--- a/engine/tests/loaders/test_adventure_sandbox_world.py
+++ b/engine/tests/loaders/test_adventure_sandbox_world.py
@@ -9,6 +9,8 @@ from tangl.journal.fragments import ContentFragment
 from tangl.loaders import WorldBundle
 from tangl.loaders.compiler import WorldCompiler
 from tangl.mechanics.sandbox import SandboxLocation
+from tangl.service.response import KvListValue
+from tangl.service.story_info import resolve_story_info_projector
 from tangl.service.world_registry import WorldRegistry
 from tangl.story import Action, InitMode
 from tangl.vm import Ledger
@@ -91,7 +93,25 @@ class TestAdventureSandboxWorld:
 
         assert ledger.cursor.label == "cobble_crawl"
 
+        _choose(ledger, contribution="take", asset="gold_nugget")
         _choose(ledger, contribution="mob", mob="wounded_pirate", action="help")
+        _choose(ledger, contribution="magic_word", word="XYZZY")
+
+        assert ledger.cursor.label == "building"
+
+        _choose(ledger, contribution="deposit_treasure", asset="gold_nugget")
+
+        projected = resolve_story_info_projector(ledger).project(ledger=ledger)
+        score_section = next(
+            section
+            for section in projected.sections
+            if section.section_id == "adventure_score"
+        )
+        assert isinstance(score_section.value, KvListValue)
+        assert [(row.key, row.value) for row in score_section.value.items] == [
+            ("Score", 10),
+            ("Deposited", 1),
+        ]
 
         content = [
             fragment.content
@@ -101,3 +121,58 @@ class TestAdventureSandboxWorld:
         assert "The key turns with a click. The grate unlocks." in content
         assert "A wounded pirate leans against the wall, watching you." in content
         assert "The pirate eyes you suspiciously, but accepts your help." in content
+        assert "A hollow voice says \"Plugh.\" You are back in the well house." in content
+        assert (
+            "The gold nugget is safely deposited in the well house. "
+            "Your score has increased."
+        ) in content
+
+    def test_adventure_movement_hazard_blocks_heavy_nugget_climb(self) -> None:
+        bundle = WorldBundle.load(_adventure_root())
+        world = WorldCompiler().compile(bundle)
+        result = world.create_story("adventure_sandbox_slice", init_mode=InitMode.EAGER)
+        ledger = Ledger.from_graph(result.graph, entry_id=result.graph.initial_cursor_id)
+
+        enter = next(
+            edge
+            for edge in ledger.cursor.edges_out()
+            if isinstance(edge, Action)
+            and edge.text == "Stand at the end of the road"
+        )
+        ledger.resolve_choice(enter.uid)
+
+        _choose(ledger, contribution="movement", direction="east")
+        _choose(ledger, contribution="take", asset="keys")
+        _choose(ledger, contribution="take", asset="brass_lamp")
+        _choose(ledger, contribution="light", asset="brass_lamp", verb="turn_on")
+        _choose(ledger, contribution="movement", direction="west")
+        _choose(ledger, contribution="movement", direction="south")
+        _choose(ledger, contribution="movement", direction="south")
+        _choose(ledger, contribution="movement", direction="south")
+        _choose(ledger, contribution="unlock", target="grate")
+        _choose(ledger, contribution="open", target="grate")
+        _choose(ledger, contribution="movement", direction="down")
+        _choose(ledger, contribution="movement", direction="west")
+        _choose(ledger, contribution="take", asset="gold_nugget")
+        _choose(ledger, contribution="movement", direction="west")
+
+        assert ledger.cursor.label == "hall_of_mists"
+
+        _choose(ledger, contribution="movement_hazard", direction="up")
+
+        assert ledger.cursor.label == "hall_of_mists"
+
+        _choose(ledger, contribution="drop", asset="gold_nugget")
+        _choose(ledger, contribution="movement", direction="up")
+
+        assert ledger.cursor.label == "top_of_small_pit"
+
+        content = [
+            fragment.content
+            for fragment in ledger.get_journal()
+            if isinstance(fragment, ContentFragment)
+        ]
+        assert (
+            "I'm not sure you'll be able to get up it with what you're carrying."
+            in content
+        )

--- a/worlds/adventure_sandbox_slice/adventure_sandbox_slice/domain.py
+++ b/worlds/adventure_sandbox_slice/adventure_sandbox_slice/domain.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from uuid import UUID
 
+from pydantic import BaseModel, Field
+
 from tangl.core import Graph, Priority, Selector, Token
+from tangl.journal.intent import KvRow
 from tangl.mechanics.sandbox import (
     ChargeFacet,
     ContainerFacet,
@@ -18,12 +21,42 @@ from tangl.mechanics.sandbox import (
     SandboxVisibilityRule,
     SwitchableFacet,
 )
-from tangl.vm import on_provision
+from tangl.mechanics.sandbox.handlers import sandbox_player_assets
+from tangl.mechanics.sandbox.story_info import SandboxStoryInfoProjector
+from tangl.service.response import KvListValue, ProjectedSection, ProjectedState
+from tangl.story import Action, StoryGraph
+from tangl.story.concepts.asset import AssetTransactionManager
+from tangl.vm import Ledger, on_gather_ns, on_provision, on_update
 from tangl.vm.ctx import VmPhaseCtx
+
+
+TREASURE_LABEL = "gold_nugget"
+
+
+class AdventureMagicAnchor(BaseModel):
+    """One Adventure-style magic-word hop sponsored by a location."""
+
+    word: str
+    target: str
+    journal_text: str
+    requires_discovery: bool = False
+
+
+class AdventureMovementHazard(BaseModel):
+    """Movement rewrite/block rule selected by Adventure domain state."""
+
+    direction: str
+    carried_asset: str | None = None
+    outcome: str = "block"
+    journal_text: str
 
 
 class AdventureSandboxLocation(SandboxLocation):
     """A demo Adventure-like location using the generic sandbox handlers."""
+
+    treasure_deposit_site: bool = False
+    magic_anchors: list[AdventureMagicAnchor] = Field(default_factory=list)
+    movement_hazards: list[AdventureMovementHazard] = Field(default_factory=list)
 
 
 def _location(graph: Graph, label: str) -> AdventureSandboxLocation:
@@ -40,6 +73,10 @@ def _asset_type(label: str, **values: object) -> SandboxCompiledAssetType:
     return SandboxCompiledAssetType(label=label, **values)
 
 
+def _graph_frozen_shape(graph: Graph) -> bool:
+    return isinstance(graph, StoryGraph) and graph.frozen_shape
+
+
 def _add_asset(
     graph: Graph,
     label: str,
@@ -53,13 +90,219 @@ def _add_asset(
     return asset
 
 
+def _adventure_scope(location: AdventureSandboxLocation) -> SandboxScope:
+    scope = _maybe_adventure_scope(location)
+    if scope is None:
+        raise ValueError("Adventure sandbox location is not under its sandbox scope")
+    return scope
+
+
+def _maybe_adventure_scope(location: AdventureSandboxLocation) -> SandboxScope | None:
+    for candidate in location.ancestors:
+        if isinstance(candidate, SandboxScope):
+            return candidate
+    return None
+
+
+def _adventure_score(location: AdventureSandboxLocation) -> int:
+    scope = _adventure_scope(location)
+    return int(scope.locals.get("adventure_score", 0))
+
+
+def _deposited_treasures(location: AdventureSandboxLocation) -> list[str]:
+    scope = _adventure_scope(location)
+    raw = scope.locals.setdefault("deposited_treasures", [])
+    if not isinstance(raw, list):
+        raise TypeError("deposited_treasures must be a list")
+    return raw
+
+
+def _treasure_deposited(location: AdventureSandboxLocation, label: str) -> bool:
+    return label in _deposited_treasures(location)
+
+
+def _player_has_asset(location: AdventureSandboxLocation, label: str) -> bool:
+    holder = sandbox_player_assets(location)
+    return bool(holder and holder.get_asset(label) is not None)
+
+
+def _clear_adventure_actions(location: AdventureSandboxLocation, ctx: VmPhaseCtx) -> None:
+    for edge in list(location.edges_out(Selector(has_kind=Action))):
+        if {"dynamic", "sandbox", "adventure"}.issubset(edge.tags or set()):
+            location.graph.remove(edge.uid, _ctx=ctx)
+
+
+def _adventure_payload(kind: str, **extra: object) -> dict[str, object]:
+    return {
+        "adventure_action": kind,
+        "sandbox_time_cost": {"kind": "adventure", "duration": 0},
+        **extra,
+    }
+
+
+def _project_adventure_action(
+    location: AdventureSandboxLocation,
+    *,
+    text: str,
+    action: str,
+    target: AdventureSandboxLocation,
+    journal_text: str,
+    **hints: object,
+) -> None:
+    Action(
+        registry=location.graph,
+        label=f"adventure_{action}_{location.get_label()}",
+        predecessor_id=location.uid,
+        successor_id=target.uid,
+        text=text,
+        payload=_adventure_payload(action, **hints),
+        journal_text=journal_text,
+        tags={"dynamic", "sandbox", "adventure", action},
+        ui_hints={
+            "source_kind": "world_authority",
+            "contribution": action,
+            **hints,
+        },
+    )
+
+
+def _asset_score(asset: Token) -> int:
+    score = getattr(asset, "treasure_score", 0)
+    return int(score)
+
+
+def _held_treasures(location: AdventureSandboxLocation) -> list[Token]:
+    holder = sandbox_player_assets(location)
+    if holder is None:
+        return []
+    treasures: list[Token] = []
+    for asset in holder.assets.values():
+        if "treasure" in asset.traits:
+            treasures.append(asset)
+    return treasures
+
+
+def _deposit_treasure(location: AdventureSandboxLocation, label: str) -> None:
+    if _treasure_deposited(location, label):
+        return
+    holder = sandbox_player_assets(location)
+    if holder is None:
+        return
+    asset = holder.get_asset(label)
+    if asset is None:
+        return
+    AssetTransactionManager().give_asset(holder, location, label)
+    scope = _adventure_scope(location)
+    _deposited_treasures(location).append(label)
+    scope.locals["adventure_score"] = _adventure_score(location) + _asset_score(asset)
+
+
+def _magic_word_known(location: AdventureSandboxLocation, word: str) -> bool:
+    scope = _adventure_scope(location)
+    known = scope.locals.setdefault("magic_words_known", [])
+    if not isinstance(known, list):
+        raise TypeError("magic_words_known must be a list")
+    return word.lower() in {str(item).lower() for item in known}
+
+
+def _movement_hazard_applies(
+    location: AdventureSandboxLocation,
+    hazard: AdventureMovementHazard,
+) -> bool:
+    if hazard.carried_asset is None:
+        return True
+    return _player_has_asset(location, hazard.carried_asset)
+
+
+def _rewrite_movement_hazards(
+    location: AdventureSandboxLocation,
+    ctx: VmPhaseCtx,
+) -> None:
+    graph = location.graph
+    if graph is None:
+        return
+    for hazard in location.movement_hazards:
+        if not _movement_hazard_applies(location, hazard):
+            continue
+        for edge in list(location.edges_out(Selector(has_kind=Action))):
+            if not {"dynamic", "sandbox", "movement"}.issubset(edge.tags or set()):
+                continue
+            hints = edge.ui_hints.model_dump()
+            if hints.get("direction") != hazard.direction:
+                continue
+            graph.remove(edge.uid, _ctx=ctx)
+            Action(
+                registry=graph,
+                label=f"adventure_hazard_{location.get_label()}_{hazard.direction}",
+                predecessor_id=location.uid,
+                successor_id=location.uid,
+                text=edge.text,
+                payload=_adventure_payload(
+                    "movement_hazard",
+                    direction=hazard.direction,
+                    outcome=hazard.outcome,
+                ),
+                journal_text=hazard.journal_text,
+                tags={"dynamic", "sandbox", "adventure", "movement", "hazard"},
+                ui_hints={
+                    **hints,
+                    "source_kind": "world_authority",
+                    "contribution": "movement_hazard",
+                    "hazard_outcome": hazard.outcome,
+                },
+            )
+
+
+class AdventureSandboxStoryInfoProjector:
+    """Adventure-specific story-info wrapper over the generic sandbox projector."""
+
+    def __init__(self) -> None:
+        self.sandbox = SandboxStoryInfoProjector()
+
+    def project(self, *, ledger: Ledger) -> ProjectedState:
+        projected = self.sandbox.project(ledger=ledger)
+        cursor = ledger.cursor
+        if not isinstance(cursor, AdventureSandboxLocation):
+            return projected
+        return ProjectedState(
+            sections=[
+                *projected.sections,
+                ProjectedSection(
+                    section_id="adventure_score",
+                    title="Score",
+                    kind="score",
+                    value=KvListValue(
+                        items=[
+                            KvRow(key="Score", value=_adventure_score(cursor), max=350),
+                            KvRow(
+                                key="Deposited",
+                                value=len(_deposited_treasures(cursor)),
+                                unit="treasure",
+                            ),
+                        ]
+                    ),
+                ),
+            ]
+        )
+
+
+def get_story_info_projector() -> AdventureSandboxStoryInfoProjector:
+    """Return the Adventure-specific projected-state adapter."""
+    return AdventureSandboxStoryInfoProjector()
+
+
 def _ensure_adventure_sandbox(graph: Graph) -> None:
     if graph.find_one(Selector.from_identifier("cave")) is not None:
         return
 
     scope = SandboxScope(
         label="cave",
-        locals={"world_turn": 0},
+        locals={
+            "world_turn": 0,
+            "adventure_score": 0,
+            "deposited_treasures": [],
+            "magic_words_known": [],
+        },
         visibility_rules=[
             SandboxVisibilityRule(
                 journal_text=(
@@ -136,6 +379,20 @@ def _ensure_adventure_sandbox(graph: Graph) -> None:
         take_text="Taken.",
         drop_text="Dropped.",
     )
+    _add_asset(
+        graph,
+        TREASURE_LABEL,
+        cobble_crawl,
+        name="gold nugget",
+        kind="treasure",
+        traits={"portable", "treasure"},
+        portable=True,
+        treasure_score=10,
+        treasure_loss_penalty=5,
+        read_text="It is a large sparkling nugget of gold.",
+        take_text="Taken.",
+        drop_text="Dropped.",
+    )
 
     grate = SandboxFixture(
         label="grate",
@@ -192,6 +449,99 @@ def setup_adventure_sandbox(
 
     _ = ctx
     _ensure_adventure_sandbox(caller.graph)
+    return None
+
+
+@on_gather_ns(
+    wants_caller_kind=AdventureSandboxLocation,
+    wants_exact_kind=False,
+)
+def contribute_adventure_score(
+    *,
+    caller: AdventureSandboxLocation,
+    **_kw: object,
+) -> dict[str, int]:
+    """Publish Adventure-specific score facts for journal formatting."""
+    if _maybe_adventure_scope(caller) is None:
+        return {"adventure_score": 0, "adventure_deposited_count": 0}
+    return {
+        "adventure_score": _adventure_score(caller),
+        "adventure_deposited_count": len(_deposited_treasures(caller)),
+    }
+
+
+@on_provision(
+    wants_caller_kind=AdventureSandboxLocation,
+    wants_exact_kind=False,
+    priority=Priority.LAST,
+)
+def project_adventure_world_actions(
+    *,
+    caller: AdventureSandboxLocation,
+    ctx: VmPhaseCtx,
+    **_kw: object,
+) -> None:
+    """Project Adventure-specific charm/rules as ordinary sandbox actions."""
+    if not caller.auto_provision:
+        return None
+    graph = caller.graph
+    if graph is None or _graph_frozen_shape(graph):
+        return None
+
+    _clear_adventure_actions(caller, ctx)
+    _rewrite_movement_hazards(caller, ctx)
+
+    if caller.treasure_deposit_site:
+        for treasure in _held_treasures(caller):
+            treasure_label = treasure.get_label()
+            if _treasure_deposited(caller, treasure_label):
+                continue
+            treasure_name = treasure.name or treasure_label
+            _project_adventure_action(
+                caller,
+                text=f"Deposit the {treasure_name}",
+                action="deposit_treasure",
+                target=caller,
+                journal_text=(
+                    f"The {treasure_name} is safely deposited in the well house. "
+                    "Your score has increased."
+                ),
+                asset=treasure_label,
+            )
+
+    for anchor in caller.magic_anchors:
+        if anchor.requires_discovery and not _magic_word_known(caller, anchor.word):
+            continue
+        target = _location(graph, anchor.target)
+        _project_adventure_action(
+            caller,
+            text=f"Say {anchor.word.upper()}",
+            action="magic_word",
+            target=target,
+            journal_text=anchor.journal_text,
+            word=anchor.word.upper(),
+        )
+    return None
+
+
+@on_update(
+    wants_caller_kind=AdventureSandboxLocation,
+    wants_exact_kind=False,
+)
+def apply_adventure_world_action(
+    *,
+    caller: AdventureSandboxLocation,
+    ctx: VmPhaseCtx,
+    **_kw: object,
+) -> None:
+    """Apply Adventure-specific world-authority action effects."""
+    payload = getattr(ctx, "selected_payload", None)
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("adventure_action") == "deposit_treasure":
+        asset = payload.get("asset")
+        if isinstance(asset, str):
+            _deposit_treasure(caller, asset)
     return None
 
 

--- a/worlds/adventure_sandbox_slice/adventure_sandbox_slice/domain.py
+++ b/worlds/adventure_sandbox_slice/adventure_sandbox_slice/domain.py
@@ -149,9 +149,14 @@ def _project_adventure_action(
     journal_text: str,
     **hints: object,
 ) -> None:
+    label_suffix = (
+        str(hints.get("asset") or hints.get("word") or target.get_label())
+        .lower()
+        .replace(" ", "_")
+    )
     Action(
         registry=location.graph,
-        label=f"adventure_{action}_{location.get_label()}",
+        label=f"adventure_{action}_{location.get_label()}_{label_suffix}",
         predecessor_id=location.uid,
         successor_id=target.uid,
         text=text,
@@ -167,8 +172,7 @@ def _project_adventure_action(
 
 
 def _asset_score(asset: Token) -> int:
-    score = getattr(asset, "treasure_score", 0)
-    return int(score)
+    return int(asset.treasure_score)
 
 
 def _held_treasures(location: AdventureSandboxLocation) -> list[Token]:
@@ -227,7 +231,7 @@ def _rewrite_movement_hazards(
         for edge in list(location.edges_out(Selector(has_kind=Action))):
             if not {"dynamic", "sandbox", "movement"}.issubset(edge.tags or set()):
                 continue
-            hints = edge.ui_hints.model_dump()
+            hints = edge.ui_hints.model_dump() if edge.ui_hints else {}
             if hints.get("direction") != hazard.direction:
                 continue
             graph.remove(edge.uid, _ctx=ctx)
@@ -535,7 +539,7 @@ def apply_adventure_world_action(
     **_kw: object,
 ) -> None:
     """Apply Adventure-specific world-authority action effects."""
-    payload = getattr(ctx, "selected_payload", None)
+    payload = ctx.selected_payload
     if not isinstance(payload, dict):
         return None
     if payload.get("adventure_action") == "deposit_treasure":

--- a/worlds/adventure_sandbox_slice/script.yaml
+++ b/worlds/adventure_sandbox_slice/script.yaml
@@ -36,6 +36,11 @@ scenes:
         kind: "adventure_sandbox_slice.domain.AdventureSandboxLocation"
         location_name: "Inside Building"
         light: true
+        treasure_deposit_site: true
+        magic_anchors:
+          - word: xyzzy
+            target: cobble_crawl
+            journal_text: "A hollow voice says \"Plugh.\" The world folds around you."
         content: |
           You are inside a building, a well house for a large spring.
         links:
@@ -102,6 +107,10 @@ scenes:
       cobble_crawl:
         kind: "adventure_sandbox_slice.domain.AdventureSandboxLocation"
         location_name: "In Cobble Crawl"
+        magic_anchors:
+          - word: xyzzy
+            target: building
+            journal_text: "A hollow voice says \"Plugh.\" You are back in the well house."
         content: |
           You are crawling over cobbles in a low passage. There is a dim light
           at the east end of the passage.
@@ -109,3 +118,32 @@ scenes:
           It is now pitch dark. If you proceed you will likely fall into a pit.
         links:
           east: below_grate
+          west: hall_of_mists
+
+      hall_of_mists:
+        kind: "adventure_sandbox_slice.domain.AdventureSandboxLocation"
+        location_name: "In Hall of Mists"
+        content: |
+          You are at one end of a vast hall stretching forward out of sight to
+          the west. Nearby, a wide stone staircase leads upward.
+        dark_text: |
+          It is now pitch dark. If you proceed you will likely fall into a pit.
+        movement_hazards:
+          - direction: up
+            carried_asset: gold_nugget
+            outcome: block
+            journal_text: "I'm not sure you'll be able to get up it with what you're carrying."
+        links:
+          east: cobble_crawl
+          up: top_of_small_pit
+
+      top_of_small_pit:
+        kind: "adventure_sandbox_slice.domain.AdventureSandboxLocation"
+        location_name: "At Top of Small Pit"
+        content: |
+          At your feet is a small pit breathing traces of white mist. Rough
+          stone steps lead back down.
+        dark_text: |
+          It is now pitch dark. If you proceed you will likely fall into a pit.
+        links:
+          down: hall_of_mists


### PR DESCRIPTION
## Summary

- add Adventure-domain data surfaces for treasure deposit sites, magic anchors, and movement hazards
- extend the Adventure sandbox demo with XYZZY, a scored gold nugget deposit, Hall of Mists, and a heavy-nugget climb block
- add loader tests and update sandbox design notes for the implemented charm slice

## Verification

- CodeRabbit local review: 0 issues
- poetry run pytest engine/tests/loaders/test_adventure_sandbox_world.py -q
- poetry run pytest engine/tests/mechanics/test_sandbox.py engine/tests/mechanics/test_sandbox_adventure_slice.py engine/tests/mechanics/test_sandbox_architecture.py engine/tests/service/test_sandbox_story_info.py -q
- poetry run pytest engine/tests -q


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Magic word anchors enable teleportation between locations
  * Treasure collection, carrying, and deposit mechanics with scoring
  * Movement hazards that restrict actions based on player inventory
  * Adventure scoring system tracking deposited treasures
  * Expanded world with new explorable locations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/derekmerck/storytangl/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->