### PR TITLE
Phase B.1: core mediation moves (credentials)

### DIFF
--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -534,6 +534,16 @@ rule set, so an author can *see* which dispositions and failure modes are
 reachable today before committing a day's rules. It is an authoring/validation
 aid for rule sets, not a runtime component.
 
+**The rules are also a narrative surface.** In Pope's *Papers, Please*, daily
+rule changes carry inscrutable political messages: who is currently allied or
+belligerent, how much the regime trusts its own people, admissibility wielded as
+a hammer against political foes. Different checkpoints can carry different
+state-vs-local-enforcement variation, governance subtly diverging from rule. The
+mechanic gives the author a way to *say something* through bureaucratic minutiae
+alone -- the rules are the politics. This is the dramatic upside of the
+data-driven design: changing a `Restrictions` instance between shifts is
+authorially equivalent to a regime memo.
+
 ### A.6 Packet-as-tokens (when structure is needed)
 
 When narrative-string findings are no longer enough, the structured packet model
@@ -742,6 +752,95 @@ right stamps -- which is the degrade / generate machinery applied from the playe
 side (inspect -> assess -> remediate -> re-assess). That is a composite loop
 (shell = shop economy, spike = legality assessment), noted as a future direction
 (not v1 scope) and a natural wing of the unified showcase world.
+
+### Worked third skin: Hall Monitor (evolving daily rules)
+
+Another reskin, exercising a dimension Chop Shop doesn't really test: **rules
+that vary day-by-day with explicit exceptions**. Border rules and chop-shop
+permits are mostly static catalogs of who-needs-what; the Hall Monitor's daily
+rules compose several orthogonal exception axes on top of the indication
+catalog:
+
+- **attribute thresholds** -- "no one with a grade lower than a B is allowed to
+  go to the bathroom"
+- **calendar / event exceptions** -- "anyone can go to the gym for the pep
+  rally in the afternoon without a note because it's a Friday"
+- **documented exemptions** -- "students using inhalers should have
+  documentation of need on file with the nurses office"
+
+Each candidate (student) has attributes (grade, schedule, prior referrals) and
+a purpose (bathroom / nurse / gym / class). The day's rules combine the
+restriction map with these exception axes; the same `derive_disposition` shape
+applies, with the rule lookup parameterized over more axes than the border
+case. Locker searches and principal referrals reskin ``request_search`` and
+ARREST respectively.
+
+Mechanically, this is the strongest validation of the rules-as-authored-story-lever
+framing (A.5): when the rules are mid-week school schedules with calendar
+carve-outs and per-student exemptions, the per-day rule churn isn't a corner
+case -- it's the gameplay. The same framework supports authoritarian-dystopia
+fiction at any scale (checkpoint, chop shop, hallway, badge desk, comp tier,
+exam proctor, customs office); the engine is fundamentally a **bureaucratic
+gatekeeping kernel**.
+
+---
+
+## Beyond the phased roadmap: cross-shift continuity and recurring candidates
+
+A procedural candidate today is generated for one shift and disappears at
+terminal. A *real* checkpoint story wants candidates to return: the
+procedurally-sampled traveler you wrongly admitted on day 1 walks back through
+your line on day 4 and recognizes you; the hand-crafted recurring character
+appears at multiple checkpoints; the unjustly-denied applicant comes back with
+new paperwork. This needs **cross-shift continuity** the engine doesn't have
+today.
+
+The seams already exist; persistence is the missing piece:
+
+- **Identity persistence.** A `CredentialCaseResult` already captures one
+  decided candidate. Continuity needs a stable *candidate id* (and the option
+  to persist a materialized `CredentialCase` snapshot keyed to that id).
+- **Recurrence as a pinned offer.** `ScenarioOffer.pinned_case` already lets a
+  shift pin a fully-authored candidate. A recurring candidate is a pinned
+  offer whose payload carries prior `CredentialCaseResult`s alongside the
+  current packet.
+- **Prior-encounter context on the case.** A `prior_encounters:
+  list[CredentialCaseResult]` field (on `CredentialCase` or a "candidate
+  dossier" wrapper). `derive_disposition` and `expected_disposition` read it
+  for recognition-driven severity bending; `get_journal_fragments` narrates
+  "you've seen this one before."
+
+**Promotion paths** (procedural → recurring):
+
+- *Wrongly admitted.* A procedural candidate dispositioned ALLOW that should
+  have been DENY/ARREST is promoted into a future shift's pinned offers as a
+  returning narrative thread -- the smuggler whose forged permit you missed
+  comes back to blackmail you (the engine equivalent of Pope's recurring
+  political consequence).
+- *Unjustly denied.* A procedural candidate denied who *should* have been
+  allowed returns with a grievance, new paperwork, or as a sympathetic NPC in
+  another scene.
+- *Hand-crafted recurring.* Authored candidates pinned across multiple shifts;
+  their `prior_encounters` accumulate naturally as they're processed.
+
+**Cross-cuts with the existing phases:**
+
+- This is where **Phase C's "context bends severity"** gets its sharpest
+  narrative edge: the context is *the player's own past mistakes catching up*.
+  Whitelist-by-political-favor becomes blackmail-by-another-name when the
+  candidate carries a `prior_encounters` record of your error.
+- **`ShiftSpec`** (A.3) gains a `recurrences: list[CandidateDossier]` field
+  (or a hook predicate) that pins prior candidates back in when conditions
+  match (region, days-since, prior-disposition).
+- The promotion **bridges procedural and authored** without breaking the
+  funnel: a recurring candidate is just a Tier 1 offer enriched with prior
+  context; the rest of the engine never learns whether it was sampled or
+  authored.
+
+This is design intent only; no implementation in scope. Worth capturing now
+because it's a cross-shift persistence step the engine doesn't currently
+support, and the seams (`ScenarioOffer.pinned_case`, `CredentialCase`,
+`CredentialCaseResult`) all need to admit the continuity story when this lands.
 
 ---
 

--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -2,7 +2,8 @@
 
 **Status:** v1 LANDED (candidate-roster shift, 2026-05-21); Phase A LANDED
 (A.1 rules-derived dispositions, A.2 candidate factory, A.3 day-spec sampling +
-lazy offer roster, 2026-05-22); Phases B/C/D designed below as overlays  
+lazy offer roster, 2026-05-22); Phase B.1 LANDED (core mediation moves,
+2026-05-23); Phases B.2/C/D designed below as overlays  
 **Scope:** the credentials / checkpoint interaction as a stacked picking-game
 composition inside `tangl.mechanics.games`  
 **Background sources:** `docs/src/notes/CREDENTIALS_INTERACTION.md`,
@@ -553,7 +554,7 @@ Phase B adds follow-up moves that can clear or confirm findings before a
 disposition. The work splits into two increments because contraband mediation
 has enough independent design surface to warrant its own pass.
 
-### B.1 — Core mediation (v1 increment)
+### B.1 — Core mediation (v1 increment, LANDED 2026-05-23)
 
 Adds three move kinds and a per-case ``finding_status: dict[str, str]``
 (values: ``"cleared"`` / ``"confirmed"``; reset by ``advance_case``).

--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -582,64 +582,92 @@ moves follow the same pattern).
 
 ### B.2 — Contraband mediation (deferred follow-up)
 
-Beyond ``request_search`` (which reveals concealment → existing ARREST), full
-contraband mediation needs a ``request_relinquish`` / ``request_declare``
-family with non-trivial interactions across possession state and permit
-validity. The matrix below is the spec to build against when B.2 lands.
+Beyond ``request_search`` (which reveals concealment), full contraband mediation
+needs a family of moves whose interactions span packet validity, possession
+state, and candidate willingness. The matrix below is the spec to build against
+when B.2 lands.
 
-**Dimensions**
-- *Possession*: ``none`` / ``declared`` / ``concealed``
-- *Permit* for that contraband indication: ``none`` / ``valid`` /
-  ``mitigatable_invalid`` (missing seal, expired, ...) / ``forged`` /
-  ``wrong_holder`` (the last two are crimes intrinsic to the permit itself)
-- *Mediation moves*: ``request_declare`` (prompt to declare any concealed),
-  ``request_relinquish`` (yield declared contraband), ``request_search``
-  (already in B.1; force reveal of concealed)
-- *Candidate compliance*: comply (declare truthfully / yield) vs decline (lie /
-  refuse to yield) — the declines-mediation axis
+**Packet validity taxonomy** (for the contraband's permit specifically):
 
-**Declared possession — relinquish path**
+- **valid** — covers the contraband; everything in order.
+- **incomplete** — required document is missing entirely (can be produced).
+- **invalid** — present but mitigatably wrong (missing seal, expired, etc.);
+  can't be repaired at the desk.
+- **illegal** — forged / wrong-holder (the document itself is criminal).
 
-| Permit | Yield (comply) | Decline yield | Notes |
-|---|---|---|---|
-| none | cleared → PASS | DENY | "fix what you brought" |
-| valid | (no mediation needed) | — | PASS by base derive |
-| mitigatable invalid | cleared → PASS | DENY | same as no permit |
-| forged | — (crime overrides) | — | ARREST |
-| wrong_holder | — (crime overrides) | — | ARREST |
+**Mediation moves B.2 introduces** (in addition to ``request_search`` from B.1):
 
-**Concealed possession — search path**
+- ``request_complete`` — ask the candidate to produce the missing piece (for
+  incomplete packets). Subsumes the "missing-doc request surface" deferred from
+  B.1.
+- ``request_disclosure`` — the polite "anything to declare?" ask. Subject to
+  the candidate's compliance (the "oops, I forgot I had this in my pocket"
+  path).
+- ``request_relinquish`` — ask the candidate to yield declared contraband.
 
-| Permit | Search reveals | Notes |
-|---|---|---|
-| none | ARREST | smuggling |
-| valid | *[open: ARREST or DENY?]* | failure-to-declare with otherwise legitimate paperwork |
-| mitigatable invalid | ARREST | smuggling + invalid paper |
-| forged | ARREST | two crimes |
-| wrong_holder | ARREST | two crimes |
-| any | (no search done) | base derive sees no contraband; player may incorrectly PASS |
+**Declared contraband** — what the player can do about visible possession:
 
-**No possession — declare path** (after request_declare or by default)
+| Packet | Outcomes available |
+|---|---|
+| valid | allow |
+| incomplete | ``request_complete``, ``request_relinquish``, or deny |
+| invalid | ``request_relinquish`` or deny |
+| illegal | arrest |
 
-| Permit | Outcome | Notes |
-|---|---|---|
-| none | PASS | nothing to assess |
-| valid | PASS | permit unused |
-| mitigatable invalid | *[open: PASS or DENY?]* | does an unused invalid permit matter? |
-| forged | *[open: ARREST or moot?]* | is presenting a fake document a crime on its own? |
-| wrong_holder | *[open: ARREST or moot?]* | same question |
+**Concealed contraband** — outcomes depend on how (or whether) it surfaces:
 
-**Open questions to resolve before B.2 implementation:**
+| Packet | If disclosed / discovered |
+|---|---|
+| valid | ``request_disclosure`` (the "oops" path) → becomes declared+valid → allow |
+| incomplete | ``request_complete``, ``request_relinquish``, or deny |
+| invalid | confusing — probably arrest |
+| illegal | arrest regardless of discovery |
 
-1. Concealed contraband with a *valid* permit — ARREST or DENY? (Failure-to-declare with otherwise legitimate paperwork.)
-2. Forged / wrong-holder permit with *no* actual contraband — is the forged document arrestable on its own, or moot?
-3. Mitigatable-invalid permit with no contraband — does the unused invalid paper deny, or pass?
+Unsearched concealment is invisible to inspection; the player decides on
+visible state alone.
 
-**B.2 ships:** the two new move kinds (``request_declare`` /
-``request_relinquish``), the declines-mediation axis (per-case
-``compliant: bool`` or per-failure-mode willingness), and the missing-doc
-request surface from B.1's deferred list. All three benefit from being
-designed together against this matrix.
+**Multiple contraband types.** A candidate may carry several restricted items;
+each is assessed against its own permit category and the worst outcome
+dominates.
+
+**Cross-product examples** (one indication's permit interacting with a
+different contraband):
+
+| Candidate | Outcome |
+|---|---|
+| medical permit (drugs) + open weapon (no weapon permit) | yield, ``request_complete``, or deny |
+| medical permit + concealed weapon | arrest |
+| medical permit + weapon that requires no permit | accept |
+| medical permit + concealed weapon that requires no permit | **[open]** |
+
+**Valid paperwork, nothing declared, but rules allow possible unpermitted
+contraband.** The gatekeeper can always request a search; the candidate may
+refuse (→ deny) or comply (search runs → arrest if anything is found, allow if
+clean).
+
+**Severity is environmental.** The arrest/deny boundary in several rows bends
+with **environment, discretion, and bribery** (a Phase C cross-cut). B.2
+computes a base disposition; Phase C composes the override on top.
+
+**Open questions (updated):**
+
+1. ~~Concealed contraband + valid permit~~ — *resolved:* takes the
+   ``request_disclosure`` path; if voluntarily disclosed → allow as
+   declared+valid. (Sub-question still open: if disclosure is refused or lied
+   and search forces the reveal, is the "oops" forgiveness still extended, or
+   does it escalate?)
+2. ~~Forged / wrong-holder permit + no actual contraband~~ — *resolved:* the
+   illegal-packet rule applies regardless of possession → arrest.
+3. Mitigatable-invalid permit + no contraband — does an unused-but-invalid
+   paper deny, or pass? *(Still open.)*
+4. **New:** concealed contraband whose category requires *no* permit — is the
+   concealment-when-not-required itself a violation, or moot?
+
+**B.2 ships, when it lands:** the three new move kinds above
+(``request_complete`` / ``request_disclosure`` / ``request_relinquish``); the
+declines-mediation axis (per-case ``compliant: bool`` or per-failure-mode
+willingness); and per-indication worst-case composition across multiple
+contraband items. The Phase C severity overlay layers on top.
 
 ---
 

--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -549,20 +549,97 @@ rather than rebuilding tokens.
 
 ## Phase B: mediation moves
 
-Add a `"mediate"` move kind (`request_document` / `request_search` /
-`verify_id`). Override two methods in `CredentialsGameHandler`:
-`get_available_moves` (super + mediation targets) and `resolve_round` (handle
-`"mediate"`, else `super()`); the picking base is untouched. Add a per-case
-`finding_status` working dict (possible -> cleared / confirmed) reset by
-`advance_case`, which `derive_disposition` reads (e.g. a declined search becomes a
-deny). Port the move set and the discrepancy / mediation table from top-level
-`enums.py` and `notes.md`.
+Phase B adds follow-up moves that can clear or confirm findings before a
+disposition. The work splits into two increments because contraband mediation
+has enough independent design surface to warrant its own pass.
 
-**Optional enabling refactor:** before Phase B, change
-`PickingGameHandler.resolve_round` from `if inspect / elif decide / else raise`
-to dispatch through a `dict[str, resolver]` (or a `resolve_move_kind` hook with
-inspect/decide defaults). This turns "add a move kind" into a registration for
-*any* picking game, keeping B and C as true overlays.
+### B.1 — Core mediation (v1 increment)
+
+Adds three move kinds and a per-case ``finding_status: dict[str, str]``
+(values: ``"cleared"`` / ``"confirmed"``; reset by ``advance_case``).
+
+- **``request_document``** — per-target fanout, one Action per *presented*
+  document whose token has a mitigatable status. Applying clears that doc's
+  finding. Maps to ``accepts.kind="pieces"`` in the rendering contract
+  (`bundles/credentials/EXTENSIONS.md`).
+- **``verify_id``** — single Action, applicable when an id is presented. Clears
+  for VALID; confirms (records the crime in the audit trail) for WRONG_HOLDER.
+- **``request_search``** — single Action; reveals concealed contraband if any.
+
+``derive_disposition`` consults ``finding_status``: a cleared mitigatable doc
+finding contributes PASS instead of DENY; everything else as before.
+
+Enabled by a small base refactor: ``PickingGameHandler.resolve_round``
+dispatches through a kind-keyed registry (with inspect/decide as defaults), so
+the new kinds register cleanly without overriding ``resolve_round`` (and Phase C
+moves follow the same pattern).
+
+**v1 assumptions (deferred, see B.2):**
+- *Missing*-document requests are out of v1: ``request_document`` only targets
+  *presented-but-invalid* docs. Missing-doc requests need a different surface
+  (pick from "required-but-absent" indications).
+- All candidates comply truthfully with requests; no "declines mediation" path.
+
+### B.2 — Contraband mediation (deferred follow-up)
+
+Beyond ``request_search`` (which reveals concealment → existing ARREST), full
+contraband mediation needs a ``request_relinquish`` / ``request_declare``
+family with non-trivial interactions across possession state and permit
+validity. The matrix below is the spec to build against when B.2 lands.
+
+**Dimensions**
+- *Possession*: ``none`` / ``declared`` / ``concealed``
+- *Permit* for that contraband indication: ``none`` / ``valid`` /
+  ``mitigatable_invalid`` (missing seal, expired, ...) / ``forged`` /
+  ``wrong_holder`` (the last two are crimes intrinsic to the permit itself)
+- *Mediation moves*: ``request_declare`` (prompt to declare any concealed),
+  ``request_relinquish`` (yield declared contraband), ``request_search``
+  (already in B.1; force reveal of concealed)
+- *Candidate compliance*: comply (declare truthfully / yield) vs decline (lie /
+  refuse to yield) — the declines-mediation axis
+
+**Declared possession — relinquish path**
+
+| Permit | Yield (comply) | Decline yield | Notes |
+|---|---|---|---|
+| none | cleared → PASS | DENY | "fix what you brought" |
+| valid | (no mediation needed) | — | PASS by base derive |
+| mitigatable invalid | cleared → PASS | DENY | same as no permit |
+| forged | — (crime overrides) | — | ARREST |
+| wrong_holder | — (crime overrides) | — | ARREST |
+
+**Concealed possession — search path**
+
+| Permit | Search reveals | Notes |
+|---|---|---|
+| none | ARREST | smuggling |
+| valid | *[open: ARREST or DENY?]* | failure-to-declare with otherwise legitimate paperwork |
+| mitigatable invalid | ARREST | smuggling + invalid paper |
+| forged | ARREST | two crimes |
+| wrong_holder | ARREST | two crimes |
+| any | (no search done) | base derive sees no contraband; player may incorrectly PASS |
+
+**No possession — declare path** (after request_declare or by default)
+
+| Permit | Outcome | Notes |
+|---|---|---|
+| none | PASS | nothing to assess |
+| valid | PASS | permit unused |
+| mitigatable invalid | *[open: PASS or DENY?]* | does an unused invalid permit matter? |
+| forged | *[open: ARREST or moot?]* | is presenting a fake document a crime on its own? |
+| wrong_holder | *[open: ARREST or moot?]* | same question |
+
+**Open questions to resolve before B.2 implementation:**
+
+1. Concealed contraband with a *valid* permit — ARREST or DENY? (Failure-to-declare with otherwise legitimate paperwork.)
+2. Forged / wrong-holder permit with *no* actual contraband — is the forged document arrestable on its own, or moot?
+3. Mitigatable-invalid permit with no contraband — does the unused invalid paper deny, or pass?
+
+**B.2 ships:** the two new move kinds (``request_declare`` /
+``request_relinquish``), the declines-mediation axis (per-case
+``compliant: bool`` or per-failure-mode willingness), and the missing-doc
+request surface from B.1's deferred list. All three benefit from being
+designed together against this matrix.
 
 ---
 

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -169,17 +169,27 @@ def _worse(a: CredentialDisposition, b: CredentialDisposition) -> CredentialDisp
     return a if _DISPOSITION_SEVERITY[a] >= _DISPOSITION_SEVERITY[b] else b
 
 
-def _assess_credential(token: CredentialToken | None) -> CredentialDisposition:
+def _assess_credential(
+    token: CredentialToken | None,
+    finding_status: dict[str, str] | None = None,
+) -> CredentialDisposition:
     if token is None:
         return CredentialDisposition.DENY  # missing -> produce it (mitigatable)
     if token.status.is_valid:
         return CredentialDisposition.PASS
     if token.status.is_crime:
-        return CredentialDisposition.ARREST  # forged
-    return CredentialDisposition.DENY  # missing seal / bad date / expired
+        return CredentialDisposition.ARREST  # forged; crimes not mediatable in B.1
+    # Mitigatable (missing seal / bad date / expired): Phase B.1 mediation can
+    # clear it via ``request_document``; check the per-case finding_status.
+    if finding_status and finding_status.get(token.indication.value) == "cleared":
+        return CredentialDisposition.PASS
+    return CredentialDisposition.DENY
 
 
-def _assess_id(case: CredentialCase) -> CredentialDisposition:
+def _assess_id(
+    case: CredentialCase,
+    finding_status: dict[str, str] | None = None,
+) -> CredentialDisposition:
     status = case.id_status()
     if status is None:
         return CredentialDisposition.DENY  # missing id -> produce it (mitigatable)
@@ -187,6 +197,9 @@ def _assess_id(case: CredentialCase) -> CredentialDisposition:
         return CredentialDisposition.PASS
     if status.is_crime:
         return CredentialDisposition.ARREST  # fake / wrong-holder id
+    # Mitigatable id (expired / bad date): cleared by future id-mediation.
+    if finding_status and finding_status.get("id") == "cleared":
+        return CredentialDisposition.PASS
     return CredentialDisposition.DENY
 
 
@@ -194,17 +207,18 @@ def _assess_requirement(
     case: CredentialCase,
     indication: Indication,
     level: RestrictionLevel,
+    finding_status: dict[str, str] | None = None,
 ) -> CredentialDisposition:
     """Assess one indication against its required level (the two error surfaces)."""
 
     worst = CredentialDisposition.PASS
     if level.requires_permit:
         permit = case.credential_for(indication)
-        worst = _worse(worst, _assess_credential(permit))
+        worst = _worse(worst, _assess_credential(permit, finding_status))
         if permit is not None and not permit.holder_matches:
             worst = _worse(worst, CredentialDisposition.ARREST)  # permit/id mismatch
     if level.requires_id:
-        worst = _worse(worst, _assess_id(case))
+        worst = _worse(worst, _assess_id(case, finding_status))
     return worst
 
 
@@ -212,23 +226,27 @@ def _assess_contraband(
     case: CredentialCase,
     item: ContrabandItem,
     level: RestrictionLevel,
+    finding_status: dict[str, str] | None = None,
 ) -> CredentialDisposition:
     if item.concealed:
         return CredentialDisposition.ARREST  # concealment is a crime
     if level is RestrictionLevel.FORBIDDEN:
         return CredentialDisposition.DENY  # declared but forbidden -> relinquish
-    return _assess_requirement(case, item.indication, level)
+    return _assess_requirement(case, item.indication, level, finding_status)
 
 
 def derive_disposition(
     case: CredentialCase,
     restrictions: Restrictions,
+    finding_status: dict[str, str] | None = None,
 ) -> CredentialDisposition:
     """Derive the correct disposition from the rules and the candidate's packet.
 
     Reads the candidate only through its discovery API, so the packet's internal
     representation stays opaque. Returns the most-severe applicable outcome
-    (ARREST > DENY > PASS).
+    (ARREST > DENY > PASS). If ``finding_status`` is given (Phase B.1 mediation
+    outcomes for the active case), cleared mitigatable findings contribute PASS
+    instead of DENY.
     """
 
     region = case.get_region()
@@ -239,11 +257,11 @@ def derive_disposition(
     if level is RestrictionLevel.FORBIDDEN:
         worst = _worse(worst, CredentialDisposition.DENY)  # purpose not allowed
     else:
-        worst = _worse(worst, _assess_requirement(case, purpose, level))
+        worst = _worse(worst, _assess_requirement(case, purpose, level, finding_status))
 
     for item in case.get_contraband():
         level = restrictions.level_for(region, item.indication, RestrictionLevel.FORBIDDEN)
-        worst = _worse(worst, _assess_contraband(case, item, level))
+        worst = _worse(worst, _assess_contraband(case, item, level, finding_status))
 
     return worst
 
@@ -294,6 +312,14 @@ class CredentialsGame(PickingGame):
     )
     shift_complete: bool = Field(
         default=False,
+        json_schema_extra={"reset_field": True},
+    )
+    # Mediation outcomes for the active case (Phase B.1): keys are an
+    # indication's value (a permit), or "id", or "search". Values are
+    # "cleared" / "confirmed". Reset by advance_case so each candidate starts
+    # with a clean slate.
+    finding_status: dict[str, str] = Field(
+        default_factory=dict,
         json_schema_extra={"reset_field": True},
     )
     # Lazy cache of materialized offers (cleared on setup; rebuilt on arrival).
@@ -410,7 +436,7 @@ class CredentialsGame(PickingGame):
             )
         if case.correct_disposition is not None:
             return case.correct_disposition
-        return derive_disposition(case, self.restriction_map)
+        return derive_disposition(case, self.restriction_map, self.finding_status)
 
     # ----- roster advancement ----------------------------------------------
     def advance_case(self) -> None:
@@ -433,6 +459,7 @@ class CredentialsGame(PickingGame):
         self.inspected_packet_targets = []
         self.packet_findings = {}
         self.committed_decision = None
+        self.finding_status = {}
 
     def to_namespace(self) -> dict[str, object]:
         namespace = super().to_namespace()
@@ -470,6 +497,35 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
 
     game_cls: ClassVar[type[Game]] = CredentialsGame
 
+    def get_available_moves(self, game: CredentialsGame) -> list[CredentialsMove]:
+        """Inspect + decide + (Phase B.1) mediation moves.
+
+        Mediation moves are gated on the packet stage, same as decisions: the
+        player inspects at least one document before mediating or deciding.
+        """
+
+        moves = list(super().get_available_moves(game))
+        if game.current_stage == "documents":
+            return moves
+
+        case = game.active_case
+        # request_document: one Action per presented permit with a mitigatable
+        # status not yet cleared. Missing-doc requests are B.2.
+        for token in case.packet:
+            if token.status.is_valid or token.status.is_crime:
+                continue
+            key = token.indication.value
+            if key in game.finding_status:
+                continue
+            moves.append(CredentialsMove(kind="request_document", target=key))
+        # verify_id: single move, only if an id is presented and not yet verified.
+        if case.id_card is not None and "id" not in game.finding_status:
+            moves.append(CredentialsMove(kind="verify_id", target=""))
+        # request_search: single move, once per case.
+        if "search" not in game.finding_status:
+            moves.append(CredentialsMove(kind="request_search", target=""))
+        return moves
+
     def get_available_inspect_targets(self, game: CredentialsGame) -> list[str]:
         case = game.active_case
         targets = [
@@ -488,6 +544,12 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             if move.target in game.active_case.packet_hidden_facts:
                 return f"Review {move.target}"
             return f"Inspect {move.target}"
+        if move.kind == "request_document":
+            return f"Request reissue of {move.target} permit"
+        if move.kind == "verify_id":
+            return "Verify identity"
+        if move.kind == "request_search":
+            return "Request search"
         return f"Choose {move.target}"
 
     def resolve_inspection(
@@ -558,6 +620,67 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         game.advance_case()
         return round_result
 
+    # ----- Phase B.1 mediation moves ---------------------------------------
+
+    def resolve_move_kind(
+        self,
+        kind: str,
+        game: CredentialsGame,
+        player_move: CredentialsMove,
+        detail: dict[str, object],
+    ) -> RoundResult:
+        if kind == "request_document":
+            return self._resolve_request_document(game, player_move.target, detail)
+        if kind == "verify_id":
+            return self._resolve_verify_id(game, detail)
+        if kind == "request_search":
+            return self._resolve_request_search(game, detail)
+        return super().resolve_move_kind(kind, game, player_move, detail)
+
+    def _resolve_request_document(
+        self,
+        game: CredentialsGame,
+        indication_value: str,
+        detail: dict[str, object],
+    ) -> RoundResult:
+        # B.1 assumes the candidate complies; the mitigatable finding is cleared.
+        # Compliance (declines path) is part of B.2.
+        game.finding_status[indication_value] = "cleared"
+        detail["outcome"] = "request_document_cleared"
+        detail["target_indication"] = indication_value
+        return RoundResult.CONTINUE
+
+    def _resolve_verify_id(
+        self,
+        game: CredentialsGame,
+        detail: dict[str, object],
+    ) -> RoundResult:
+        status = game.active_case.id_status()
+        if status is None or status.is_valid:
+            game.finding_status["id"] = "cleared"
+            detail["outcome"] = "id_verified_clean"
+        else:
+            game.finding_status["id"] = "confirmed"
+            detail["outcome"] = "id_verified_problem"
+        return RoundResult.CONTINUE
+
+    def _resolve_request_search(
+        self,
+        game: CredentialsGame,
+        detail: dict[str, object],
+    ) -> RoundResult:
+        concealed = [item for item in game.active_case.get_contraband() if item.concealed]
+        if concealed:
+            game.finding_status["search"] = "confirmed"
+            detail["outcome"] = "search_found_concealment"
+            detail["concealed"] = [item.indication.value for item in concealed]
+        else:
+            game.finding_status["search"] = "cleared"
+            detail["outcome"] = "search_clean"
+        return RoundResult.CONTINUE
+
+    # ----- lifecycle / projection ------------------------------------------
+
     def evaluate(self, game: CredentialsGame) -> GameResult:
         """Own shift terminality: in process until the final candidate is decided."""
 
@@ -611,6 +734,33 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             return [
                 ContentFragment(content=f"You inspect the {target}."),
                 ContentFragment(content=str(notes.get("finding", "Nothing new emerges."))),
+            ]
+
+        if action == "request_document":
+            return [
+                ContentFragment(content=f"You request a reissue of the {target} permit."),
+                ContentFragment(content="The candidate produces a corrected copy."),
+            ]
+        if action == "verify_id":
+            line = (
+                "The id matches the bearer."
+                if notes.get("outcome") == "id_verified_clean"
+                else "The id does not match the bearer."
+            )
+            return [
+                ContentFragment(content="You verify the bearer's identity."),
+                ContentFragment(content=line),
+            ]
+        if action == "request_search":
+            if notes.get("outcome") == "search_found_concealment":
+                items = notes.get("concealed") or []
+                what = ", ".join(items) if items else "contraband"
+                line = f"You uncover concealed {what}."
+            else:
+                line = "The search turns up nothing concealed."
+            return [
+                ContentFragment(content="You request a search."),
+                ContentFragment(content=line),
             ]
 
         candidate = notes.get("candidate", "the traveler")

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -518,8 +518,16 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             if key in game.finding_status:
                 continue
             moves.append(CredentialsMove(kind="request_document", target=key))
-        # verify_id: single move, only if an id is presented and not yet verified.
-        if case.id_card is not None and "id" not in game.finding_status:
+        # verify_id: identity-check move. Narrow to statuses where "does the id
+        # match the bearer?" is the relevant question: VALID (clears the doubt)
+        # or WRONG_HOLDER (confirms the mismatch). Mitigatable id issues like
+        # EXPIRED / BAD_DATE / MISSING_SEAL are date-or-seal problems, not
+        # holder problems, and need an id-mediation move that lands with B.2.
+        if (
+            case.id_card is not None
+            and case.id_status() in (CredentialStatus.VALID, CredentialStatus.WRONG_HOLDER)
+            and "id" not in game.finding_status
+        ):
             moves.append(CredentialsMove(kind="verify_id", target=""))
         # request_search: single move, once per case.
         if "search" not in game.finding_status:
@@ -643,6 +651,21 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         indication_value: str,
         detail: dict[str, object],
     ) -> RoundResult:
+        # Defensive guard: the menu filters to presented permits with a
+        # mitigatable status, but ``GameHandler.receive_move`` does not call
+        # ``validate_move``. Skip rather than corrupt finding_status if an
+        # off-menu payload arrives. (Off-menu clears against valid/crime/missing
+        # permits are already idempotent for derive thanks to its short-circuits,
+        # but explicit validation keeps the audit trail honest.)
+        permit = next(
+            (t for t in game.active_case.packet if t.indication.value == indication_value),
+            None,
+        )
+        if permit is None or permit.status.is_valid or permit.status.is_crime:
+            detail["outcome"] = "request_document_not_applicable"
+            detail["target_indication"] = indication_value
+            return RoundResult.CONTINUE
+
         # B.1 assumes the candidate complies; the mitigatable finding is cleared.
         # Compliance (declines path) is part of B.2.
         game.finding_status[indication_value] = "cleared"
@@ -655,13 +678,19 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         game: CredentialsGame,
         detail: dict[str, object],
     ) -> RoundResult:
+        # verify_id specifically answers "does the id match the bearer?", so it
+        # only ever clears for VALID or confirms for WRONG_HOLDER. Other id
+        # statuses (no id presented, expired, bad date) need different mediation
+        # (B.2's id-replacement path) and shouldn't have surfaced this move.
         status = game.active_case.id_status()
-        if status is None or status.is_valid:
+        if status is CredentialStatus.VALID:
             game.finding_status["id"] = "cleared"
             detail["outcome"] = "id_verified_clean"
-        else:
+        elif status is CredentialStatus.WRONG_HOLDER:
             game.finding_status["id"] = "confirmed"
             detail["outcome"] = "id_verified_problem"
+        else:
+            detail["outcome"] = "verify_id_not_applicable"
         return RoundResult.CONTINUE
 
     def _resolve_request_search(
@@ -742,11 +771,13 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                 ContentFragment(content="The candidate produces a corrected copy."),
             ]
         if action == "verify_id":
-            line = (
-                "The id matches the bearer."
-                if notes.get("outcome") == "id_verified_clean"
-                else "The id does not match the bearer."
-            )
+            outcome = notes.get("outcome")
+            if outcome == "id_verified_clean":
+                line = "The id matches the bearer."
+            elif outcome == "id_verified_problem":
+                line = "The id does not match the bearer."
+            else:
+                line = "The id offers no clear answer to the bearer question."
             return [
                 ContentFragment(content="You verify the bearer's identity."),
                 ContentFragment(content=line),

--- a/engine/src/tangl/mechanics/games/picking_game.py
+++ b/engine/src/tangl/mechanics/games/picking_game.py
@@ -170,17 +170,33 @@ class PickingGameHandler(GameHandler[PickingGameT]):
             "target": player_move.target,
         }
 
-        if player_move.kind == "inspect":
-            game.inspected_targets.append(player_move.target)
-            result = self.resolve_inspection(game, player_move.target, detail)
-        elif player_move.kind == "decide":
-            game.committed_decision = player_move.target
-            result = self.resolve_decision(game, player_move.target, detail)
-        else:
-            raise ValueError(f"Unknown picking move kind: {player_move.kind}")
+        result = self.resolve_move_kind(player_move.kind, game, player_move, detail)
 
         game.round_detail = detail
         return result
+
+    def resolve_move_kind(
+        self,
+        kind: str,
+        game: PickingGameT,
+        player_move: PickingMove,
+        detail: dict[str, object],
+    ) -> RoundResult:
+        """Dispatch a move by its ``kind``.
+
+        Subclasses register new kinds by overriding this method, handling the
+        new kinds themselves and delegating unknown ones to ``super()``. The
+        base handles the picking kernel's two kinds: ``"inspect"`` and
+        ``"decide"``.
+        """
+
+        if kind == "inspect":
+            game.inspected_targets.append(player_move.target)
+            return self.resolve_inspection(game, player_move.target, detail)
+        if kind == "decide":
+            game.committed_decision = player_move.target
+            return self.resolve_decision(game, player_move.target, detail)
+        raise ValueError(f"Unknown picking move kind: {kind}")
 
     @abstractmethod
     def resolve_inspection(

--- a/engine/tests/mechanics/games/test_credentials_mediation.py
+++ b/engine/tests/mechanics/games/test_credentials_mediation.py
@@ -91,6 +91,30 @@ class TestMediationAvailability:
 
         assert "verify_id" not in _move_kinds(handler, game)
 
+    def test_verify_id_skipped_for_mitigatable_id_status(self) -> None:
+        # EXPIRED is a date issue, not a holder mismatch; verify_id is the
+        # wrong move for it (id-renewal mediation is deferred to B.2).
+        case = CredentialCase(purpose=IND.TRAVEL, id_card=_id(S.EXPIRED))
+        game, handler = _game(case)
+        handler.receive_move(game, ("inspect", "passport"))
+
+        assert "verify_id" not in _move_kinds(handler, game)
+
+    def test_request_document_off_menu_target_is_noop(self) -> None:
+        # An off-menu request_document for an indication with no mitigatable
+        # permit (here, a forged work permit) must NOT clear finding_status.
+        case = CredentialCase(
+            purpose=IND.WORK, id_card=_id(), packet=[_permit(IND.WORK, S.FORGED)]
+        )
+        game, handler = _game(case)
+        handler.receive_move(game, ("inspect", "passport"))
+        # Forced off-menu invocation (the menu would not offer this).
+        handler.receive_move(game, ("request_document", IND.WORK.value))
+
+        # finding_status not mutated; expected disposition still ARREST.
+        assert IND.WORK.value not in game.finding_status
+        assert game.expected_disposition(case) is D.ARREST
+
     def test_each_mediation_move_offered_once_per_case(self) -> None:
         case = CredentialCase(
             purpose=IND.WORK, id_card=_id(), packet=[_permit(IND.WORK, S.MISSING_SEAL)]

--- a/engine/tests/mechanics/games/test_credentials_mediation.py
+++ b/engine/tests/mechanics/games/test_credentials_mediation.py
@@ -1,0 +1,207 @@
+"""Tests for Phase B.1 mediation moves (request_document / verify_id / request_search)."""
+
+from __future__ import annotations
+
+from tangl.mechanics.games import (
+    ContrabandItem,
+    CredentialCase,
+    CredentialDisposition,
+    CredentialStatus,
+    CredentialToken,
+    CredentialsGame,
+    CredentialsGameHandler,
+    Indication,
+    Region,
+    Restrictions,
+    RestrictionLevel,
+)
+
+D = CredentialDisposition
+S = CredentialStatus
+IND = Indication
+L = RestrictionLevel
+
+RULES = Restrictions.from_map(
+    {
+        Region.LOCAL: {
+            IND.TRAVEL: L.WITH_ID,
+            IND.WORK: L.WITH_PERMIT,
+            IND.WEAPON: L.WITH_PERMIT,
+            IND.DRUGS: L.FORBIDDEN,
+        }
+    }
+)
+
+
+def _id(status: S = S.VALID) -> CredentialToken:
+    return CredentialToken(indication=IND.TRAVEL, status=status)
+
+
+def _permit(indication: IND, status: S = S.VALID) -> CredentialToken:
+    return CredentialToken(indication=indication, status=status, requires_id=True)
+
+
+def _game(*cases: CredentialCase, **overrides) -> tuple[CredentialsGame, CredentialsGameHandler]:
+    game = CredentialsGame(roster=list(cases), restriction_map=RULES, **overrides)
+    handler = CredentialsGameHandler()
+    handler.setup(game)
+    return game, handler
+
+
+def _move_kinds(handler: CredentialsGameHandler, game: CredentialsGame) -> set[str]:
+    return {m.kind for m in handler.get_available_moves(game)}
+
+
+class TestMediationAvailability:
+    def test_mediation_moves_gated_on_packet_stage(self) -> None:
+        case = CredentialCase(
+            purpose=IND.WORK, id_card=_id(), packet=[_permit(IND.WORK, S.MISSING_SEAL)]
+        )
+        game, handler = _game(case)
+        # documents stage: only inspect moves available.
+        assert _move_kinds(handler, game) == {"inspect"}
+
+        handler.receive_move(game, ("inspect", "passport"))
+        # packet stage: inspect (remaining) + decide + mediation kinds appear.
+        kinds = _move_kinds(handler, game)
+        assert {"decide", "request_document", "verify_id", "request_search"}.issubset(kinds)
+
+    def test_request_document_only_for_mitigatable_present_permits(self) -> None:
+        # valid + forged + mitigatable -> only the mitigatable one gets request_document.
+        case = CredentialCase(
+            purpose=IND.WORK,
+            id_card=_id(),
+            packet=[
+                _permit(IND.WORK, S.MISSING_SEAL),
+                _permit(IND.WEAPON, S.FORGED),
+            ],
+        )
+        game, handler = _game(case)
+        handler.receive_move(game, ("inspect", "passport"))
+
+        request_targets = [m.target for m in handler.get_available_moves(game) if m.kind == "request_document"]
+        assert request_targets == [IND.WORK.value]  # WEAPON forged is a crime, not mediatable
+
+    def test_verify_id_skipped_without_id(self) -> None:
+        case = CredentialCase(purpose=IND.TRAVEL, id_card=None)
+        # purpose travel requires id; missing id -> derive DENY. Add a faux inspect target.
+        case.presented_documents = {"baggage": "An empty case."}
+        game, handler = _game(case)
+        handler.receive_move(game, ("inspect", "baggage"))
+
+        assert "verify_id" not in _move_kinds(handler, game)
+
+    def test_each_mediation_move_offered_once_per_case(self) -> None:
+        case = CredentialCase(
+            purpose=IND.WORK, id_card=_id(), packet=[_permit(IND.WORK, S.MISSING_SEAL)]
+        )
+        game, handler = _game(case)
+        handler.receive_move(game, ("inspect", "passport"))
+        handler.receive_move(game, ("verify_id", ""))
+
+        # After running verify_id, it's recorded in finding_status and not offered again.
+        assert "verify_id" not in _move_kinds(handler, game)
+
+
+class TestMediationEffects:
+    def test_request_document_clears_mitigatable_finding(self) -> None:
+        case = CredentialCase(
+            purpose=IND.WORK, id_card=_id(), packet=[_permit(IND.WORK, S.MISSING_SEAL)]
+        )
+        game, handler = _game(case)
+        # Before mediation: derives DENY.
+        assert game.expected_disposition(case) is D.DENY
+
+        handler.receive_move(game, ("inspect", "passport"))
+        handler.receive_move(game, ("request_document", IND.WORK.value))
+
+        assert game.finding_status[IND.WORK.value] == "cleared"
+        # After mediation: derives PASS.
+        assert game.expected_disposition(case) is D.PASS
+
+    def test_verify_id_clears_a_valid_id(self) -> None:
+        case = CredentialCase(purpose=IND.TRAVEL, id_card=_id(S.VALID))
+        game, handler = _game(case)
+        handler.receive_move(game, ("inspect", "passport"))
+        handler.receive_move(game, ("verify_id", ""))
+
+        assert game.finding_status["id"] == "cleared"
+        assert game.expected_disposition(case) is D.PASS  # unchanged but audited
+
+    def test_verify_id_confirms_a_fake_id(self) -> None:
+        case = CredentialCase(purpose=IND.TRAVEL, id_card=_id(S.WRONG_HOLDER))
+        game, handler = _game(case)
+        handler.receive_move(game, ("inspect", "passport"))
+        handler.receive_move(game, ("verify_id", ""))
+
+        assert game.finding_status["id"] == "confirmed"
+        assert game.expected_disposition(case) is D.ARREST  # unchanged, still arrest
+
+    def test_request_search_finds_concealed_contraband(self) -> None:
+        case = CredentialCase(
+            purpose=IND.TRAVEL,
+            id_card=_id(),
+            possessions=[ContrabandItem(indication=IND.WEAPON, concealed=True)],
+        )
+        case.presented_documents = {"passport": "An identity document."}
+        game, handler = _game(case)
+        handler.receive_move(game, ("inspect", "passport"))
+        handler.receive_move(game, ("request_search", ""))
+
+        assert game.finding_status["search"] == "confirmed"
+        # Concealment is already ARREST; mediation confirms in the audit.
+        assert game.expected_disposition(case) is D.ARREST
+
+    def test_request_search_clean_when_no_concealment(self) -> None:
+        case = CredentialCase(purpose=IND.TRAVEL, id_card=_id())
+        game, handler = _game(case)
+        handler.receive_move(game, ("inspect", "passport"))
+        handler.receive_move(game, ("request_search", ""))
+
+        assert game.finding_status["search"] == "cleared"
+        assert game.expected_disposition(case) is D.PASS
+
+    def test_request_document_does_not_help_a_crime(self) -> None:
+        # FORGED permit is a crime; not offered as a request_document target,
+        # and even if forced, derive stays ARREST.
+        case = CredentialCase(
+            purpose=IND.WORK, id_card=_id(), packet=[_permit(IND.WORK, S.FORGED)]
+        )
+        game, handler = _game(case)
+        handler.receive_move(game, ("inspect", "passport"))
+        # Crimes are filtered from the menu.
+        assert IND.WORK.value not in [
+            m.target for m in handler.get_available_moves(game) if m.kind == "request_document"
+        ]
+
+
+class TestMediationLifecycle:
+    def test_finding_status_resets_on_advance_case(self) -> None:
+        # case 0 mediated (cleared), then dispositioned -> case 1 starts fresh.
+        case0 = CredentialCase(
+            purpose=IND.WORK, id_card=_id(), packet=[_permit(IND.WORK, S.MISSING_SEAL)]
+        )
+        case1 = CredentialCase(purpose=IND.TRAVEL, id_card=_id(S.VALID))
+        game, handler = _game(case0, case1)
+
+        handler.receive_move(game, ("inspect", "passport"))
+        handler.receive_move(game, ("request_document", IND.WORK.value))
+        handler.receive_move(game, ("decide", "pass"))  # cleared -> PASS
+
+        assert game.case_index == 1
+        assert game.finding_status == {}  # reset for the next candidate
+
+    def test_inspect_and_decide_still_work_unchanged(self) -> None:
+        # Regression: the picking kernel's inspect/decide path is unaffected.
+        case = CredentialCase(
+            purpose=IND.WORK, id_card=_id(), packet=[_permit(IND.WORK, S.MISSING_SEAL)]
+        )
+        # Author the answer so we exercise the decide path without going via derive.
+        case.correct_disposition = D.DENY
+        game, handler = _game(case)
+
+        handler.receive_move(game, ("inspect", "passport"))
+        result = handler.receive_move(game, ("decide", "deny"))
+
+        assert result.name == "WIN"
+        assert game.shift_complete


### PR DESCRIPTION
## Summary

Phase B.1 of the credentials mechanic from #246 — core mediation moves on top of the inspect/decide loop. The contraband-mediation matrix (B.2) is captured in the design doc but deferred to its own follow-up.

**Three commits**, each independently reviewable:

1. **`c762f46e` Split Phase B into B.1 / B.2 (design doc).** Frames the B.1 / B.2 split, with an initial contraband matrix.
2. **`a2157070` Refine B.2 contraband matrix (design doc).** Restructures around the 4-way packet validity taxonomy (valid / incomplete / invalid / illegal) and the declared-vs-concealed axis. Adds the "oops, I forgot" `request_disclosure` path, multi-contraband composition, cross-product examples, and the search-on-clean-paperwork rule. Notes severity bends with environment/discretion/bribery (Phase C cross-cut). Three open questions logged for B.2.
3. **`396bec35` Phase B.1: core mediation moves.** The implementation.

## What the implementation adds

- **Base refactor (lead-in)**: `PickingGameHandler.resolve_round` now dispatches through a `resolve_move_kind` hook with inspect/decide defaults. Subclasses extend (not override) to register new kinds; Kim is unaffected. Keeps B.1 and Phase C true overlays.
- **`finding_status: dict[str, str]`** on `CredentialsGame` (reset by `advance_case`). Keys are an indication's value (for permits), `"id"`, or `"search"`. Values: `"cleared"` / `"confirmed"`.
- **`derive_disposition`** gains an optional `finding_status` arg; cleared mitigatable findings contribute PASS instead of DENY. Default empty preserves existing behavior.
- **Three move kinds:**
  - **`request_document`** — per-target fanout over presented permits with a mitigatable status (forged/wrong-holder permits are filtered as crimes). v1 assumes compliance; cleared.
  - **`verify_id`** — single move; clears for VALID, confirms for WRONG_HOLDER. Disposition unchanged but audit-meaningful.
  - **`request_search`** — single move; reveals concealed contraband (confirmed) or notes clean.
- Mediation moves are gated on the packet stage (same as decisions), so the player inspects first.

## Scope (deferred to B.2, tracked in #246)

- Missing-doc requests (`request_complete`).
- Yield/relinquish for declared contraband (`request_relinquish`).
- The "oops" path for valid packets with concealed contraband (`request_disclosure`).
- Declines-mediation axis (per-case `compliant` / per-failure-mode willingness).

## Test plan

- [x] `engine/tests/mechanics/games/test_credentials_mediation.py` — 12 new tests covering availability gating, per-move effects, finding_status reset across `advance_case`, and a regression that inspect/decide still works untouched.
- [x] Full `engine/tests/mechanics/games` + `engine/tests/loaders`: 298 passed, 6 skipped locally (+12 from baseline).
- [ ] CI green.

Refs #246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced credential verification mediation actions: request documents, verify identity, and authorize searches during case review
  * Enhanced credential assessment to incorporate mitigation findings in disposition decisions

* **Tests**
  * Added comprehensive test coverage for credential mediation workflows including availability validation and action effects

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/derekmerck/storytangl/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->