### PR TITLE
Bridge.1: credentials emits typed widget fragments (+ PieceFragment graduation)

### DIFF
--- a/engine/src/tangl/journal/fragments.py
+++ b/engine/src/tangl/journal/fragments.py
@@ -55,11 +55,18 @@ class ContentFragment(BaseFragment):
 
 
 class GroupFragment(BaseFragment, extra="allow"):
-    """Relational overlay tying peer fragments together by identifier."""
+    """Relational overlay tying peer fragments together by identifier.
+
+    ``zone_role`` annotates a ``group_type="zone"`` group with its semantic role
+    (``"packet"``, ``"field"``, ...) for ports that style zones by role. ``hints``
+    carries the same advisory presentation metadata as the other fragments.
+    """
 
     fragment_type: Literal["group"] = "group"
     group_type: str | Enum | None = None
     member_ids: list[UUID] = Field(default_factory=list)
+    zone_role: str | None = None
+    presentation_hints: PresentationHints | None = Field(None, alias="hints")
 
     def members(self, registry: Registry[BaseFragment]) -> list[BaseFragment]:
         return [

--- a/engine/src/tangl/journal/fragments.py
+++ b/engine/src/tangl/journal/fragments.py
@@ -69,6 +69,28 @@ class GroupFragment(BaseFragment, extra="allow"):
         ]
 
 
+class PieceFragment(BaseFragment, extra="allow"):
+    """Identified game piece: a tracked object the player can reference, place
+    into a zone, or pick as a choice payload (candidate, document, token, asset).
+
+    A stable ``piece_id`` (and ``uid``) let multi-envelope sequences update the
+    same piece in place as it changes state or moves between zones. ``zone_ref``
+    names the containing ``group_type="zone"`` fragment. ``properties`` carries
+    per-kind structured data (a candidate's declared purpose, a permit's expiry,
+    ...). Graduates the typed shape tracked as the ``PieceFragment`` row in
+    ``WIDGET_CONTRACT_RECONCILIATION.md``; matches the existing conformance
+    fixture shape.
+    """
+
+    fragment_type: Literal["piece"] = "piece"
+    piece_id: str
+    kind: str | None = None
+    display_state: str | None = None
+    zone_ref: UUID | None = None
+    properties: dict[str, Any] = Field(default_factory=dict)
+    presentation_hints: PresentationHints | None = Field(None, alias="hints")
+
+
 class KvFragment(BaseFragment, extra="allow", arbitrary_types_allowed=True):
     """Ordered key-value fragment for info-like surfaces."""
 
@@ -232,6 +254,7 @@ __all__ = [
     "KvFragment",
     "KvRow",
     "MediaFragment",
+    "PieceFragment",
     "PresentationHints",
     "StagingHints",
     "UIHints",

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -12,6 +12,7 @@ next candidate after every disposition until the game reports terminal.
 """
 from __future__ import annotations
 
+import uuid
 from enum import Enum
 from typing import TYPE_CHECKING, ClassVar
 
@@ -20,8 +21,36 @@ from pydantic import Field
 if TYPE_CHECKING:
     from .credentials_roster import ScenarioOffer
 
+from tangl.core import BaseFragment
 from tangl.core.bases import BaseModelPlus
-from tangl.journal.fragments import ContentFragment
+from tangl.journal.fragments import (
+    ContentFragment,
+    GroupFragment,
+    KvFragment,
+    KvRow,
+    PieceFragment,
+    PresentationHints,
+)
+
+# Fixed namespace so a candidate / packet / document gets a stable fragment uid
+# across rounds: the client fragment registry then updates pieces in place
+# rather than treating each round's re-emission as new.
+_PIECE_NS = uuid.UUID("b7c3f6e2-1d4a-4c9b-9f2e-7a6d5c4b3a21")
+
+
+def _piece_uid(case_index: int, key: str) -> uuid.UUID:
+    return uuid.uuid5(_PIECE_NS, f"credentials:{case_index}:{key}")
+
+
+def _document_kind(label: str) -> str:
+    low = label.lower()
+    if "passport" in low or "id" in low:
+        return "id_card"
+    if "permit" in low:
+        return "permit"
+    if "ticket" in low:
+        return "ticket"
+    return "document"
 
 from .credentials_enums import (
     DEFAULT_RESTRICTIONS,
@@ -744,16 +773,37 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         detail["shift_complete"] = game.shift_complete
         return detail
 
-    def get_journal_fragments(self, game: CredentialsGame) -> list[ContentFragment] | None:
+    def get_journal_fragments(self, game: CredentialsGame) -> list[BaseFragment] | None:
         last_round = game.last_round
         if last_round is None:
             return []
 
         move = self._normalize_move(last_round.player_move)
-        action = move.kind
-        target = move.target
-        notes = last_round.notes or {}
+        prose = self._prose_fragments(game, last_round, move.kind, move.target, last_round.notes or {})
 
+        fragments: list[BaseFragment] = []
+        # Structured candidate / packet view (Bridge.1). Skip once the shift is
+        # over -- there is no next candidate to present. On a non-final decision
+        # this is the *arriving* candidate, which lands alongside the
+        # "next traveler steps up" prose.
+        if not game.shift_complete:
+            fragments.extend(self._candidate_fragments(game))
+        # Findings table for the active case; present on inspect / mediation
+        # rounds, empty after a decision resets the working state.
+        findings = self._findings_fragment(game)
+        if findings is not None:
+            fragments.append(findings)
+        fragments.extend(prose)
+        return fragments
+
+    def _prose_fragments(
+        self,
+        game: CredentialsGame,
+        last_round,
+        action: str,
+        target: str,
+        notes: dict,
+    ) -> list[ContentFragment]:
         if action == "inspect":
             if str(notes.get("outcome", "")).startswith("packet"):
                 return [
@@ -821,6 +871,73 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                 ContentFragment(content="The next traveler steps up to the counter.")
             )
         return fragments
+
+    # ----- Bridge.1: structured (typed) fragment projection ----------------
+
+    def _candidate_fragments(self, game: CredentialsGame) -> list[BaseFragment]:
+        """Project the active candidate + packet zone + document pieces.
+
+        Deterministic uids (per case index) let the client update these pieces
+        in place across rounds rather than re-creating them each turn.
+        """
+
+        case = game.active_case
+        idx = game.case_index
+        packet_uid = _piece_uid(idx, "packet")
+
+        candidate = PieceFragment(
+            uid=_piece_uid(idx, "candidate"),
+            piece_id=f"candidate-{idx}",
+            kind="candidate",
+            content=case.candidate_name,
+            properties={
+                "declared_purpose": case.get_purpose().value,
+                "declared_region": case.get_region().value,
+            },
+            hints=PresentationHints(label_text=case.candidate_name),
+        )
+
+        doc_uids: list[uuid.UUID] = []
+        doc_pieces: list[BaseFragment] = []
+        for label, description in case.presented_documents.items():
+            doc_uid = _piece_uid(idx, f"doc:{label}")
+            doc_uids.append(doc_uid)
+            doc_pieces.append(
+                PieceFragment(
+                    uid=doc_uid,
+                    piece_id=f"{idx}:{label}",
+                    kind=_document_kind(label),
+                    content=description,
+                    zone_ref=packet_uid,
+                    hints=PresentationHints(label_text=label),
+                )
+            )
+
+        packet = GroupFragment(
+            uid=packet_uid,
+            group_type="zone",
+            member_ids=doc_uids,
+            zone_role="packet",
+            hints={"label_text": "Credentials packet"},
+        )
+        return [candidate, packet, *doc_pieces]
+
+    def _findings_fragment(self, game: CredentialsGame) -> KvFragment | None:
+        """Project revealed document/packet findings as a KvFragment.
+
+        Discloses only what the player has already surfaced through inspection
+        (no leaking of unrevealed truth). Document findings are flagged
+        ``warn``; packet-level contradictions are ``danger``.
+        """
+
+        rows: list[KvRow] = []
+        for target, finding in game.revealed_findings.items():
+            rows.append(KvRow(key=target, value=finding, emphasis="warn"))
+        for target, finding in game.packet_findings.items():
+            rows.append(KvRow(key=target, value=finding, emphasis="danger"))
+        if not rows:
+            return None
+        return KvFragment(content=rows)
 
     def _packet_finding(self, game: CredentialsGame, target: str) -> str | None:
         case = game.active_case

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -32,26 +32,6 @@ from tangl.journal.fragments import (
     PresentationHints,
 )
 
-# Fixed namespace so a candidate / packet / document gets a stable fragment uid
-# across rounds: the client fragment registry then updates pieces in place
-# rather than treating each round's re-emission as new.
-_PIECE_NS = uuid.UUID("b7c3f6e2-1d4a-4c9b-9f2e-7a6d5c4b3a21")
-
-
-def _piece_uid(case_index: int, key: str) -> uuid.UUID:
-    return uuid.uuid5(_PIECE_NS, f"credentials:{case_index}:{key}")
-
-
-def _document_kind(label: str) -> str:
-    low = label.lower()
-    if "passport" in low or "id" in low:
-        return "id_card"
-    if "permit" in low:
-        return "permit"
-    if "ticket" in low:
-        return "ticket"
-    return "document"
-
 from .credentials_enums import (
     DEFAULT_RESTRICTIONS,
     ContrabandItem,
@@ -65,6 +45,36 @@ from .credentials_enums import (
 from .enums import GameResult, RoundResult
 from .game import Game
 from .picking_game import PickingGame, PickingGameHandler, PickingMove
+
+
+# Fixed namespace so a candidate / packet / document gets a stable fragment uid
+# across rounds: the client fragment registry then updates pieces in place
+# rather than treating each round's re-emission as new. The game uid is folded
+# into the seed so distinct credentials blocks in one journal (e.g. a scheduled
+# and a randomized shift) never collide on a shared global fragment id.
+_PIECE_NS = uuid.UUID("b7c3f6e2-1d4a-4c9b-9f2e-7a6d5c4b3a21")
+
+
+def _piece_uid(game_uid: uuid.UUID, case_index: int, key: str) -> uuid.UUID:
+    return uuid.uuid5(_PIECE_NS, f"credentials:{game_uid}:{case_index}:{key}")
+
+
+def _document_kind(label: str) -> str:
+    """Best-effort document classification for piece styling.
+
+    Specific document nouns first; a whole-word ``id`` / ``identity`` check last
+    so substrings like "valid"/"residence" don't masquerade as id cards.
+    """
+
+    low = label.lower()
+    words = set(low.split())
+    if "permit" in low:
+        return "permit"
+    if "ticket" in low:
+        return "ticket"
+    if "passport" in low or "identity" in low or {"id", "ids"} & words:
+        return "id_card"
+    return "document"
 
 
 class CredentialDisposition(Enum):
@@ -877,16 +887,16 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
     def _candidate_fragments(self, game: CredentialsGame) -> list[BaseFragment]:
         """Project the active candidate + packet zone + document pieces.
 
-        Deterministic uids (per case index) let the client update these pieces
-        in place across rounds rather than re-creating them each turn.
+        Deterministic uids (per game + case index) let the client update these
+        pieces in place across rounds rather than re-creating them each turn.
         """
 
         case = game.active_case
         idx = game.case_index
-        packet_uid = _piece_uid(idx, "packet")
+        packet_uid = _piece_uid(game.uid, idx, "packet")
 
         candidate = PieceFragment(
-            uid=_piece_uid(idx, "candidate"),
+            uid=_piece_uid(game.uid, idx, "candidate"),
             piece_id=f"candidate-{idx}",
             kind="candidate",
             content=case.candidate_name,
@@ -900,7 +910,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         doc_uids: list[uuid.UUID] = []
         doc_pieces: list[BaseFragment] = []
         for label, description in case.presented_documents.items():
-            doc_uid = _piece_uid(idx, f"doc:{label}")
+            doc_uid = _piece_uid(game.uid, idx, f"doc:{label}")
             doc_uids.append(doc_uid)
             doc_pieces.append(
                 PieceFragment(
@@ -918,7 +928,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             group_type="zone",
             member_ids=doc_uids,
             zone_role="packet",
-            hints={"label_text": "Credentials packet"},
+            hints=PresentationHints(label_text="Credentials packet"),
         )
         return [candidate, packet, *doc_pieces]
 

--- a/engine/tests/journal/test_piece_fragment.py
+++ b/engine/tests/journal/test_piece_fragment.py
@@ -1,0 +1,52 @@
+"""Tests for the typed PieceFragment graduation.
+
+Pins the serialized shape to the established conformance-fixture convention
+(`fragment_type="piece"`, flat `piece_id`/`kind`/`content`/`display_state`/
+`zone_ref`, and `hints.label_text`).
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from tangl.journal.fragments import PieceFragment, PresentationHints
+
+
+def test_piece_fragment_serializes_to_fixture_shape() -> None:
+    uid = UUID("00000000-0000-4000-8000-000000000504")
+    zone = UUID("00000000-0000-4000-8000-000000000503")
+    piece = PieceFragment(
+        uid=uid,
+        piece_id="lamp",
+        kind="item",
+        content="brass lamp",
+        display_state="available",
+        zone_ref=zone,
+        hints=PresentationHints(label_text="brass lamp"),
+    )
+
+    data = piece.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+    assert data["fragment_type"] == "piece"
+    assert data["piece_id"] == "lamp"
+    assert data["kind"] == "item"
+    assert data["content"] == "brass lamp"
+    assert data["display_state"] == "available"
+    assert str(data["zone_ref"]) == str(zone)
+    assert data["hints"]["label_text"] == "brass lamp"
+
+
+def test_piece_fragment_carries_properties_for_richer_kinds() -> None:
+    piece = PieceFragment(
+        piece_id="candidate-0",
+        kind="candidate",
+        content="Bek Tarsus",
+        properties={"declared_purpose": "merchant", "declared_origin": "Kalden"},
+        hints=PresentationHints(label_text="Bek Tarsus (merchant)"),
+    )
+
+    data = piece.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+    assert data["properties"]["declared_purpose"] == "merchant"
+    assert data["kind"] == "candidate"
+    assert data["hints"]["label_text"] == "Bek Tarsus (merchant)"

--- a/engine/tests/loaders/test_credential_gate_world.py
+++ b/engine/tests/loaders/test_credential_gate_world.py
@@ -75,7 +75,7 @@ class TestCredentialGateWorld:
         content = " ".join(
             f.content
             for f in ledger.get_journal()
-            if isinstance(getattr(f, "content", None), str)
+            if isinstance(f.content, str)
         )
         assert "shift complete" in content.lower()
 
@@ -117,7 +117,7 @@ class TestCredentialGateWorld:
         content = " ".join(
             f.content
             for f in ledger.get_journal()
-            if isinstance(getattr(f, "content", None), str)
+            if isinstance(f.content, str)
         )
         assert "shift complete" in content.lower()
         assert f"of {total}" in content

--- a/engine/tests/loaders/test_credential_gate_world.py
+++ b/engine/tests/loaders/test_credential_gate_world.py
@@ -72,7 +72,11 @@ class TestCredentialGateWorld:
         _choose(ledger, "Choose arrest")
 
         assert ledger.cursor.label == "victory"
-        content = " ".join(getattr(fragment, "content", "") for fragment in ledger.get_journal())
+        content = " ".join(
+            f.content
+            for f in ledger.get_journal()
+            if isinstance(getattr(f, "content", None), str)
+        )
         assert "shift complete" in content.lower()
 
     def test_randomized_shift_materializes_lazily_and_routes_to_victory(self) -> None:
@@ -110,6 +114,10 @@ class TestCredentialGateWorld:
             _choose(ledger, f"Choose {target}")
 
         assert ledger.cursor.label == "victory"
-        content = " ".join(getattr(fragment, "content", "") for fragment in ledger.get_journal())
+        content = " ".join(
+            f.content
+            for f in ledger.get_journal()
+            if isinstance(getattr(f, "content", None), str)
+        )
         assert "shift complete" in content.lower()
         assert f"of {total}" in content

--- a/engine/tests/mechanics/games/test_credentials_fragments.py
+++ b/engine/tests/mechanics/games/test_credentials_fragments.py
@@ -93,6 +93,22 @@ class TestStructuredEmission:
 
         assert first.uid == second.uid  # same candidate -> in-place update
 
+    def test_distinct_games_get_distinct_piece_uids(self) -> None:
+        # Two credentials games (e.g. a scheduled + a randomized shift) must not
+        # collide on a shared global fragment uid in the client registry.
+        game_a, handler_a = _game()
+        game_b, handler_b = _game()
+        handler_a.receive_move(game_a, ("inspect", "passport"))
+        handler_b.receive_move(game_b, ("inspect", "passport"))
+
+        def candidate_uid(handler, game):
+            return [
+                p for p in _by_type(handler.get_journal_fragments(game), PieceFragment)
+                if p.kind == "candidate"
+            ][0].uid
+
+        assert candidate_uid(handler_a, game_a) != candidate_uid(handler_b, game_b)
+
     def test_no_structural_pieces_once_shift_complete(self) -> None:
         game, handler = _game(_case())  # single-candidate shift
         handler.receive_move(game, ("inspect", "passport"))

--- a/engine/tests/mechanics/games/test_credentials_fragments.py
+++ b/engine/tests/mechanics/games/test_credentials_fragments.py
@@ -1,0 +1,116 @@
+"""Tests for credentials' structured fragment emission (Bridge.1).
+
+Verifies that the handler projects candidate / packet-zone / document pieces and
+finding KvFragments alongside the prose fallback, with stable uids for in-place
+update across rounds.
+"""
+
+from __future__ import annotations
+
+from tangl.journal.fragments import (
+    ContentFragment,
+    GroupFragment,
+    KvFragment,
+    PieceFragment,
+)
+from tangl.mechanics.games import (
+    CredentialCase,
+    CredentialDisposition,
+    CredentialsGame,
+    CredentialsGameHandler,
+)
+
+
+def _case() -> CredentialCase:
+    return CredentialCase(
+        candidate_name="Edda Marrow",
+        presented_documents={
+            "passport": "A worn passport.",
+            "work permit": "A permit lacking its seal.",
+        },
+        hidden_facts={"passport": "The seal impression is wrong for this border."},
+        correct_disposition=CredentialDisposition.DENY,
+    )
+
+
+def _game(*cases: CredentialCase) -> tuple[CredentialsGame, CredentialsGameHandler]:
+    game = CredentialsGame(roster=list(cases) or [_case()])
+    handler = CredentialsGameHandler()
+    handler.setup(game)
+    return game, handler
+
+
+def _by_type(fragments, kind):
+    return [f for f in fragments if isinstance(f, kind)]
+
+
+class TestStructuredEmission:
+    def test_inspect_emits_candidate_packet_and_documents(self) -> None:
+        game, handler = _game()
+        handler.receive_move(game, ("inspect", "passport"))
+        frags = handler.get_journal_fragments(game)
+
+        pieces = _by_type(frags, PieceFragment)
+        candidate = [p for p in pieces if p.kind == "candidate"]
+        docs = [p for p in pieces if p.kind != "candidate"]
+
+        assert candidate and candidate[0].content == "Edda Marrow"
+        assert candidate[0].properties["declared_purpose"]  # populated
+        assert {p.content for p in docs} == {"A worn passport.", "A permit lacking its seal."}
+
+        groups = _by_type(frags, GroupFragment)
+        assert groups and groups[0].group_type == "zone"
+        # The packet zone references exactly the document piece uids.
+        assert set(groups[0].member_ids) == {p.uid for p in docs}
+        # Each document points back at the packet zone.
+        assert all(p.zone_ref == groups[0].uid for p in docs)
+
+    def test_revealed_finding_emits_kv_row(self) -> None:
+        game, handler = _game()
+        handler.receive_move(game, ("inspect", "passport"))
+        frags = handler.get_journal_fragments(game)
+
+        kvs = _by_type(frags, KvFragment)
+        assert kvs
+        rows = kvs[0].content
+        assert any(row.key == "passport" and row.emphasis == "warn" for row in rows)
+
+    def test_prose_fallback_preserved(self) -> None:
+        game, handler = _game()
+        handler.receive_move(game, ("inspect", "passport"))
+        frags = handler.get_journal_fragments(game)
+
+        prose = _by_type(frags, ContentFragment)
+        assert any("inspect" in str(f.content).lower() for f in prose)
+
+    def test_candidate_uid_is_stable_across_rounds(self) -> None:
+        game, handler = _game()
+        handler.receive_move(game, ("inspect", "passport"))
+        first = [p for p in _by_type(handler.get_journal_fragments(game), PieceFragment) if p.kind == "candidate"][0]
+
+        handler.receive_move(game, ("inspect", "work permit"))
+        second = [p for p in _by_type(handler.get_journal_fragments(game), PieceFragment) if p.kind == "candidate"][0]
+
+        assert first.uid == second.uid  # same candidate -> in-place update
+
+    def test_no_structural_pieces_once_shift_complete(self) -> None:
+        game, handler = _game(_case())  # single-candidate shift
+        handler.receive_move(game, ("inspect", "passport"))
+        handler.receive_move(game, ("decide", "deny"))
+        assert game.shift_complete
+
+        frags = handler.get_journal_fragments(game)
+        assert not _by_type(frags, PieceFragment)
+        prose = _by_type(frags, ContentFragment)
+        assert any("shift complete" in str(f.content).lower() for f in prose)
+
+    def test_arriving_candidate_pieces_on_non_final_decision(self) -> None:
+        # Two-candidate shift: deciding case 0 advances to case 1, whose pieces
+        # arrive alongside the "next traveler" prose.
+        game, handler = _game(_case(), CredentialCase(candidate_name="Tomas Vey"))
+        handler.receive_move(game, ("inspect", "passport"))
+        handler.receive_move(game, ("decide", "deny"))
+
+        frags = handler.get_journal_fragments(game)
+        candidate = [p for p in _by_type(frags, PieceFragment) if p.kind == "candidate"]
+        assert candidate and candidate[0].content == "Tomas Vey"

--- a/engine/tests/mechanics/games/test_credentials_game.py
+++ b/engine/tests/mechanics/games/test_credentials_game.py
@@ -253,7 +253,11 @@ class TestCredentialsIntegration:
         self._choose(ledger, "Choose pass")
 
         assert ledger.cursor_id == victory.uid
-        content = " ".join(getattr(f, "content", "") for f in ledger.get_journal())
+        content = " ".join(
+            f.content
+            for f in ledger.get_journal()
+            if isinstance(getattr(f, "content", None), str)
+        )
         assert "shift complete" in content.lower()
 
     def test_context_exports_discovered_findings(self) -> None:

--- a/engine/tests/mechanics/games/test_credentials_game.py
+++ b/engine/tests/mechanics/games/test_credentials_game.py
@@ -256,7 +256,7 @@ class TestCredentialsIntegration:
         content = " ".join(
             f.content
             for f in ledger.get_journal()
-            if isinstance(getattr(f, "content", None), str)
+            if isinstance(f.content, str)
         )
         assert "shift complete" in content.lower()
 


### PR DESCRIPTION
## Summary

Bridge.1 of the credentials → v1.5 widget-vocab work (#246): the credentials engine now emits **typed structured fragments**, not just prose, so the reference renderer can show the candidate, their packet, the documents, and the findings as first-class widgets.

**Two commits:**

1. **`0f4bb216` Graduate typed `PieceFragment`.** No bundle emitted piece-shaped fragments from Python before — they existed only as hand-built conformance fixtures and client TS. This adds `PieceFragment(BaseFragment)` to `engine/src/tangl/journal/fragments.py` matching the **established fixture shape** (`fragment_type="piece"`; flat `piece_id` / `kind` / `content` / `display_state` / `zone_ref`; `properties` for richer per-kind data; `hints.label_text`). Graduates the `PieceFragment` row tracked in `WIDGET_CONTRACT_RECONCILIATION.md`. **@widget-vocab folks: this is the typed-shape graduation — would value a vet that the field set matches your intent before more bundles build on it.**

2. **`1d985224` Credentials emits structured fragments.** `CredentialsGameHandler.get_journal_fragments` now projects, alongside the existing prose (kept as fallback):
   - candidate `PieceFragment(kind="candidate")` with declared purpose/region in `properties`;
   - packet `GroupFragment(group_type="zone", zone_role="packet")` whose `member_ids` reference the document pieces;
   - one `PieceFragment` per presented document, `zone_ref`-linked back to the packet;
   - a `KvFragment` of revealed findings (document → `warn`, packet-level → `danger`), **disclosing only what the player has already surfaced** through inspection (no leaking unrevealed truth).

   Deterministic `uuid5`-based uids (per case index) let the client update pieces in place across rounds. Structural pieces are suppressed once the shift completes; on a non-final decision the *arriving* candidate's pieces land alongside the "next traveler" prose.

## Notes

- **Independent of the story-info side-channel** (PR #252, now merged). Bridge.2b (credentials' `rules` / `roster_progress` / `case_summary` info channels) builds on that dispatch separately.
- Journal-text test assertions now filter to string content, since journals carry typed non-text fragments now; renderers dispatch by `fragment_type`, so this is test-only.

## Test plan

- [x] New `engine/tests/journal/test_piece_fragment.py` — serialized shape matches the fixture convention.
- [x] New `engine/tests/mechanics/games/test_credentials_fragments.py` — candidate/packet/document emission, zone membership + back-refs, finding rows, prose fallback, uid stability, shift-complete suppression, arriving-candidate on non-final decision.
- [x] Full sweep `engine/tests/{mechanics/games,loaders,journal,service,conformance}`: 434 passed, 6 skipped locally.
- [ ] CI green.

Refs #246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured game pieces (stable IDs, kind/display state, properties) and zone presentation hints added to journal fragments.

* **Refactor**
  * Journal emission now returns multiple typed fragments (pieces, zones, findings) with deterministic piece tracking for consistent in-place updates.

* **Tests**
  * New tests for piece fragment serialization and structured fragment emission.
  * Updated tests to filter/validate string-based content when asserting journal prose.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/derekmerck/storytangl/pull/253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->