### PR TITLE
Bridge.2b: credentials story-info side-channels (rules/progress/findings)

### DIFF
--- a/engine/src/tangl/mechanics/games/credentials_story_info.py
+++ b/engine/src/tangl/mechanics/games/credentials_story_info.py
@@ -41,17 +41,22 @@ PROGRESS_KIND = "roster_progress"
 CASE_SUMMARY_KIND = "case_summary"
 
 
-def _credentials_game(caller: object) -> CredentialsGame | None:
-    """Return the active CredentialsGame if ``caller`` hosts one, else None."""
+def _credentials_game(caller: HasGame) -> CredentialsGame | None:
+    """Return the active game if it is a CredentialsGame, else None.
 
-    game = getattr(caller, "game", None)
+    The handlers register for every ``HasGame`` caller, so ``caller.game`` is the
+    typed accessor; the isinstance check discriminates the credentials mechanic
+    from the other game types that share the same story-info dispatch.
+    """
+
+    game = caller.game
     return game if isinstance(game, CredentialsGame) else None
 
 
 @on_advertise_info_channels(wants_caller_kind=HasGame, wants_exact_kind=False)
 def advertise_credentials_info_channels(
     *,
-    caller: object,
+    caller: HasGame,
     ctx: PhaseCtx,
     **_kw: object,
 ) -> list[InfoAffordance]:
@@ -84,7 +89,7 @@ def advertise_credentials_info_channels(
 @on_get_story_info(wants_caller_kind=HasGame, wants_exact_kind=False)
 def project_credentials_info(
     *,
-    caller: object,
+    caller: HasGame,
     ctx: PhaseCtx,
     request: StoryInfoRequest,
     **_kw: object,
@@ -136,11 +141,16 @@ def _progress_sections(game: CredentialsGame) -> list[ProjectedSection]:
 
     total = game._total_cases()
     decided = len(game.case_results)
+    progress_text = (
+        "Shift complete"
+        if game.shift_complete
+        else f"Candidate {min(decided + 1, total)} of {total}"
+    )
     summary = ProjectedSection(
         section_id="credential_progress",
         title="Shift Progress",
         kind=PROGRESS_KIND,
-        value=ScalarValue(value=f"Candidate {min(decided + 1, total)} of {total}"),
+        value=ScalarValue(value=progress_text),
     )
     if not game.case_results:
         return [summary]
@@ -174,7 +184,7 @@ def _case_summary_section(game: CredentialsGame) -> ProjectedSection | None:
         rows.append(KvRow(key=target, value=finding, emphasis="danger"))
     for target, status in game.finding_status.items():
         emphasis = "ok" if status == "cleared" else "danger"
-        rows.append(KvRow(key=f"{target} ({status})", value=status, emphasis=emphasis))
+        rows.append(KvRow(key=target, value=status, emphasis=emphasis))
     if not rows:
         return None
     return ProjectedSection(

--- a/engine/src/tangl/mechanics/games/credentials_story_info.py
+++ b/engine/src/tangl/mechanics/games/credentials_story_info.py
@@ -1,0 +1,185 @@
+"""Story-info channels for the credentials checkpoint shift (Bridge.2b).
+
+Registers ``advertise`` / ``get_story_info`` dispatch handlers (the side-channel
+surface from ``STORYTANGL_WIDGET_VOCAB.md`` §1.6) so a client can pull
+supplementary projected state on demand: the day's rules, the player's shift
+progress, and the findings surfaced so far for the active candidate.
+
+Disclosure discipline ("a disclosed projection of world state, not world state
+itself"):
+
+- ``rules`` -- the posted checkpoint rulebook; public by construction.
+- ``roster_progress`` -- the player's *own* rulings and how far through the
+  shift they are. It does **not** reveal whether each ruling was correct: the
+  expected disposition is hidden truth, surfaced only when the shift resolves.
+- ``case_summary`` -- only the findings the player has already revealed for the
+  active candidate (inspection + mediation outcomes). No unrevealed packet
+  truth, no expected disposition.
+
+Service-layer imports are isolated to this module (mirroring
+``tangl.mechanics.sandbox.story_info``); importing it registers the handlers.
+"""
+from __future__ import annotations
+
+from tangl.service.dispatch import on_advertise_info_channels, on_get_story_info
+from tangl.service.response import (
+    InfoAffordance,
+    KvListValue,
+    KvRow,
+    ProjectedSection,
+    ScalarValue,
+    StoryInfoRequest,
+    TableValue,
+)
+from tangl.vm.runtime.frame import PhaseCtx
+
+from .credentials_game import CredentialsGame
+from .has_game import HasGame
+
+RULES_KIND = "rules"
+PROGRESS_KIND = "roster_progress"
+CASE_SUMMARY_KIND = "case_summary"
+
+
+def _credentials_game(caller: object) -> CredentialsGame | None:
+    """Return the active CredentialsGame if ``caller`` hosts one, else None."""
+
+    game = getattr(caller, "game", None)
+    return game if isinstance(game, CredentialsGame) else None
+
+
+@on_advertise_info_channels(wants_caller_kind=HasGame, wants_exact_kind=False)
+def advertise_credentials_info_channels(
+    *,
+    caller: object,
+    ctx: PhaseCtx,
+    **_kw: object,
+) -> list[InfoAffordance]:
+    """Advertise the credentials side-channels for a checkpoint-shift block."""
+
+    if _credentials_game(caller) is None:
+        return []
+    return [
+        InfoAffordance(
+            kind=RULES_KIND,
+            label="Today's rules",
+            shortcuts=["r", "rules"],
+            query={"kinds": [RULES_KIND]},
+        ),
+        InfoAffordance(
+            kind=PROGRESS_KIND,
+            label="Shift progress",
+            shortcuts=["p", "shift"],
+            query={"kinds": [PROGRESS_KIND]},
+        ),
+        InfoAffordance(
+            kind=CASE_SUMMARY_KIND,
+            label="Findings",
+            shortcuts=["c", "findings"],
+            query={"kinds": [CASE_SUMMARY_KIND]},
+        ),
+    ]
+
+
+@on_get_story_info(wants_caller_kind=HasGame, wants_exact_kind=False)
+def project_credentials_info(
+    *,
+    caller: object,
+    ctx: PhaseCtx,
+    request: StoryInfoRequest,
+    **_kw: object,
+) -> list[ProjectedSection] | None:
+    """Project the requested credentials channels for the active shift."""
+
+    game = _credentials_game(caller)
+    if game is None:
+        return None
+
+    kinds = request.requested_kinds()
+    sections: list[ProjectedSection] = []
+    if RULES_KIND in kinds:
+        sections.append(_rules_section(game))
+    if PROGRESS_KIND in kinds:
+        sections.extend(_progress_sections(game))
+    if CASE_SUMMARY_KIND in kinds:
+        summary = _case_summary_section(game)
+        if summary is not None:
+            sections.append(summary)
+    return sections or None
+
+
+def _rules_section(game: CredentialsGame) -> ProjectedSection:
+    """The day's restriction map -- public checkpoint rules."""
+
+    rows: list[KvRow] = []
+    for rule in game.restriction_map.rules:
+        rows.append(
+            KvRow(
+                key=f"{rule.indication.value} ({rule.region.value})",
+                value=rule.level.value,
+            )
+        )
+    return ProjectedSection(
+        section_id="credential_rules",
+        title="Checkpoint Rules",
+        kind=RULES_KIND,
+        value=KvListValue(items=rows),
+    )
+
+
+def _progress_sections(game: CredentialsGame) -> list[ProjectedSection]:
+    """Shift progress: how far along, and the rulings made so far.
+
+    Deliberately omits correctness -- whether a past ruling was right is hidden
+    truth until the shift resolves.
+    """
+
+    total = game._total_cases()
+    decided = len(game.case_results)
+    summary = ProjectedSection(
+        section_id="credential_progress",
+        title="Shift Progress",
+        kind=PROGRESS_KIND,
+        value=ScalarValue(value=f"Candidate {min(decided + 1, total)} of {total}"),
+    )
+    if not game.case_results:
+        return [summary]
+
+    rulings = ProjectedSection(
+        section_id="credential_rulings",
+        title="Rulings So Far",
+        kind=PROGRESS_KIND,
+        value=TableValue(
+            columns=["Candidate", "Your ruling"],
+            rows=[
+                [result.candidate_name, result.chosen_disposition.value]
+                for result in game.case_results
+            ],
+        ),
+    )
+    return [summary, rulings]
+
+
+def _case_summary_section(game: CredentialsGame) -> ProjectedSection | None:
+    """Findings the player has surfaced for the active candidate.
+
+    Discloses only revealed document/packet findings and mediation outcomes --
+    never unrevealed truth or the expected disposition.
+    """
+
+    rows: list[KvRow] = []
+    for target, finding in game.revealed_findings.items():
+        rows.append(KvRow(key=target, value=finding, emphasis="warn"))
+    for target, finding in game.packet_findings.items():
+        rows.append(KvRow(key=target, value=finding, emphasis="danger"))
+    for target, status in game.finding_status.items():
+        emphasis = "ok" if status == "cleared" else "danger"
+        rows.append(KvRow(key=f"{target} ({status})", value=status, emphasis=emphasis))
+    if not rows:
+        return None
+    return ProjectedSection(
+        section_id="credential_case_summary",
+        title="Findings",
+        kind=CASE_SUMMARY_KIND,
+        value=KvListValue(items=rows),
+    )

--- a/engine/tests/service/test_credentials_story_info.py
+++ b/engine/tests/service/test_credentials_story_info.py
@@ -115,6 +115,17 @@ class TestProgressChannel:
         # No rulings table yet.
         assert "credential_rulings" not in sections
 
+    def test_progress_reads_shift_complete_at_end(self) -> None:
+        block, ctx = _block_and_ctx()
+        handler = block.game_handler
+        for _ in range(block.game._total_cases()):
+            handler.receive_move(block.game, ("inspect", "passport"))
+            handler.receive_move(block.game, ("decide", "pass"))
+        assert block.game.shift_complete
+
+        sections = _sections(block, ctx, kind="roster_progress")
+        assert sections["credential_progress"].value.value == "Shift complete"
+
     def test_progress_shows_rulings_without_correctness(self) -> None:
         block, ctx = _block_and_ctx()
         handler = block.game_handler
@@ -149,3 +160,36 @@ class TestCaseSummaryChannel:
         # The expected disposition (hidden truth) never appears.
         flat = str(value.model_dump()).lower()
         assert "deny" not in flat and "expected" not in flat
+
+    def test_mediation_outcome_row_uses_bare_target_key(self) -> None:
+        # A work candidate with a mitigatable (unsealed) work permit, so
+        # request_document is available and clears the finding.
+        graph = Graph(label="credentials_mediation_info")
+        block = graph.add_node(kind=CredentialsBlock, label="checkpoint")
+        block.game.roster = [
+            CredentialCase(
+                candidate_name="Goran Siv",
+                presented_documents={"passport": "An id.", "work permit": "Unsealed."},
+                region=Region.LOCAL,
+                purpose=IND.WORK,
+                id_card=CredentialToken(indication=IND.WORK, status=S.VALID),
+                packet=[
+                    CredentialToken(
+                        indication=IND.WORK, status=S.MISSING_SEAL, requires_id=True
+                    )
+                ],
+            )
+        ]
+        block.game.restriction_map = RULES
+        block.game_handler.setup(block.game)
+        ledger = Ledger.from_graph(graph, entry_id=block.uid)
+        ctx = PhaseCtx(graph=graph, cursor_id=block.uid, step=ledger.step)
+
+        block.game_handler.receive_move(block.game, ("inspect", "passport"))
+        block.game_handler.receive_move(block.game, ("request_document", IND.WORK.value))
+
+        sections = _sections(block, ctx, kind="case_summary")
+        value = sections["credential_case_summary"].value
+        cleared = [row for row in value.items if row.value == "cleared"]
+        assert cleared and cleared[0].key == IND.WORK.value  # no "(cleared)" suffix
+        assert cleared[0].emphasis == "ok"

--- a/engine/tests/service/test_credentials_story_info.py
+++ b/engine/tests/service/test_credentials_story_info.py
@@ -1,0 +1,151 @@
+"""Story-info side-channel contracts for the credentials shift (Bridge.2b).
+
+Exercises the advertise / get_story_info dispatch handlers and the disclosure
+discipline: rules are public, progress shows the player's own rulings without
+correctness, and case_summary shows only surfaced findings.
+"""
+
+from __future__ import annotations
+
+from tangl.core import Graph
+
+# Importing the module registers its dispatch handlers.
+import tangl.mechanics.games.credentials_story_info  # noqa: F401
+from tangl.mechanics.games import (
+    CredentialCase,
+    CredentialDisposition,
+    CredentialStatus,
+    CredentialToken,
+    CredentialsGame,
+    CredentialsGameHandler,
+    HasGame,
+    Indication,
+    Region,
+    Restrictions,
+    RestrictionLevel,
+)
+from tangl.service.dispatch import do_advertise_info_channels, do_get_story_info
+from tangl.service.response import KvListValue, ScalarValue, StoryInfoRequest, TableValue
+from tangl.story import Block
+from tangl.vm.runtime.frame import PhaseCtx
+from tangl.vm.runtime.ledger import Ledger
+
+D = CredentialDisposition
+IND = Indication
+S = CredentialStatus
+L = RestrictionLevel
+
+RULES = Restrictions.from_map(
+    {Region.LOCAL: {IND.TRAVEL: L.WITH_ID, IND.WORK: L.WITH_PERMIT}}
+)
+
+
+class CredentialsBlock(HasGame, Block):
+    _game_class = CredentialsGame
+    _game_handler_class = CredentialsGameHandler
+
+
+def _roster() -> list[CredentialCase]:
+    return [
+        CredentialCase(
+            candidate_name="Edda Marrow",
+            presented_documents={"passport": "A worn passport."},
+            hidden_facts={"passport": "The seal is wrong for this border."},
+            region=Region.LOCAL,
+            purpose=IND.TRAVEL,
+            id_card=CredentialToken(indication=IND.TRAVEL, status=S.MISSING_SEAL),
+        ),
+        CredentialCase(
+            candidate_name="Tomas Vey",
+            presented_documents={"passport": "A crisp passport."},
+            region=Region.LOCAL,
+            purpose=IND.TRAVEL,
+            id_card=CredentialToken(indication=IND.TRAVEL, status=S.VALID),
+        ),
+    ]
+
+
+def _block_and_ctx() -> tuple[CredentialsBlock, PhaseCtx]:
+    graph = Graph(label="credentials_info")
+    block = graph.add_node(kind=CredentialsBlock, label="checkpoint")
+    block.game.roster = _roster()
+    block.game.restriction_map = RULES
+    block.game_handler.setup(block.game)
+    ledger = Ledger.from_graph(graph, entry_id=block.uid)
+    ctx = PhaseCtx(graph=graph, cursor_id=block.uid, step=ledger.step)
+    return block, ctx
+
+
+def _sections(block, ctx, **request_kwargs):
+    state = do_get_story_info(block, ctx=ctx, request=StoryInfoRequest(**request_kwargs))
+    return {section.section_id: section for section in state.sections}
+
+
+class TestAdvertise:
+    def test_advertises_three_channels(self) -> None:
+        block, ctx = _block_and_ctx()
+        kinds = {a.kind for a in do_advertise_info_channels(block, ctx=ctx)}
+        assert kinds == {"rules", "roster_progress", "case_summary"}
+
+    def test_non_credentials_caller_advertises_nothing(self) -> None:
+        graph = Graph(label="plain")
+        plain = graph.add_node(kind=Block, label="plain")
+        ledger = Ledger.from_graph(graph, entry_id=plain.uid)
+        ctx = PhaseCtx(graph=graph, cursor_id=plain.uid, step=ledger.step)
+        assert do_advertise_info_channels(plain, ctx=ctx) == []
+
+
+class TestRulesChannel:
+    def test_rules_project_the_restriction_map(self) -> None:
+        block, ctx = _block_and_ctx()
+        sections = _sections(block, ctx, kind="rules")
+        value = sections["credential_rules"].value
+        assert isinstance(value, KvListValue)
+        pairs = {(row.key, row.value) for row in value.items}
+        assert ("travel (local)", "with_id") in pairs
+        assert ("work (local)", "with_permit") in pairs
+
+
+class TestProgressChannel:
+    def test_progress_scalar_before_any_ruling(self) -> None:
+        block, ctx = _block_and_ctx()
+        sections = _sections(block, ctx, kind="roster_progress")
+        assert isinstance(sections["credential_progress"].value, ScalarValue)
+        assert sections["credential_progress"].value.value == "Candidate 1 of 2"
+        # No rulings table yet.
+        assert "credential_rulings" not in sections
+
+    def test_progress_shows_rulings_without_correctness(self) -> None:
+        block, ctx = _block_and_ctx()
+        handler = block.game_handler
+        handler.receive_move(block.game, ("inspect", "passport"))
+        handler.receive_move(block.game, ("decide", "pass"))  # wrong (should be deny)
+
+        sections = _sections(block, ctx, kind="roster_progress")
+        rulings = sections["credential_rulings"].value
+        assert isinstance(rulings, TableValue)
+        # The ruling is disclosed; correctness is not.
+        assert rulings.columns == ["Candidate", "Your ruling"]
+        assert rulings.rows == [["Edda Marrow", "pass"]]
+        flat = str(rulings.model_dump()).lower()
+        assert "correct" not in flat and "expected" not in flat
+
+
+class TestCaseSummaryChannel:
+    def test_empty_before_inspection(self) -> None:
+        block, ctx = _block_and_ctx()
+        sections = _sections(block, ctx, kind="case_summary")
+        assert "credential_case_summary" not in sections
+
+    def test_discloses_only_revealed_findings(self) -> None:
+        block, ctx = _block_and_ctx()
+        block.game_handler.receive_move(block.game, ("inspect", "passport"))
+
+        sections = _sections(block, ctx, kind="case_summary")
+        value = sections["credential_case_summary"].value
+        assert isinstance(value, KvListValue)
+        keys = {row.key for row in value.items}
+        assert "passport" in keys
+        # The expected disposition (hidden truth) never appears.
+        flat = str(value.model_dump()).lower()
+        assert "deny" not in flat and "expected" not in flat

--- a/worlds/credential_gate/credential_gate/domain.py
+++ b/worlds/credential_gate/credential_gate/domain.py
@@ -24,6 +24,12 @@ from tangl.mechanics.games.credentials_roster import (
     ShiftSpec,
     generate_roster,
 )
+
+# Importing the story-info module registers the credentials side-channels
+# (rules / roster_progress / case_summary) on the service dispatch when this
+# world loads. Mirrors how the adventure sandbox world pulls in its map channel.
+import tangl.mechanics.games.credentials_story_info  # noqa: F401
+
 from tangl.story import Block
 
 


### PR DESCRIPTION
## Summary

Bridge.2b of the credentials → v1.5 work (#246): the credentials shift now exposes **story-info side-channels** so a client can pull supplementary projected state on demand. Builds directly on the story-info dispatch from PR #252 (now merged) and mirrors the sandbox map channel's structure.

**Three channels**, registered via the `advertise` / `get_story_info` dispatch:

| Channel | Shows | Value type |
|---|---|---|
| `rules` | the day's restriction map (public checkpoint rulebook) | `kv_list` |
| `roster_progress` | candidate *n*-of-*N* + the player's own rulings | `scalar` + `table` |
| `case_summary` | findings the player has already surfaced for the active candidate | `kv_list` (severity-emphasized) |

## Disclosure discipline

Honors the negotiated *"disclosed projection of world state, not world state itself"* rule:

- **`roster_progress` deliberately omits correctness.** It shows *what* the player ruled (disclosed — they chose it) but never *whether it was right* — the expected disposition is hidden truth, surfaced only when the shift resolves. A test asserts no `correct`/`expected` leaks into the rulings table.
- **`case_summary` shows only revealed findings** (inspection + mediation outcomes), never unrevealed packet truth or the expected disposition. A test asserts the hidden disposition never appears.

## Structure / template notes

- Mirrors `tangl.mechanics.sandbox.story_info` exactly: a dedicated module with the service-layer imports isolated, registered against `HasGame` (guarded on `CredentialsGame`, so it no-ops for any other game type).
- **Registration is opt-in via the world domain import** (`credential_gate/domain.py` imports the module), matching how the adventure sandbox world pulls in its map channel. This keeps `tangl.mechanics.games` free of service imports by default — mechanics doesn't depend on service unless a world opts in.
- This is the **second feature into the story-info dispatch** (after sandbox's `map`); the registration + guard + disclosure pattern here is meant to be a clean template for further channels.

## Test plan

- [x] `engine/tests/service/test_credentials_story_info.py` — 7 tests: advertises the three channels, each channel projects correctly, non-credentials caller advertises nothing, progress shows rulings without correctness, case_summary discloses only surfaced findings.
- [x] Broad sweep `engine/tests/{service,mechanics/games,loaders,conformance,journal}`: 442 passed, 6 skipped locally (sandbox story-info unaffected — the `HasGame` guard prevents cross-contamination).
- [ ] CI green.

Refs #246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Credentials checkpoint adds three info channels: restriction rules reference, roster/shift progress (shows current candidate or “Shift complete” and reveals a rulings table after decisions), and case findings summary (lists surfaced findings for inspected cases).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/derekmerck/storytangl/pull/254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->