### PR TITLE
Bridge.3: credentials conformance fixture + move-menu disclosure discipline

### DIFF
--- a/engine/contrib/conformance/fixtures/credentials_shift.json
+++ b/engine/contrib/conformance/fixtures/credentials_shift.json
@@ -14,7 +14,9 @@
         "00000000-0000-4000-8000-000000000610",
         "00000000-0000-4000-8000-000000000611",
         "00000000-0000-4000-8000-000000000612",
-        "00000000-0000-4000-8000-000000000613"
+        "00000000-0000-4000-8000-000000000613",
+        "00000000-0000-4000-8000-000000000614",
+        "00000000-0000-4000-8000-000000000615"
       ],
       "hints": { "label_text": "Checkpoint" }
     },
@@ -100,8 +102,6 @@
       "edge_id": "decide_pass",
       "text": "Choose pass.",
       "accepts": { "kind": "pick" },
-      "available": false,
-      "unavailable_reason": "The work permit is expired (see findings).",
       "ui_hints": { "hotkey": "a", "emphasis": "primary" }
     },
     {
@@ -119,6 +119,22 @@
       "text": "Request reissue of work permit.",
       "accepts": { "kind": "pick" },
       "ui_hints": { "hotkey": "r" }
+    },
+    {
+      "uid": "00000000-0000-4000-8000-000000000614",
+      "fragment_type": "choice",
+      "edge_id": "verify_id",
+      "text": "Verify identity.",
+      "accepts": { "kind": "pick" },
+      "ui_hints": { "hotkey": "v" }
+    },
+    {
+      "uid": "00000000-0000-4000-8000-000000000615",
+      "fragment_type": "choice",
+      "edge_id": "request_search",
+      "text": "Request search.",
+      "accepts": { "kind": "pick" },
+      "ui_hints": { "hotkey": "s" }
     }
   ],
   "metadata": {

--- a/engine/contrib/conformance/fixtures/credentials_shift.json
+++ b/engine/contrib/conformance/fixtures/credentials_shift.json
@@ -1,0 +1,152 @@
+{
+  "cursor_id": "00000000-0000-4000-8000-000000000601",
+  "step": 4,
+  "fragments": [
+    {
+      "uid": "00000000-0000-4000-8000-000000000601",
+      "fragment_type": "group",
+      "group_type": "scene",
+      "member_ids": [
+        "00000000-0000-4000-8000-000000000602",
+        "00000000-0000-4000-8000-000000000603",
+        "00000000-0000-4000-8000-000000000604",
+        "00000000-0000-4000-8000-000000000607",
+        "00000000-0000-4000-8000-000000000610",
+        "00000000-0000-4000-8000-000000000611",
+        "00000000-0000-4000-8000-000000000612",
+        "00000000-0000-4000-8000-000000000613"
+      ],
+      "hints": { "label_text": "Checkpoint" }
+    },
+    {
+      "uid": "00000000-0000-4000-8000-000000000602",
+      "fragment_type": "content",
+      "content": "You unfold the work permit. The seal is sound, but the date stamp shows expiry months past."
+    },
+    {
+      "uid": "00000000-0000-4000-8000-000000000603",
+      "fragment_type": "piece",
+      "piece_id": "candidate-0",
+      "kind": "candidate",
+      "content": "Bek Tarsus",
+      "properties": {
+        "declared_purpose": "work",
+        "declared_region": "local"
+      },
+      "hints": { "label_text": "Bek Tarsus" }
+    },
+    {
+      "uid": "00000000-0000-4000-8000-000000000604",
+      "fragment_type": "group",
+      "group_type": "zone",
+      "zone_role": "packet",
+      "member_ids": [
+        "00000000-0000-4000-8000-000000000605",
+        "00000000-0000-4000-8000-000000000606"
+      ],
+      "hints": { "label_text": "Credentials packet" }
+    },
+    {
+      "uid": "00000000-0000-4000-8000-000000000605",
+      "fragment_type": "piece",
+      "piece_id": "0:passport",
+      "kind": "id_card",
+      "content": "An identity document.",
+      "zone_ref": "00000000-0000-4000-8000-000000000604",
+      "hints": { "label_text": "passport" }
+    },
+    {
+      "uid": "00000000-0000-4000-8000-000000000606",
+      "fragment_type": "piece",
+      "piece_id": "0:work permit",
+      "kind": "permit",
+      "content": "A work permit, its issue stamp long lapsed.",
+      "display_state": "flagged",
+      "zone_ref": "00000000-0000-4000-8000-000000000604",
+      "hints": { "label_text": "work permit" }
+    },
+    {
+      "uid": "00000000-0000-4000-8000-000000000607",
+      "fragment_type": "kv",
+      "content": [
+        {
+          "key": "work permit",
+          "value": "The permit's issue stamp has expired.",
+          "emphasis": "warn"
+        },
+        {
+          "key": "packet consistency",
+          "value": "An expired permit does not satisfy the work rule.",
+          "emphasis": "danger"
+        }
+      ]
+    },
+    {
+      "uid": "00000000-0000-4000-8000-000000000610",
+      "fragment_type": "choice",
+      "edge_id": "inspect",
+      "text": "Inspect a document.",
+      "accepts": {
+        "kind": "pieces",
+        "min": 1,
+        "max": 1,
+        "constraints": { "target_zone_ref": "00000000-0000-4000-8000-000000000604" }
+      },
+      "ui_hints": { "hotkey": "1" }
+    },
+    {
+      "uid": "00000000-0000-4000-8000-000000000611",
+      "fragment_type": "choice",
+      "edge_id": "decide_pass",
+      "text": "Choose pass.",
+      "accepts": { "kind": "pick" },
+      "available": false,
+      "unavailable_reason": "The work permit is expired (see findings).",
+      "ui_hints": { "hotkey": "a", "emphasis": "primary" }
+    },
+    {
+      "uid": "00000000-0000-4000-8000-000000000612",
+      "fragment_type": "choice",
+      "edge_id": "decide_deny",
+      "text": "Choose deny.",
+      "accepts": { "kind": "pick" },
+      "ui_hints": { "hotkey": "d", "emphasis": "warning" }
+    },
+    {
+      "uid": "00000000-0000-4000-8000-000000000613",
+      "fragment_type": "choice",
+      "edge_id": "request_document",
+      "text": "Request reissue of work permit.",
+      "accepts": { "kind": "pick" },
+      "ui_hints": { "hotkey": "r" }
+    }
+  ],
+  "metadata": {
+    "fixture": "credentials_shift",
+    "info_affordances": [
+      {
+        "kind": "rules",
+        "label": "Today's rules",
+        "shortcuts": ["r", "rules"],
+        "query": { "kinds": ["rules"] }
+      },
+      {
+        "kind": "roster_progress",
+        "label": "Shift progress",
+        "shortcuts": ["p", "shift"],
+        "query": { "kinds": ["roster_progress"] }
+      },
+      {
+        "kind": "case_summary",
+        "label": "Findings",
+        "shortcuts": ["c", "findings"],
+        "query": { "kinds": ["case_summary"] }
+      }
+    ],
+    "info_state": {
+      "version": 4,
+      "dirty_kinds": ["rules", "roster_progress", "case_summary"],
+      "available_kinds": ["rules", "roster_progress", "case_summary"]
+    }
+  }
+}

--- a/engine/contrib/conformance/fixtures/credentials_shift.json
+++ b/engine/contrib/conformance/fixtures/credentials_shift.json
@@ -18,7 +18,9 @@
         "00000000-0000-4000-8000-000000000614",
         "00000000-0000-4000-8000-000000000615"
       ],
-      "hints": { "label_text": "Checkpoint" }
+      "hints": {
+        "label_text": "Checkpoint"
+      }
     },
     {
       "uid": "00000000-0000-4000-8000-000000000602",
@@ -35,7 +37,9 @@
         "declared_purpose": "work",
         "declared_region": "local"
       },
-      "hints": { "label_text": "Bek Tarsus" }
+      "hints": {
+        "label_text": "Bek Tarsus"
+      }
     },
     {
       "uid": "00000000-0000-4000-8000-000000000604",
@@ -46,7 +50,9 @@
         "00000000-0000-4000-8000-000000000605",
         "00000000-0000-4000-8000-000000000606"
       ],
-      "hints": { "label_text": "Credentials packet" }
+      "hints": {
+        "label_text": "Credentials packet"
+      }
     },
     {
       "uid": "00000000-0000-4000-8000-000000000605",
@@ -55,7 +61,9 @@
       "kind": "id_card",
       "content": "An identity document.",
       "zone_ref": "00000000-0000-4000-8000-000000000604",
-      "hints": { "label_text": "passport" }
+      "hints": {
+        "label_text": "passport"
+      }
     },
     {
       "uid": "00000000-0000-4000-8000-000000000606",
@@ -65,7 +73,9 @@
       "content": "A work permit, its issue stamp long lapsed.",
       "display_state": "flagged",
       "zone_ref": "00000000-0000-4000-8000-000000000604",
-      "hints": { "label_text": "work permit" }
+      "hints": {
+        "label_text": "work permit"
+      }
     },
     {
       "uid": "00000000-0000-4000-8000-000000000607",
@@ -86,55 +96,81 @@
     {
       "uid": "00000000-0000-4000-8000-000000000610",
       "fragment_type": "choice",
-      "edge_id": "inspect",
+      "edge_id": "00000000-0000-4000-8000-0000000006e0",
       "text": "Inspect a document.",
       "accepts": {
         "kind": "pieces",
         "min": 1,
         "max": 1,
-        "constraints": { "target_zone_ref": "00000000-0000-4000-8000-000000000604" }
+        "constraints": {
+          "target_zone_ref": "00000000-0000-4000-8000-000000000604"
+        }
       },
-      "ui_hints": { "hotkey": "1" }
+      "ui_hints": {
+        "hotkey": "1"
+      }
     },
     {
       "uid": "00000000-0000-4000-8000-000000000611",
       "fragment_type": "choice",
-      "edge_id": "decide_pass",
+      "edge_id": "00000000-0000-4000-8000-0000000006e1",
       "text": "Choose pass.",
-      "accepts": { "kind": "pick" },
-      "ui_hints": { "hotkey": "a", "emphasis": "primary" }
+      "accepts": {
+        "kind": "pick"
+      },
+      "ui_hints": {
+        "hotkey": "a",
+        "emphasis": "primary"
+      }
     },
     {
       "uid": "00000000-0000-4000-8000-000000000612",
       "fragment_type": "choice",
-      "edge_id": "decide_deny",
+      "edge_id": "00000000-0000-4000-8000-0000000006e2",
       "text": "Choose deny.",
-      "accepts": { "kind": "pick" },
-      "ui_hints": { "hotkey": "d", "emphasis": "warning" }
+      "accepts": {
+        "kind": "pick"
+      },
+      "ui_hints": {
+        "hotkey": "d",
+        "emphasis": "warning"
+      }
     },
     {
       "uid": "00000000-0000-4000-8000-000000000613",
       "fragment_type": "choice",
-      "edge_id": "request_document",
+      "edge_id": "00000000-0000-4000-8000-0000000006e3",
       "text": "Request reissue of work permit.",
-      "accepts": { "kind": "pick" },
-      "ui_hints": { "hotkey": "r" }
+      "accepts": {
+        "kind": "pick"
+      },
+      "ui_hints": {
+        "hotkey": "r"
+      }
     },
     {
       "uid": "00000000-0000-4000-8000-000000000614",
       "fragment_type": "choice",
-      "edge_id": "verify_id",
+      "edge_id": "00000000-0000-4000-8000-0000000006e4",
       "text": "Verify identity.",
-      "accepts": { "kind": "pick" },
-      "ui_hints": { "hotkey": "v" }
+      "accepts": {
+        "kind": "pick"
+      },
+      "ui_hints": {
+        "hotkey": "v"
+      }
     },
     {
       "uid": "00000000-0000-4000-8000-000000000615",
       "fragment_type": "choice",
-      "edge_id": "request_search",
+      "edge_id": "00000000-0000-4000-8000-0000000006e5",
       "text": "Request search.",
-      "accepts": { "kind": "pick" },
-      "ui_hints": { "hotkey": "s" }
+      "accepts": {
+        "kind": "pick"
+      },
+      "ui_hints": {
+        "hotkey": "s"
+      }
     }
   ],
   "metadata": {
@@ -143,26 +179,55 @@
       {
         "kind": "rules",
         "label": "Today's rules",
-        "shortcuts": ["r", "rules"],
-        "query": { "kinds": ["rules"] }
+        "shortcuts": [
+          "r",
+          "rules"
+        ],
+        "query": {
+          "kinds": [
+            "rules"
+          ]
+        }
       },
       {
         "kind": "roster_progress",
         "label": "Shift progress",
-        "shortcuts": ["p", "shift"],
-        "query": { "kinds": ["roster_progress"] }
+        "shortcuts": [
+          "p",
+          "shift"
+        ],
+        "query": {
+          "kinds": [
+            "roster_progress"
+          ]
+        }
       },
       {
         "kind": "case_summary",
         "label": "Findings",
-        "shortcuts": ["c", "findings"],
-        "query": { "kinds": ["case_summary"] }
+        "shortcuts": [
+          "c",
+          "findings"
+        ],
+        "query": {
+          "kinds": [
+            "case_summary"
+          ]
+        }
       }
     ],
     "info_state": {
       "version": 4,
-      "dirty_kinds": ["rules", "roster_progress", "case_summary"],
-      "available_kinds": ["rules", "roster_progress", "case_summary"]
+      "dirty_kinds": [
+        "rules",
+        "roster_progress",
+        "case_summary"
+      ],
+      "available_kinds": [
+        "rules",
+        "roster_progress",
+        "case_summary"
+      ]
     }
   }
 }

--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -567,15 +567,32 @@ has enough independent design surface to warrant its own pass.
 ### B.1 — Core mediation (v1 increment, LANDED 2026-05-23)
 
 Adds three move kinds and a per-case ``finding_status: dict[str, str]``
-(values: ``"cleared"`` / ``"confirmed"``; reset by ``advance_case``).
+(values: ``"cleared"`` / ``"verified"`` / ``"confirmed"``; reset by
+``advance_case``).
 
 - **``request_document``** — per-target fanout, one Action per *presented*
-  document whose token has a mitigatable status. Applying clears that doc's
-  finding. Maps to ``accepts.kind="pieces"`` in the rendering contract
+  permit. Committing it discloses the permit's standing: a mitigatable flaw is
+  ``cleared`` (the candidate produces a corrected copy), a sound permit is
+  ``verified`` (re-presented unchanged), a forgery is ``confirmed`` (cannot be
+  reissued). Maps to ``accepts.kind="pieces"`` in the rendering contract
   (`bundles/credentials/EXTENSIONS.md`).
-- **``verify_id``** — single Action, applicable when an id is presented. Clears
-  for VALID; confirms (records the crime in the audit trail) for WRONG_HOLDER.
+- **``verify_id``** — single Action, available whenever an id is presented.
+  Answers only the holder question: ``confirmed`` for WRONG_HOLDER (a crime),
+  ``verified`` otherwise. It never repairs a stale id, so an expired/mis-dated
+  id stays a deny (id-reissue is B.2).
 - **``request_search``** — single Action; reveals concealed contraband if any.
+
+**Disclosure discipline on the move menu.** Mediation availability is gated on
+*visible* state only -- which documents the candidate presented -- never on
+hidden validity. A useful mediation is indistinguishable from a dud until it is
+committed; the *outcome* discloses, not the move's presence. (A move absent
+because a document is *visibly* not present, e.g. no id at all, reveals nothing
+the client cannot already see.) Likewise, dispositions are never pre-gated by
+the correct answer -- all of allow/deny/arrest stay available and correctness is
+hidden until the shift resolves. ``available=false`` with a reason is reserved
+for genuinely-blocked actions (e.g. deciding before any inspection), not for
+leaking backend logic. Only a ``cleared`` mitigatable finding upgrades
+``derive_disposition``; ``verified`` / ``confirmed`` are audit-only.
 
 ``derive_disposition`` consults ``finding_status``: a cleared mitigatable doc
 finding contributes PASS instead of DENY; everything else as before.

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -548,25 +548,20 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             return moves
 
         case = game.active_case
-        # request_document: one Action per presented permit with a mitigatable
-        # status not yet cleared. Missing-doc requests are B.2.
+        # Mediation availability is gated on *visible* state only -- which
+        # documents the candidate presented -- never on hidden validity. The
+        # menu must not let a client read backend logic off it: a useful
+        # mediation is indistinguishable from a dud until it is committed. (The
+        # outcome is disclosed by running the move, not by its presence.)
+        #
+        # request_document: offer for every presented permit not yet requested.
         for token in case.packet:
-            if token.status.is_valid or token.status.is_crime:
-                continue
             key = token.indication.value
             if key in game.finding_status:
                 continue
             moves.append(CredentialsMove(kind="request_document", target=key))
-        # verify_id: identity-check move. Narrow to statuses where "does the id
-        # match the bearer?" is the relevant question: VALID (clears the doubt)
-        # or WRONG_HOLDER (confirms the mismatch). Mitigatable id issues like
-        # EXPIRED / BAD_DATE / MISSING_SEAL are date-or-seal problems, not
-        # holder problems, and need an id-mediation move that lands with B.2.
-        if (
-            case.id_card is not None
-            and case.id_status() in (CredentialStatus.VALID, CredentialStatus.WRONG_HOLDER)
-            and "id" not in game.finding_status
-        ):
+        # verify_id: offer whenever an id is presented and not yet verified.
+        if case.id_card is not None and "id" not in game.finding_status:
             moves.append(CredentialsMove(kind="verify_id", target=""))
         # request_search: single move, once per case.
         if "search" not in game.finding_status:
@@ -690,25 +685,30 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         indication_value: str,
         detail: dict[str, object],
     ) -> RoundResult:
-        # Defensive guard: the menu filters to presented permits with a
-        # mitigatable status, but ``GameHandler.receive_move`` does not call
-        # ``validate_move``. Skip rather than corrupt finding_status if an
-        # off-menu payload arrives. (Off-menu clears against valid/crime/missing
-        # permits are already idempotent for derive thanks to its short-circuits,
-        # but explicit validation keeps the audit trail honest.)
+        # The outcome -- not the move's availability -- is what discloses the
+        # permit's standing. Requesting a reissue:
+        #   mitigatable -> the candidate produces a corrected copy ("cleared");
+        #   valid       -> they re-present the same sound permit ("verified");
+        #   crime        -> the forgery cannot be reissued; it stands ("confirmed").
+        # Only a cleared mitigatable finding upgrades derive_disposition.
         permit = next(
             (t for t in game.active_case.packet if t.indication.value == indication_value),
             None,
         )
-        if permit is None or permit.status.is_valid or permit.status.is_crime:
+        if permit is None:  # off-menu safety; receive_move does not validate
             detail["outcome"] = "request_document_not_applicable"
             detail["target_indication"] = indication_value
             return RoundResult.CONTINUE
 
-        # B.1 assumes the candidate complies; the mitigatable finding is cleared.
-        # Compliance (declines path) is part of B.2.
-        game.finding_status[indication_value] = "cleared"
-        detail["outcome"] = "request_document_cleared"
+        if permit.status.is_crime:
+            game.finding_status[indication_value] = "confirmed"
+            detail["outcome"] = "request_document_confirmed"
+        elif permit.status.is_valid:
+            game.finding_status[indication_value] = "verified"
+            detail["outcome"] = "request_document_verified"
+        else:
+            game.finding_status[indication_value] = "cleared"
+            detail["outcome"] = "request_document_cleared"
         detail["target_indication"] = indication_value
         return RoundResult.CONTINUE
 
@@ -717,19 +717,17 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         game: CredentialsGame,
         detail: dict[str, object],
     ) -> RoundResult:
-        # verify_id specifically answers "does the id match the bearer?", so it
-        # only ever clears for VALID or confirms for WRONG_HOLDER. Other id
-        # statuses (no id presented, expired, bad date) need different mediation
-        # (B.2's id-replacement path) and shouldn't have surfaced this move.
+        # verify_id answers only "does the id match the bearer?". It discloses a
+        # holder mismatch (a crime) but never mechanically repairs a stale id --
+        # an expired or mis-dated id stays a deny until a future id-reissue move
+        # (B.2). So it records "verified" / "confirmed", never "cleared".
         status = game.active_case.id_status()
-        if status is CredentialStatus.VALID:
-            game.finding_status["id"] = "cleared"
-            detail["outcome"] = "id_verified_clean"
-        elif status is CredentialStatus.WRONG_HOLDER:
+        if status is CredentialStatus.WRONG_HOLDER:
             game.finding_status["id"] = "confirmed"
             detail["outcome"] = "id_verified_problem"
         else:
-            detail["outcome"] = "verify_id_not_applicable"
+            game.finding_status["id"] = "verified"
+            detail["outcome"] = "id_verified_clean"
         return RoundResult.CONTINUE
 
     def _resolve_request_search(
@@ -826,18 +824,25 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             ]
 
         if action == "request_document":
+            outcome = notes.get("outcome")
+            if outcome == "request_document_cleared":
+                line = "The candidate produces a corrected copy."
+            elif outcome == "request_document_verified":
+                line = "The candidate re-presents the same sound permit."
+            elif outcome == "request_document_confirmed":
+                line = "No valid copy is forthcoming; the permit will not hold up."
+            else:
+                line = "There is nothing to reissue."
             return [
                 ContentFragment(content=f"You request a reissue of the {target} permit."),
-                ContentFragment(content="The candidate produces a corrected copy."),
+                ContentFragment(content=line),
             ]
         if action == "verify_id":
             outcome = notes.get("outcome")
-            if outcome == "id_verified_clean":
-                line = "The id matches the bearer."
-            elif outcome == "id_verified_problem":
+            if outcome == "id_verified_problem":
                 line = "The id does not match the bearer."
             else:
-                line = "The id offers no clear answer to the bearer question."
+                line = "The id matches the bearer."
             return [
                 ContentFragment(content="You verify the bearer's identity."),
                 ContentFragment(content=line),

--- a/engine/src/tangl/mechanics/games/credentials_story_info.py
+++ b/engine/src/tangl/mechanics/games/credentials_story_info.py
@@ -182,9 +182,11 @@ def _case_summary_section(game: CredentialsGame) -> ProjectedSection | None:
         rows.append(KvRow(key=target, value=finding, emphasis="warn"))
     for target, finding in game.packet_findings.items():
         rows.append(KvRow(key=target, value=finding, emphasis="danger"))
+    _mediation_emphasis = {"cleared": "ok", "verified": "subtle", "confirmed": "danger"}
     for target, status in game.finding_status.items():
-        emphasis = "ok" if status == "cleared" else "danger"
-        rows.append(KvRow(key=target, value=status, emphasis=emphasis))
+        rows.append(
+            KvRow(key=target, value=status, emphasis=_mediation_emphasis.get(status, "subtle"))
+        )
     if not rows:
         return None
     return ProjectedSection(

--- a/engine/tests/conformance/test_widget_conformance_fixtures.py
+++ b/engine/tests/conformance/test_widget_conformance_fixtures.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
+from uuid import UUID
 
 import pytest
 
@@ -307,6 +308,7 @@ def test_credentials_shift_fixture_round_trips_through_typed_models() -> None:
     """Pin the credentials envelope to the typed engine fragments (Bridge.1/2b)."""
 
     from tangl.journal.fragments import (
+        ChoiceFragment,
         GroupFragment,
         KvFragment,
         PieceFragment,
@@ -328,7 +330,7 @@ def test_credentials_shift_fixture_round_trips_through_typed_models() -> None:
     packet = GroupFragment.model_validate(by_uid["00000000-0000-4000-8000-000000000604"])
     assert packet.group_type == "zone"
     assert packet.zone_role == "packet"
-    assert str(permit.uid) in {str(m) for m in packet.member_ids}
+    assert permit.uid in packet.member_ids
 
     # Findings validate as a typed KvFragment with severity emphasis.
     findings = KvFragment.model_validate(by_uid["00000000-0000-4000-8000-000000000607"])
@@ -336,14 +338,24 @@ def test_credentials_shift_fixture_round_trips_through_typed_models() -> None:
     assert emphases["work permit"] == "warn"
     assert emphases["packet consistency"] == "danger"
 
+    # Choices validate as typed ChoiceFragments -- proving the edge_ids are
+    # real UUIDs that round-trip through the service/client typed path, not
+    # loose semantic strings the typed decoder would reject.
+    choices = [
+        ChoiceFragment.model_validate(f)
+        for f in payload["fragments"]
+        if f.get("fragment_type") == "choice"
+    ]
+    assert all(isinstance(c.edge_id, UUID) for c in choices)
+
     # Disclosure discipline: every plausible mediation is offered uniformly and
     # no disposition is pre-gated by the answer, so the menu reveals nothing
-    # about which call is correct or which mediation is useful.
-    choices = [f for f in payload["fragments"] if f.get("fragment_type") == "choice"]
-    edge_ids = {c["edge_id"] for c in choices}
-    assert {"request_document", "verify_id", "request_search"} <= edge_ids
-    dispositions = [c for c in choices if c["edge_id"].startswith("decide_")]
-    assert dispositions and all(c.get("available") is not False for c in dispositions)
+    # about which call is correct or which mediation is useful. (Choices are
+    # identified by display text; edge_ids are opaque to the client.)
+    texts = {c.text for c in choices}
+    assert {"Request reissue of work permit.", "Verify identity.", "Request search."} <= texts
+    dispositions = [c for c in choices if c.text.startswith("Choose ")]
+    assert dispositions and all(c.available is not False for c in dispositions)
 
     advertised = {a["kind"] for a in payload["metadata"]["info_affordances"]}
     assert advertised == {"rules", "roster_progress", "case_summary"}

--- a/engine/tests/conformance/test_widget_conformance_fixtures.py
+++ b/engine/tests/conformance/test_widget_conformance_fixtures.py
@@ -336,8 +336,14 @@ def test_credentials_shift_fixture_round_trips_through_typed_models() -> None:
     assert emphases["work permit"] == "warn"
     assert emphases["packet consistency"] == "danger"
 
-    # The gated disposition carries a reason; the side-channels are advertised.
-    gated = by_uid["00000000-0000-4000-8000-000000000611"]
-    assert gated["available"] is False and gated["unavailable_reason"]
+    # Disclosure discipline: every plausible mediation is offered uniformly and
+    # no disposition is pre-gated by the answer, so the menu reveals nothing
+    # about which call is correct or which mediation is useful.
+    choices = [f for f in payload["fragments"] if f.get("fragment_type") == "choice"]
+    edge_ids = {c["edge_id"] for c in choices}
+    assert {"request_document", "verify_id", "request_search"} <= edge_ids
+    dispositions = [c for c in choices if c["edge_id"].startswith("decide_")]
+    assert dispositions and all(c.get("available") is not False for c in dispositions)
+
     advertised = {a["kind"] for a in payload["metadata"]["info_affordances"]}
     assert advertised == {"rules", "roster_progress", "case_summary"}

--- a/engine/tests/conformance/test_widget_conformance_fixtures.py
+++ b/engine/tests/conformance/test_widget_conformance_fixtures.py
@@ -23,6 +23,7 @@ EXPECTED_FIXTURES = {
     "command_hints.json",
     "compose_payload.json",
     "control_delete.json",
+    "credentials_shift.json",
     "crossroads_inn.json",
     "dialog_with_avatar.json",
     "pending_media_update.json",
@@ -300,3 +301,43 @@ def test_control_update_and_delete_fixtures_apply_to_registry() -> None:
     delete_payload = _load_fixture(FIXTURE_DIR / "control_delete.json")
     delete_registry = _registry_after_controls(delete_payload["fragments"])
     assert "00000000-0000-4000-8000-000000000702" not in delete_registry
+
+
+def test_credentials_shift_fixture_round_trips_through_typed_models() -> None:
+    """Pin the credentials envelope to the typed engine fragments (Bridge.1/2b)."""
+
+    from tangl.journal.fragments import (
+        GroupFragment,
+        KvFragment,
+        PieceFragment,
+    )
+
+    payload = _load_fixture(FIXTURE_DIR / "credentials_shift.json")
+    by_uid = {f["uid"]: f for f in payload["fragments"]}
+
+    # Candidate + document pieces validate as typed PieceFragments.
+    candidate = PieceFragment.model_validate(by_uid["00000000-0000-4000-8000-000000000603"])
+    assert candidate.kind == "candidate"
+    assert candidate.properties["declared_purpose"] == "work"
+
+    permit = PieceFragment.model_validate(by_uid["00000000-0000-4000-8000-000000000606"])
+    assert permit.kind == "permit"
+    assert str(permit.zone_ref) == "00000000-0000-4000-8000-000000000604"
+
+    # Packet zone validates as a typed GroupFragment carrying its zone_role.
+    packet = GroupFragment.model_validate(by_uid["00000000-0000-4000-8000-000000000604"])
+    assert packet.group_type == "zone"
+    assert packet.zone_role == "packet"
+    assert str(permit.uid) in {str(m) for m in packet.member_ids}
+
+    # Findings validate as a typed KvFragment with severity emphasis.
+    findings = KvFragment.model_validate(by_uid["00000000-0000-4000-8000-000000000607"])
+    emphases = {row.key: row.emphasis for row in findings.content}
+    assert emphases["work permit"] == "warn"
+    assert emphases["packet consistency"] == "danger"
+
+    # The gated disposition carries a reason; the side-channels are advertised.
+    gated = by_uid["00000000-0000-4000-8000-000000000611"]
+    assert gated["available"] is False and gated["unavailable_reason"]
+    advertised = {a["kind"] for a in payload["metadata"]["info_affordances"]}
+    assert advertised == {"rules", "roster_progress", "case_summary"}

--- a/engine/tests/mechanics/games/test_credentials_mediation.py
+++ b/engine/tests/mechanics/games/test_credentials_mediation.py
@@ -66,8 +66,11 @@ class TestMediationAvailability:
         kinds = _move_kinds(handler, game)
         assert {"decide", "request_document", "verify_id", "request_search"}.issubset(kinds)
 
-    def test_request_document_only_for_mitigatable_present_permits(self) -> None:
-        # valid + forged + mitigatable -> only the mitigatable one gets request_document.
+    def test_request_document_offered_for_all_present_permits(self) -> None:
+        # Disclosure discipline: the menu must NOT reveal which permits are
+        # flawed. request_document is offered for every presented permit
+        # (valid, mitigatable, or forged) -- you can't tell the dud from the
+        # useful one until you commit it.
         case = CredentialCase(
             purpose=IND.WORK,
             id_card=_id(),
@@ -79,40 +82,42 @@ class TestMediationAvailability:
         game, handler = _game(case)
         handler.receive_move(game, ("inspect", "passport"))
 
-        request_targets = [m.target for m in handler.get_available_moves(game) if m.kind == "request_document"]
-        assert request_targets == [IND.WORK.value]  # WEAPON forged is a crime, not mediatable
+        request_targets = {
+            m.target for m in handler.get_available_moves(game) if m.kind == "request_document"
+        }
+        assert request_targets == {IND.WORK.value, IND.WEAPON.value}
 
     def test_verify_id_skipped_without_id(self) -> None:
+        # No id presented at all -- a *visible* absence, not hidden validity --
+        # so the move is meaningless and absent. (This reveals nothing the
+        # client can't already see in the packet.)
         case = CredentialCase(purpose=IND.TRAVEL, id_card=None)
-        # purpose travel requires id; missing id -> derive DENY. Add a faux inspect target.
         case.presented_documents = {"baggage": "An empty case."}
         game, handler = _game(case)
         handler.receive_move(game, ("inspect", "baggage"))
 
         assert "verify_id" not in _move_kinds(handler, game)
 
-    def test_verify_id_skipped_for_mitigatable_id_status(self) -> None:
-        # EXPIRED is a date issue, not a holder mismatch; verify_id is the
-        # wrong move for it (id-renewal mediation is deferred to B.2).
+    def test_verify_id_offered_regardless_of_hidden_id_status(self) -> None:
+        # An expired id is mitigatably invalid, but the menu must not leak that:
+        # verify_id is offered the same as for a valid id.
         case = CredentialCase(purpose=IND.TRAVEL, id_card=_id(S.EXPIRED))
         game, handler = _game(case)
         handler.receive_move(game, ("inspect", "passport"))
 
-        assert "verify_id" not in _move_kinds(handler, game)
+        assert "verify_id" in _move_kinds(handler, game)
 
-    def test_request_document_off_menu_target_is_noop(self) -> None:
-        # An off-menu request_document for an indication with no mitigatable
-        # permit (here, a forged work permit) must NOT clear finding_status.
+    def test_request_document_on_a_crime_records_without_clearing(self) -> None:
+        # Requesting reissue of a forged permit discloses (via the outcome) that
+        # it won't hold up, but never upgrades the disposition.
         case = CredentialCase(
             purpose=IND.WORK, id_card=_id(), packet=[_permit(IND.WORK, S.FORGED)]
         )
         game, handler = _game(case)
         handler.receive_move(game, ("inspect", "passport"))
-        # Forced off-menu invocation (the menu would not offer this).
         handler.receive_move(game, ("request_document", IND.WORK.value))
 
-        # finding_status not mutated; expected disposition still ARREST.
-        assert IND.WORK.value not in game.finding_status
+        assert game.finding_status[IND.WORK.value] == "confirmed"
         assert game.expected_disposition(case) is D.ARREST
 
     def test_each_mediation_move_offered_once_per_case(self) -> None:
@@ -143,14 +148,28 @@ class TestMediationEffects:
         # After mediation: derives PASS.
         assert game.expected_disposition(case) is D.PASS
 
-    def test_verify_id_clears_a_valid_id(self) -> None:
+    def test_verify_id_verifies_a_valid_id(self) -> None:
         case = CredentialCase(purpose=IND.TRAVEL, id_card=_id(S.VALID))
         game, handler = _game(case)
         handler.receive_move(game, ("inspect", "passport"))
         handler.receive_move(game, ("verify_id", ""))
 
-        assert game.finding_status["id"] == "cleared"
+        # "verified", not "cleared": verifying the holder does not repair docs.
+        assert game.finding_status["id"] == "verified"
         assert game.expected_disposition(case) is D.PASS  # unchanged but audited
+
+    def test_verify_id_does_not_repair_an_expired_id(self) -> None:
+        # verify_id confirms the holder matches, but the id is still expired:
+        # the disposition stays DENY (id-reissue is B.2).
+        case = CredentialCase(purpose=IND.TRAVEL, id_card=_id(S.EXPIRED))
+        game, handler = _game(case)
+        assert game.expected_disposition(case) is D.DENY
+
+        handler.receive_move(game, ("inspect", "passport"))
+        handler.receive_move(game, ("verify_id", ""))
+
+        assert game.finding_status["id"] == "verified"
+        assert game.expected_disposition(case) is D.DENY  # holder ok, still expired
 
     def test_verify_id_confirms_a_fake_id(self) -> None:
         case = CredentialCase(purpose=IND.TRAVEL, id_card=_id(S.WRONG_HOLDER))
@@ -184,20 +203,6 @@ class TestMediationEffects:
 
         assert game.finding_status["search"] == "cleared"
         assert game.expected_disposition(case) is D.PASS
-
-    def test_request_document_does_not_help_a_crime(self) -> None:
-        # FORGED permit is a crime; not offered as a request_document target,
-        # and even if forced, derive stays ARREST.
-        case = CredentialCase(
-            purpose=IND.WORK, id_card=_id(), packet=[_permit(IND.WORK, S.FORGED)]
-        )
-        game, handler = _game(case)
-        handler.receive_move(game, ("inspect", "passport"))
-        # Crimes are filtered from the menu.
-        assert IND.WORK.value not in [
-            m.target for m in handler.get_available_moves(game) if m.kind == "request_document"
-        ]
-
 
 class TestMediationLifecycle:
     def test_finding_status_resets_on_advance_case(self) -> None:


### PR DESCRIPTION
## Summary

Bridge.3 — closes out the credentials UI-bridge thread (#246) with a **portable conformance fixture** that pins what Bridge.1 (typed fragments) and Bridge.2b (info channels) actually emit, so any port (the reference port, the web app, future CLI/Godot ports) can load a canonical credentials envelope and validate its own rendering against it.

`engine/contrib/conformance/fixtures/credentials_shift.json` captures the richest single turn — post-inspection of an expired work permit:

- a **scene** group containing:
  - a candidate `PieceFragment(kind="candidate")` with declared purpose/region;
  - a packet `GroupFragment(group_type="zone", zone_role="packet")` holding two document pieces (`id_card`, `permit`), the permit flagged;
  - a `KvFragment` of findings with severity emphasis (`warn` document finding, `danger` packet-level);
  - an **inspect** choice (`accepts.kind="pieces"`, `target_zone_ref` → the packet zone);
  - a **gated** pass disposition (`available: false` + `unavailable_reason`) and an open deny;
  - a **mediation** choice (request reissue);
- `metadata.info_affordances` + `info_state` advertising the Bridge.2b side-channels (`rules` / `roster_progress` / `case_summary`).

## What it locks down

- Registered in the harness `EXPECTED_FIXTURES`, so it must validate as a `RuntimeEnvelope` and pass the generic portable-shape + open-choice-renderability checks (the inspect choice's `target_zone_ref` must resolve to a fragment visible in the scene — it does).
- A credentials-specific test **round-trips the candidate / packet / findings through the typed `PieceFragment` / `GroupFragment` / `KvFragment` models**, so the fixture stays pinned to the graduated Bridge.1 shapes rather than loose dicts — if the typed fragment shapes drift, this fails.

## Test plan

- [x] `engine/tests/conformance`: 66 passed (the fixture validates against every parametrized check + the new typed round-trip).
- [x] Broad sweep `conformance + service + mechanics/games + loaders`: 433 passed, 6 skipped locally.
- [ ] CI green.

Refs #246. This completes the bridge trio: Bridge.1 (typed fragments, merged), Bridge.2b (info channels, merged), Bridge.3 (this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded document verification actions and improved identity verification workflow in credential review scenarios.

* **Improvements**
  * Enhanced verification status tracking with refined categorization and visual emphasis for different outcomes.

* **Tests**
  * Added comprehensive conformance and mediation test coverage for credential verification mechanics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/derekmerck/storytangl/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->