### PR TITLE
Polish sandbox story-info dispatch and Adventure score projection

### DIFF
--- a/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
+++ b/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
@@ -817,14 +817,17 @@ surface. The backend owns world truth, action availability, hidden schedules,
 and mutation. A client receives only the facts the current reader/player is
 allowed to know.
 
-`SandboxStoryInfoProjector` lives in the sandbox package and attaches through
-the existing service `StoryInfoProjector` seam. Service remains generic; sandbox
-worlds opt in by installing the projector on the world. The projector emits
-ordinary `ProjectedState` sections using the existing `kv_list` and `item_list`
-value types. It does not add sandbox widgets or require a SugarCube-like
-interface. A web client may render those sections as a room header, inventory
-panel, time chip, map modal, or roster; a CLI may print them as status lines; an
-ebook compiler may ignore them or fold them into generated prose.
+Sandbox attaches through the service story-info dispatch seam. Service remains
+generic; sandbox handlers advertise and fulfill ordinary channel requests for
+location, time, inventory, local presence, exits, and map state. The older
+`SandboxStoryInfoProjector` remains as a compatibility/convenience wrapper over
+the same disclosed sections for worlds that still install a world projector
+directly. Both paths emit ordinary `ProjectedState` sections using the existing
+`kv_list`, `item_list`, and `table` value types. They do not add sandbox widgets
+or require a SugarCube-like interface. A web client may render those sections as
+a room header, inventory panel, time chip, map modal, or roster; a CLI may print
+them as status lines; an ebook compiler may ignore them or fold them into
+generated prose.
 
 Current disclosed sections are intentionally conservative:
 
@@ -837,13 +840,16 @@ Current disclosed sections are intentionally conservative:
 - present visible mobs;
 - visible authored exits.
 
-Sandbox can also satisfy explicit story-info channel requests through the
-service `get_story_info` dispatch task. The `kind="map"` provider emits ordinary
-`ProjectedState` sections (`sandbox_map_summary`, `sandbox_map_nodes`, and
-`sandbox_map_edges`) rather than a sandbox-only widget type. The map is still
-disclosed state: current and known locations, visible/known exits, and known
-blocked or locked state. It must not expose secret geography, hidden mobs, raw
-pathfinding truth, or future schedule state.
+Explicit story-info channel requests use the same service `get_story_info`
+dispatch task. Status-like channels (`location`, `world_time`, `inventory`,
+`presence`, `exits`, `fixtures`, and `local_assets`) return the matching
+portable section. The `kind="map"` provider emits ordinary `ProjectedState`
+sections (`sandbox_map_summary`, `sandbox_map_nodes`, and `sandbox_map_edges`)
+rather than a sandbox-only widget type; clients may also request narrower map
+sections such as `map_nodes` or `map_edges`. The map is still disclosed state:
+current and known locations, visible/known exits, and known blocked or locked
+state. It must not expose secret geography, hidden mobs, raw pathfinding truth,
+or future schedule state.
 
 Visibility rules filter projected state the same way they filter journal and
 local affordances. Darkness may leave current location, time, and inventory

--- a/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
+++ b/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
@@ -841,15 +841,17 @@ Current disclosed sections are intentionally conservative:
 - visible authored exits.
 
 Explicit story-info channel requests use the same service `get_story_info`
-dispatch task. Status-like channels (`location`, `world_time`, `inventory`,
-`presence`, `exits`, `fixtures`, and `local_assets`) return the matching
-portable section. The `kind="map"` provider emits ordinary `ProjectedState`
-sections (`sandbox_map_summary`, `sandbox_map_nodes`, and `sandbox_map_edges`)
-rather than a sandbox-only widget type; clients may also request narrower map
-sections such as `map_nodes` or `map_edges`. The map is still disclosed state:
-current and known locations, visible/known exits, and known blocked or locked
-state. It must not expose secret geography, hidden mobs, raw pathfinding truth,
-or future schedule state.
+dispatch task. The dispatch handler is explicit-only so it can coexist with
+worlds that still install `SandboxStoryInfoProjector` as a broad fallback
+projector without duplicating default sections. Status-like channels
+(`location`, `world_time`, `inventory`, `presence`, `exits`, `fixtures`, and
+`local_assets`) return the matching portable section. The `kind="map"` provider
+emits ordinary `ProjectedState` sections (`sandbox_map_summary`,
+`sandbox_map_nodes`, and `sandbox_map_edges`) rather than a sandbox-only widget
+type; clients may also request narrower map sections such as `map_nodes` or
+`map_edges`. The map is still disclosed state: current and known locations,
+visible/known exits, and known blocked or locked state. It must not expose
+secret geography, hidden mobs, raw pathfinding truth, or future schedule state.
 
 Visibility rules filter projected state the same way they filter journal and
 local affordances. Darkness may leave current location, time, and inventory

--- a/engine/src/tangl/mechanics/sandbox/story_info.py
+++ b/engine/src/tangl/mechanics/sandbox/story_info.py
@@ -232,6 +232,24 @@ def advertise_sandbox_info_channels(
     ]
     if projection.suppress_location_description:
         return affordances
+    if not projection.suppress_asset_affordances:
+        affordances.append(
+            InfoAffordance(
+                kind="local_assets",
+                label="Here",
+                shortcuts=["a", "assets"],
+                query={"kinds": ["local_assets"]},
+            )
+        )
+    if not projection.suppress_fixture_affordances:
+        affordances.append(
+            InfoAffordance(
+                kind="fixtures",
+                label="Fixtures",
+                shortcuts=["f"],
+                query={"kinds": ["fixtures"]},
+            )
+        )
     affordances.append(
         InfoAffordance(
             kind="presence",
@@ -263,10 +281,10 @@ def project_sandbox_map_info(
     **_kw: object,
 ) -> list[ProjectedSection] | None:
     """Project requested disclosed sandbox channels for side-panel clients."""
-    requested = request.requested_kinds()
+    requested = set(request.requested_kinds())
     if not requested:
-        return SandboxStoryInfoProjector().sections_for(caller, ctx=ctx)
-    if not any(kind in SANDBOX_INFO_KINDS for kind in requested):
+        return None
+    if requested.isdisjoint(SANDBOX_INFO_KINDS):
         return None
 
     sections: list[ProjectedSection] = []
@@ -286,7 +304,7 @@ def _requested_map_sections(
     location: SandboxLocation,
     *,
     ctx: PhaseCtx,
-    requested: list[str],
+    requested: set[str],
 ) -> list[ProjectedSection]:
     if not _map_requested(requested):
         return []
@@ -300,8 +318,8 @@ def _requested_map_sections(
     ]
 
 
-def _map_requested(requested: list[str]) -> bool:
-    return any(kind in requested for kind in (MAP_KIND, "map_nodes", "map_edges"))
+def _map_requested(requested: set[str]) -> bool:
+    return not requested.isdisjoint({MAP_KIND, "map_nodes", "map_edges"})
 
 
 def _map_sections(location: SandboxLocation, ctx: PhaseCtx) -> list[ProjectedSection]:
@@ -504,12 +522,12 @@ def _section_empty(section: ProjectedSection) -> bool:
 
 def _section_matches_requested(
     section: ProjectedSection,
-    requested: list[str],
+    requested: set[str],
 ) -> bool:
     labels = {section.section_id}
     if section.kind is not None:
         labels.add(section.kind)
-    return any(label in requested for label in labels)
+    return not labels.isdisjoint(requested)
 
 
 def _asset_items(holder: HasAssets | None) -> list[ProjectedItem]:

--- a/engine/src/tangl/mechanics/sandbox/story_info.py
+++ b/engine/src/tangl/mechanics/sandbox/story_info.py
@@ -35,6 +35,18 @@ from .time import current_world_time
 
 DEFAULT_PERIOD_LABELS = ("morning", "afternoon", "evening", "night")
 MAP_KIND = "map"
+SANDBOX_INFO_KINDS = {
+    "exits",
+    "fixtures",
+    "inventory",
+    "local_assets",
+    "location",
+    MAP_KIND,
+    "map_edges",
+    "map_nodes",
+    "presence",
+    "world_time",
+}
 
 
 class ProjectedAssetSurface(Protocol):
@@ -64,27 +76,30 @@ class SandboxStoryInfoProjector:
             return DEFAULT_STORY_INFO_PROJECTOR.project(ledger=ledger)
 
         ctx = PhaseCtx(graph=ledger.graph, cursor_id=cursor.uid)
-        projection = sandbox_projection_state(cursor, ctx)
+        return ProjectedState(sections=self.sections_for(cursor, ctx=ctx))
+
+    def sections_for(
+        self,
+        location: SandboxLocation,
+        *,
+        ctx: PhaseCtx,
+    ) -> list[ProjectedSection]:
+        """Return disclosed sandbox status sections for ``location``."""
+        projection = sandbox_projection_state(location, ctx)
         sections = [
-            self._location_section(cursor, projection_active=projection.active),
-            self._time_section(cursor),
-            self._inventory_section(cursor),
+            self._location_section(location, projection_active=projection.active),
+            self._time_section(location),
+            self._inventory_section(location),
         ]
         if not projection.suppress_location_description:
-            sections.append(self._exits_section(cursor))
+            sections.append(self._exits_section(location))
         if not projection.suppress_asset_affordances:
-            sections.append(self._local_assets_section(cursor))
+            sections.append(self._local_assets_section(location))
         if not projection.suppress_fixture_affordances:
-            sections.append(self._fixtures_section(cursor))
+            sections.append(self._fixtures_section(location))
         if not projection.suppress_location_description:
-            sections.append(self._presence_section(cursor))
-        return ProjectedState(
-            sections=[
-                section
-                for section in sections
-                if not _section_empty(section)
-            ]
-        )
+            sections.append(self._presence_section(location))
+        return [section for section in sections if not _section_empty(section)]
 
     def _location_section(
         self,
@@ -247,10 +262,46 @@ def project_sandbox_map_info(
     request: StoryInfoRequest,
     **_kw: object,
 ) -> list[ProjectedSection] | None:
-    """Project disclosed sandbox geography for map-capable clients."""
-    if MAP_KIND not in request.requested_kinds():
+    """Project requested disclosed sandbox channels for side-panel clients."""
+    requested = request.requested_kinds()
+    if not requested:
+        return SandboxStoryInfoProjector().sections_for(caller, ctx=ctx)
+    if not any(kind in SANDBOX_INFO_KINDS for kind in requested):
         return None
-    return _map_sections(caller, ctx)
+
+    sections: list[ProjectedSection] = []
+    status_sections = SandboxStoryInfoProjector().sections_for(caller, ctx=ctx)
+    sections.extend(
+        section
+        for section in status_sections
+        if _section_matches_requested(section, requested)
+    )
+
+    map_sections = _requested_map_sections(caller, ctx=ctx, requested=requested)
+    sections.extend(map_sections)
+    return sections or None
+
+
+def _requested_map_sections(
+    location: SandboxLocation,
+    *,
+    ctx: PhaseCtx,
+    requested: list[str],
+) -> list[ProjectedSection]:
+    if not _map_requested(requested):
+        return []
+    sections = _map_sections(location, ctx)
+    if MAP_KIND in requested:
+        return sections
+    return [
+        section
+        for section in sections
+        if _section_matches_requested(section, requested)
+    ]
+
+
+def _map_requested(requested: list[str]) -> bool:
+    return any(kind in requested for kind in (MAP_KIND, "map_nodes", "map_edges"))
 
 
 def _map_sections(location: SandboxLocation, ctx: PhaseCtx) -> list[ProjectedSection]:
@@ -449,6 +500,16 @@ def _section_empty(section: ProjectedSection) -> bool:
     if isinstance(value, ItemListValue):
         return not value.items
     return False
+
+
+def _section_matches_requested(
+    section: ProjectedSection,
+    requested: list[str],
+) -> bool:
+    labels = {section.section_id}
+    if section.kind is not None:
+        labels.add(section.kind)
+    return any(label in requested for label in labels)
 
 
 def _asset_items(holder: HasAssets | None) -> list[ProjectedItem]:

--- a/engine/tests/service/test_sandbox_story_info.py
+++ b/engine/tests/service/test_sandbox_story_info.py
@@ -197,6 +197,8 @@ def test_sandbox_advertises_map_info_channel() -> None:
         "location",
         "inventory",
         "map",
+        "local_assets",
+        "fixtures",
         "presence",
         "exits",
     ]
@@ -281,7 +283,7 @@ def test_sandbox_dispatch_filters_requested_status_channels() -> None:
     ]
 
 
-def test_sandbox_dispatch_empty_request_projects_default_status_bundle() -> None:
+def test_sandbox_dispatch_empty_request_stays_explicit_only() -> None:
     graph = Graph(label="tiny_cave")
     road = SandboxLocation(
         label="road",
@@ -300,11 +302,7 @@ def test_sandbox_dispatch_empty_request_projects_default_status_bundle() -> None
         request=StoryInfoRequest(),
     )
 
-    assert [section.section_id for section in projected.sections] == [
-        "sandbox_location",
-        "sandbox_time",
-        "sandbox_exits",
-    ]
+    assert projected.sections == []
 
 
 def test_sandbox_map_projects_known_geography_as_portable_sections() -> None:

--- a/engine/tests/service/test_sandbox_story_info.py
+++ b/engine/tests/service/test_sandbox_story_info.py
@@ -206,6 +206,107 @@ def test_sandbox_advertises_map_info_channel() -> None:
     assert map_affordance.query == {"kinds": ["map"], "scope": "known"}
 
 
+def test_sandbox_dispatch_projects_requested_status_channels() -> None:
+    graph = Graph(label="tiny_cave")
+    scope = SandboxScope(label="tiny_cave_scope", locals={"world_turn": 1})
+    road = SandboxLocation(
+        label="road",
+        location_name="End of Road",
+        links={"east": "building"},
+    )
+    building = SandboxLocation(label="building", location_name="Inside Building")
+    pirate = SandboxMob(label="pirate", name="wounded pirate", location="road")
+    SandboxInfoItemType(label="lamp", name="brass lantern", traits={"portable"})
+    lamp = Token[SandboxInfoItemType](token_from="lamp", label="lamp")
+    scope.player_assets.add_asset(lamp)
+    for item in (scope, road, building, pirate, lamp):
+        graph.add(item)
+    scope.add_child(road)
+    scope.add_child(building)
+    scope.add_child(pirate)
+    scope.mobs.append(pirate)
+    ledger = Ledger.from_graph(graph, entry_id=road.uid)
+    ctx = PhaseCtx(graph=graph, cursor_id=road.uid, step=ledger.step)
+
+    projected = do_get_story_info(
+        road,
+        ctx=ctx,
+        request=StoryInfoRequest(
+            kinds=["location", "world_time", "inventory", "presence", "exits"]
+        ),
+    )
+    sections = _section_by_id(projected.sections)
+
+    assert set(sections) == {
+        "sandbox_location",
+        "sandbox_time",
+        "sandbox_inventory",
+        "sandbox_presence",
+        "sandbox_exits",
+    }
+    assert _item_labels(sections["sandbox_inventory"]) == ["brass lantern"]
+    assert _item_labels(sections["sandbox_presence"]) == ["wounded pirate"]
+    assert _item_labels(sections["sandbox_exits"]) == ["east"]
+
+
+def test_sandbox_dispatch_filters_requested_status_channels() -> None:
+    graph = Graph(label="tiny_cave")
+    road = SandboxLocation(
+        label="road",
+        location_name="End of Road",
+        links={"east": "building"},
+    )
+    building = SandboxLocation(label="building", location_name="Inside Building")
+    for item in (road, building):
+        graph.add(item)
+    ledger = Ledger.from_graph(graph, entry_id=road.uid)
+    ctx = PhaseCtx(graph=graph, cursor_id=road.uid, step=ledger.step)
+
+    projected = do_get_story_info(
+        road,
+        ctx=ctx,
+        request=StoryInfoRequest(kind="location"),
+    )
+    assert [section.section_id for section in projected.sections] == [
+        "sandbox_location"
+    ]
+
+    map_nodes = do_get_story_info(
+        road,
+        ctx=ctx,
+        request=StoryInfoRequest(kind="map_nodes"),
+    )
+    assert [section.section_id for section in map_nodes.sections] == [
+        "sandbox_map_nodes"
+    ]
+
+
+def test_sandbox_dispatch_empty_request_projects_default_status_bundle() -> None:
+    graph = Graph(label="tiny_cave")
+    road = SandboxLocation(
+        label="road",
+        location_name="End of Road",
+        links={"east": "building"},
+    )
+    building = SandboxLocation(label="building", location_name="Inside Building")
+    for item in (road, building):
+        graph.add(item)
+    ledger = Ledger.from_graph(graph, entry_id=road.uid)
+    ctx = PhaseCtx(graph=graph, cursor_id=road.uid, step=ledger.step)
+
+    projected = do_get_story_info(
+        road,
+        ctx=ctx,
+        request=StoryInfoRequest(),
+    )
+
+    assert [section.section_id for section in projected.sections] == [
+        "sandbox_location",
+        "sandbox_time",
+        "sandbox_exits",
+    ]
+
+
 def test_sandbox_map_projects_known_geography_as_portable_sections() -> None:
     graph = Graph(label="tiny_cave")
     road = SandboxLocation(

--- a/worlds/adventure_sandbox_slice/adventure_sandbox_slice/domain.py
+++ b/worlds/adventure_sandbox_slice/adventure_sandbox_slice/domain.py
@@ -23,6 +23,7 @@ from tangl.mechanics.sandbox import (
 )
 from tangl.mechanics.sandbox.handlers import sandbox_player_assets
 from tangl.service.response import KvListValue, ProjectedSection, ProjectedState
+from tangl.service.story_info import DEFAULT_STORY_INFO_PROJECTOR
 from tangl.story import Action, StoryGraph
 from tangl.story.concepts.asset import AssetTransactionManager
 from tangl.vm import Ledger, on_gather_ns, on_provision, on_update
@@ -262,7 +263,7 @@ class AdventureSandboxStoryInfoProjector:
     def project(self, *, ledger: Ledger) -> ProjectedState:
         cursor = ledger.cursor
         if not isinstance(cursor, AdventureSandboxLocation):
-            return ProjectedState()
+            return DEFAULT_STORY_INFO_PROJECTOR.project(ledger=ledger)
         return ProjectedState(
             sections=[
                 ProjectedSection(

--- a/worlds/adventure_sandbox_slice/adventure_sandbox_slice/domain.py
+++ b/worlds/adventure_sandbox_slice/adventure_sandbox_slice/domain.py
@@ -22,7 +22,6 @@ from tangl.mechanics.sandbox import (
     SwitchableFacet,
 )
 from tangl.mechanics.sandbox.handlers import sandbox_player_assets
-from tangl.mechanics.sandbox.story_info import SandboxStoryInfoProjector
 from tangl.service.response import KvListValue, ProjectedSection, ProjectedState
 from tangl.story import Action, StoryGraph
 from tangl.story.concepts.asset import AssetTransactionManager
@@ -258,19 +257,14 @@ def _rewrite_movement_hazards(
 
 
 class AdventureSandboxStoryInfoProjector:
-    """Adventure-specific story-info wrapper over the generic sandbox projector."""
-
-    def __init__(self) -> None:
-        self.sandbox = SandboxStoryInfoProjector()
+    """Adventure-specific story-info wrapper for world-owned sections."""
 
     def project(self, *, ledger: Ledger) -> ProjectedState:
-        projected = self.sandbox.project(ledger=ledger)
         cursor = ledger.cursor
         if not isinstance(cursor, AdventureSandboxLocation):
-            return projected
+            return ProjectedState()
         return ProjectedState(
             sections=[
-                *projected.sections,
                 ProjectedSection(
                     section_id="adventure_score",
                     title="Score",


### PR DESCRIPTION
## Summary
- Promote sandbox story-info to the generic service dispatch seam for the standard disclosed channels: `location`, `world_time`, `inventory`, `presence`, `exits`, `fixtures`, `local_assets`, and `map`.
- Keep `SandboxStoryInfoProjector` as a compatibility wrapper over the same disclosed section logic, so worlds can still install a projector directly if they want.
- Let explicit `kind` / `kinds` requests return the matching portable `ProjectedState` sections, including narrower map slices like `map_nodes` and `map_edges`.
- Trim the Adventure sandbox projector so it only contributes Adventure-specific score state, avoiding duplicate generic sandbox sections.

## Testing
- Added focused service tests for advertised channels, filtered requests, empty requests, and map-specific projections.
- Verified the Adventure world still projects its score section while sandbox generic disclosure comes from the shared sandbox handler path.
- Focused sandbox/story-info and REST integration tests passed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified sandbox story-info projection mechanisms and request handling behavior.

* **Refactor**
  * Enhanced story-info request filtering and routing to better support selective channel requests for sandbox worlds.

* **Tests**
  * Added comprehensive unit tests validating story-info request behavior and projection output consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->