### PR TITLE
Add conformance harness promotion and archive brand references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # temporary
 dump*
 tmp*
+private/
 **/old
 **/old_*
 #schemas

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 # temporary
 dump*
 tmp*
-private/
+/private/
 **/old
 **/old_*
 #schemas

--- a/docs/src/design/index.rst
+++ b/docs/src/design/index.rst
@@ -24,6 +24,8 @@ See also
    story/STORYTANGL_WIDGET_VOCAB
    story/WIDGET_CONTRACT_RECONCILIATION
    story/WIDGET_WIREFRAMES
+   story/brand/README
+   story/brand/v1_0/USAGE
    story/GENRE_AUDIT_NOTES
    story/bundles/carwars/EXTENSIONS
    story/bundles/credentials/EXTENSIONS

--- a/docs/src/design/story/WIDGET_CONTRACT_RECONCILIATION.md
+++ b/docs/src/design/story/WIDGET_CONTRACT_RECONCILIATION.md
@@ -64,7 +64,7 @@ the negotiation is mostly about typed-shape graduations.
 | `PresentationHints` (style_name, style_tags, style_dict, icon) | S | partial (basic style/icon fields) | done | audit aliases and long-tail hints before treating complete |
 | Bundle customization / presentation profiles | S target | partial (docs + older world `ui_config`) | not_started | keep advisory; requires world-info catalog before conformance |
 | §5.1 Decision Legibility Contract | S | partial (JSON harness covers fixtures/sequences) | n/a (contract; not a capability) | expand field coverage as new decision surfaces promote |
-| §5.2 Time Parity Rule (visual ritual skip, media advance) | S | partial (skip available, not enforced) | n/a | webapp conformance harness |
+| §5.2 Time Parity Rule (visual ritual skip, media advance) | S | partial (JSON harness covers readable fallbacks) | n/a | browser timing/skip E2E remains later |
 | §5.3 Input Parity Rule (drag fallback, hotkey numbers) | S | partial (JSON harness covers fixture submit floors) | n/a | extend toward renderer-specific drag/keyboard fallbacks |
 | §0.2 CLI Floor Rule | S | n/a | n/a (gating rule on PRs) | wire into CI for Tier S graduations |
 
@@ -184,7 +184,7 @@ graduations and as the regression suite for cross-port parity.
 | `engine/contrib/conformance/cli_reference_port.py` | Tier S CLI rendering for every fragment / value_type | partial (Tier S + current P1 widgets) | extend coverage as Tier P1 → S graduations happen |
 | `engine/contrib/conformance/legibility.py` | §5.1 — referenced UIDs are rendered | initial | covers fixture and sequence choices; expand as new P1/P2 fields promote |
 | `engine/contrib/conformance/parity.py` | §5.3 input parity | initial | covers fixture and sequence submit floors; time parity remains next harness |
-| `engine/contrib/conformance/time_parity.py` | §5.2 time parity | not_started | third harness |
+| `engine/contrib/conformance/time_parity.py` | §5.2 time parity | initial | covers JSON-readable media/roll fallbacks; browser skip timing remains later |
 | `engine/contrib/conformance/test_conformance.py` | pytest harness binding fixtures + ports | not_started | wire into CI |
 | `engine/contrib/conformance/fixtures/*.json` | canonical envelopes per surface | partial (Tier S + current P1 fixtures) | keep promoting proposal fixtures as implementation lands |
 | `engine/contrib/conformance/proposals/*.json` | forward-compatible proposal envelopes | partial | current set covers carwars garage, piece realization, place accepts, record KvRow, roll fragment, and one UUID-shaped v1.5 wireframe interpretation sample; CLI/Tk can inspect them without promotion |
@@ -351,8 +351,9 @@ API maps them.
   4. HTTP API: type responses on `/story/do` / `/story/update`; add `query`
      param routing on `/story/info`.
   5. Conformance harness: ✅ initial `legibility.py`; ✅ initial
-     input-parity `parity.py`; next write a time-parity harness and extend
-     `cli_reference_port.py` for new Tier P1 surfaces.
+     input-parity `parity.py`; ✅ initial `time_parity.py`; next extend
+     `cli_reference_port.py` for new Tier P1 surfaces and add browser timing
+     E2E only after promoted surfaces stabilize.
 
 **Phase 4 — Tier P1 → S graduation.** Surfaces in §B promote one
 at a time, gated on the CLI reference port and the conformance

--- a/docs/src/design/story/WIDGET_CONTRACT_RECONCILIATION.md
+++ b/docs/src/design/story/WIDGET_CONTRACT_RECONCILIATION.md
@@ -65,7 +65,7 @@ the negotiation is mostly about typed-shape graduations.
 | Bundle customization / presentation profiles | S target | partial (docs + older world `ui_config`) | not_started | keep advisory; requires world-info catalog before conformance |
 | §5.1 Decision Legibility Contract | S | partial (JSON harness covers fixtures/sequences) | n/a (contract; not a capability) | expand field coverage as new decision surfaces promote |
 | §5.2 Time Parity Rule (visual ritual skip, media advance) | S | partial (skip available, not enforced) | n/a | webapp conformance harness |
-| §5.3 Input Parity Rule (drag fallback, hotkey numbers) | S | partial (positional hotkeys done; drag-fallback in carwars) | n/a | webapp conformance harness |
+| §5.3 Input Parity Rule (drag fallback, hotkey numbers) | S | partial (JSON harness covers fixture submit floors) | n/a | extend toward renderer-specific drag/keyboard fallbacks |
 | §0.2 CLI Floor Rule | S | n/a | n/a (gating rule on PRs) | wire into CI for Tier S graduations |
 
 ---
@@ -183,7 +183,8 @@ graduations and as the regression suite for cross-port parity.
 |---|---|---|---|
 | `engine/contrib/conformance/cli_reference_port.py` | Tier S CLI rendering for every fragment / value_type | partial (Tier S + current P1 widgets) | extend coverage as Tier P1 → S graduations happen |
 | `engine/contrib/conformance/legibility.py` | §5.1 — referenced UIDs are rendered | initial | covers fixture and sequence choices; expand as new P1/P2 fields promote |
-| `engine/contrib/conformance/parity.py` | §5.2 time parity, §5.3 input parity | not_started | second harness |
+| `engine/contrib/conformance/parity.py` | §5.3 input parity | initial | covers fixture and sequence submit floors; time parity remains next harness |
+| `engine/contrib/conformance/time_parity.py` | §5.2 time parity | not_started | third harness |
 | `engine/contrib/conformance/test_conformance.py` | pytest harness binding fixtures + ports | not_started | wire into CI |
 | `engine/contrib/conformance/fixtures/*.json` | canonical envelopes per surface | partial (Tier S + current P1 fixtures) | keep promoting proposal fixtures as implementation lands |
 | `engine/contrib/conformance/proposals/*.json` | forward-compatible proposal envelopes | partial | current set covers carwars garage, piece realization, place accepts, record KvRow, roll fragment, and one UUID-shaped v1.5 wireframe interpretation sample; CLI/Tk can inspect them without promotion |
@@ -349,8 +350,9 @@ API maps them.
   3. Typed `metadata.grammar` and `metadata.info_affordances`.
   4. HTTP API: type responses on `/story/do` / `/story/update`; add `query`
      param routing on `/story/info`.
-  5. Conformance harness: ✅ initial `legibility.py`; next write
-     `parity.py` and extend `cli_reference_port.py` for new Tier P1 surfaces.
+  5. Conformance harness: ✅ initial `legibility.py`; ✅ initial
+     input-parity `parity.py`; next write a time-parity harness and extend
+     `cli_reference_port.py` for new Tier P1 surfaces.
 
 **Phase 4 — Tier P1 → S graduation.** Surfaces in §B promote one
 at a time, gated on the CLI reference port and the conformance

--- a/docs/src/design/story/WIDGET_CONTRACT_RECONCILIATION.md
+++ b/docs/src/design/story/WIDGET_CONTRACT_RECONCILIATION.md
@@ -63,7 +63,7 @@ the negotiation is mostly about typed-shape graduations.
 | `ProjectedState.sections` with five `value_type`s | S | done | done | — |
 | `PresentationHints` (style_name, style_tags, style_dict, icon) | S | partial (basic style/icon fields) | done | audit aliases and long-tail hints before treating complete |
 | Bundle customization / presentation profiles | S target | partial (docs + older world `ui_config`) | not_started | keep advisory; requires world-info catalog before conformance |
-| §5.1 Decision Legibility Contract | S | partial (no automated check) | n/a (contract; not a capability) | webapp conformance harness (see §F) |
+| §5.1 Decision Legibility Contract | S | partial (JSON harness covers fixtures/sequences) | n/a (contract; not a capability) | expand field coverage as new decision surfaces promote |
 | §5.2 Time Parity Rule (visual ritual skip, media advance) | S | partial (skip available, not enforced) | n/a | webapp conformance harness |
 | §5.3 Input Parity Rule (drag fallback, hotkey numbers) | S | partial (positional hotkeys done; drag-fallback in carwars) | n/a | webapp conformance harness |
 | §0.2 CLI Floor Rule | S | n/a | n/a (gating rule on PRs) | wire into CI for Tier S graduations |
@@ -182,7 +182,7 @@ graduations and as the regression suite for cross-port parity.
 | Harness | What it checks | Status | Plan |
 |---|---|---|---|
 | `engine/contrib/conformance/cli_reference_port.py` | Tier S CLI rendering for every fragment / value_type | partial (Tier S + current P1 widgets) | extend coverage as Tier P1 → S graduations happen |
-| `engine/contrib/conformance/legibility.py` | §5.1 — referenced UIDs are rendered | not_started | first conformance harness to write |
+| `engine/contrib/conformance/legibility.py` | §5.1 — referenced UIDs are rendered | initial | covers fixture and sequence choices; expand as new P1/P2 fields promote |
 | `engine/contrib/conformance/parity.py` | §5.2 time parity, §5.3 input parity | not_started | second harness |
 | `engine/contrib/conformance/test_conformance.py` | pytest harness binding fixtures + ports | not_started | wire into CI |
 | `engine/contrib/conformance/fixtures/*.json` | canonical envelopes per surface | partial (Tier S + current P1 fixtures) | keep promoting proposal fixtures as implementation lands |
@@ -349,8 +349,8 @@ API maps them.
   3. Typed `metadata.grammar` and `metadata.info_affordances`.
   4. HTTP API: type responses on `/story/do` / `/story/update`; add `query`
      param routing on `/story/info`.
-  5. Conformance harness: write `legibility.py`, `parity.py`, extend
-     `cli_reference_port.py` for new Tier P1 surfaces.
+  5. Conformance harness: ✅ initial `legibility.py`; next write
+     `parity.py` and extend `cli_reference_port.py` for new Tier P1 surfaces.
 
 **Phase 4 — Tier P1 → S graduation.** Surfaces in §B promote one
 at a time, gated on the CLI reference port and the conformance

--- a/docs/src/design/story/WIDGET_WIREFRAMES.md
+++ b/docs/src/design/story/WIDGET_WIREFRAMES.md
@@ -3,6 +3,10 @@
 The canonical wireframe bundle for the current widget vocabulary is archived
 under `docs/src/design/story/wireframes/v1_5/`.
 
+Brand-direction references from the same design pass are archived separately
+under [`brand/`](brand/). They are visual and tone references only; they are not
+deployed app/docs assets.
+
 - [`StoryTangl-Wireframes-v1.5.html`](wireframes/v1_5/StoryTangl-Wireframes-v1.5.html)
   is the rendered reference artifact.
 - The adjacent `v15-*.jsx`, `v15-*.js`, and `v15-*.css` files are retained as

--- a/docs/src/design/story/WIDGET_WIREFRAMES.md
+++ b/docs/src/design/story/WIDGET_WIREFRAMES.md
@@ -3,9 +3,9 @@
 The canonical wireframe bundle for the current widget vocabulary is archived
 under `docs/src/design/story/wireframes/v1_5/`.
 
-Brand-direction references from the same design pass are archived separately
-under [`brand/`](brand/). They are visual and tone references only; they are not
-deployed app/docs assets.
+Brand-direction references from the same design pass are archived separately in
+the [brand reference note](brand/README.md). They are visual and tone references
+only; they are not deployed app/docs assets.
 
 - [`StoryTangl-Wireframes-v1.5.html`](wireframes/v1_5/StoryTangl-Wireframes-v1.5.html)
   is the rendered reference artifact.

--- a/docs/src/design/story/brand/README.md
+++ b/docs/src/design/story/brand/README.md
@@ -1,0 +1,23 @@
+# StoryTangl Brand References
+
+This directory archives brand-direction artifacts from the design-agent UI work.
+Treat them as visual and voice references, not as deployed product assets.
+
+## v1.0
+
+- [`v1_0/StoryTangl-Brand-Sheet.html`](v1_0/StoryTangl-Brand-Sheet.html) is the
+  captured brand sheet. It is the useful artifact in this pass.
+- [`v1_0/USAGE.md`](v1_0/USAGE.md) records the implied rules for wordmark,
+  palette, type, and tone.
+- [`v1_0/assets/palette.css`](v1_0/assets/palette.css) and
+  [`v1_0/assets/type.css`](v1_0/assets/type.css) are included only because the
+  brand sheet depends on them.
+
+The generated SVGs, favicon candidates, social-card exports, and screenshot
+checks from the handoff package are intentionally not archived here. They were
+useful design-agent outputs, but they are not yet correct enough to become
+canonical repo assets.
+
+Before using this material in `apps/web/`, `docs/src/_static/`, package icons,
+or GitHub social previews, regenerate and visually review the relevant assets
+from the current brand sheet.

--- a/docs/src/design/story/brand/v1_0/StoryTangl-Brand-Sheet.html
+++ b/docs/src/design/story/brand/v1_0/StoryTangl-Brand-Sheet.html
@@ -1,0 +1,1774 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=1280" />
+<title>StoryTan⅁l · brand sheet</title>
+<link rel="stylesheet" href="assets/palette.css">
+<link rel="stylesheet" href="assets/type.css">
+
+<style>
+/* ─────────────────────────────────────────────────────────────────────
+   StoryTangl brand sheet — internal style.
+
+   This file is the canonical reference. Every CSS rule that defines the
+   wordmark, glyph, lockup, or applied surface lives below.
+
+   Read top-to-bottom. Edit nothing without updating USAGE.md to match.
+   ───────────────────────────────────────────────────────────────────── */
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; background: var(--st-paper); color: var(--st-ink); }
+body { font-family: var(--st-font-chrome); font-size: 14px; line-height: 1.55; }
+
+a { color: var(--st-blue); }
+
+/* layout ──────────────────────────────────────────────────────────── */
+
+.sheet {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 56px 64px 96px;
+  position: relative;
+}
+
+.sheet > header {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 16px;
+  align-items: flex-end;
+  padding-bottom: 24px;
+  border-bottom: 1.5px solid var(--st-rule-strong);
+  margin-bottom: 56px;
+}
+.sheet > header .meta {
+  text-align: right;
+  font-family: var(--st-font-mono);
+  font-size: 11px;
+  color: var(--st-ink-3);
+  line-height: 1.6;
+}
+
+h2.sec {
+  font-family: var(--st-font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--st-ink-3);
+  margin: 56px 0 16px;
+  padding-bottom: 6px;
+  border-bottom: 1px dotted var(--st-rule);
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 12px;
+  align-items: baseline;
+}
+h2.sec .n { color: var(--st-ink); font-weight: 700; }
+h2.sec .right { color: var(--st-ink-4); font-weight: 500; letter-spacing: 0.06em; }
+
+h3.sub {
+  font-family: var(--st-font-prose);
+  font-size: 22px;
+  font-weight: 600;
+  margin: 24px 0 12px;
+  color: var(--st-ink);
+}
+
+p.intro {
+  font-family: var(--st-font-prose);
+  font-size: 16.5px;
+  line-height: 1.6;
+  max-width: 70ch;
+  color: var(--st-ink-2);
+  margin: 6px 0 18px;
+}
+p.intro b { color: var(--st-ink); }
+
+p.note {
+  font-family: var(--st-font-chrome);
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--st-ink-3);
+  max-width: 70ch;
+}
+.marg {
+  font-family: var(--st-font-prose);
+  font-style: italic;
+  font-size: 13px;
+  color: var(--st-ink-3);
+  border-left: 2px solid var(--st-blue);
+  padding: 4px 0 4px 12px;
+  margin: 10px 0;
+  max-width: 56ch;
+}
+
+code, .mono { font-family: var(--st-font-mono); }
+code { font-size: 0.92em; background: var(--st-paper-2); padding: 1px 5px; border: 1px solid var(--st-rule); }
+
+/* ─────────────────────────────────────────────────────────────────────
+   THE WORDMARK
+   ───────────────────────────────────────────────────────────────────── */
+
+/* Generic wordmark. Use .st-wm <span class=g>g</span> wraps the inverted glyph.
+ * Tunable per-font via the --st-wm-* custom properties.
+ */
+.st-wm {
+  font-family: var(--st-wm-font, var(--st-font-prose));
+  font-weight: var(--st-wm-weight, 600);
+  font-size: var(--st-wm-size, 96px);
+  letter-spacing: var(--st-wm-tracking, -0.005em);
+  line-height: 1;
+  color: var(--st-ink);
+  white-space: nowrap;
+  display: inline-block;
+}
+.st-wm .g {
+  display: inline-block;
+  text-transform: capitalize;       /* defends against parent text-transform */
+  transform-origin: center 50%;
+  transform: rotate(180deg)
+             scaleY(var(--st-wm-g-sy, 1.00))
+             scaleX(var(--st-wm-g-sx, 0.75))
+             translateY(var(--st-wm-g-ty, 5%));
+  margin-inline: var(--st-wm-g-margin, -0.10em);
+  color: inherit;
+}
+
+/* per-font tuning ─────────────────────────────────────────────────── */
+
+.st-wm.font-newsreader {
+  --st-wm-font: var(--st-font-prose);
+  --st-wm-weight: 600;
+  --st-wm-tracking: -0.01em;
+  /* Newsreader sits its bowl high and curls a deep descender. Flipped, the
+   * curl becomes the ascender and the bowl drops; the g rides DOWN (+5%) so
+   * its new descender seats on the basement line shared with the y. No
+   * vertical stretch needed — sy stays at 1.0. */
+  --st-wm-g-sy: 1.00;
+  --st-wm-g-sx: 0.75;
+  --st-wm-g-ty: 5%;
+  --st-wm-g-margin: -0.10em;
+}
+.st-wm.font-mono {
+  --st-wm-font: var(--st-font-mono);
+  --st-wm-weight: 700;
+  --st-wm-tracking: -0.02em;
+  /* JetBrains Mono is monospaced and vertically even: no horizontal squish,
+   * no sidebearing pull. The flipped g rides UP (-20%) onto the basement. */
+  --st-wm-g-sy: 1.00;
+  --st-wm-g-sx: 1.00;
+  --st-wm-g-ty: -20%;
+  --st-wm-g-margin: 0em;
+}
+.st-wm.font-chrome {
+  --st-wm-font: var(--st-font-chrome);
+  --st-wm-weight: 700;
+  --st-wm-tracking: -0.015em;
+  /* Inter Tight's single-storey g is wide; squish X to 0.75 and pull the
+   * sidebearings in (-0.10em). Rides UP (-20%) onto the basement line. */
+  --st-wm-g-sy: 1.00;
+  --st-wm-g-sx: 0.75;
+  --st-wm-g-ty: -20%;
+  --st-wm-g-margin: -0.10em;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   THE STANDALONE GLYPH
+   The same flipped g, isolated as a mark. Used for favicon, social
+   card watermark, brand-only buttons, and any context the wordmark
+   is too wide for.
+   ───────────────────────────────────────────────────────────────────── */
+
+.st-glyph {
+  display: inline-grid;
+  place-items: center;
+  width: var(--st-glyph-size, 96px);
+  height: var(--st-glyph-size, 96px);
+  font-family: var(--st-font-prose);
+  font-weight: 700;
+  font-size: calc(var(--st-glyph-size, 96px) * 0.78);
+  line-height: 1;
+  color: var(--st-paper);
+  background: var(--st-ink);
+  position: relative;
+  overflow: hidden;
+}
+.st-glyph::after {
+  /* the g, baked in via ::after content so the element can be a single tag in
+   * markup. Just a 180° turn plus a horizontal squish that varies by voice —
+   * NO vertical scale and NO shift. place-items:center on .st-glyph handles the
+   * centering; mono isn't squished at all. */
+  content: "g";
+  display: inline-block;
+  text-transform: capitalize;
+  transform: rotate(180deg) scaleX(var(--st-glyph-sx, 0.82));
+  line-height: 1;
+}
+.st-glyph.inverted    { background: var(--st-paper); color: var(--st-ink); border: 2px solid var(--st-ink); }
+.st-glyph.blue        { background: var(--st-blue); }
+.st-glyph.burnt       { background: var(--st-burnt); }
+.st-glyph.round       { border-radius: 50%; }
+.st-glyph.frame       { background: transparent; color: var(--st-ink); border: 2.5px solid var(--st-ink); }
+
+/* lockups ─────────────────────────────────────────────────────────── */
+
+.st-lock {
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+}
+.st-lock .st-glyph { --st-glyph-size: 1.18em; font-size: 0.92em; }
+.st-lock .st-tag {
+  font-family: var(--st-font-mono);
+  font-size: 0.42em;
+  color: var(--st-ink-3);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  line-height: 1.4;
+  border-left: 1px solid var(--st-rule-strong);
+  padding-left: 12px;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   tiles / grid scaffolding
+   ───────────────────────────────────────────────────────────────────── */
+
+.tile {
+  background: #fff;
+  border: 1.5px solid var(--st-rule);
+  padding: 22px;
+  position: relative;
+}
+.tile .tile-label {
+  position: absolute;
+  top: -10px; left: 14px;
+  background: var(--st-paper);
+  font-family: var(--st-font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--st-ink-3);
+  padding: 0 6px;
+  white-space: nowrap;
+}
+.tile .tile-foot {
+  margin-top: 16px;
+  padding-top: 10px;
+  border-top: 1px dotted var(--st-rule);
+  font-family: var(--st-font-mono);
+  font-size: 10.5px;
+  color: var(--st-ink-3);
+  line-height: 1.6;
+}
+.tile .tile-foot code { background: transparent; border: none; padding: 0; color: var(--st-ink-2); }
+
+.grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; margin-top: 18px; }
+.grid-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 18px; margin-top: 18px; }
+.grid-4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; margin-top: 18px; }
+.grid-asym { display: grid; grid-template-columns: 1.4fr 1fr; gap: 18px; margin-top: 18px; }
+
+/* ─────────────────────────────────────────────────────────────────────
+   color swatches
+   ───────────────────────────────────────────────────────────────────── */
+
+.swatch {
+  display: grid;
+  grid-template-columns: 56px 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 8px 10px;
+  border-bottom: 1px dotted var(--st-rule);
+  font-family: var(--st-font-mono);
+  font-size: 11.5px;
+}
+.swatch:last-child { border-bottom: none; }
+.swatch .sw-chip {
+  width: 56px; height: 32px;
+  border: 1px solid var(--st-ink);
+}
+.swatch .sw-name { color: var(--st-ink); }
+.swatch .sw-hex { color: var(--st-ink-3); letter-spacing: -0.01em; }
+
+/* ─────────────────────────────────────────────────────────────────────
+   README banner mockup
+   ───────────────────────────────────────────────────────────────────── */
+
+.readme-banner {
+  background: var(--st-paper);
+  border: 1.5px solid var(--st-rule-strong);
+  padding: 56px 64px 64px;
+  position: relative;
+  overflow: hidden;
+  min-height: 380px;
+}
+.readme-banner::before {
+  /* knot of thin ink lines, marginalia-style */
+  content: "";
+  position: absolute;
+  top: 0; right: 0; bottom: 0;
+  width: 280px;
+  background:
+    radial-gradient(circle at 60% 30%, var(--st-rule) 0 1.5px, transparent 1.5px 100%) 0 0 / 26px 26px,
+    radial-gradient(circle at 60% 30%, var(--st-rule) 0 1.5px, transparent 1.5px 100%) 13px 13px / 26px 26px;
+  opacity: 0.5;
+  mask-image: linear-gradient(to left, black 0%, transparent 80%);
+  -webkit-mask-image: linear-gradient(to left, black 0%, transparent 80%);
+  pointer-events: none;
+}
+.readme-banner .b-wm   { --st-wm-size: 96px; }
+.readme-banner .b-tag  {
+  font-family: var(--st-font-prose);
+  font-style: italic;
+  font-size: 18px;
+  color: var(--st-ink-2);
+  margin-top: 14px;
+  margin-bottom: 56px;
+  max-width: 50ch;
+  line-height: 1.4;
+}
+.readme-banner .b-meta {
+  position: absolute;
+  bottom: 22px; left: 64px;
+  font-family: var(--st-font-mono);
+  font-size: 10.5px;
+  color: var(--st-ink-3);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.readme-banner .b-rule {
+  position: absolute;
+  bottom: 22px; right: 64px;
+  font-family: var(--st-font-mono);
+  font-size: 10.5px;
+  color: var(--st-ink-3);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   CLI splash
+   ───────────────────────────────────────────────────────────────────── */
+
+.cli-splash {
+  background: #15140f;
+  color: #e8dfc6;
+  font-family: var(--st-font-mono);
+  font-size: 12.5px;
+  line-height: 1.55;
+  padding: 22px 24px;
+  border-radius: 4px;
+  position: relative;
+  overflow: hidden;
+}
+.cli-splash .dots {
+  display: inline-flex;
+  gap: 6px;
+  margin-bottom: 14px;
+}
+.cli-splash .dots span {
+  width: 10px; height: 10px; border-radius: 50%;
+  background: #4d4a3d;
+}
+.cli-splash .cli-wm {
+  color: #e8dfc6;
+  --st-wm-size: 38px;
+  --st-wm-font: var(--st-font-mono);
+}
+.cli-splash .cli-banner-line { color: #6b6a64; }
+.cli-splash .cli-prompt {
+  color: #e8dfc6;
+  display: flex; align-items: baseline; gap: 8px;
+}
+.cli-splash .cli-prompt .glyph {
+  font-family: var(--st-font-mono);
+  font-weight: 700;
+  display: inline-block;
+  transform: rotate(180deg);
+  text-transform: capitalize;
+  color: #d6a35a;
+}
+.cli-splash .cli-cursor {
+  display: inline-block;
+  width: 7px;
+  background: #e8dfc6;
+  animation: blink 1.1s steps(2) infinite;
+  margin-left: 2px;
+}
+.cli-splash .dim { color: #8a8472; }
+.cli-splash .accent { color: #d6a35a; }
+@keyframes blink { 50% { opacity: 0; } }
+
+/* ─────────────────────────────────────────────────────────────────────
+   social card preview
+   ───────────────────────────────────────────────────────────────────── */
+
+.social-card {
+  width: 100%;
+  aspect-ratio: 1280 / 640;
+  background: var(--st-paper);
+  border: 1.5px solid var(--st-ink);
+  padding: 56px 64px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: 1fr auto auto;
+  gap: 16px;
+  position: relative;
+  overflow: hidden;
+}
+.social-card::before {
+  content: "";
+  position: absolute;
+  top: 0; right: -80px; bottom: 0;
+  width: 480px;
+  background:
+    radial-gradient(circle, var(--st-rule-strong) 0 2px, transparent 2px 100%) 0 0 / 38px 38px;
+  opacity: 0.4;
+  mask-image: radial-gradient(circle at 100% 50%, black 0 50%, transparent 80%);
+  -webkit-mask-image: radial-gradient(circle at 100% 50%, black 0 50%, transparent 80%);
+}
+.social-card .sc-wm { --st-wm-size: 96px; grid-column: 1 / 2; }
+.social-card .sc-tag {
+  grid-column: 1 / -1;
+  font-family: var(--st-font-prose);
+  font-style: italic;
+  font-size: 22px;
+  color: var(--st-ink-2);
+  max-width: 60ch;
+}
+.social-card .sc-meta {
+  grid-column: 1 / 2;
+  font-family: var(--st-font-mono);
+  font-size: 12.5px;
+  color: var(--st-ink-3);
+}
+.social-card .sc-glyph { grid-column: 2 / 3; grid-row: 3 / 4; align-self: end; }
+
+/* ─────────────────────────────────────────────────────────────────────
+   rtd / docs header
+   ───────────────────────────────────────────────────────────────────── */
+
+.docs-strip {
+  background: var(--st-paper);
+  border: 1.5px solid var(--st-rule-strong);
+  border-bottom-width: 2px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 24px;
+  padding: 14px 22px;
+  align-items: center;
+}
+.docs-strip .d-wm   { --st-wm-size: 28px; }
+.docs-strip .d-nav  {
+  display: flex; gap: 22px;
+  font-family: var(--st-font-chrome);
+  font-size: 12.5px;
+  color: var(--st-ink-2);
+}
+.docs-strip .d-nav a { text-decoration: none; }
+.docs-strip .d-nav a.on { color: var(--st-ink); font-weight: 600; border-bottom: 1.5px solid var(--st-ink); padding-bottom: 4px; }
+.docs-strip .d-meta {
+  font-family: var(--st-font-mono);
+  font-size: 11px;
+  color: var(--st-ink-3);
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   favicons
+   ───────────────────────────────────────────────────────────────────── */
+
+.favicon-grid {
+  display: grid;
+  grid-template-columns: repeat(5, auto);
+  gap: 16px;
+  align-items: end;
+  justify-content: start;
+  padding-top: 12px;
+}
+.favicon-cell { display: grid; gap: 6px; text-align: center; font-family: var(--st-font-mono); font-size: 10px; color: var(--st-ink-3); }
+
+/* do / don't ─────────────────────────────────────────────────────── */
+
+.dodont {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 18px;
+}
+.dodont .card {
+  background: #fff;
+  border: 1.5px solid var(--st-rule);
+  padding: 16px;
+  display: grid;
+  grid-template-rows: 1fr auto;
+  gap: 12px;
+  min-height: 140px;
+}
+.dodont .card.bad { border-color: var(--st-bad); }
+.dodont .card.good { border-color: var(--st-ok); }
+.dodont .card .demo { display: grid; place-items: center; padding: 12px; }
+.dodont .card .label {
+  font-family: var(--st-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--st-ink-3);
+  display: flex; align-items: center; gap: 6px;
+}
+.dodont .card .label .tag { padding: 1px 6px; font-weight: 700; color: #fff; }
+.dodont .card.bad .label .tag { background: var(--st-bad); }
+.dodont .card.good .label .tag { background: var(--st-ok); }
+.dodont .card .label .body { color: var(--st-ink-2); text-transform: none; font-family: var(--st-font-chrome); font-weight: 400; letter-spacing: 0; font-size: 12px; }
+
+/* asset index ───────────────────────────────────────────────────── */
+table.assets {
+  width: 100%; border-collapse: collapse;
+  font-family: var(--st-font-mono); font-size: 11.5px;
+  margin-top: 4px;
+}
+table.assets th, table.assets td {
+  text-align: left; padding: 6px 10px;
+  border-bottom: 1px dotted var(--st-rule);
+}
+table.assets th {
+  font-weight: 600;
+  font-family: var(--st-font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--st-ink-3);
+  border-bottom: 1.5px solid var(--st-rule-strong);
+}
+table.assets td.path { color: var(--st-ink); }
+table.assets td.purpose { color: var(--st-ink-2); }
+table.assets td.note { color: var(--st-ink-3); }
+
+/* big hero ──────────────────────────────────────────────────────── */
+.hero {
+  padding: 40px 0 24px;
+  border-bottom: 1px dotted var(--st-rule);
+  margin-bottom: 32px;
+}
+.hero .st-wm { --st-wm-size: 160px; }
+.hero .tagline {
+  font-family: var(--st-font-prose);
+  font-style: italic;
+  font-size: 22px;
+  color: var(--st-ink-2);
+  margin: 18px 0 8px;
+  max-width: 56ch;
+}
+.hero .subtag {
+  font-family: var(--st-font-mono);
+  font-size: 12px;
+  color: var(--st-ink-3);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   TWEAKS — three expressive postures.
+   Each control rewrites a gestalt of the sheet, not a single property.
+   §1 variants and §4 type samples stay locked (see .voice-locked).
+   ───────────────────────────────────────────────────────────────────── */
+
+/* SURFACE — paper (canonical) · ink (negative) · blueprint (cyanotype) */
+
+body[data-st-mode="ink"] {
+  --st-paper:       #15140f;
+  --st-paper-2:     #1f1e18;
+  --st-paper-3:     #2a2920;
+  --st-ink:         #e8dfc6;
+  --st-ink-2:       #c9c2ad;
+  --st-ink-3:       #8a8472;
+  --st-ink-4:       #6b6a64;
+  --st-rule:        #2f2d24;
+  --st-rule-strong: #4d4a3d;
+  --st-blue:        #8db4ff;
+  --st-burnt:       #e07a40;
+  --st-ok:          #6fbf8c;
+  --st-warn:        #d6a35a;
+  --st-bad:         #d65a4a;
+}
+
+body[data-st-mode="blueprint"] {
+  --st-paper:       #c9d6e8;
+  --st-paper-2:     #b8c8dd;
+  --st-paper-3:     #a3b6d0;
+  --st-ink:         #0c2447;
+  --st-ink-2:       #1a3460;
+  --st-ink-3:       #486487;
+  --st-ink-4:       #6e83a4;
+  --st-rule:        #7891b3;
+  --st-rule-strong: #34507e;
+  --st-blue:        #0c2447;     /* ink IS the blue here */
+  --st-burnt:       #c25028;
+  --st-ok:          #2c6f54;
+  --st-warn:        #b58440;
+  --st-bad:         #962b22;
+}
+
+/* tile / card backgrounds were hard-coded #fff — make them mode-aware */
+body[data-st-mode="ink"] .tile,
+body[data-st-mode="ink"] .dodont .card { background: #1f1e18; }
+body[data-st-mode="blueprint"] .tile,
+body[data-st-mode="blueprint"] .dodont .card { background: #dde6f1; }
+
+/* sheet background follows the surface */
+body[data-st-mode="ink"],
+body[data-st-mode="blueprint"] { background: var(--st-paper); }
+html { background: var(--st-paper); }
+
+/* the bad-example gradient card should keep its identity in every mode */
+body[data-st-mode] .dodont .card.bad .demo[style*="gradient"] { background-image: linear-gradient(135deg, #ff6b9d, #c77dff, #4cc9f0) !important; }
+
+
+/* VOICE — swap the wordmark font globally for non-locked instances */
+
+body[data-st-voice="prose"] .st-wm:not(.voice-locked) {
+  --st-wm-font: var(--st-font-prose);
+  --st-wm-weight: 600;
+  --st-wm-tracking: -0.01em;
+  --st-wm-g-sy: 1.00;
+  --st-wm-g-sx: 0.75;
+  --st-wm-g-ty: 5%;
+  --st-wm-g-margin: -0.10em;
+}
+body[data-st-voice="mono"] .st-wm:not(.voice-locked) {
+  --st-wm-font: var(--st-font-mono);
+  --st-wm-weight: 700;
+  --st-wm-tracking: -0.02em;
+  --st-wm-g-sy: 1.00;
+  --st-wm-g-sx: 1.00;
+  --st-wm-g-ty: -20%;
+  --st-wm-g-margin: 0em;
+}
+body[data-st-voice="chrome"] .st-wm:not(.voice-locked) {
+  --st-wm-font: var(--st-font-chrome);
+  --st-wm-weight: 700;
+  --st-wm-tracking: -0.015em;
+  --st-wm-g-sy: 1.00;
+  --st-wm-g-sx: 0.75;
+  --st-wm-g-ty: -20%;
+  --st-wm-g-margin: -0.10em;
+}
+/* glyph follows voice too — same font fuels the standalone mark. Only the
+ * horizontal squish changes per font; mono stays at its natural width. */
+body[data-st-voice="prose"]  .st-glyph:not(.voice-locked) { font-family: var(--st-font-prose);  --st-glyph-sx: 0.82; }
+body[data-st-voice="mono"]   .st-glyph:not(.voice-locked) { font-family: var(--st-font-mono);   --st-glyph-sx: 1.00; }
+body[data-st-voice="chrome"] .st-glyph:not(.voice-locked) { font-family: var(--st-font-chrome); --st-glyph-sx: 0.75; }
+
+
+/* POSTURE — editorial (slow) · engineering (default) · terminal (fast) */
+
+body[data-st-posture="editorial"] .sheet { max-width: 1080px; padding: 88px 88px 128px; }
+body[data-st-posture="editorial"] p.intro {
+  font-size: 19.5px; line-height: 1.72; max-width: 60ch;
+  font-style: italic; color: var(--st-ink-2);
+}
+body[data-st-posture="editorial"] p.intro b { font-style: normal; color: var(--st-ink); }
+body[data-st-posture="editorial"] h2.sec { margin: 96px 0 24px; padding-bottom: 12px; }
+body[data-st-posture="editorial"] h3.sub { font-size: 28px; margin: 40px 0 18px; }
+body[data-st-posture="editorial"] .hero { padding: 64px 0 48px; }
+body[data-st-posture="editorial"] .hero .st-wm { --st-wm-size: 200px; }
+body[data-st-posture="editorial"] .hero .tagline { font-size: 26px; margin: 28px 0 10px; }
+body[data-st-posture="editorial"] .tile { padding: 32px; }
+body[data-st-posture="editorial"] .marg { font-size: 15px; padding: 6px 0 6px 18px; max-width: 50ch; }
+body[data-st-posture="editorial"] .grid-2,
+body[data-st-posture="editorial"] .grid-3,
+body[data-st-posture="editorial"] .grid-4,
+body[data-st-posture="editorial"] .grid-asym { gap: 28px; margin-top: 28px; }
+
+body[data-st-posture="terminal"] { font-family: var(--st-font-mono); font-size: 12.5px; }
+body[data-st-posture="terminal"] .sheet { max-width: 1280px; padding: 28px 36px 56px; }
+body[data-st-posture="terminal"] > .sheet > header { margin-bottom: 28px; padding-bottom: 12px; }
+body[data-st-posture="terminal"] p.intro {
+  font-family: var(--st-font-mono);
+  font-size: 12.5px; line-height: 1.55;
+  max-width: 84ch;
+}
+body[data-st-posture="terminal"] p.intro::before {
+  content: "// "; color: var(--st-ink-3); font-weight: 400;
+}
+body[data-st-posture="terminal"] h2.sec { margin: 36px 0 8px; font-size: 11.5px; }
+body[data-st-posture="terminal"] h3.sub {
+  font-family: var(--st-font-mono); font-size: 13.5px;
+  text-transform: lowercase; letter-spacing: 0;
+  font-weight: 700; margin: 16px 0 6px;
+}
+body[data-st-posture="terminal"] h3.sub::before { content: "$ "; color: var(--st-ink-3); font-weight: 400; }
+body[data-st-posture="terminal"] .hero { padding: 18px 0 14px; }
+body[data-st-posture="terminal"] .hero .st-wm { --st-wm-size: 96px; }
+body[data-st-posture="terminal"] .hero .tagline {
+  font-family: var(--st-font-mono); font-size: 14px;
+  font-style: normal; margin: 8px 0 4px;
+}
+body[data-st-posture="terminal"] .tile { padding: 14px 16px; }
+body[data-st-posture="terminal"] .marg {
+  font-family: var(--st-font-mono); font-style: normal;
+  font-size: 12px; border-left-color: var(--st-warn);
+  padding: 3px 0 3px 10px;
+}
+body[data-st-posture="terminal"] .marg::before { content: "// "; color: var(--st-ink-3); }
+body[data-st-posture="terminal"] .grid-2,
+body[data-st-posture="terminal"] .grid-3,
+body[data-st-posture="terminal"] .grid-4,
+body[data-st-posture="terminal"] .grid-asym { gap: 10px; margin-top: 10px; }
+body[data-st-posture="terminal"] .readme-banner { padding: 28px 36px 36px; min-height: 0; }
+body[data-st-posture="terminal"] .readme-banner::before { display: none; }
+body[data-st-posture="terminal"] .readme-banner .b-tag {
+  font-family: var(--st-font-mono); font-style: normal; font-size: 14px; margin-bottom: 28px;
+}
+body[data-st-posture="terminal"] .social-card { padding: 28px 36px; }
+body[data-st-posture="terminal"] .social-card .sc-tag { font-family: var(--st-font-mono); font-style: normal; font-size: 16px; }
+
+
+/* ─────────────────────────────────────────────────────────────────────
+   TWEAKS PANEL — host-driven; hidden until toolbar toggle activates it.
+   ───────────────────────────────────────────────────────────────────── */
+
+.tw-panel {
+  position: fixed; bottom: 24px; right: 24px;
+  z-index: 1000;
+  width: 280px;
+  background: var(--st-paper);
+  color: var(--st-ink);
+  border: 1.5px solid var(--st-ink);
+  box-shadow: 0 18px 40px -12px rgba(0,0,0,0.35);
+  font-family: var(--st-font-chrome);
+  display: none;
+}
+.tw-panel.on { display: block; }
+.tw-panel .tw-hd {
+  display: flex; justify-content: space-between; align-items: center;
+  font-family: var(--st-font-mono);
+  font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase;
+  font-weight: 700; color: var(--st-ink);
+  background: var(--st-paper-2);
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--st-rule-strong);
+}
+.tw-panel .tw-hd .close {
+  background: none; border: none; cursor: pointer;
+  font-family: var(--st-font-mono); font-size: 16px; color: var(--st-ink-3);
+  padding: 0 4px; line-height: 1;
+}
+.tw-panel .tw-hd .close:hover { color: var(--st-ink); }
+.tw-panel .tw-bd { padding: 14px; display: grid; gap: 16px; }
+.tw-panel .tw-row { display: grid; gap: 5px; }
+.tw-panel .tw-lab {
+  font-family: var(--st-font-mono);
+  font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--st-ink-3);
+}
+.tw-panel .tw-seg { display: flex; border: 1px solid var(--st-ink); }
+.tw-panel .tw-seg button {
+  flex: 1;
+  background: var(--st-paper); color: var(--st-ink-2);
+  border: none; border-right: 1px solid var(--st-rule);
+  font-family: var(--st-font-mono); font-size: 11px;
+  padding: 7px 6px; cursor: pointer;
+  letter-spacing: 0; text-transform: lowercase;
+}
+.tw-panel .tw-seg button:last-child { border-right: none; }
+.tw-panel .tw-seg button:hover { background: var(--st-paper-3); }
+.tw-panel .tw-seg button.on {
+  background: var(--st-ink); color: var(--st-paper); font-weight: 700;
+}
+.tw-panel .tw-foot {
+  font-family: var(--st-font-mono);
+  font-size: 9.5px; line-height: 1.55;
+  color: var(--st-ink-4);
+  padding: 0 14px 12px;
+}
+
+/* G-tune sliders ─────────────────────────────────────────────────── */
+.tw-panel .tw-tune {
+  display: grid; gap: 7px;
+  border-top: 1px dotted var(--st-rule);
+  padding-top: 14px;
+  margin-top: 4px;
+}
+.tw-panel .tw-tune .tw-tune-row {
+  display: grid;
+  grid-template-columns: 64px 1fr 50px;
+  align-items: center;
+  gap: 8px;
+}
+.tw-panel .tw-tune .tw-tune-row > label {
+  font-family: var(--st-font-mono);
+  font-size: 9.5px; letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--st-ink-3);
+}
+.tw-panel .tw-tune .tw-tune-row > .tw-num {
+  font-family: var(--st-font-mono);
+  font-size: 10.5px;
+  color: var(--st-ink);
+  text-align: right;
+}
+.tw-panel input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%; height: 4px;
+  background: var(--st-rule);
+  outline: none; margin: 0;
+}
+.tw-panel input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 14px; height: 14px;
+  background: var(--st-ink);
+  cursor: pointer; border-radius: 0;
+}
+.tw-panel input[type="range"]::-moz-range-thumb {
+  width: 14px; height: 14px;
+  background: var(--st-ink);
+  cursor: pointer; border-radius: 0; border: none;
+}
+.tw-panel .tw-reset {
+  font-family: var(--st-font-mono);
+  font-size: 10px; letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: transparent; color: var(--st-ink-3);
+  border: 1px solid var(--st-rule);
+  padding: 5px 8px;
+  cursor: pointer;
+  justify-self: start;
+  margin-top: 4px;
+}
+.tw-panel .tw-reset:hover { color: var(--st-ink); border-color: var(--st-ink); }
+</style>
+</head>
+<body>
+
+<div class="sheet">
+
+  <!-- ──────────────────────────────────────────────────────────────
+       HEADER
+       ────────────────────────────────────────────────────────────── -->
+  <header>
+    <div>
+      <div class="st-lock" style="font-size: 0">
+        <span class="st-glyph round" style="--st-glyph-size: 36px"></span>
+        <span class="st-wm font-newsreader" style="--st-wm-size: 28px">StoryTan<span class="g">g</span>l</span>
+        <span class="st-tag" style="font-size: 28px">brand sheet<br/>v1.0 · 2026-05</span>
+      </div>
+    </div>
+    <div class="meta">
+      a research platform for graph-based<br/>
+      computational narratology<br/>
+      <span style="color: var(--st-ink-4)">github.com/derekmerck/storytangl</span>
+    </div>
+  </header>
+
+
+  <!-- ──────────────────────────────────────────────────────────────
+       HERO
+       ────────────────────────────────────────────────────────────── -->
+  <div class="hero">
+    <span class="st-wm font-newsreader">StoryTan<span class="g">g</span>l</span>
+    <div class="tagline">A research platform for graph-based computational narratology.</div>
+    <div class="subtag">Turn the <code style="font-family: var(--st-font-mono); font-size: 12px; background:transparent; border:none; padding:0; font-weight:700;">g</code> over and read the rest.</div>
+  </div>
+
+
+  <!-- ──────────────────────────────────────────────────────────────
+       §1 — Wordmark (the canonical form)
+       ────────────────────────────────────────────────────────────── -->
+  <h2 class="sec">
+    <span class="n">§1</span>
+    <span>Wordmark</span>
+    <span class="right">canonical · do not redraw</span>
+  </h2>
+
+  <p class="intro">
+    The wordmark is <b>"StoryTangl" set in the body font, with the lowercase <code>g</code> rotated 180°.</b>
+    The rotation is the mark; everything else is typography. The flipped descender becomes an ascender,
+    the bowl becomes a descender, and the joke is visible at every size from favicon to billboard.
+    Origin: an earlier project used an inverted <code>Ɐ</code> as a currency mark — when this engine
+    needed a name, the same transformation applied to a different letter produced both the name and
+    its identity in one stroke.
+  </p>
+
+  <div class="marg">
+    The inversion exists on the page in CSS, in the terminal as Unicode <code>U+2141 ⅁</code>, and
+    in SVG as a transform on the glyph. The mark survives medium-shift; the transform doesn't matter.
+  </div>
+
+  <h3 class="sub">Canonical · Newsreader 600</h3>
+  <div class="tile" style="padding: 36px; background: var(--st-paper);">
+    <div class="tile-label">canonical wordmark</div>
+    <div style="text-align: center; padding: 18px 0;">
+      <span class="st-wm voice-locked font-newsreader" style="--st-wm-size: 132px">StoryTan<span class="g">g</span>l</span>
+    </div>
+    <div class="tile-foot">
+      <code>font: Newsreader 600</code> · <code>--st-wm-g-sy: 1.00</code> ·
+      <code>--st-wm-g-sx: 0.75</code> · <code>--st-wm-g-ty: 5%</code> ·
+      <code>--st-wm-g-margin: -.10em</code>
+    </div>
+  </div>
+
+  <h3 class="sub">Variants · per context</h3>
+  <p class="note">
+    Different surfaces use different fonts in the underlying type stack. The <code>g</code>
+    transform is re-tuned per font so the lip lands on the baseline and the new descender matches
+    the depth of neighboring descenders. The three tunings below are the only sanctioned variants.
+  </p>
+
+  <div class="grid-3" style="margin-top: 18px">
+    <div class="tile" style="padding: 28px 22px;">
+      <div class="tile-label">Newsreader · prose / docs</div>
+      <div style="display: grid; place-items: center; padding: 14px 0;">
+        <span class="st-wm voice-locked font-newsreader" style="--st-wm-size: 56px">StoryTan<span class="g">g</span>l</span>
+      </div>
+      <div class="tile-foot">use in: README banner · RTD title · social card · paper-form prose · the wireframe doc</div>
+    </div>
+
+    <div class="tile" style="padding: 28px 22px;">
+      <div class="tile-label">JetBrains Mono · code / CLI</div>
+      <div style="display: grid; place-items: center; padding: 14px 0;">
+        <span class="st-wm voice-locked font-mono" style="--st-wm-size: 48px">StoryTan<span class="g">g</span>l</span>
+      </div>
+      <div class="tile-foot">use in: CLI splash · log banners · terminal headers · prompts where the wordmark appears verbatim</div>
+    </div>
+
+    <div class="tile" style="padding: 28px 22px;">
+      <div class="tile-label">Inter Tight · web chrome</div>
+      <div style="display: grid; place-items: center; padding: 14px 0;">
+        <span class="st-wm voice-locked font-chrome" style="--st-wm-size: 52px">StoryTan<span class="g">g</span>l</span>
+      </div>
+      <div class="tile-foot">use in: web app navbar · admin chrome · any context already typeset in Inter Tight</div>
+    </div>
+  </div>
+
+  <h3 class="sub">Sizes — keep the ratios; no minimum height</h3>
+  <p class="note">
+    The wordmark scales freely; the transform is unitless. The flipped <code>g</code> remains legible
+    at small sizes because the inversion <i>is</i> the legibility. Below 16px the wordmark drops to
+    the glyph-only form (see §2).
+  </p>
+  <div class="tile" style="padding: 22px; display: grid; gap: 18px;">
+    <div><span class="st-wm voice-locked font-newsreader" style="--st-wm-size: 132px">StoryTan<span class="g">g</span>l</span></div>
+    <div><span class="st-wm voice-locked font-newsreader" style="--st-wm-size: 88px">StoryTan<span class="g">g</span>l</span></div>
+    <div><span class="st-wm voice-locked font-newsreader" style="--st-wm-size: 56px">StoryTan<span class="g">g</span>l</span></div>
+    <div><span class="st-wm voice-locked font-newsreader" style="--st-wm-size: 32px">StoryTan<span class="g">g</span>l</span></div>
+    <div><span class="st-wm voice-locked font-newsreader" style="--st-wm-size: 20px">StoryTan<span class="g">g</span>l</span></div>
+    <div><span class="st-wm voice-locked font-newsreader" style="--st-wm-size: 16px">StoryTan<span class="g">g</span>l</span></div>
+  </div>
+
+  <!-- ──────────────────────────────────────────────────────────────
+       §2 — Glyph
+       ────────────────────────────────────────────────────────────── -->
+  <h2 class="sec">
+    <span class="n">§2</span>
+    <span>Glyph</span>
+    <span class="right">standalone mark · favicon · social card</span>
+  </h2>
+
+  <p class="intro">
+    The glyph is the wordmark's <code>g</code> alone, set bold in the wordmark font and centered.
+    Use it when the wordmark is too wide (favicons, app icons, social-card watermark, small UI
+    chrome). The glyph is always square; choose round or framed only when the host surface demands it.
+  </p>
+
+  <div class="grid-4" style="margin-top: 18px">
+    <div class="tile" style="display: grid; place-items: center; padding: 32px 22px 22px;">
+      <div class="tile-label">primary</div>
+      <span class="st-glyph" style="--st-glyph-size: 132px"></span>
+      <div class="tile-foot" style="text-align: center">ink on paper-knockout</div>
+    </div>
+    <div class="tile" style="display: grid; place-items: center; padding: 32px 22px 22px;">
+      <div class="tile-label">inverted</div>
+      <span class="st-glyph inverted" style="--st-glyph-size: 132px"></span>
+      <div class="tile-foot" style="text-align: center">paper on ink-knockout</div>
+    </div>
+    <div class="tile" style="display: grid; place-items: center; padding: 32px 22px 22px;">
+      <div class="tile-label">blue-pencil</div>
+      <span class="st-glyph blue" style="--st-glyph-size: 132px"></span>
+      <div class="tile-foot" style="text-align: center">for moments of emphasis</div>
+    </div>
+    <div class="tile" style="display: grid; place-items: center; padding: 32px 22px 22px;">
+      <div class="tile-label">framed</div>
+      <span class="st-glyph frame" style="--st-glyph-size: 132px"></span>
+      <div class="tile-foot" style="text-align: center">for narrow chrome lines</div>
+    </div>
+  </div>
+
+  <div class="grid-4" style="margin-top: 18px">
+    <div class="tile" style="display: grid; place-items: center; padding: 32px 22px 22px;">
+      <div class="tile-label">round</div>
+      <span class="st-glyph round" style="--st-glyph-size: 132px"></span>
+      <div class="tile-foot" style="text-align: center">app icons · circular avatars</div>
+    </div>
+    <div class="tile" style="display: grid; place-items: center; padding: 32px 22px 22px;">
+      <div class="tile-label">round · inverted</div>
+      <span class="st-glyph round inverted" style="--st-glyph-size: 132px"></span>
+      <div class="tile-foot" style="text-align: center">light-on-dark contexts</div>
+    </div>
+    <div class="tile" style="display: grid; place-items: center; padding: 32px 22px 22px;">
+      <div class="tile-label">burnt accent</div>
+      <span class="st-glyph burnt round" style="--st-glyph-size: 132px"></span>
+      <div class="tile-foot" style="text-align: center">single brand pop · sparingly</div>
+    </div>
+    <div class="tile" style="display: grid; place-items: center; padding: 32px 22px 22px;">
+      <div class="tile-label">mono · ASCII fallback</div>
+      <div style="font-family: var(--st-font-mono); font-weight: 700; font-size: 132px; line-height: 1; color: var(--st-ink); transform: scaleX(0.9);">⅁</div>
+      <div class="tile-foot" style="text-align: center"><code>U+2141</code> · terminal · text-only</div>
+    </div>
+  </div>
+
+  <!-- ──────────────────────────────────────────────────────────────
+       §3 — Lockups
+       ────────────────────────────────────────────────────────────── -->
+  <h2 class="sec">
+    <span class="n">§3</span>
+    <span>Lockups</span>
+    <span class="right">one mark + descriptor · never both marks</span>
+  </h2>
+
+  <p class="intro">
+    A lockup pairs <b>one</b> mark with a descriptor — never two marks. The glyph <i>is</i> the
+    wordmark's flipped <code>g</code>, so setting them together just says the same thing twice.
+    Use the <b>wordmark</b> when there's room to read it, the <b>glyph</b> when there isn't. The
+    optional descriptor sits behind a <code>1px</code> ink-3 rule at a <code>0.18em</code> gap.
+  </p>
+
+  <div class="grid-2" style="margin-top: 30px">
+    <div class="tile" style="display: grid; place-items: center; padding: 36px;">
+      <div class="tile-label">wordmark + descriptor</div>
+      <div class="st-lock" style="font-size: 48px;">
+        <span class="st-wm font-newsreader" style="--st-wm-size: 1em">StoryTan<span class="g">g</span>l</span>
+        <span class="st-tag">interactive<br/>narrative engine</span>
+      </div>
+    </div>
+    <div class="tile" style="display: grid; place-items: center; padding: 36px;">
+      <div class="tile-label">glyph + descriptor · compact</div>
+      <div class="st-lock" style="font-size: 48px;">
+        <span class="st-glyph round" style="--st-glyph-size: 1.2em"></span>
+        <span class="st-tag">interactive<br/>narrative engine</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="dodont" style="margin-top: 18px;">
+    <div class="card good">
+      <div class="demo">
+        <span class="st-wm font-newsreader" style="--st-wm-size: 52px">StoryTan<span class="g">g</span>l</span>
+      </div>
+      <div class="label"><span class="tag">DO</span><span class="body">one mark, standing alone · the wordmark already carries the glyph</span></div>
+    </div>
+    <div class="card bad">
+      <div class="demo">
+        <div class="st-lock" style="font-size: 52px;">
+          <span class="st-glyph round" style="--st-glyph-size: 1.2em"></span>
+          <span class="st-wm font-newsreader" style="--st-wm-size: 1em">StoryTan<span class="g">g</span>l</span>
+        </div>
+      </div>
+      <div class="label"><span class="tag">DON'T</span><span class="body">glyph + wordmark together · the flipped <code>g</code>, twice over</span></div>
+    </div>
+  </div>
+
+  <!-- ──────────────────────────────────────────────────────────────
+       §4 — Typography
+       ────────────────────────────────────────────────────────────── -->
+  <h2 class="sec">
+    <span class="n">§4</span>
+    <span>Type stack</span>
+    <span class="right">three families · three roles · never mixed</span>
+  </h2>
+
+  <p class="intro">
+    Three families. Each family belongs to one role. No fourth family. If a context needs typographic
+    emphasis, reach for weight or size, never an additional family. The wordmark sets in the prose
+    family by default and falls back per §1 when context demands.
+  </p>
+
+  <div class="grid-3" style="margin-top: 18px">
+    <div class="tile" style="padding: 22px;">
+      <div class="tile-label">prose · titles · wordmark</div>
+      <div style="font-family: var(--st-font-prose); margin-top: 8px;">
+        <div style="font-size: 11px; color: var(--st-ink-3); font-family: var(--st-font-mono); letter-spacing: 0.06em; text-transform: uppercase;">Newsreader</div>
+        <div style="font-size: 64px; line-height: 1; font-weight: 600; margin: 6px 0 4px;">Aa Gg</div>
+        <div style="font-size: 22px; line-height: 1.3; color: var(--st-ink-2); font-weight: 500;">The bridge is out — you'll want the long way.</div>
+        <div style="font-size: 13.5px; line-height: 1.55; color: var(--st-ink-3); font-style: italic; margin-top: 6px;">A finger-post points east toward the river and west toward the mill.</div>
+      </div>
+      <div class="tile-foot">
+        weights · <code>400 / 500 / 600 / 700</code><br/>
+        use · prose · titles · wordmark · narrative copy
+      </div>
+    </div>
+
+    <div class="tile" style="padding: 22px;">
+      <div class="tile-label">engine output · cli · code</div>
+      <div style="font-family: var(--st-font-mono); margin-top: 8px;">
+        <div style="font-size: 11px; color: var(--st-ink-3); letter-spacing: 0.06em; text-transform: uppercase;">JetBrains Mono</div>
+        <div style="font-size: 56px; line-height: 1; font-weight: 700; margin: 6px 0 4px;">Aa Gg</div>
+        <div style="font-size: 13px; line-height: 1.5; color: var(--st-ink-2);">{ uid: "g-scene", fragment_type: "group" }</div>
+        <div style="font-size: 12px; line-height: 1.6; color: var(--st-ink-3); margin-top: 6px;">
+          $ tangl-cli<br/>
+          ⅁&gt; play coronate_the_regent
+        </div>
+      </div>
+      <div class="tile-foot">
+        weights · <code>400 / 500 / 600 / 700</code><br/>
+        use · engine output · cli · code · fragment data
+      </div>
+    </div>
+
+    <div class="tile" style="padding: 22px;">
+      <div class="tile-label">ui chrome · small labels</div>
+      <div style="font-family: var(--st-font-chrome); margin-top: 8px;">
+        <div style="font-size: 11px; color: var(--st-ink-3); font-family: var(--st-font-mono); letter-spacing: 0.06em; text-transform: uppercase;">Inter Tight</div>
+        <div style="font-size: 56px; line-height: 1; font-weight: 700; margin: 6px 0 4px;">Aa Gg</div>
+        <div style="font-size: 14px; line-height: 1.4; color: var(--st-ink-2); font-weight: 500;">World &nbsp;·&nbsp; Inspect &nbsp;·&nbsp; History</div>
+        <div style="font-size: 11px; line-height: 1.4; color: var(--st-ink-3); margin-top: 8px; text-transform: uppercase; letter-spacing: 0.08em;">Ledger · Step 14 · Cursor active</div>
+      </div>
+      <div class="tile-foot">
+        weights · <code>400 / 500 / 600 / 700</code><br/>
+        use · navbar · buttons · tags · table headers
+      </div>
+    </div>
+  </div>
+
+  <!-- ──────────────────────────────────────────────────────────────
+       §5 — Palette
+       ────────────────────────────────────────────────────────────── -->
+  <h2 class="sec">
+    <span class="n">§5</span>
+    <span>Palette</span>
+    <span class="right">engineering-notebook · closed set</span>
+  </h2>
+
+  <p class="intro">
+    The palette is small and closed. <b>Paper, ink, blue-pencil, burnt accent</b>, plus three
+    severity tokens that round-trip with <code>KvRow.emphasis</code> in the widget vocabulary.
+    Do not add hues; if a new severity surfaces, propose an addition in <code>USAGE.md</code>.
+    The dark mode is a literal photographic negative; it is not a second palette.
+  </p>
+
+  <div class="grid-2" style="margin-top: 18px">
+    <div class="tile" style="padding: 20px;">
+      <div class="tile-label">surface · structure</div>
+      <div style="margin-top: 10px;">
+        <div class="swatch">
+          <div class="sw-chip" style="background: #f6f3ea"></div>
+          <div><div class="sw-name">--st-paper</div><div style="font-size: 10px; color: var(--st-ink-3)">primary surface</div></div>
+          <div class="sw-hex">#f6f3ea</div>
+        </div>
+        <div class="swatch">
+          <div class="sw-chip" style="background: #eee8d6"></div>
+          <div><div class="sw-name">--st-paper-2</div><div style="font-size: 10px; color: var(--st-ink-3)">banded · hover</div></div>
+          <div class="sw-hex">#eee8d6</div>
+        </div>
+        <div class="swatch">
+          <div class="sw-chip" style="background: #e3dcc4"></div>
+          <div><div class="sw-name">--st-paper-3</div><div style="font-size: 10px; color: var(--st-ink-3)">margins · inactive</div></div>
+          <div class="sw-hex">#e3dcc4</div>
+        </div>
+        <div class="swatch">
+          <div class="sw-chip" style="background: #c9c2ad"></div>
+          <div><div class="sw-name">--st-rule</div><div style="font-size: 10px; color: var(--st-ink-3)">hairline rules</div></div>
+          <div class="sw-hex">#c9c2ad</div>
+        </div>
+        <div class="swatch">
+          <div class="sw-chip" style="background: #8a8472"></div>
+          <div><div class="sw-name">--st-rule-strong</div><div style="font-size: 10px; color: var(--st-ink-3)">structural borders</div></div>
+          <div class="sw-hex">#8a8472</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="tile" style="padding: 20px;">
+      <div class="tile-label">ink · text</div>
+      <div style="margin-top: 10px;">
+        <div class="swatch">
+          <div class="sw-chip" style="background: #1a1a1a"></div>
+          <div><div class="sw-name">--st-ink</div><div style="font-size: 10px; color: var(--st-ink-3)">primary · wordmark</div></div>
+          <div class="sw-hex">#1a1a1a</div>
+        </div>
+        <div class="swatch">
+          <div class="sw-chip" style="background: #3b3a36"></div>
+          <div><div class="sw-name">--st-ink-2</div><div style="font-size: 10px; color: var(--st-ink-3)">body prose</div></div>
+          <div class="sw-hex">#3b3a36</div>
+        </div>
+        <div class="swatch">
+          <div class="sw-chip" style="background: #6b6a64"></div>
+          <div><div class="sw-name">--st-ink-3</div><div style="font-size: 10px; color: var(--st-ink-3)">metadata · secondary</div></div>
+          <div class="sw-hex">#6b6a64</div>
+        </div>
+        <div class="swatch">
+          <div class="sw-chip" style="background: #93918a"></div>
+          <div><div class="sw-name">--st-ink-4</div><div style="font-size: 10px; color: var(--st-ink-3)">tertiary · disabled</div></div>
+          <div class="sw-hex">#93918a</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="grid-2" style="margin-top: 18px">
+    <div class="tile" style="padding: 20px;">
+      <div class="tile-label">accents</div>
+      <div style="margin-top: 10px;">
+        <div class="swatch">
+          <div class="sw-chip" style="background: #2a4e87"></div>
+          <div><div class="sw-name">--st-blue</div><div style="font-size: 10px; color: var(--st-ink-3)">blue-pencil · links · brand mark</div></div>
+          <div class="sw-hex">#2a4e87</div>
+        </div>
+        <div class="swatch">
+          <div class="sw-chip" style="background: #b2542a"></div>
+          <div><div class="sw-name">--st-burnt</div><div style="font-size: 10px; color: var(--st-ink-3)">single warm pop · sparingly</div></div>
+          <div class="sw-hex">#b2542a</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="tile" style="padding: 20px;">
+      <div class="tile-label">severity · round-trip with KvRow.emphasis</div>
+      <div style="margin-top: 10px;">
+        <div class="swatch">
+          <div class="sw-chip" style="background: #3e7f57"></div>
+          <div><div class="sw-name">--st-ok</div><div style="font-size: 10px; color: var(--st-ink-3)">✓ &nbsp; passed · no issue</div></div>
+          <div class="sw-hex">#3e7f57</div>
+        </div>
+        <div class="swatch">
+          <div class="sw-chip" style="background: #a8762a"></div>
+          <div><div class="sw-name">--st-warn</div><div style="font-size: 10px; color: var(--st-ink-3)">! &nbsp;&nbsp; flagged for review</div></div>
+          <div class="sw-hex">#a8762a</div>
+        </div>
+        <div class="swatch">
+          <div class="sw-chip" style="background: #a8362a"></div>
+          <div><div class="sw-name">--st-bad</div><div style="font-size: 10px; color: var(--st-ink-3)">!! &nbsp; failed · criminal</div></div>
+          <div class="sw-hex">#a8362a</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+
+  <!-- ──────────────────────────────────────────────────────────────
+       §6 — Applications
+       ────────────────────────────────────────────────────────────── -->
+  <h2 class="sec">
+    <span class="n">§6</span>
+    <span>Applications</span>
+    <span class="right">what the brand looks like in the wild</span>
+  </h2>
+
+  <h3 class="sub">README banner</h3>
+  <p class="note">Drop into <code>assets/brand/README-banner.svg</code>; reference in README.md as a hero image above the title. Replaces the markdown title that lost the rotated <code>g</code>.</p>
+
+  <div class="readme-banner" style="margin-top: 12px;">
+    <span class="st-wm font-newsreader b-wm">StoryTan<span class="g">g</span>l</span>
+    <div class="b-tag">A research platform for graph-based computational narratology.<br/>Fabula, navigation, journal — written once, projected three ways.</div>
+    <div class="b-meta">github.com/derekmerck/storytangl · MIT</div>
+    <div class="b-rule">v38 · ⅁</div>
+  </div>
+
+
+  <h3 class="sub">CLI splash</h3>
+  <p class="note">What <code>tangl-cli</code> prints on launch. Already-implemented surface; this just dresses it. The prompt itself uses <code>⅁&gt;</code> as the input prompt — the same flipped <code>g</code> the wordmark uses.</p>
+
+  <div class="cli-splash" style="margin-top: 12px;">
+    <div class="dots"><span></span><span></span><span></span></div>
+    <div style="margin-bottom: 4px;">
+      <span class="cli-wm st-wm font-mono" style="color:#e8dfc6">StoryTan<span class="g">g</span>l</span>
+      <span style="font-family: var(--st-font-mono); font-size: 14px; color: #8a8472; margin-left: 12px;">v38.3</span>
+    </div>
+    <div class="cli-banner-line">────────────────────────────────────────────────────────────</div>
+    <div style="color: #c9c2ad; margin-top: 6px;">
+      a research platform for graph-based computational narratology
+    </div>
+    <div class="dim" style="margin-top: 4px;">type <span class="accent">help</span> for commands · <span class="accent">play &lt;world&gt;</span> to begin · <span class="accent">^d</span> to exit</div>
+    <div style="margin-top: 14px;" class="dim">user: derek · ledger: (none) · world: (none)</div>
+    <div style="margin-top: 18px;" class="cli-prompt">
+      <span class="glyph">g</span><span>&gt;</span>
+      <span class="cli-cursor">&nbsp;</span>
+    </div>
+  </div>
+
+  <h3 class="sub">GitHub social card · 1280×640</h3>
+  <p class="note">The image GitHub uses when the repo is shared on Mastodon, Bluesky, X, Slack. Drop as <code>.github/social-preview.png</code>.</p>
+
+  <div class="social-card" style="margin-top: 12px;">
+    <span class="st-wm font-newsreader sc-wm">StoryTan<span class="g">g</span>l</span>
+    <div class="sc-tag">A research platform for graph-based computational narratology. Fabula, navigation, journal — written once, projected three ways.</div>
+    <div class="sc-meta">github.com/derekmerck/storytangl · MIT · v38</div>
+    <span class="st-glyph round sc-glyph" style="--st-glyph-size: 96px"></span>
+  </div>
+
+  <h3 class="sub">RTD docs header strip</h3>
+  <p class="note">Replaces the default Sphinx top-bar. Shipped via <code>docs/src/_static/storytangl-theme.css</code> + <code>docs/src/_templates/layout.html</code>.</p>
+
+  <div class="docs-strip" style="margin-top: 12px;">
+    <span class="st-wm font-newsreader d-wm">StoryTan<span class="g">g</span>l</span>
+    <div class="d-nav">
+      <a href="#" class="on">overview</a>
+      <a href="#">vocabulary</a>
+      <a href="#">authoring</a>
+      <a href="#">api</a>
+      <a href="#">design notes</a>
+    </div>
+    <div class="d-meta">v38.3 · github</div>
+  </div>
+
+  <h3 class="sub">Favicons</h3>
+  <p class="note">All sizes derive from <code>brand/assets/glyph.svg</code>. The 16×16 case drops the round mask and uses the glyph alone to preserve readability.</p>
+
+  <div class="favicon-grid" style="margin-top: 12px;">
+    <div class="favicon-cell">
+      <span class="st-glyph round" style="--st-glyph-size: 192px"></span>
+      <div>192 × 192 · apple-touch</div>
+    </div>
+    <div class="favicon-cell">
+      <span class="st-glyph round" style="--st-glyph-size: 96px"></span>
+      <div>96 × 96</div>
+    </div>
+    <div class="favicon-cell">
+      <span class="st-glyph round" style="--st-glyph-size: 48px"></span>
+      <div>48 × 48</div>
+    </div>
+    <div class="favicon-cell">
+      <span class="st-glyph round" style="--st-glyph-size: 32px"></span>
+      <div>32 × 32</div>
+    </div>
+    <div class="favicon-cell">
+      <span class="st-glyph" style="--st-glyph-size: 16px"></span>
+      <div>16 × 16 · no mask</div>
+    </div>
+  </div>
+
+
+  <!-- ──────────────────────────────────────────────────────────────
+       §7 — Do / Don't
+       ────────────────────────────────────────────────────────────── -->
+  <h2 class="sec">
+    <span class="n">§7</span>
+    <span>Do · Don't</span>
+    <span class="right">opinionated · short list · enforce in PRs</span>
+  </h2>
+
+  <div class="dodont">
+    <div class="card good">
+      <div class="demo">
+        <span class="st-wm font-newsreader" style="--st-wm-size: 64px">StoryTan<span class="g">g</span>l</span>
+      </div>
+      <div class="label"><span class="tag">DO</span><span class="body">flipped <code>g</code> tuned per font · ascender depth matches neighbors</span></div>
+    </div>
+    <div class="card bad">
+      <div class="demo">
+        <span style="font-family: var(--st-font-prose); font-weight: 600; font-size: 64px; line-height: 1;">StoryTangl</span>
+      </div>
+      <div class="label"><span class="tag">DON'T</span><span class="body">plain wordmark · no rotation · indistinguishable from any other project</span></div>
+    </div>
+
+    <div class="card good">
+      <div class="demo">
+        <span class="st-wm font-newsreader" style="--st-wm-size: 64px">StoryTan<span class="g">g</span>l</span>
+      </div>
+      <div class="label"><span class="tag">DO</span><span class="body">wordmark in the body font · part of the typesetting</span></div>
+    </div>
+    <div class="card bad">
+      <div class="demo">
+        <span style="font-family: 'Brush Script MT', 'Lucida Handwriting', cursive; font-weight: 700; font-size: 56px; line-height: 1;">StoryTan<span style="display:inline-block; transform: rotate(180deg);">g</span>l</span>
+      </div>
+      <div class="label"><span class="tag">DON'T</span><span class="body">decorative or display fonts · the wordmark is editorial, not whimsical</span></div>
+    </div>
+
+    <div class="card good">
+      <div class="demo">
+        <span class="st-wm font-newsreader" style="--st-wm-size: 64px; color: var(--st-ink)">StoryTan<span class="g">g</span>l</span>
+      </div>
+      <div class="label"><span class="tag">DO</span><span class="body">monochrome ink-on-paper · the mark holds without color</span></div>
+    </div>
+    <div class="card bad">
+      <div class="demo" style="background: linear-gradient(135deg, #ff6b9d, #c77dff, #4cc9f0); border-radius: 8px;">
+        <span style="font-family: var(--st-font-prose); font-weight: 700; font-size: 64px; line-height: 1; color: white; text-shadow: 0 2px 8px rgba(0,0,0,.3);">StoryTan<span style="display:inline-block; transform: rotate(180deg) scaleY(1.2) scaleX(0.8) translateY(-15%);">g</span>l</span>
+      </div>
+      <div class="label"><span class="tag">DON'T</span><span class="body">gradient backgrounds · color-pop wordmark · saas-startup typography</span></div>
+    </div>
+
+    <div class="card good">
+      <div class="demo" style="background: var(--st-paper); padding: 14px 28px;">
+        <span class="st-wm font-newsreader" style="--st-wm-size: 64px">StoryTan<span class="g">g</span>l</span>
+      </div>
+      <div class="label"><span class="tag">DO</span><span class="body">generous clear-space · at least <code>0.6em</code> on every side</span></div>
+    </div>
+    <div class="card bad">
+      <div class="demo" style="background: var(--st-paper); padding: 2px;">
+        <span class="st-wm font-newsreader" style="--st-wm-size: 64px">StoryTan<span class="g">g</span>l</span>
+      </div>
+      <div class="label"><span class="tag">DON'T</span><span class="body">crowded edges · the descender needs room</span></div>
+    </div>
+
+    <div class="card good">
+      <div class="demo">
+        <div style="font-family: var(--st-font-prose); font-size: 16px; color: var(--st-ink-2); max-width: 38ch; text-align: center; line-height: 1.5;">
+          The <span class="st-wm font-newsreader" style="--st-wm-size: 18px; display: inline;">StoryTan<span class="g">g</span>l</span> engine compiles authored scripts into a runtime graph.
+        </div>
+      </div>
+      <div class="label"><span class="tag">DO</span><span class="body">wordmark inline in body prose · scales naturally with line-height</span></div>
+    </div>
+    <div class="card bad">
+      <div class="demo">
+        <div style="font-family: var(--st-font-prose); font-size: 16px; color: var(--st-ink-2); max-width: 38ch; text-align: center; line-height: 1.5;">
+          The <b>StoryTangl</b> engine compiles authored scripts into a runtime graph.
+        </div>
+      </div>
+      <div class="label"><span class="tag">DON'T</span><span class="body">strip the rotation when inline · in prose it's <em>especially</em> the rotation</span></div>
+    </div>
+  </div>
+
+
+  <!-- ──────────────────────────────────────────────────────────────
+       §8 — Voice & tone
+       ────────────────────────────────────────────────────────────── -->
+  <h2 class="sec">
+    <span class="n">§8</span>
+    <span>Voice &amp; tone</span>
+    <span class="right">how the project writes about itself</span>
+  </h2>
+
+  <div class="grid-asym" style="margin-top: 18px">
+    <div class="tile" style="padding: 22px;">
+      <div class="tile-label">voice</div>
+      <p class="intro" style="font-size: 14px;">
+        Cynical, wry, technically precise. The writer is a research engineer with a PhD, dry humor,
+        and no patience for marketing copy. Prose makes claims it can back up. Jokes are dry; metaphors
+        are accurate; superlatives are rare and earned. When the project is honest about being a research
+        platform, the writing says so without apology.
+      </p>
+      <p class="intro" style="font-size: 14px;">
+        Lineage: the README, ARCHITECTURE.md, and AGENTS.md set the canonical voice. New copy lives at the
+        intersection of those three documents. Anything that sounds like a SaaS landing page belongs
+        somewhere else.
+      </p>
+    </div>
+    <div class="tile" style="padding: 22px;">
+      <div class="tile-label">tone register</div>
+      <table style="width: 100%; font-family: var(--st-font-mono); font-size: 11px; border-collapse: collapse;">
+        <tr style="border-bottom: 1px dotted var(--st-rule);"><td style="padding: 6px 0; color: var(--st-ok); font-weight: 700;">YES</td><td style="padding: 6px 0;">"the engine's real job is untangling"</td></tr>
+        <tr style="border-bottom: 1px dotted var(--st-rule);"><td style="padding: 6px 0; color: var(--st-ok); font-weight: 700;">YES</td><td style="padding: 6px 0;">"~37 architectural iterations"</td></tr>
+        <tr style="border-bottom: 1px dotted var(--st-rule);"><td style="padding: 6px 0; color: var(--st-ok); font-weight: 700;">YES</td><td style="padding: 6px 0;">"useful for development, not a production MVP"</td></tr>
+        <tr style="border-bottom: 1px dotted var(--st-rule);"><td style="padding: 6px 0; color: var(--st-ok); font-weight: 700;">YES</td><td style="padding: 6px 0;">"AI agents occasionally suggest things that are actually good"</td></tr>
+        <tr style="border-bottom: 1px dotted var(--st-rule);"><td style="padding: 6px 0; color: var(--st-bad); font-weight: 700;">NO</td><td style="padding: 6px 0;">"revolutionize interactive storytelling"</td></tr>
+        <tr style="border-bottom: 1px dotted var(--st-rule);"><td style="padding: 6px 0; color: var(--st-bad); font-weight: 700;">NO</td><td style="padding: 6px 0;">"the world's first…"</td></tr>
+        <tr style="border-bottom: 1px dotted var(--st-rule);"><td style="padding: 6px 0; color: var(--st-bad); font-weight: 700;">NO</td><td style="padding: 6px 0;">"unlock the full potential of…"</td></tr>
+        <tr><td style="padding: 6px 0; color: var(--st-bad); font-weight: 700;">NO</td><td style="padding: 6px 0;">emoji 🎉 in headlines</td></tr>
+      </table>
+    </div>
+  </div>
+
+
+  <!-- ──────────────────────────────────────────────────────────────
+       §9 — Lineage
+       ────────────────────────────────────────────────────────────── -->
+  <h2 class="sec">
+    <span class="n">§9</span>
+    <span>Lineage</span>
+    <span class="right">where the mark came from · why it's the right one</span>
+  </h2>
+
+  <p class="intro">
+    The flipped letterform is older than this project. Earlier work used an inverted <code>Ɐ</code>
+    as the mark of an imperial currency — soldiers' helmets, occupier coinage, the "<b>Ɐ$</b> horn"
+    of an earlier game. When the engine needed a name, the same transform applied to a different
+    letter produced both. <b>StoryTangl</b> means what its glyph means: a thing that has been
+    turned over, and reads differently from that side.
+  </p>
+
+  <div class="grid-3" style="margin-top: 14px;">
+    <div class="tile" style="padding: 22px; text-align: center;">
+      <div class="tile-label">ancestor · Ɐ$ horn</div>
+      <div style="font-size: 88px; font-family: var(--st-font-prose); font-weight: 700; color: var(--st-ink); line-height: 1; padding: 16px 0;">Ɐ$</div>
+      <div class="tile-foot" style="text-align: center;">inverted A · earlier currency mark</div>
+    </div>
+    <div class="tile" style="padding: 22px; text-align: center;">
+      <div class="tile-label">transformation</div>
+      <div style="font-family: var(--st-font-mono); font-size: 14px; line-height: 1.7; padding: 24px 0; color: var(--st-ink-2);">
+        rotate 180°<br/>
+        ↓<br/>
+        same operation,<br/>
+        different letter<br/>
+        ↓<br/>
+        new mark
+      </div>
+      <div class="tile-foot" style="text-align: center;">the transform is the brand</div>
+    </div>
+    <div class="tile" style="padding: 22px; text-align: center;">
+      <div class="tile-label">descendant · StoryTangl glyph</div>
+      <div style="padding: 16px 0;">
+        <span class="st-glyph" style="--st-glyph-size: 88px"></span>
+      </div>
+      <div class="tile-foot" style="text-align: center;">flipped g · the engine's untangle</div>
+    </div>
+  </div>
+
+
+  <!-- ──────────────────────────────────────────────────────────────
+       §10 — Asset index
+       ────────────────────────────────────────────────────────────── -->
+  <h2 class="sec">
+    <span class="n">§10</span>
+    <span>Assets · index</span>
+    <span class="right">files in this directory · drop-in for the repo</span>
+  </h2>
+
+  <table class="assets">
+    <thead><tr><th style="width: 32%">path</th><th style="width: 36%">purpose</th><th>note</th></tr></thead>
+    <tbody>
+      <tr><td class="path">brand/StoryTangl-Brand-Sheet.html</td><td class="purpose">this document — canonical reference</td><td class="note">review-only; not a production artifact</td></tr>
+      <tr><td class="path">brand/assets/palette.css</td><td class="purpose">color tokens (light + ink-mode)</td><td class="note"><code>:root</code> + <code>[data-st-mode="ink"]</code></td></tr>
+      <tr><td class="path">brand/assets/type.css</td><td class="purpose">type stack (Newsreader / Mono / Inter Tight)</td><td class="note">Google Fonts import</td></tr>
+      <tr><td class="path">brand/assets/wordmark.svg</td><td class="purpose">canonical wordmark · Newsreader 600</td><td class="note">paths only, no font dependency</td></tr>
+      <tr><td class="path">brand/assets/wordmark-mono.svg</td><td class="purpose">mono wordmark · for CLI banner</td><td class="note">JetBrains Mono</td></tr>
+      <tr><td class="path">brand/assets/glyph.svg</td><td class="purpose">standalone glyph · ink-on-paper</td><td class="note">square; clip-path-friendly</td></tr>
+      <tr><td class="path">brand/assets/glyph-round.svg</td><td class="purpose">round-masked glyph · for favicons</td><td class="note">used at 16/32/48/96/192 px</td></tr>
+      <tr><td class="path">brand/assets/favicon.svg</td><td class="purpose">browser tab icon · 32×32 source</td><td class="note">deploys at <code>apps/web/public/favicon.svg</code></td></tr>
+      <tr><td class="path">brand/assets/social-card.svg</td><td class="purpose">GitHub social preview · 1280×640</td><td class="note">deploys at <code>.github/social-preview.png</code> (rasterize)</td></tr>
+      <tr><td class="path">brand/assets/README-banner.svg</td><td class="purpose">README hero · 1280×320</td><td class="note">drop above the <code># StoryTangl</code> line</td></tr>
+      <tr><td class="path">brand/assets/cli-splash.txt</td><td class="purpose">terminal launch banner · ANSI</td><td class="note">used by <code>tangl-cli</code> on start</td></tr>
+      <tr><td class="path">brand/USAGE.md</td><td class="purpose">do / don't · sizing rules · what an LLM agent must never do</td><td class="note">opinionated; enforce in PRs</td></tr>
+    </tbody>
+  </table>
+
+  <div class="marg" style="margin-top: 24px;">
+    The brand is intentionally small. If an asset doesn't exist here, the answer is probably "you
+    don't need one." If you genuinely do, add it here first; then deploy.
+  </div>
+
+
+  <!-- end ──────────────────────────────────────────────────────────────── -->
+  <div style="margin-top: 80px; padding-top: 18px; border-top: 1px dotted var(--st-rule); font-family: var(--st-font-mono); font-size: 10.5px; color: var(--st-ink-3); display: grid; grid-template-columns: 1fr auto; gap: 16px;">
+    <div>StoryTangl brand sheet v1.0 · 2026-05 · supersedes nothing · all values closed unless re-opened in USAGE.md</div>
+    <div>⅁</div>
+  </div>
+
+</div>
+
+<!-- ────────────────────────────────────────────────────────────────
+     Tweaks panel — host-driven; appears when the toolbar toggle activates it.
+     ──────────────────────────────────────────────────────────────── -->
+<div class="tw-panel" id="tw-panel">
+  <div class="tw-hd">
+    <span>Tweaks</span>
+    <button class="close" type="button" aria-label="close" id="tw-close">×</button>
+  </div>
+  <div class="tw-bd">
+    <div class="tw-row">
+      <div class="tw-lab">Surface · mode</div>
+      <div class="tw-seg" data-tweak="mode">
+        <button type="button" data-val="paper">paper</button>
+        <button type="button" data-val="ink">ink</button>
+        <button type="button" data-val="blueprint">blueprint</button>
+      </div>
+    </div>
+    <div class="tw-row">
+      <div class="tw-lab">Wordmark · voice</div>
+      <div class="tw-seg" data-tweak="voice">
+        <button type="button" data-val="prose">prose</button>
+        <button type="button" data-val="mono">mono</button>
+        <button type="button" data-val="chrome">chrome</button>
+      </div>
+    </div>
+    <div class="tw-row">
+      <div class="tw-lab">Posture · rhythm</div>
+      <div class="tw-seg" data-tweak="posture">
+        <button type="button" data-val="editorial">editorial</button>
+        <button type="button" data-val="engineering">engineering</button>
+        <button type="button" data-val="terminal">terminal</button>
+      </div>
+    </div>
+
+    <div class="tw-tune">
+      <div class="tw-lab" style="margin-bottom: 2px;">G · fine tuning <span id="tw-tune-voice" style="color: var(--st-ink); letter-spacing: 0;"></span></div>
+      <div class="tw-tune-row">
+        <label for="tw-sy">scale y</label>
+        <input type="range" id="tw-sy" min="0.60" max="1.60" step="0.01">
+        <span class="tw-num" id="tw-sy-n"></span>
+      </div>
+      <div class="tw-tune-row">
+        <label for="tw-sx">scale x</label>
+        <input type="range" id="tw-sx" min="0.50" max="1.20" step="0.01">
+        <span class="tw-num" id="tw-sx-n"></span>
+      </div>
+      <div class="tw-tune-row">
+        <label for="tw-ty">shift y</label>
+        <input type="range" id="tw-ty" min="-40" max="20" step="1">
+        <span class="tw-num" id="tw-ty-n"></span>
+      </div>
+      <div class="tw-tune-row">
+        <label for="tw-mg">margin</label>
+        <input type="range" id="tw-mg" min="-0.20" max="0.05" step="0.005">
+        <span class="tw-num" id="tw-mg-n"></span>
+      </div>
+      <button type="button" class="tw-reset" id="tw-reset">reset tuning</button>
+    </div>
+  </div>
+  <div class="tw-foot">
+    Segmented controls rewrite a whole gestalt. The sliders tune the flipped-<code>g</code> for the
+    <b>active voice only</b> — each font needs its own geometry — and persist per voice. §1 variants
+    and the sizing scale stay locked as reference.
+  </div>
+</div>
+
+<script>
+(function(){
+  // Default state — these are the canonical Newsreader-tuned values. The
+  // host writes them back through the EDITMODE-BEGIN/END block when the
+  // user persists a tweak.
+  const TWEAKS = /*EDITMODE-BEGIN*/{
+    "mode": "ink",
+    "voice": "chrome",
+    "posture": "terminal",
+    "prose_sy": 1,
+    "prose_sx": 0.85,
+    "prose_ty": 5,
+    "prose_mg": -0.1,
+    "mono_sy": 1,
+    "mono_sx": 1,
+    "mono_ty": -20,
+    "mono_mg": 0,
+    "chrome_sy": 1,
+    "chrome_sx": 0.75,
+    "chrome_ty": -20,
+    "chrome_mg": -0.1
+  }/*EDITMODE-END*/;
+
+  // Canonical per-voice geometry for the flipped g. Each font needs its own
+  // numbers — the same transform can't sit right on Newsreader, JetBrains Mono
+  // and Inter Tight at once. These mirror the per-font CSS classes and feed
+  // the per-voice reset button.
+  const CANON = {
+    prose:  { sy: 1.00, sx: 0.75, ty: 5,   mg: -0.10 },
+    mono:   { sy: 1.00, sx: 1.00, ty: -20, mg:  0.00 },
+    chrome: { sy: 1.00, sx: 0.75, ty: -20, mg: -0.10 },
+  };
+
+  let state = Object.assign({}, TWEAKS);
+  const panel = document.getElementById("tw-panel");
+  const root  = document.documentElement;
+
+  // ── segmented controls (mode / voice / posture) ───────────────────
+  panel.querySelectorAll(".tw-seg").forEach(seg => {
+    const key = seg.dataset.tweak;
+    seg.querySelectorAll("button").forEach(btn => {
+      btn.addEventListener("click", () => {
+        state[key] = btn.dataset.val;
+        applyAll();
+        // sliders tune ONE voice at a time — reload them when voice changes
+        if (key === "voice") { syncSliders(); writeNums(); }
+        persist();
+      });
+    });
+  });
+
+  // ── G fine-tuning sliders ──────────────────────────────────────────
+  const sliders = {
+    sy: { el: document.getElementById("tw-sy"), out: document.getElementById("tw-sy-n"),
+          fmt: v => Number(v).toFixed(2) },
+    sx: { el: document.getElementById("tw-sx"), out: document.getElementById("tw-sx-n"),
+          fmt: v => Number(v).toFixed(2) },
+    ty: { el: document.getElementById("tw-ty"), out: document.getElementById("tw-ty-n"),
+          fmt: v => Math.round(v) + "%" },
+    mg: { el: document.getElementById("tw-mg"), out: document.getElementById("tw-mg-n"),
+          fmt: v => Number(v).toFixed(3) + "em" },
+  };
+  // each slider edits the field for the CURRENTLY ACTIVE voice (e.g. chrome_sx)
+  Object.entries(sliders).forEach(([field, s]) => {
+    s.el.addEventListener("input", () => {
+      state[state.voice + "_" + field] = parseFloat(s.el.value);
+      applyTune();
+      writeNums();
+    });
+    s.el.addEventListener("change", persist);
+  });
+
+  document.getElementById("tw-reset").addEventListener("click", () => {
+    const c = CANON[state.voice];
+    state[state.voice + "_sy"] = c.sy;
+    state[state.voice + "_sx"] = c.sx;
+    state[state.voice + "_ty"] = c.ty;
+    state[state.voice + "_mg"] = c.mg;
+    syncSliders();
+    applyTune();
+    writeNums();
+    persist();
+  });
+
+  document.getElementById("tw-close").addEventListener("click", () => {
+    panel.classList.remove("on");
+    try { window.parent.postMessage({type: "__edit_mode_dismissed"}, "*"); } catch(e) {}
+  });
+
+  // ── apply ──────────────────────────────────────────────────────────
+  function applyAll() {
+    root.setAttribute("data-st-mode",    state.mode);
+    root.setAttribute("data-st-voice",   state.voice);
+    root.setAttribute("data-st-posture", state.posture);
+    document.body.setAttribute("data-st-mode",    state.mode);
+    document.body.setAttribute("data-st-voice",   state.voice);
+    document.body.setAttribute("data-st-posture", state.posture);
+    // light up the active button in each segmented control
+    panel.querySelectorAll(".tw-seg").forEach(seg => {
+      const key = seg.dataset.tweak;
+      seg.querySelectorAll("button").forEach(b => {
+        b.classList.toggle("on", b.dataset.val === state[key]);
+      });
+    });
+    applyTune();
+  }
+
+  function applyTune() {
+    // Inline custom-property overrides on every non-locked .st-wm element,
+    // using the ACTIVE voice's geometry. Inline beats the per-font class rules,
+    // so the sliders win. Because every non-locked wordmark already follows the
+    // active voice's FONT, one set of numbers is correct for all of them at
+    // once. .voice-locked wordmarks keep their spec-canonical per-font tuning.
+    const v = state.voice;
+    document.querySelectorAll(".st-wm:not(.voice-locked)").forEach(el => {
+      el.style.setProperty("--st-wm-g-sy",     state[v + "_sy"]);
+      el.style.setProperty("--st-wm-g-sx",     state[v + "_sx"]);
+      el.style.setProperty("--st-wm-g-ty",     state[v + "_ty"] + "%");
+      el.style.setProperty("--st-wm-g-margin", state[v + "_mg"] + "em");
+    });
+  }
+
+  function syncSliders() {
+    const v = state.voice;
+    sliders.sy.el.value = state[v + "_sy"];
+    sliders.sx.el.value = state[v + "_sx"];
+    sliders.ty.el.value = state[v + "_ty"];
+    sliders.mg.el.value = state[v + "_mg"];
+    const tag = document.getElementById("tw-tune-voice");
+    if (tag) tag.textContent = "· " + v;
+  }
+
+  function writeNums() {
+    const v = state.voice;
+    Object.entries(sliders).forEach(([field, s]) => {
+      s.out.textContent = s.fmt(state[v + "_" + field]);
+    });
+  }
+
+  function persist() {
+    try { window.parent.postMessage({type: "__edit_mode_set_keys", edits: state}, "*"); } catch(e) {}
+  }
+
+  // ── host protocol (listener BEFORE announcement) ───────────────────
+  window.addEventListener("message", (e) => {
+    const m = e.data;
+    if (!m || typeof m !== "object") return;
+    if (m.type === "__activate_edit_mode")   panel.classList.add("on");
+    if (m.type === "__deactivate_edit_mode") panel.classList.remove("on");
+  });
+  try { window.parent.postMessage({type: "__edit_mode_available"}, "*"); } catch(e) {}
+
+  // ── init ───────────────────────────────────────────────────────────
+  syncSliders();
+  writeNums();
+  applyAll();
+})();
+</script>
+
+</body>
+</html>

--- a/docs/src/design/story/brand/v1_0/StoryTangl-Brand-Sheet.html
+++ b/docs/src/design/story/brand/v1_0/StoryTangl-Brand-Sheet.html
@@ -1510,30 +1510,31 @@ body[data-st-posture="terminal"] .social-card .sc-tag { font-family: var(--st-fo
   <h2 class="sec">
     <span class="n">§10</span>
     <span>Assets · index</span>
-    <span class="right">files in this directory · drop-in for the repo</span>
+    <span class="right">archived reference files · generated targets</span>
   </h2>
 
   <table class="assets">
     <thead><tr><th style="width: 32%">path</th><th style="width: 36%">purpose</th><th>note</th></tr></thead>
     <tbody>
       <tr><td class="path">brand/StoryTangl-Brand-Sheet.html</td><td class="purpose">this document — canonical reference</td><td class="note">review-only; not a production artifact</td></tr>
+      <tr><td class="path">brand/USAGE.md</td><td class="purpose">do / don't · sizing rules · what an LLM agent must never do</td><td class="note">opinionated; enforce in PRs</td></tr>
       <tr><td class="path">brand/assets/palette.css</td><td class="purpose">color tokens (light + ink-mode)</td><td class="note"><code>:root</code> + <code>[data-st-mode="ink"]</code></td></tr>
       <tr><td class="path">brand/assets/type.css</td><td class="purpose">type stack (Newsreader / Mono / Inter Tight)</td><td class="note">Google Fonts import</td></tr>
-      <tr><td class="path">brand/assets/wordmark.svg</td><td class="purpose">canonical wordmark · Newsreader 600</td><td class="note">paths only, no font dependency</td></tr>
-      <tr><td class="path">brand/assets/wordmark-mono.svg</td><td class="purpose">mono wordmark · for CLI banner</td><td class="note">JetBrains Mono</td></tr>
-      <tr><td class="path">brand/assets/glyph.svg</td><td class="purpose">standalone glyph · ink-on-paper</td><td class="note">square; clip-path-friendly</td></tr>
-      <tr><td class="path">brand/assets/glyph-round.svg</td><td class="purpose">round-masked glyph · for favicons</td><td class="note">used at 16/32/48/96/192 px</td></tr>
-      <tr><td class="path">brand/assets/favicon.svg</td><td class="purpose">browser tab icon · 32×32 source</td><td class="note">deploys at <code>apps/web/public/favicon.svg</code></td></tr>
-      <tr><td class="path">brand/assets/social-card.svg</td><td class="purpose">GitHub social preview · 1280×640</td><td class="note">deploys at <code>.github/social-preview.png</code> (rasterize)</td></tr>
-      <tr><td class="path">brand/assets/README-banner.svg</td><td class="purpose">README hero · 1280×320</td><td class="note">drop above the <code># StoryTangl</code> line</td></tr>
-      <tr><td class="path">brand/assets/cli-splash.txt</td><td class="purpose">terminal launch banner · ANSI</td><td class="note">used by <code>tangl-cli</code> on start</td></tr>
-      <tr><td class="path">brand/USAGE.md</td><td class="purpose">do / don't · sizing rules · what an LLM agent must never do</td><td class="note">opinionated; enforce in PRs</td></tr>
+      <tr><td class="path">brand/assets/wordmark.svg</td><td class="purpose">canonical wordmark · Newsreader 600</td><td class="note">not archived here; regenerate and review before deploying</td></tr>
+      <tr><td class="path">brand/assets/wordmark-mono.svg</td><td class="purpose">mono wordmark · for CLI banner</td><td class="note">not archived here; regenerate and review before deploying</td></tr>
+      <tr><td class="path">brand/assets/glyph.svg</td><td class="purpose">standalone glyph · ink-on-paper</td><td class="note">not archived here; regenerate and review before deploying</td></tr>
+      <tr><td class="path">brand/assets/glyph-round.svg</td><td class="purpose">round-masked glyph · for favicons</td><td class="note">not archived here; regenerate and review before deploying</td></tr>
+      <tr><td class="path">brand/assets/favicon.svg</td><td class="purpose">browser tab icon · 32×32 source</td><td class="note">deployment target: <code>apps/web/public/favicon.svg</code></td></tr>
+      <tr><td class="path">brand/assets/social-card.svg</td><td class="purpose">GitHub social preview · 1280×640</td><td class="note">deployment target: rasterized <code>.github/social-preview.png</code></td></tr>
+      <tr><td class="path">brand/assets/README-banner.svg</td><td class="purpose">README hero · 1280×320</td><td class="note">deployment target: README hero above the H1</td></tr>
+      <tr><td class="path">brand/assets/cli-splash.txt</td><td class="purpose">terminal launch banner · ANSI</td><td class="note">proposal only; regenerate if the CLI adopts it</td></tr>
     </tbody>
   </table>
 
   <div class="marg" style="margin-top: 24px;">
-    The brand is intentionally small. If an asset doesn't exist here, the answer is probably "you
-    don't need one." If you genuinely do, add it here first; then deploy.
+    The brand is intentionally small. Generated targets listed above are deployment guidance, not
+    broken references in this archive. If you genuinely need a new target, add the rule here first;
+    then deploy.
   </div>
 
 
@@ -1617,9 +1618,9 @@ body[data-st-posture="terminal"] .social-card .sc-tag { font-family: var(--st-fo
   // host writes them back through the EDITMODE-BEGIN/END block when the
   // user persists a tweak.
   const TWEAKS = /*EDITMODE-BEGIN*/{
-    "mode": "ink",
-    "voice": "chrome",
-    "posture": "terminal",
+    "mode": "paper",
+    "voice": "prose",
+    "posture": "engineering",
     "prose_sy": 1,
     "prose_sx": 0.85,
     "prose_ty": 5,

--- a/docs/src/design/story/brand/v1_0/StoryTangl-Brand-Sheet.html
+++ b/docs/src/design/story/brand/v1_0/StoryTangl-Brand-Sheet.html
@@ -1516,11 +1516,10 @@ body[data-st-posture="terminal"] .social-card .sc-tag { font-family: var(--st-fo
   <table class="assets">
     <thead><tr><th style="width: 32%">path</th><th style="width: 36%">purpose</th><th>note</th></tr></thead>
     <tbody>
-      <tr><td class="path">brand/StoryTangl-Brand-Sheet.html</td><td class="purpose">this document — canonical reference</td><td class="note">review-only; not a production artifact</td></tr>
-      <tr><td class="path">brand/USAGE.md</td><td class="purpose">do / don't · sizing rules · what an LLM agent must never do</td><td class="note">opinionated; enforce in PRs</td></tr>
-      <tr><td class="path">brand/assets/palette.css</td><td class="purpose">color tokens (light + ink-mode)</td><td class="note"><code>:root</code> + <code>[data-st-mode="ink"]</code></td></tr>
-      <tr><td class="path">brand/assets/type.css</td><td class="purpose">type stack (Newsreader / Mono / Inter Tight)</td><td class="note">Google Fonts import</td></tr>
-      <tr><td class="path">brand/assets/wordmark.svg</td><td class="purpose">canonical wordmark · Newsreader 600</td><td class="note">not archived here; regenerate and review before deploying</td></tr>
+      <tr><td class="path">brand/v1_0/StoryTangl-Brand-Sheet.html</td><td class="purpose">this document — canonical reference</td><td class="note">review-only; not a production artifact</td></tr>
+      <tr><td class="path">brand/v1_0/USAGE.md</td><td class="purpose">do / don't · sizing rules · what an LLM agent must never do</td><td class="note">opinionated; enforce in PRs</td></tr>
+      <tr><td class="path">brand/v1_0/assets/palette.css</td><td class="purpose">color tokens (light + ink-mode)</td><td class="note"><code>:root</code> + <code>[data-st-mode="ink"]</code></td></tr>
+      <tr><td class="path">brand/v1_0/assets/type.css</td><td class="purpose">type stack (Newsreader / Mono / Inter Tight)</td><td class="note">Google Fonts import</td></tr>
       <tr><td class="path">brand/assets/wordmark-mono.svg</td><td class="purpose">mono wordmark · for CLI banner</td><td class="note">not archived here; regenerate and review before deploying</td></tr>
       <tr><td class="path">brand/assets/glyph.svg</td><td class="purpose">standalone glyph · ink-on-paper</td><td class="note">not archived here; regenerate and review before deploying</td></tr>
       <tr><td class="path">brand/assets/glyph-round.svg</td><td class="purpose">round-masked glyph · for favicons</td><td class="note">not archived here; regenerate and review before deploying</td></tr>

--- a/docs/src/design/story/brand/v1_0/USAGE.md
+++ b/docs/src/design/story/brand/v1_0/USAGE.md
@@ -16,18 +16,29 @@ the new descender matches its neighbors. Three tunings are sanctioned:
 Newsreader (canonical), JetBrains Mono (CLI), Inter Tight (web chrome).
 Custom tunings for new fonts require updating the brand sheet first.
 
-## 2. Where each asset goes
+## 2. What is archived here
 
-| Asset | Destination | Format |
-|-------|-------------|--------|
-| `wordmark.svg` | `assets/brand/wordmark.svg` (or wherever the repo's brand assets live) | SVG with webfont |
-| `glyph.svg` / `glyph-round.svg` | `assets/brand/glyph*.svg` | SVG with webfont |
-| `favicon.svg` | `apps/web/public/favicon.svg`, `docs/src/_static/favicon.svg` | SVG with webfont (browsers cache it locally; fallback to `favicon.ico` for IE11-era) |
-| `README-banner.svg` | `assets/brand/README-banner.svg`; reference in `README.md` as the hero image above the `# StoryTangl` line | SVG with webfont |
-| `social-card.svg` | `.github/social-preview.png` (rasterize first; GitHub doesn't accept SVG for social previews) | PNG export at 1280×640 |
-| `cli-splash.txt` | `apps/cli/src/tangl/cli/assets/splash.txt`, loaded by the cmd2 app on launch | plain text |
-| `palette.css` | `apps/web/src/styles/storytangl-palette.css`; `docs/src/_static/storytangl-palette.css` | CSS |
-| `type.css` | same | CSS |
+This directory is a reference archive, not a deployed asset package.
+
+| Archived file | Purpose | Note |
+|---------------|---------|------|
+| `StoryTangl-Brand-Sheet.html` | visual reference | review-only; not production HTML |
+| `USAGE.md` | rules and deployment guidance | this file |
+| `assets/palette.css` | color tokens | copied from the brand package |
+| `assets/type.css` | type tokens | copied from the brand package |
+
+Generated outputs stay out of this archive until they are visually reviewed.
+When the brand stabilizes, regenerate and deploy only the outputs a target
+client actually needs.
+
+| Generated output | Intended destination | Format |
+|------------------|----------------------|--------|
+| `wordmark.svg` | `assets/brand/wordmark.svg` | SVG, reviewed for font tuning |
+| `glyph.svg` / `glyph-round.svg` | `assets/brand/glyph*.svg` | SVG |
+| `favicon.svg` | `apps/web/public/favicon.svg`, `docs/src/_static/favicon.svg` | SVG |
+| `README-banner.svg` | README hero above the `# StoryTangl` line | SVG |
+| `social-card.png` | `.github/social-preview.png` | PNG export at 1280×640 |
+| `cli-splash.txt` | CLI launch splash, if adopted | plain text |
 
 ## 3. SVGs are font-dependent — when to convert to paths
 
@@ -50,15 +61,18 @@ inkscape wordmark.svg --export-type=svg --export-filename=wordmark-paths.svg \
 # online: https://danmarshall.github.io/google-font-to-svg-path/
 ```
 
-The path version is checked in alongside the font-dependent SVG; downstream
-choose by context. Do not regenerate paths without confirming the
-typographic tuning matches §1 of the brand sheet (per-font sx/sy/ty values).
+No path exports are checked in here. If a downstream target needs one, commit
+the font-dependent source and the path export together in that target's asset
+directory. Do not regenerate paths without confirming the typographic tuning
+matches §1 of the brand sheet (per-font sx/sy/ty values).
 
-## 4. The lockup is the wordmark or the wordmark + glyph — never the glyph alone with text
+## 4. Lockups use one primary mark plus a descriptor
 
-The glyph stands alone. The wordmark stands alone. A glyph + wordmark
-lockup is sanctioned (see §3 of the brand sheet). What is **not** sanctioned:
+The glyph stands alone. The wordmark stands alone. A lockup may pair either
+primary mark with a descriptor such as `engine`, `docs`, or `cli`. It should
+not pair the glyph and wordmark together. What is **not** sanctioned:
 
+- **glyph + wordmark together** (two primary marks competing)
 - **glyph + plain "StoryTangl" text** (defeats the whole mark)
 - **glyph + a different word** (the mark is bound to its wordmark)
 - **two glyphs as a repeating pattern** (use the dotty knot texture instead)

--- a/docs/src/design/story/brand/v1_0/USAGE.md
+++ b/docs/src/design/story/brand/v1_0/USAGE.md
@@ -1,0 +1,151 @@
+# StoryTan⅁l · brand usage
+
+Read [`StoryTangl-Brand-Sheet.html`](./StoryTangl-Brand-Sheet.html) first.
+This file is the rules-of-the-road that the brand sheet implies but doesn't
+spell out. Same voice as `AGENTS.md` — opinionated, parsimonious, explicit
+about what an agent must never do.
+
+## 1. The mark
+
+The wordmark is **"StoryTangl" in the body font, with the lowercase `g`
+rotated 180°.** The rotation *is* the brand. Stripping it produces a
+wordmark indistinguishable from any other project; do not do this.
+
+The rotation requires per-font tuning so the lip lands on the baseline and
+the new descender matches its neighbors. Three tunings are sanctioned:
+Newsreader (canonical), JetBrains Mono (CLI), Inter Tight (web chrome).
+Custom tunings for new fonts require updating the brand sheet first.
+
+## 2. Where each asset goes
+
+| Asset | Destination | Format |
+|-------|-------------|--------|
+| `wordmark.svg` | `assets/brand/wordmark.svg` (or wherever the repo's brand assets live) | SVG with webfont |
+| `glyph.svg` / `glyph-round.svg` | `assets/brand/glyph*.svg` | SVG with webfont |
+| `favicon.svg` | `apps/web/public/favicon.svg`, `docs/src/_static/favicon.svg` | SVG with webfont (browsers cache it locally; fallback to `favicon.ico` for IE11-era) |
+| `README-banner.svg` | `assets/brand/README-banner.svg`; reference in `README.md` as the hero image above the `# StoryTangl` line | SVG with webfont |
+| `social-card.svg` | `.github/social-preview.png` (rasterize first; GitHub doesn't accept SVG for social previews) | PNG export at 1280×640 |
+| `cli-splash.txt` | `apps/cli/src/tangl/cli/assets/splash.txt`, loaded by the cmd2 app on launch | plain text |
+| `palette.css` | `apps/web/src/styles/storytangl-palette.css`; `docs/src/_static/storytangl-palette.css` | CSS |
+| `type.css` | same | CSS |
+
+## 3. SVGs are font-dependent — when to convert to paths
+
+The shipped SVGs reference Newsreader and JetBrains Mono via Google Fonts
+`@import`. This works wherever webfonts can load (RTD docs, web app, any
+HTML page). It does **not** work for:
+
+- GitHub social previews (must be rasterized PNG)
+- LaTeX includes, PowerPoint, anywhere the renderer can't fetch URLs
+- Offline-first contexts
+
+For those, convert the wordmark and glyph to outlined paths using any of:
+
+```bash
+# inkscape
+inkscape wordmark.svg --export-type=svg --export-filename=wordmark-paths.svg \
+         --export-text-to-path
+
+# fontforge / harfbuzz approaches also work
+# online: https://danmarshall.github.io/google-font-to-svg-path/
+```
+
+The path version is checked in alongside the font-dependent SVG; downstream
+choose by context. Do not regenerate paths without confirming the
+typographic tuning matches §1 of the brand sheet (per-font sx/sy/ty values).
+
+## 4. The lockup is the wordmark or the wordmark + glyph — never the glyph alone with text
+
+The glyph stands alone. The wordmark stands alone. A glyph + wordmark
+lockup is sanctioned (see §3 of the brand sheet). What is **not** sanctioned:
+
+- **glyph + plain "StoryTangl" text** (defeats the whole mark)
+- **glyph + a different word** (the mark is bound to its wordmark)
+- **two glyphs as a repeating pattern** (use the dotty knot texture instead)
+
+## 5. The ⅁ character (U+2141) is the ASCII fallback
+
+Where SVG isn't available (terminal, plain text, code comments, commit
+messages, this very file's H1), use the Unicode codepoint **U+2141 TURNED
+SANS-SERIF CAPITAL G** — `⅁`. It's the project's name in 7-bit-clean
+contexts. Acceptable substitutes: none.
+
+Examples:
+
+```
+StoryTan⅁l         ← H1 in plain markdown
+⅁>                  ← CLI prompt
+[ ⅁ v38.3 ]        ← log banner
+```
+
+## 6. Type stack rules
+
+Three families, three roles, never mixed.
+
+- **Newsreader** — prose, titles, narrative copy, the wordmark
+- **JetBrains Mono** — engine output, CLI, inline code, fragment data
+- **Inter Tight** — UI chrome, navbar, buttons, small labels, table headers
+
+If you find yourself reaching for a fourth font, stop. Reach for weight or
+size instead. The only sanctioned weight escalation is 400 → 500 → 600 →
+700, in order. No 800/900 unless you need a wordmark above 200px.
+
+## 7. Palette rules
+
+The palette is **closed.** Additions require updating this file AND the
+brand sheet AND `palette.css`. Specifically:
+
+- **No new surfaces.** Paper / paper-2 / paper-3 cover everything from
+  page background to banded table rows. If your design "needs" a fourth,
+  it doesn't.
+- **No new ink levels.** Ink / ink-2 / ink-3 / ink-4 cover the hierarchy.
+- **No new accents.** Blue-pencil and burnt are the two. Burnt is for
+  *one* moment per page; never two.
+- **Severity is fixed at three.** `ok` / `warn` / `danger`. If a context
+  needs four (e.g. distinguishing "criminal" from "failed"), use weight or
+  emphasis on the danger color, not a fourth hue.
+
+The dark mode (`[data-st-mode="ink"]`) is a literal photographic negative.
+Do not tune it independently; if the light mode changes, the dark mode
+changes in lockstep.
+
+## 8. Voice and tone rules
+
+Lineage: README.md, ARCHITECTURE.md, AGENTS.md.
+
+- **The project is a research platform**, not a SaaS product. Copy says
+  so without apology.
+- **No SaaS verbs.** Revolutionize, unlock, empower, transform — all
+  forbidden. The engine *compiles*, *materializes*, *projects*, *traverses*.
+- **No emoji in headlines.** Body text rarely; never decorative.
+- **Dry humor is in.** "AI agents occasionally suggest things that are
+  actually good." That register. Not zany; not corporate-friendly.
+- **Caveats live in the prose, not in disclaimers.** "Useful for development,
+  not a production MVP" is one of the project's better sentences.
+
+## 9. What an agent must never do
+
+This section exists because agents have done some of these things.
+
+| Never | Why |
+|-------|-----|
+| Strip the `g` rotation from the README title because it "looks silly in markdown" | The rotation is the brand. The fix is an SVG banner above the title, not removing the rotation. |
+| Replace the wordmark with a generic logo because "the project doesn't have a logo" | It does. It's the wordmark. The wordmark *is* the logo. |
+| Add a "modern" gradient or "playful" color pop because the palette "feels muted" | Muted is the brand. Reach for the blue-pencil or burnt accent if you need a pop. |
+| Substitute Inter or a system font for Newsreader because "fewer requests" | The wordmark is set in Newsreader. The body prose is set in Newsreader. Removing it removes the brand. |
+| Auto-update SVG path data without re-tuning per §1 | Path data carries the per-font tuning. Regenerating without confirming the visual tuning will produce a wrong wordmark that looks subtly off. |
+| Emoji in the README, the docs, or commit messages | See §8. |
+
+## 10. Provenance
+
+The flipped letterform comes from an earlier currency mark — inverted `Ɐ`
+in `Ɐ$`, the "horn" of an imperial coinage from a worldbuilding project
+predating StoryTangl. The transformation moved to a different letter when
+this engine needed a name. The lineage is recorded in §9 of the brand sheet
+because lineage matters for a research platform.
+
+Do not "modernize" the mark away from this lineage.
+
+---
+
+*Brand sheet v1.0 · 2026-05 · ⅁*

--- a/docs/src/design/story/brand/v1_0/assets/palette.css
+++ b/docs/src/design/story/brand/v1_0/assets/palette.css
@@ -1,0 +1,60 @@
+/* StoryTangl · color tokens
+ *
+ * Engineering-notebook palette. Paper-warm neutrals, ink darks,
+ * blue-pencil accent (the editor's color), three severity tokens.
+ *
+ * Tokens are stable across surfaces (README banner, CLI, web shell,
+ * RTD theme). The only acceptable additions to this palette are new
+ * severity tokens; the rest is closed.
+ */
+
+:root {
+  /* surface / structure */
+  --st-paper:       #f6f3ea;   /* card / page background           */
+  --st-paper-2:     #eee8d6;   /* hover / banded rows / tape       */
+  --st-paper-3:     #e3dcc4;   /* margins / inactive surfaces      */
+
+  /* ink / text */
+  --st-ink:         #1a1a1a;   /* primary text, wordmark           */
+  --st-ink-2:       #3b3a36;   /* body prose                       */
+  --st-ink-3:       #6b6a64;   /* secondary / metadata             */
+  --st-ink-4:       #93918a;   /* tertiary / disabled              */
+
+  /* rules / borders */
+  --st-rule:        #c9c2ad;   /* hairline rules                   */
+  --st-rule-strong: #8a8472;   /* structural borders               */
+
+  /* accents */
+  --st-blue:        #2a4e87;   /* blue-pencil / link / brand mark  */
+  --st-burnt:       #b2542a;   /* warm accent / single brand pop   */
+
+  /* severity (must round-trip with KvRow.emphasis) */
+  --st-ok:          #3e7f57;
+  --st-warn:        #a8762a;
+  --st-bad:         #a8362a;
+}
+
+/* dark inversion — used in CLI splash, social card, web "lights-off"
+ * mode. Not a different palette: a literal photographic negative of
+ * the paper one, with one or two tone adjustments.
+ */
+:root[data-st-mode="ink"] {
+  --st-paper:       #15140f;
+  --st-paper-2:     #1f1e18;
+  --st-paper-3:     #2a2920;
+
+  --st-ink:         #e8dfc6;
+  --st-ink-2:       #c9c2ad;
+  --st-ink-3:       #8a8472;
+  --st-ink-4:       #6b6a64;
+
+  --st-rule:        #2f2d24;
+  --st-rule-strong: #4d4a3d;
+
+  --st-blue:        #8db4ff;
+  --st-burnt:       #e07a40;
+
+  --st-ok:          #6fbf8c;
+  --st-warn:        #d6a35a;
+  --st-bad:         #d65a4a;
+}

--- a/docs/src/design/story/brand/v1_0/assets/type.css
+++ b/docs/src/design/story/brand/v1_0/assets/type.css
@@ -1,0 +1,20 @@
+/* StoryTangl · type stack
+ *
+ * Three families, three roles, never mixed.
+ *
+ *   Newsreader       — prose, titles, editorial copy, the wordmark
+ *   JetBrains Mono   — engine output, CLI, inline code, fragment data
+ *   Inter Tight      — UI chrome, nav, small labels, metadata
+ *
+ * No fourth family. No display-script. No "fun" override for headings.
+ * If a context needs typographic emphasis, reach for weight or size,
+ * never an additional family.
+ */
+
+@import url('https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;0,6..72,700;1,6..72,400&family=JetBrains+Mono:wght@400;500;600;700&family=Inter+Tight:wght@400;500;600;700&display=swap');
+
+:root {
+  --st-font-prose:  "Newsreader", "Source Serif Pro", Georgia, serif;
+  --st-font-mono:   "JetBrains Mono", "SF Mono", "Menlo", monospace;
+  --st-font-chrome: "Inter Tight", -apple-system, "Segoe UI", sans-serif;
+}

--- a/engine/contrib/conformance/README.md
+++ b/engine/contrib/conformance/README.md
@@ -31,6 +31,10 @@ their referenced state renderable after each envelope.
 JSON-only decision-legibility check: after applying update/delete controls, each
 available choice must be renderable in the current scene shell and any
 piece/zone/state references in its decision surfaces must also be renderable.
+`parity.py` is the sibling input-parity harness: available choices must expose
+enough `accepts` shape for a low-capability client to submit a portable payload
+for `pick`, `text`, `quantity`, `raw_command`, `pieces`, `place`, and recursive
+`compose` controls.
 
 `reference_port.py` is the smallest current proof of that portability. It
 renders the fixtures into a UI-neutral `RenderDocument` from JSON only, without

--- a/engine/contrib/conformance/README.md
+++ b/engine/contrib/conformance/README.md
@@ -8,8 +8,7 @@ target in `STORYTANGL_WIDGET_VOCAB.md`. In particular:
 
 - `piece` / `zone` fixtures are current web pressure fixtures and decision-
   legibility examples while engine-side typed fragment support catches up.
-- `kv` fragments use the current web tuple-like row shape. Record-shaped
-  `KvRow` remains a migration target.
+- `kv` fragments use the unified record-shaped `KvRow` contract.
 - `interpretation` uses the v1.5 `result` / `text` / `message` shape while the
   reference renderers still accept the older fallback field names.
 

--- a/engine/contrib/conformance/README.md
+++ b/engine/contrib/conformance/README.md
@@ -27,6 +27,11 @@ fragment registry: media placeholders update in place, pieces move between
 zones, stale offers or fallback fragments can be deleted, and open choices keep
 their referenced state renderable after each envelope.
 
+`legibility.py` contains the first promoted conformance harness. It is a
+JSON-only decision-legibility check: after applying update/delete controls, each
+available choice must be renderable in the current scene shell and any
+piece/zone/state references in its decision surfaces must also be renderable.
+
 `reference_port.py` is the smallest current proof of that portability. It
 renders the fixtures into a UI-neutral `RenderDocument` from JSON only, without
 importing engine models or calling the service layer. `cli_reference_port.py`

--- a/engine/contrib/conformance/README.md
+++ b/engine/contrib/conformance/README.md
@@ -35,6 +35,9 @@ piece/zone/state references in its decision surfaces must also be renderable.
 enough `accepts` shape for a low-capability client to submit a portable payload
 for `pick`, `text`, `quantity`, `raw_command`, `pieces`, `place`, and recursive
 `compose` controls.
+`time_parity.py` covers the JSON-visible part of timed presentation parity:
+pending media and roll/ritual fragments need immediate readable fallbacks, and
+advisory timing hints cannot require waiting for presentation time.
 
 `reference_port.py` is the smallest current proof of that portability. It
 renders the fixtures into a UI-neutral `RenderDocument` from JSON only, without

--- a/engine/contrib/conformance/legibility.py
+++ b/engine/contrib/conformance/legibility.py
@@ -25,6 +25,8 @@ FragmentRegistry = dict[str, JsonObject]
 REFERENCE_KEYS = {
     "blocker_ref",
     "blocker_refs",
+    "edge_ref",
+    "edge_refs",
     "fragment_ref",
     "fragment_refs",
     "piece_id",
@@ -32,6 +34,7 @@ REFERENCE_KEYS = {
     "piece_ref",
     "piece_refs",
     "source_zone_ref",
+    "refs",
     "state_ref",
     "state_refs",
     "target_zone_ref",
@@ -196,11 +199,10 @@ def current_shell_reference_ids(
         fragment = registry.get(uid)
         if fragment is None:
             continue
-        refs.update(
-            value
-            for key in ("piece_id", "state_id", "zone_id")
-            if isinstance((value := fragment.get(key)), str)
-        )
+        for key in ("piece_id", "state_id", "zone_id"):
+            value = fragment.get(key)
+            if isinstance(value, str):
+                refs.add(value)
     return refs
 
 

--- a/engine/contrib/conformance/legibility.py
+++ b/engine/contrib/conformance/legibility.py
@@ -49,6 +49,7 @@ CHOICE_REFERENCE_SURFACES = (
     "ui_hints",
 )
 
+
 @dataclass(frozen=True)
 class LegibilityIssue:
     """A choice references state that is not renderable in the current shell."""

--- a/engine/contrib/conformance/legibility.py
+++ b/engine/contrib/conformance/legibility.py
@@ -1,0 +1,262 @@
+"""Decision-legibility checks for StoryTangl conformance fixtures.
+
+The harness is intentionally JSON-only. It validates the portable rule that an
+available choice may only reference state that the current shell can render.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence, cast
+
+
+JsonValue = (
+    str
+    | int
+    | float
+    | bool
+    | None
+    | list["JsonValue"]
+    | dict[str, "JsonValue"]
+)
+JsonObject = dict[str, JsonValue]
+FragmentRegistry = dict[str, JsonObject]
+
+REFERENCE_KEYS = {
+    "blocker_ref",
+    "blocker_refs",
+    "fragment_ref",
+    "fragment_refs",
+    "piece_id",
+    "piece_ids",
+    "piece_ref",
+    "piece_refs",
+    "source_zone_ref",
+    "state_ref",
+    "state_refs",
+    "target_zone_ref",
+    "token_ref",
+    "token_refs",
+    "zone_id",
+    "zone_ids",
+    "zone_ref",
+    "zone_refs",
+}
+CHOICE_REFERENCE_SURFACES = (
+    "accepts",
+    "blockers",
+    "cost_previews",
+    "ui_hints",
+)
+
+@dataclass(frozen=True)
+class LegibilityIssue:
+    """A choice references state that is not renderable in the current shell."""
+
+    choice_uid: str
+    ref_id: str
+    reason: str
+    step_index: int | None = None
+
+    def describe(self) -> str:
+        prefix = f"step {self.step_index}: " if self.step_index is not None else ""
+        return f"{prefix}choice {self.choice_uid} references {self.ref_id}: {self.reason}"
+
+
+@dataclass(frozen=True)
+class EnvelopeLegibilityResult:
+    """Registry snapshot plus issues after checking one envelope."""
+
+    registry: FragmentRegistry
+    issues: tuple[LegibilityIssue, ...]
+
+
+def check_runtime_envelope(
+    envelope: JsonObject,
+    registry: FragmentRegistry | None = None,
+    *,
+    step_index: int | None = None,
+) -> EnvelopeLegibilityResult:
+    """Apply one envelope and return decision-legibility issues."""
+
+    next_registry = apply_runtime_envelope(registry or {}, envelope)
+    renderable_uids = current_shell_ids(next_registry)
+    renderable_refs = current_shell_reference_ids(next_registry, renderable_uids)
+    issues: list[LegibilityIssue] = []
+
+    for choice in _available_choices(next_registry):
+        choice_uid = _text(choice, "uid") or "<unknown>"
+        if choice_uid not in renderable_uids:
+            issues.append(
+                LegibilityIssue(
+                    choice_uid=choice_uid,
+                    ref_id=choice_uid,
+                    reason="choice is not renderable",
+                    step_index=step_index,
+                )
+            )
+            continue
+
+        for ref_id in sorted(choice_reference_ids(choice)):
+            if ref_id not in renderable_refs:
+                issues.append(
+                    LegibilityIssue(
+                        choice_uid=choice_uid,
+                        ref_id=ref_id,
+                        reason="referenced state is not renderable",
+                        step_index=step_index,
+                    )
+                )
+
+    return EnvelopeLegibilityResult(registry=next_registry, issues=tuple(issues))
+
+
+def check_sequence(sequence: JsonObject) -> tuple[LegibilityIssue, ...]:
+    """Check every envelope in a multi-envelope fixture sequence."""
+
+    registry: FragmentRegistry = {}
+    issues: list[LegibilityIssue] = []
+    for step_index, envelope in enumerate(_object_list(sequence.get("envelopes")), start=1):
+        result = check_runtime_envelope(envelope, registry, step_index=step_index)
+        registry = result.registry
+        issues.extend(result.issues)
+    return tuple(issues)
+
+
+def assert_no_issues(issues: Sequence[LegibilityIssue]) -> None:
+    """Raise an AssertionError with readable issue descriptions."""
+
+    if issues:
+        details = "\n".join(issue.describe() for issue in issues)
+        raise AssertionError(f"Decision-legibility violations:\n{details}")
+
+
+def apply_runtime_envelope(registry: FragmentRegistry, envelope: JsonObject) -> FragmentRegistry:
+    """Return the fragment registry after applying update/delete controls."""
+
+    next_registry = dict(registry)
+    for fragment in _object_list(envelope.get("fragments")):
+        fragment_type = _text(fragment, "fragment_type")
+        if fragment_type == "delete":
+            ref_id = _text(fragment, "ref_id", "reference_id")
+            if ref_id:
+                next_registry.pop(ref_id, None)
+            continue
+        if fragment_type == "update":
+            ref_id = _text(fragment, "ref_id", "reference_id")
+            payload = _object(fragment.get("payload"))
+            if ref_id and payload is not None:
+                existing = next_registry.get(ref_id, {"uid": ref_id})
+                next_registry[ref_id] = {**existing, **payload, "uid": ref_id}
+            continue
+        uid = _text(fragment, "uid")
+        if uid:
+            next_registry[uid] = fragment
+    return next_registry
+
+
+def current_shell_ids(registry: FragmentRegistry) -> set[str]:
+    """Return fragment ids reachable from every rendered scene group."""
+
+    renderable: set[str] = set()
+    scenes = [
+        fragment
+        for fragment in registry.values()
+        if fragment.get("fragment_type") == "group" and fragment.get("group_type") == "scene"
+    ]
+
+    def visit(uid: str) -> None:
+        if uid in renderable:
+            return
+        fragment = registry.get(uid)
+        if fragment is None:
+            return
+        renderable.add(uid)
+        if fragment.get("fragment_type") != "group":
+            return
+        for member_id in _string_list(fragment.get("member_ids")):
+            visit(member_id)
+
+    for scene in scenes:
+        scene_uid = _text(scene, "uid")
+        if scene_uid:
+            visit(scene_uid)
+    return renderable
+
+
+def current_shell_reference_ids(
+    registry: FragmentRegistry,
+    renderable_uids: set[str],
+) -> set[str]:
+    """Return uid plus stable domain ids for renderable fragments."""
+
+    refs = set(renderable_uids)
+    for uid in renderable_uids:
+        fragment = registry.get(uid)
+        if fragment is None:
+            continue
+        refs.update(
+            value
+            for key in ("piece_id", "state_id", "zone_id")
+            if isinstance((value := fragment.get(key)), str)
+        )
+    return refs
+
+
+def choice_reference_ids(choice: JsonObject) -> set[str]:
+    """Collect renderable-state references from a choice's decision surfaces."""
+
+    refs: set[str] = set()
+    for key in CHOICE_REFERENCE_SURFACES:
+        refs.update(_collect_reference_ids(choice.get(key)))
+    return refs
+
+
+def _available_choices(registry: FragmentRegistry) -> list[JsonObject]:
+    return [
+        fragment
+        for fragment in registry.values()
+        if fragment.get("fragment_type") == "choice" and fragment.get("available") is not False
+    ]
+
+
+def _collect_reference_ids(value: JsonValue | None, parent_key: str = "") -> set[str]:
+    if isinstance(value, str):
+        return {value} if parent_key in REFERENCE_KEYS else set()
+    if isinstance(value, list):
+        if parent_key in REFERENCE_KEYS:
+            return {item for item in value if isinstance(item, str)}
+        return {ref_id for item in value for ref_id in _collect_reference_ids(item, parent_key)}
+    if not isinstance(value, dict):
+        return set()
+
+    refs: set[str] = set()
+    for key, item in value.items():
+        refs.update(_collect_reference_ids(item, key))
+    return refs
+
+
+def _object(value: JsonValue | None) -> JsonObject | None:
+    return cast(JsonObject, value) if isinstance(value, dict) else None
+
+
+def _object_list(value: JsonValue | None) -> list[JsonObject]:
+    if not isinstance(value, list):
+        return []
+    return [cast(JsonObject, item) for item in value if isinstance(item, dict)]
+
+
+def _string_list(value: JsonValue | None) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _text(mapping: JsonObject | None, *keys: str) -> str | None:
+    if mapping is None:
+        return None
+    for key in keys:
+        value = mapping.get(key)
+        if isinstance(value, str):
+            return value
+    return None

--- a/engine/contrib/conformance/parity.py
+++ b/engine/contrib/conformance/parity.py
@@ -1,0 +1,507 @@
+"""Input-parity checks for StoryTangl conformance fixtures.
+
+The harness verifies that available choices declare enough JSON shape for a
+lowest-capability client to build a boring submit control. It does not care
+whether a renderer uses buttons, listboxes, text input, or drag/drop flourishes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence, cast
+
+
+JsonValue = (
+    str
+    | int
+    | float
+    | bool
+    | None
+    | list["JsonValue"]
+    | dict[str, "JsonValue"]
+)
+JsonObject = dict[str, JsonValue]
+FragmentRegistry = dict[str, JsonObject]
+
+SUPPORTED_ACCEPTS_KINDS = {
+    "pick",
+    "text",
+    "quantity",
+    "raw_command",
+    "pieces",
+    "place",
+    "compose",
+}
+
+
+@dataclass(frozen=True)
+class InputParityIssue:
+    """A choice cannot be submitted by a lowest-capability client."""
+
+    choice_uid: str
+    accepts_path: str
+    reason: str
+    step_index: int | None = None
+
+    def describe(self) -> str:
+        prefix = f"step {self.step_index}: " if self.step_index is not None else ""
+        return f"{prefix}choice {self.choice_uid} {self.accepts_path}: {self.reason}"
+
+
+@dataclass(frozen=True)
+class EnvelopeInputParityResult:
+    """Registry snapshot plus issues after checking one envelope."""
+
+    registry: FragmentRegistry
+    issues: tuple[InputParityIssue, ...]
+
+
+def check_runtime_envelope(
+    envelope: JsonObject,
+    registry: FragmentRegistry | None = None,
+    *,
+    step_index: int | None = None,
+) -> EnvelopeInputParityResult:
+    """Apply one envelope and return input-parity issues."""
+
+    next_registry = apply_runtime_envelope(registry or {}, envelope)
+    renderable_uids = current_shell_ids(next_registry)
+    renderable_refs = current_shell_reference_ids(next_registry, renderable_uids)
+    issues: list[InputParityIssue] = []
+
+    for choice in _available_choices(next_registry):
+        choice_uid = _text(choice, "uid") or "<unknown>"
+        if choice_uid not in renderable_uids:
+            continue
+        accepts = _object(choice.get("accepts"))
+        if accepts is None:
+            continue
+        issues.extend(
+            _check_accepts(
+                accepts,
+                next_registry,
+                renderable_refs,
+                choice_uid=choice_uid,
+                accepts_path="accepts",
+                step_index=step_index,
+            )
+        )
+
+    return EnvelopeInputParityResult(registry=next_registry, issues=tuple(issues))
+
+
+def check_sequence(sequence: JsonObject) -> tuple[InputParityIssue, ...]:
+    """Check every envelope in a multi-envelope fixture sequence."""
+
+    registry: FragmentRegistry = {}
+    issues: list[InputParityIssue] = []
+    for step_index, envelope in enumerate(_object_list(sequence.get("envelopes")), start=1):
+        result = check_runtime_envelope(envelope, registry, step_index=step_index)
+        registry = result.registry
+        issues.extend(result.issues)
+    return tuple(issues)
+
+
+def assert_no_issues(issues: Sequence[InputParityIssue]) -> None:
+    """Raise an AssertionError with readable issue descriptions."""
+
+    if issues:
+        details = "\n".join(issue.describe() for issue in issues)
+        raise AssertionError(f"Input-parity violations:\n{details}")
+
+
+def apply_runtime_envelope(registry: FragmentRegistry, envelope: JsonObject) -> FragmentRegistry:
+    """Return the fragment registry after applying update/delete controls."""
+
+    next_registry = dict(registry)
+    for fragment in _object_list(envelope.get("fragments")):
+        fragment_type = _text(fragment, "fragment_type")
+        if fragment_type == "delete":
+            ref_id = _text(fragment, "ref_id", "reference_id")
+            if ref_id:
+                next_registry.pop(ref_id, None)
+            continue
+        if fragment_type == "update":
+            ref_id = _text(fragment, "ref_id", "reference_id")
+            payload = _object(fragment.get("payload"))
+            if ref_id and payload is not None:
+                existing = next_registry.get(ref_id, {"uid": ref_id})
+                next_registry[ref_id] = {**existing, **payload, "uid": ref_id}
+            continue
+        uid = _text(fragment, "uid")
+        if uid:
+            next_registry[uid] = fragment
+    return next_registry
+
+
+def current_shell_ids(registry: FragmentRegistry) -> set[str]:
+    """Return fragment ids reachable from every rendered scene group."""
+
+    renderable: set[str] = set()
+    scenes = [
+        fragment
+        for fragment in registry.values()
+        if fragment.get("fragment_type") == "group" and fragment.get("group_type") == "scene"
+    ]
+
+    def visit(uid: str) -> None:
+        if uid in renderable:
+            return
+        fragment = registry.get(uid)
+        if fragment is None:
+            return
+        renderable.add(uid)
+        if fragment.get("fragment_type") != "group":
+            return
+        for member_id in _string_list(fragment.get("member_ids")):
+            visit(member_id)
+
+    for scene in scenes:
+        scene_uid = _text(scene, "uid")
+        if scene_uid:
+            visit(scene_uid)
+    return renderable
+
+
+def current_shell_reference_ids(
+    registry: FragmentRegistry,
+    renderable_uids: set[str],
+) -> set[str]:
+    """Return uid plus stable domain ids for renderable fragments."""
+
+    refs = set(renderable_uids)
+    for uid in renderable_uids:
+        fragment = registry.get(uid)
+        if fragment is None:
+            continue
+        refs.update(
+            value
+            for key in ("piece_id", "state_id", "zone_id")
+            if isinstance((value := fragment.get(key)), str)
+        )
+    return refs
+
+
+def _check_accepts(
+    accepts: JsonObject,
+    registry: FragmentRegistry,
+    renderable_refs: set[str],
+    *,
+    choice_uid: str,
+    accepts_path: str,
+    step_index: int | None,
+) -> list[InputParityIssue]:
+    kind = _text(accepts, "kind")
+    if kind not in SUPPORTED_ACCEPTS_KINDS:
+        return [
+            InputParityIssue(
+                choice_uid,
+                accepts_path,
+                "missing or unsupported accepts kind",
+                step_index,
+            )
+        ]
+
+    if kind in {"pick", "text", "raw_command"}:
+        return []
+    if kind == "quantity":
+        return _check_quantity(accepts, choice_uid, accepts_path, step_index)
+    if kind == "pieces":
+        return _check_pieces(
+            accepts,
+            registry,
+            renderable_refs,
+            choice_uid,
+            accepts_path,
+            step_index,
+        )
+    if kind == "place":
+        return _check_place(
+            accepts,
+            registry,
+            renderable_refs,
+            choice_uid,
+            accepts_path,
+            step_index,
+        )
+    return _check_compose(accepts, registry, renderable_refs, choice_uid, accepts_path, step_index)
+
+
+def _check_quantity(
+    accepts: JsonObject,
+    choice_uid: str,
+    accepts_path: str,
+    step_index: int | None,
+) -> list[InputParityIssue]:
+    issues: list[InputParityIssue] = []
+    minimum = accepts.get("min")
+    maximum = accepts.get("max")
+    if minimum is not None and not _is_int(minimum):
+        issues.append(
+            InputParityIssue(choice_uid, accepts_path, "`min` must be an integer", step_index)
+        )
+    if maximum is not None and not _is_int(maximum):
+        issues.append(
+            InputParityIssue(choice_uid, accepts_path, "`max` must be an integer", step_index)
+        )
+    if _is_int(minimum) and _is_int(maximum) and minimum > maximum:
+        issues.append(InputParityIssue(choice_uid, accepts_path, "`min` exceeds `max`", step_index))
+    return issues
+
+
+def _check_pieces(
+    accepts: JsonObject,
+    registry: FragmentRegistry,
+    renderable_refs: set[str],
+    choice_uid: str,
+    accepts_path: str,
+    step_index: int | None,
+) -> list[InputParityIssue]:
+    issues = _check_selection_bounds(accepts, choice_uid, accepts_path, step_index)
+    constraints = _object(accepts.get("constraints"))
+    zone_ref = _text(accepts, "target_zone_ref") or _text(constraints, "target_zone_ref")
+    if zone_ref is None:
+        issues.append(
+            InputParityIssue(choice_uid, accepts_path, "missing target_zone_ref", step_index)
+        )
+        return issues
+    if zone_ref not in renderable_refs:
+        issues.append(
+            InputParityIssue(
+                choice_uid,
+                accepts_path,
+                f"target zone {zone_ref!r} is not renderable",
+                step_index,
+            )
+        )
+        return issues
+    if _minimum_selection(accepts) > 0 and not _piece_options_in_zone(
+        registry,
+        zone_ref,
+        renderable_refs,
+    ):
+        issues.append(
+            InputParityIssue(
+                choice_uid,
+                accepts_path,
+                f"target zone {zone_ref!r} has no selectable pieces",
+                step_index,
+            )
+        )
+    return issues
+
+
+def _check_place(
+    accepts: JsonObject,
+    registry: FragmentRegistry,
+    renderable_refs: set[str],
+    choice_uid: str,
+    accepts_path: str,
+    step_index: int | None,
+) -> list[InputParityIssue]:
+    constraints = _object(accepts.get("constraints"))
+    source_ref = _text(accepts, "source_zone_ref") or _text(constraints, "source_zone_ref")
+    target_ref = _text(accepts, "target_zone_ref") or _text(constraints, "target_zone_ref")
+    edge_ref = _text(accepts, "edge_ref") or _text(constraints, "edge_ref")
+    issues: list[InputParityIssue] = []
+
+    if source_ref is None:
+        issues.append(
+            InputParityIssue(choice_uid, accepts_path, "missing source_zone_ref", step_index)
+        )
+    elif source_ref not in renderable_refs:
+        issues.append(
+            InputParityIssue(
+                choice_uid,
+                accepts_path,
+                f"source zone {source_ref!r} is not renderable",
+                step_index,
+            )
+        )
+    elif not _piece_options_in_zone(registry, source_ref, renderable_refs):
+        issues.append(
+            InputParityIssue(
+                choice_uid,
+                accepts_path,
+                f"source zone {source_ref!r} has no selectable pieces",
+                step_index,
+            )
+        )
+
+    if target_ref is None and edge_ref is None:
+        issues.append(
+            InputParityIssue(
+                choice_uid,
+                accepts_path,
+                "missing target_zone_ref or edge_ref",
+                step_index,
+            )
+        )
+    elif target_ref is not None and target_ref not in renderable_refs:
+        issues.append(
+            InputParityIssue(
+                choice_uid,
+                accepts_path,
+                f"target zone {target_ref!r} is not renderable",
+                step_index,
+            )
+        )
+    elif edge_ref is not None and edge_ref not in renderable_refs:
+        issues.append(
+            InputParityIssue(
+                choice_uid,
+                accepts_path,
+                f"edge {edge_ref!r} is not renderable",
+                step_index,
+            )
+        )
+    return issues
+
+
+def _check_compose(
+    accepts: JsonObject,
+    registry: FragmentRegistry,
+    renderable_refs: set[str],
+    choice_uid: str,
+    accepts_path: str,
+    step_index: int | None,
+) -> list[InputParityIssue]:
+    parts = _object_list(accepts.get("parts"))
+    issues: list[InputParityIssue] = []
+    if not parts:
+        return [
+            InputParityIssue(choice_uid, accepts_path, "compose accepts requires parts", step_index)
+        ]
+
+    seen_roles: set[str] = set()
+    for index, part in enumerate(parts):
+        path = f"{accepts_path}.parts[{index}]"
+        role = _text(part, "role")
+        if role is None:
+            issues.append(InputParityIssue(choice_uid, path, "missing role", step_index))
+        elif role in seen_roles:
+            issues.append(
+                InputParityIssue(choice_uid, path, f"duplicate role {role!r}", step_index)
+            )
+        else:
+            seen_roles.add(role)
+
+        child_accepts = _object(part.get("accepts"))
+        if child_accepts is None:
+            issues.append(InputParityIssue(choice_uid, path, "missing nested accepts", step_index))
+            continue
+        issues.extend(
+            _check_accepts(
+                child_accepts,
+                registry,
+                renderable_refs,
+                choice_uid=choice_uid,
+                accepts_path=f"{path}.accepts",
+                step_index=step_index,
+            )
+        )
+    return issues
+
+
+def _check_selection_bounds(
+    accepts: JsonObject,
+    choice_uid: str,
+    accepts_path: str,
+    step_index: int | None,
+) -> list[InputParityIssue]:
+    issues: list[InputParityIssue] = []
+    minimum = accepts.get("min")
+    maximum = accepts.get("max")
+    if minimum is not None and not _is_int(minimum):
+        issues.append(
+            InputParityIssue(choice_uid, accepts_path, "`min` must be an integer", step_index)
+        )
+    if maximum is not None and not _is_int(maximum):
+        issues.append(
+            InputParityIssue(choice_uid, accepts_path, "`max` must be an integer", step_index)
+        )
+    if _is_int(minimum) and _is_int(maximum) and minimum > maximum:
+        issues.append(InputParityIssue(choice_uid, accepts_path, "`min` exceeds `max`", step_index))
+    return issues
+
+
+def _minimum_selection(accepts: JsonObject) -> int:
+    minimum = accepts.get("min")
+    return minimum if _is_int(minimum) else 1
+
+
+def _piece_options_in_zone(
+    registry: FragmentRegistry,
+    zone_ref: str,
+    renderable_refs: set[str],
+) -> list[JsonObject]:
+    zone = _fragment_by_uid_or_domain_id(registry, zone_ref)
+    if zone is None:
+        return []
+    pieces: list[JsonObject] = []
+    for member_id in _string_list(zone.get("member_ids")):
+        if member_id not in renderable_refs:
+            continue
+        member = _fragment_by_uid_or_domain_id(registry, member_id)
+        if (
+            member is not None
+            and member.get("fragment_type") == "piece"
+            and _text(member, "piece_id")
+        ):
+            pieces.append(member)
+    return pieces
+
+
+def _is_int(value: JsonValue | None) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _fragment_by_uid_or_domain_id(
+    registry: FragmentRegistry,
+    ref: str,
+) -> JsonObject | None:
+    fragment = registry.get(ref)
+    if fragment is not None:
+        return fragment
+    for candidate in registry.values():
+        if ref in {
+            value
+            for key in ("piece_id", "state_id", "zone_id")
+            if isinstance((value := candidate.get(key)), str)
+        }:
+            return candidate
+    return None
+
+
+def _available_choices(registry: FragmentRegistry) -> list[JsonObject]:
+    return [
+        fragment
+        for fragment in registry.values()
+        if fragment.get("fragment_type") == "choice" and fragment.get("available") is not False
+    ]
+
+
+def _object(value: JsonValue | None) -> JsonObject | None:
+    return cast(JsonObject, value) if isinstance(value, dict) else None
+
+
+def _object_list(value: JsonValue | None) -> list[JsonObject]:
+    if not isinstance(value, list):
+        return []
+    return [cast(JsonObject, item) for item in value if isinstance(item, dict)]
+
+
+def _string_list(value: JsonValue | None) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _text(mapping: JsonObject | None, *keys: str) -> str | None:
+    if mapping is None:
+        return None
+    for key in keys:
+        value = mapping.get(key)
+        if isinstance(value, str):
+            return value
+    return None

--- a/engine/contrib/conformance/parity.py
+++ b/engine/contrib/conformance/parity.py
@@ -174,11 +174,10 @@ def current_shell_reference_ids(
         fragment = registry.get(uid)
         if fragment is None:
             continue
-        refs.update(
-            value
-            for key in ("piece_id", "state_id", "zone_id")
-            if isinstance((value := fragment.get(key)), str)
-        )
+        for key in ("piece_id", "state_id", "zone_id"):
+            value = fragment.get(key)
+            if isinstance(value, str):
+                refs.add(value)
     return refs
 
 
@@ -233,20 +232,7 @@ def _check_quantity(
     accepts_path: str,
     step_index: int | None,
 ) -> list[InputParityIssue]:
-    issues: list[InputParityIssue] = []
-    minimum = accepts.get("min")
-    maximum = accepts.get("max")
-    if minimum is not None and not _is_int(minimum):
-        issues.append(
-            InputParityIssue(choice_uid, accepts_path, "`min` must be an integer", step_index)
-        )
-    if maximum is not None and not _is_int(maximum):
-        issues.append(
-            InputParityIssue(choice_uid, accepts_path, "`max` must be an integer", step_index)
-        )
-    if _is_int(minimum) and _is_int(maximum) and minimum > maximum:
-        issues.append(InputParityIssue(choice_uid, accepts_path, "`min` exceeds `max`", step_index))
-    return issues
+    return _check_non_negative_bounds(accepts, choice_uid, accepts_path, step_index)
 
 
 def _check_pieces(
@@ -409,17 +395,46 @@ def _check_selection_bounds(
     accepts_path: str,
     step_index: int | None,
 ) -> list[InputParityIssue]:
+    return _check_non_negative_bounds(accepts, choice_uid, accepts_path, step_index)
+
+
+def _check_non_negative_bounds(
+    accepts: JsonObject,
+    choice_uid: str,
+    accepts_path: str,
+    step_index: int | None,
+) -> list[InputParityIssue]:
     issues: list[InputParityIssue] = []
     minimum = accepts.get("min")
     maximum = accepts.get("max")
-    if minimum is not None and not _is_int(minimum):
-        issues.append(
-            InputParityIssue(choice_uid, accepts_path, "`min` must be an integer", step_index)
-        )
-    if maximum is not None and not _is_int(maximum):
-        issues.append(
-            InputParityIssue(choice_uid, accepts_path, "`max` must be an integer", step_index)
-        )
+    if minimum is not None:
+        if not _is_int(minimum):
+            issues.append(
+                InputParityIssue(choice_uid, accepts_path, "`min` must be an integer", step_index)
+            )
+        elif minimum < 0:
+            issues.append(
+                InputParityIssue(
+                    choice_uid,
+                    accepts_path,
+                    "`min` must be non-negative",
+                    step_index,
+                )
+            )
+    if maximum is not None:
+        if not _is_int(maximum):
+            issues.append(
+                InputParityIssue(choice_uid, accepts_path, "`max` must be an integer", step_index)
+            )
+        elif maximum < 0:
+            issues.append(
+                InputParityIssue(
+                    choice_uid,
+                    accepts_path,
+                    "`max` must be non-negative",
+                    step_index,
+                )
+            )
     if _is_int(minimum) and _is_int(maximum) and minimum > maximum:
         issues.append(InputParityIssue(choice_uid, accepts_path, "`min` exceeds `max`", step_index))
     return issues
@@ -464,11 +479,7 @@ def _fragment_by_uid_or_domain_id(
     if fragment is not None:
         return fragment
     for candidate in registry.values():
-        if ref in {
-            value
-            for key in ("piece_id", "state_id", "zone_id")
-            if isinstance((value := candidate.get(key)), str)
-        }:
+        if ref in (candidate.get("piece_id"), candidate.get("state_id"), candidate.get("zone_id")):
             return candidate
     return None
 

--- a/engine/contrib/conformance/time_parity.py
+++ b/engine/contrib/conformance/time_parity.py
@@ -1,0 +1,265 @@
+"""Time-parity checks for StoryTangl conformance fixtures.
+
+The harness verifies the JSON-visible part of the contract: pending media and
+ritualized outcomes must have an immediate readable fallback, and advisory
+timing hints must not require the player to wait for presentation time.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence, cast
+
+
+JsonValue = (
+    str
+    | int
+    | float
+    | bool
+    | None
+    | list["JsonValue"]
+    | dict[str, "JsonValue"]
+)
+JsonObject = dict[str, JsonValue]
+FragmentRegistry = dict[str, JsonObject]
+
+TIME_BOUND_MEDIA_ROLES = {"bgm", "sfx", "video"}
+BLOCKING_HINT_KEYS = {
+    "blocking",
+    "require_completion",
+    "requires_completion",
+    "wait_for_completion",
+}
+
+
+@dataclass(frozen=True)
+class TimeParityIssue:
+    """A timed fragment lacks an immediate readable fallback."""
+
+    fragment_uid: str
+    reason: str
+    step_index: int | None = None
+
+    def describe(self) -> str:
+        prefix = f"step {self.step_index}: " if self.step_index is not None else ""
+        return f"{prefix}fragment {self.fragment_uid}: {self.reason}"
+
+
+@dataclass(frozen=True)
+class EnvelopeTimeParityResult:
+    """Registry snapshot plus issues after checking one envelope."""
+
+    registry: FragmentRegistry
+    issues: tuple[TimeParityIssue, ...]
+
+
+def check_runtime_envelope(
+    envelope: JsonObject,
+    registry: FragmentRegistry | None = None,
+    *,
+    step_index: int | None = None,
+) -> EnvelopeTimeParityResult:
+    """Apply one envelope and return time-parity issues."""
+
+    next_registry = apply_runtime_envelope(registry or {}, envelope)
+    renderable_uids = current_shell_ids(next_registry)
+    issues: list[TimeParityIssue] = []
+
+    for uid in sorted(renderable_uids):
+        fragment = next_registry.get(uid)
+        if fragment is None:
+            continue
+        fragment_type = _text(fragment, "fragment_type")
+        if fragment_type == "media":
+            issues.extend(_check_media(fragment, uid, step_index))
+        elif fragment_type == "roll":
+            issues.extend(_check_roll(fragment, uid, step_index))
+
+    return EnvelopeTimeParityResult(registry=next_registry, issues=tuple(issues))
+
+
+def check_sequence(sequence: JsonObject) -> tuple[TimeParityIssue, ...]:
+    """Check every envelope in a multi-envelope fixture sequence."""
+
+    registry: FragmentRegistry = {}
+    issues: list[TimeParityIssue] = []
+    for step_index, envelope in enumerate(_object_list(sequence.get("envelopes")), start=1):
+        result = check_runtime_envelope(envelope, registry, step_index=step_index)
+        registry = result.registry
+        issues.extend(result.issues)
+    return tuple(issues)
+
+
+def assert_no_issues(issues: Sequence[TimeParityIssue]) -> None:
+    """Raise an AssertionError with readable issue descriptions."""
+
+    if issues:
+        details = "\n".join(issue.describe() for issue in issues)
+        raise AssertionError(f"Time-parity violations:\n{details}")
+
+
+def apply_runtime_envelope(registry: FragmentRegistry, envelope: JsonObject) -> FragmentRegistry:
+    """Return the fragment registry after applying update/delete controls."""
+
+    next_registry = dict(registry)
+    for fragment in _object_list(envelope.get("fragments")):
+        fragment_type = _text(fragment, "fragment_type")
+        if fragment_type == "delete":
+            ref_id = _text(fragment, "ref_id", "reference_id")
+            if ref_id:
+                next_registry.pop(ref_id, None)
+            continue
+        if fragment_type == "update":
+            ref_id = _text(fragment, "ref_id", "reference_id")
+            payload = _object(fragment.get("payload"))
+            if ref_id and payload is not None:
+                existing = next_registry.get(ref_id, {"uid": ref_id})
+                next_registry[ref_id] = {**existing, **payload, "uid": ref_id}
+            continue
+        uid = _text(fragment, "uid")
+        if uid:
+            next_registry[uid] = fragment
+    return next_registry
+
+
+def current_shell_ids(registry: FragmentRegistry) -> set[str]:
+    """Return fragment ids reachable from every rendered scene group."""
+
+    renderable: set[str] = set()
+    scenes = [
+        fragment
+        for fragment in registry.values()
+        if fragment.get("fragment_type") == "group" and fragment.get("group_type") == "scene"
+    ]
+
+    def visit(uid: str) -> None:
+        if uid in renderable:
+            return
+        fragment = registry.get(uid)
+        if fragment is None:
+            return
+        renderable.add(uid)
+        if fragment.get("fragment_type") != "group":
+            return
+        for member_id in _string_list(fragment.get("member_ids")):
+            visit(member_id)
+
+    for scene in scenes:
+        scene_uid = _text(scene, "uid")
+        if scene_uid:
+            visit(scene_uid)
+    return renderable
+
+
+def _check_media(
+    fragment: JsonObject,
+    uid: str,
+    step_index: int | None,
+) -> list[TimeParityIssue]:
+    content_format = _text(fragment, "content_format")
+    content = fragment.get("content")
+    media_role = _text(fragment, "media_role")
+    issues: list[TimeParityIssue] = []
+
+    if not content_format:
+        issues.append(TimeParityIssue(uid, "media is missing content_format", step_index))
+    if not _has_readable_value(content):
+        issues.append(TimeParityIssue(uid, "media is missing readable content", step_index))
+
+    if content_format == "rit":
+        status = _text(fragment, "generation_status")
+        if status == "ready":
+            issues.append(TimeParityIssue(uid, "ready media must resolve beyond rit", step_index))
+        elif status not in {None, "pending", "loading", "error"}:
+            issues.append(
+                TimeParityIssue(uid, f"unknown rit generation_status {status!r}", step_index)
+            )
+
+    if media_role in TIME_BOUND_MEDIA_ROLES:
+        issues.extend(_blocking_hint_issues(fragment, uid, step_index))
+    return issues
+
+
+def _check_roll(
+    fragment: JsonObject,
+    uid: str,
+    step_index: int | None,
+) -> list[TimeParityIssue]:
+    issues: list[TimeParityIssue] = []
+    if not _text(fragment, "label"):
+        issues.append(TimeParityIssue(uid, "roll is missing label", step_index))
+    if not _text(fragment, "outcome"):
+        issues.append(TimeParityIssue(uid, "roll is missing outcome", step_index))
+    if not _object(fragment.get("inputs")) and not _text(fragment, "narrative"):
+        issues.append(
+            TimeParityIssue(uid, "roll needs inputs or narrative for fallback", step_index)
+        )
+
+    ritual_hints = _object(fragment.get("ritual_hints"))
+    if ritual_hints is None:
+        return issues
+
+    duration = ritual_hints.get("duration_ms")
+    if duration is not None and (not _is_int(duration) or duration < 0):
+        issues.append(
+            TimeParityIssue(uid, "ritual duration_ms must be a non-negative integer", step_index)
+        )
+    skip_label = ritual_hints.get("skip_label")
+    if skip_label is not None and not _has_readable_value(skip_label):
+        issues.append(
+            TimeParityIssue(uid, "ritual skip_label must be readable when present", step_index)
+        )
+    issues.extend(_blocking_hint_issues(ritual_hints, uid, step_index))
+    return issues
+
+
+def _blocking_hint_issues(
+    mapping: JsonObject,
+    uid: str,
+    step_index: int | None,
+) -> list[TimeParityIssue]:
+    issues: list[TimeParityIssue] = []
+    for key in sorted(BLOCKING_HINT_KEYS):
+        if mapping.get(key) is True:
+            issues.append(TimeParityIssue(uid, f"timing hint {key!r} cannot be true", step_index))
+
+    staging_hints = _object(mapping.get("staging_hints"))
+    if staging_hints is not None:
+        issues.extend(_blocking_hint_issues(staging_hints, uid, step_index))
+    return issues
+
+
+def _has_readable_value(value: JsonValue | None) -> bool:
+    if isinstance(value, str):
+        return bool(value.strip())
+    return isinstance(value, (int, float, bool, dict, list))
+
+
+def _is_int(value: JsonValue | None) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _object(value: JsonValue | None) -> JsonObject | None:
+    return cast(JsonObject, value) if isinstance(value, dict) else None
+
+
+def _object_list(value: JsonValue | None) -> list[JsonObject]:
+    if not isinstance(value, list):
+        return []
+    return [cast(JsonObject, item) for item in value if isinstance(item, dict)]
+
+
+def _string_list(value: JsonValue | None) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _text(mapping: JsonObject | None, *keys: str) -> str | None:
+    if mapping is None:
+        return None
+    for key in keys:
+        value = mapping.get(key)
+        if isinstance(value, str):
+            return value
+    return None

--- a/engine/contrib/conformance/time_parity.py
+++ b/engine/contrib/conformance/time_parity.py
@@ -232,7 +232,11 @@ def _blocking_hint_issues(
 def _has_readable_value(value: JsonValue | None) -> bool:
     if isinstance(value, str):
         return bool(value.strip())
-    return isinstance(value, (int, float, bool, dict, list))
+    if isinstance(value, list):
+        return any(_has_readable_value(item) for item in value)
+    if isinstance(value, dict):
+        return any(_has_readable_value(item) for item in value.values())
+    return isinstance(value, (int, float, bool))
 
 
 def _is_int(value: JsonValue | None) -> bool:

--- a/engine/tests/conformance/test_multi_envelope_sequences.py
+++ b/engine/tests/conformance/test_multi_envelope_sequences.py
@@ -15,9 +15,9 @@ from tangl.service.response import RuntimeEnvelope
 ROOT = Path(__file__).parents[3]
 SEQUENCE_DIR = ROOT / "engine" / "contrib" / "conformance" / "sequences"
 REFERENCE_PATH = ROOT / "engine" / "contrib" / "conformance" / "reference_port.py"
+LEGIBILITY_PATH = ROOT / "engine" / "contrib" / "conformance" / "legibility.py"
 EXPECTED_SEQUENCES = {"garage_buy_mount.json"}
 
-SCENE_ID = "00000000-0000-4000-8000-000000021001"
 MEDIA_ID = "00000000-0000-4000-8000-000000021003"
 CATALOG_ID = "00000000-0000-4000-8000-000000021004"
 LOOSE_ID = "00000000-0000-4000-8000-000000021006"
@@ -26,8 +26,8 @@ CUSTOM_ID = "00000000-0000-4000-8000-000000021009"
 FLAME_ID = "00000000-0000-4000-8000-000000021013"
 
 
-def _load_port() -> ModuleType:
-    spec = importlib.util.spec_from_file_location("reference_port", REFERENCE_PATH)
+def _load_module(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
@@ -36,7 +36,8 @@ def _load_port() -> ModuleType:
     return module
 
 
-PORT = _load_port()
+PORT = _load_module("reference_port", REFERENCE_PATH)
+LEGIBILITY = _load_module("legibility", LEGIBILITY_PATH)
 
 
 def _load_sequence(name: str) -> dict[str, Any]:
@@ -98,47 +99,58 @@ def test_reference_port_applies_registry_updates_across_envelopes() -> None:
 def test_sequence_open_choice_references_stay_renderable() -> None:
     sequence = _load_sequence("garage_buy_mount.json")
 
-    for step in PORT.render_sequence_steps(sequence):
-        visible = _visible_ids_from_scene(step.registry, SCENE_ID)
-        for choice in step.document.choices:
-            if not choice.available or choice.accepts is None:
-                continue
-            refs = _collect_reference_ids(choice.accepts)
-            assert refs <= visible, f"step {step.index}: hidden refs {refs - visible}"
+    LEGIBILITY.assert_no_issues(LEGIBILITY.check_sequence(sequence))
 
 
-def _visible_ids_from_scene(registry: dict[str, dict[str, Any]], scene_id: str) -> set[str]:
-    visible: set[str] = set()
+def test_sequence_legibility_uses_current_registry_after_updates() -> None:
+    sequence = {
+        "sequence_id": "hidden_ref_after_update",
+        "envelopes": [
+            {
+                "cursor_id": "fixture",
+                "step": 1,
+                "fragments": [
+                    {
+                        "uid": "scene",
+                        "fragment_type": "group",
+                        "group_type": "scene",
+                        "member_ids": ["zone", "choice"],
+                    },
+                    {
+                        "uid": "zone",
+                        "fragment_type": "group",
+                        "group_type": "zone",
+                        "member_ids": [],
+                    },
+                    {
+                        "uid": "choice",
+                        "fragment_type": "choice",
+                        "text": "Use the zone.",
+                        "accepts": {
+                            "kind": "pieces",
+                            "constraints": {"target_zone_ref": "zone"},
+                        },
+                    },
+                ],
+            },
+            {
+                "cursor_id": "fixture",
+                "step": 2,
+                "fragments": [
+                    {
+                        "uid": "scene-update",
+                        "fragment_type": "update",
+                        "ref_id": "scene",
+                        "payload": {"member_ids": ["choice"]},
+                    }
+                ],
+            },
+        ],
+    }
 
-    def visit(uid: str) -> None:
-        if uid in visible:
-            return
-        visible.add(uid)
-        fragment = registry.get(uid)
-        if fragment is None or fragment.get("fragment_type") != "group":
-            return
-        member_ids = fragment.get("member_ids", [])
-        assert isinstance(member_ids, list)
-        for member_id in member_ids:
-            if isinstance(member_id, str):
-                visit(member_id)
+    issues = LEGIBILITY.check_sequence(sequence)
 
-    visit(scene_id)
-    return visible
-
-
-def _collect_reference_ids(value: object, parent_key: str = "") -> set[str]:
-    if isinstance(value, str):
-        return {value} if parent_key.endswith(("_ref", "_id")) else set()
-    if isinstance(value, list):
-        return {ref for item in value for ref in _collect_reference_ids(item, parent_key)}
-    if not isinstance(value, dict):
-        return set()
-
-    refs: set[str] = set()
-    for key, item in value.items():
-        if key.endswith(("_refs", "_ids")) and isinstance(item, list):
-            refs.update(entry for entry in item if isinstance(entry, str))
-            continue
-        refs.update(_collect_reference_ids(item, key))
-    return refs
+    assert len(issues) == 1
+    assert issues[0].step_index == 2
+    assert issues[0].choice_uid == "choice"
+    assert issues[0].ref_id == "zone"

--- a/engine/tests/conformance/test_multi_envelope_sequences.py
+++ b/engine/tests/conformance/test_multi_envelope_sequences.py
@@ -29,11 +29,12 @@ FLAME_ID = "00000000-0000-4000-8000-000000021013"
 
 
 def _load_module(name: str, path: Path) -> ModuleType:
-    spec = importlib.util.spec_from_file_location(name, path)
+    module_name = f"{__name__}.{name}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
+    sys.modules[module_name] = module
     spec.loader.exec_module(module)
     return module
 

--- a/engine/tests/conformance/test_multi_envelope_sequences.py
+++ b/engine/tests/conformance/test_multi_envelope_sequences.py
@@ -17,6 +17,7 @@ SEQUENCE_DIR = ROOT / "engine" / "contrib" / "conformance" / "sequences"
 REFERENCE_PATH = ROOT / "engine" / "contrib" / "conformance" / "reference_port.py"
 LEGIBILITY_PATH = ROOT / "engine" / "contrib" / "conformance" / "legibility.py"
 PARITY_PATH = ROOT / "engine" / "contrib" / "conformance" / "parity.py"
+TIME_PARITY_PATH = ROOT / "engine" / "contrib" / "conformance" / "time_parity.py"
 EXPECTED_SEQUENCES = {"garage_buy_mount.json"}
 
 MEDIA_ID = "00000000-0000-4000-8000-000000021003"
@@ -40,6 +41,7 @@ def _load_module(name: str, path: Path) -> ModuleType:
 PORT = _load_module("reference_port", REFERENCE_PATH)
 LEGIBILITY = _load_module("legibility", LEGIBILITY_PATH)
 PARITY = _load_module("parity", PARITY_PATH)
+TIME_PARITY = _load_module("time_parity", TIME_PARITY_PATH)
 
 
 def _load_sequence(name: str) -> dict[str, Any]:
@@ -111,6 +113,12 @@ def test_sequence_open_choices_keep_portable_input_shapes() -> None:
     sequence = _load_sequence("garage_buy_mount.json")
 
     PARITY.assert_no_issues(PARITY.check_sequence(sequence))
+
+
+def test_sequence_timed_fragments_keep_portable_fallbacks() -> None:
+    sequence = _load_sequence("garage_buy_mount.json")
+
+    TIME_PARITY.assert_no_issues(TIME_PARITY.check_sequence(sequence))
 
 
 def test_sequence_legibility_uses_current_registry_after_updates() -> None:

--- a/engine/tests/conformance/test_multi_envelope_sequences.py
+++ b/engine/tests/conformance/test_multi_envelope_sequences.py
@@ -16,6 +16,7 @@ ROOT = Path(__file__).parents[3]
 SEQUENCE_DIR = ROOT / "engine" / "contrib" / "conformance" / "sequences"
 REFERENCE_PATH = ROOT / "engine" / "contrib" / "conformance" / "reference_port.py"
 LEGIBILITY_PATH = ROOT / "engine" / "contrib" / "conformance" / "legibility.py"
+PARITY_PATH = ROOT / "engine" / "contrib" / "conformance" / "parity.py"
 EXPECTED_SEQUENCES = {"garage_buy_mount.json"}
 
 MEDIA_ID = "00000000-0000-4000-8000-000000021003"
@@ -38,6 +39,7 @@ def _load_module(name: str, path: Path) -> ModuleType:
 
 PORT = _load_module("reference_port", REFERENCE_PATH)
 LEGIBILITY = _load_module("legibility", LEGIBILITY_PATH)
+PARITY = _load_module("parity", PARITY_PATH)
 
 
 def _load_sequence(name: str) -> dict[str, Any]:
@@ -78,7 +80,10 @@ def test_reference_port_applies_registry_updates_across_envelopes() -> None:
     assert "gen:garage-card" not in _lines(steps[1])
     assert "Murph's wares:\n  (empty)" in _lines(steps[1])
     assert "parts on hand:\n  - Flamethrower" in _lines(steps[1])
-    assert "1) Mount the flamethrower. <place from parts on hand to front mount>" in _lines(steps[1])
+    assert (
+        "1) Mount the flamethrower. <place from parts on hand to front mount>"
+        in _lines(steps[1])
+    )
     assert "Buy from Murph's." not in _lines(steps[1])
     assert "[unsupported custom_probe] debug marker" in _lines(steps[1])
 
@@ -100,6 +105,12 @@ def test_sequence_open_choice_references_stay_renderable() -> None:
     sequence = _load_sequence("garage_buy_mount.json")
 
     LEGIBILITY.assert_no_issues(LEGIBILITY.check_sequence(sequence))
+
+
+def test_sequence_open_choices_keep_portable_input_shapes() -> None:
+    sequence = _load_sequence("garage_buy_mount.json")
+
+    PARITY.assert_no_issues(PARITY.check_sequence(sequence))
 
 
 def test_sequence_legibility_uses_current_registry_after_updates() -> None:
@@ -154,3 +165,69 @@ def test_sequence_legibility_uses_current_registry_after_updates() -> None:
     assert issues[0].step_index == 2
     assert issues[0].choice_uid == "choice"
     assert issues[0].ref_id == "zone"
+
+
+def test_sequence_input_parity_uses_current_registry_after_updates() -> None:
+    sequence = {
+        "sequence_id": "empty_source_after_update",
+        "envelopes": [
+            {
+                "cursor_id": "fixture",
+                "step": 1,
+                "fragments": [
+                    {
+                        "uid": "scene",
+                        "fragment_type": "group",
+                        "group_type": "scene",
+                        "member_ids": ["source", "target", "piece", "choice"],
+                    },
+                    {
+                        "uid": "source",
+                        "fragment_type": "group",
+                        "group_type": "zone",
+                        "member_ids": ["piece"],
+                    },
+                    {
+                        "uid": "target",
+                        "fragment_type": "group",
+                        "group_type": "zone",
+                        "member_ids": [],
+                    },
+                    {
+                        "uid": "piece",
+                        "fragment_type": "piece",
+                        "piece_id": "lamp",
+                    },
+                    {
+                        "uid": "choice",
+                        "fragment_type": "choice",
+                        "text": "Move it.",
+                        "accepts": {
+                            "kind": "place",
+                            "source_zone_ref": "source",
+                            "target_zone_ref": "target",
+                        },
+                    },
+                ],
+            },
+            {
+                "cursor_id": "fixture",
+                "step": 2,
+                "fragments": [
+                    {
+                        "uid": "source-update",
+                        "fragment_type": "update",
+                        "ref_id": "source",
+                        "payload": {"member_ids": []},
+                    }
+                ],
+            },
+        ],
+    }
+
+    issues = PARITY.check_sequence(sequence)
+
+    assert len(issues) == 1
+    assert issues[0].step_index == 2
+    assert issues[0].choice_uid == "choice"
+    assert issues[0].reason == "source zone 'source' has no selectable pieces"

--- a/engine/tests/conformance/test_widget_conformance_fixtures.py
+++ b/engine/tests/conformance/test_widget_conformance_fixtures.py
@@ -22,6 +22,7 @@ from tangl.service.response import ProjectedState, RuntimeEnvelope
 FIXTURE_DIR = Path(__file__).parents[2] / "contrib" / "conformance" / "fixtures"
 PROPOSAL_DIR = Path(__file__).parents[2] / "contrib" / "conformance" / "proposals"
 LEGIBILITY_PATH = Path(__file__).parents[2] / "contrib" / "conformance" / "legibility.py"
+PARITY_PATH = Path(__file__).parents[2] / "contrib" / "conformance" / "parity.py"
 PROJECTED_STATE_FIXTURE = "projected_state_all_values.json"
 EXPECTED_FIXTURES = {
     "command_hints.json",
@@ -44,8 +45,8 @@ EXPECTED_PROPOSALS = {
 }
 
 
-def _load_legibility() -> ModuleType:
-    spec = importlib.util.spec_from_file_location("legibility", LEGIBILITY_PATH)
+def _load_module(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
@@ -54,7 +55,8 @@ def _load_legibility() -> ModuleType:
     return module
 
 
-LEGIBILITY = _load_legibility()
+LEGIBILITY = _load_module("legibility", LEGIBILITY_PATH)
+PARITY = _load_module("parity", PARITY_PATH)
 
 
 def _load_fixture(path: Path) -> dict[str, Any]:
@@ -212,6 +214,15 @@ def test_runtime_fixtures_pass_decision_legibility(path: Path) -> None:
     LEGIBILITY.assert_no_issues(result.issues)
 
 
+@pytest.mark.parametrize("path", _runtime_fixture_paths(), ids=lambda path: path.name)
+def test_runtime_fixtures_pass_input_parity(path: Path) -> None:
+    payload = _load_fixture(path)
+
+    result = PARITY.check_runtime_envelope(payload)
+
+    PARITY.assert_no_issues(result.issues)
+
+
 def test_decision_legibility_reports_hidden_choice_references() -> None:
     payload = {
         "cursor_id": "fixture",
@@ -287,6 +298,82 @@ def test_decision_legibility_accepts_visible_piece_domain_ids() -> None:
     result = LEGIBILITY.check_runtime_envelope(payload)
 
     assert result.issues == ()
+
+
+def test_input_parity_reports_unsubmittable_piece_choices() -> None:
+    payload = {
+        "cursor_id": "fixture",
+        "step": 1,
+        "fragments": [
+            {
+                "uid": "scene",
+                "fragment_type": "group",
+                "group_type": "scene",
+                "member_ids": ["choice"],
+            },
+            {
+                "uid": "zone",
+                "fragment_type": "group",
+                "group_type": "zone",
+                "member_ids": [],
+            },
+            {
+                "uid": "choice",
+                "fragment_type": "choice",
+                "text": "Take one.",
+                "available": True,
+                "accepts": {
+                    "kind": "pieces",
+                    "min": 1,
+                    "constraints": {"target_zone_ref": "zone"},
+                },
+            },
+        ],
+    }
+
+    result = PARITY.check_runtime_envelope(payload)
+
+    assert [issue.reason for issue in result.issues] == [
+        "target zone 'zone' is not renderable",
+    ]
+
+
+def test_input_parity_reports_invalid_compose_parts() -> None:
+    payload = {
+        "cursor_id": "fixture",
+        "step": 1,
+        "fragments": [
+            {
+                "uid": "scene",
+                "fragment_type": "group",
+                "group_type": "scene",
+                "member_ids": ["choice"],
+            },
+            {
+                "uid": "choice",
+                "fragment_type": "choice",
+                "text": "Give something.",
+                "available": True,
+                "accepts": {
+                    "kind": "compose",
+                    "parts": [
+                        {"role": "amount", "accepts": {"kind": "quantity", "min": 5, "max": 1}},
+                        {"role": "amount", "accepts": {"kind": "text"}},
+                        {"accepts": {"kind": "unknown"}},
+                    ],
+                },
+            },
+        ],
+    }
+
+    result = PARITY.check_runtime_envelope(payload)
+
+    assert [issue.reason for issue in result.issues] == [
+        "`min` exceeds `max`",
+        "duplicate role 'amount'",
+        "missing role",
+        "missing or unsupported accepts kind",
+    ]
 
 
 def test_command_hint_fixture_keeps_grammar_advisory() -> None:

--- a/engine/tests/conformance/test_widget_conformance_fixtures.py
+++ b/engine/tests/conformance/test_widget_conformance_fixtures.py
@@ -7,8 +7,11 @@ the engine today.
 
 from __future__ import annotations
 
+import importlib.util
 import json
+import sys
 from pathlib import Path
+from types import ModuleType
 from typing import Any
 
 import pytest
@@ -18,6 +21,7 @@ from tangl.service.response import ProjectedState, RuntimeEnvelope
 
 FIXTURE_DIR = Path(__file__).parents[2] / "contrib" / "conformance" / "fixtures"
 PROPOSAL_DIR = Path(__file__).parents[2] / "contrib" / "conformance" / "proposals"
+LEGIBILITY_PATH = Path(__file__).parents[2] / "contrib" / "conformance" / "legibility.py"
 PROJECTED_STATE_FIXTURE = "projected_state_all_values.json"
 EXPECTED_FIXTURES = {
     "command_hints.json",
@@ -38,6 +42,19 @@ EXPECTED_PROPOSALS = {
     "roll_fragment.json",
     "wireframe_v15_interpretation_samples.json",
 }
+
+
+def _load_legibility() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("legibility", LEGIBILITY_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+LEGIBILITY = _load_legibility()
 
 
 def _load_fixture(path: Path) -> dict[str, Any]:
@@ -89,64 +106,6 @@ def _registry_after_controls(fragments: list[dict[str, Any]]) -> dict[str, dict[
             continue
         registry[_fragment_uid(fragment)] = fragment
     return registry
-
-
-def _renderable_ids_by_scene(fragments: list[dict[str, Any]]) -> list[set[str]]:
-    registry = _registry_after_controls(fragments)
-    scenes = [
-        fragment
-        for fragment in registry.values()
-        if fragment.get("fragment_type") == "group" and fragment.get("group_type") == "scene"
-    ]
-
-    visible_by_scene: list[set[str]] = []
-    for scene in scenes:
-        visible: set[str] = set()
-
-        def visit(uid: str) -> None:
-            if uid in visible:
-                return
-            visible.add(uid)
-            fragment = registry.get(uid)
-            if fragment is None:
-                return
-            if fragment.get("fragment_type") == "group":
-                member_ids = fragment.get("member_ids", [])
-                assert isinstance(member_ids, list)
-                for member_id in member_ids:
-                    if isinstance(member_id, str):
-                        visit(member_id)
-
-        member_ids = scene.get("member_ids", [])
-        assert isinstance(member_ids, list)
-        for member_id in member_ids:
-            if isinstance(member_id, str):
-                visit(member_id)
-        visible_by_scene.append(visible)
-
-    return visible_by_scene
-
-
-def _collect_reference_ids(value: object, parent_key: str = "") -> list[str]:
-    if isinstance(value, str):
-        return [value] if parent_key.endswith(("_ref", "_id")) else []
-    if isinstance(value, list):
-        return [
-            ref
-            for item in value
-            for ref in _collect_reference_ids(item, parent_key)
-        ]
-    if not isinstance(value, dict):
-        return []
-
-    refs: list[str] = []
-    for key, item in value.items():
-        if key.endswith(("_refs", "_ids")):
-            if isinstance(item, list):
-                refs.extend(entry for entry in item if isinstance(entry, str))
-            continue
-        refs.extend(_collect_reference_ids(item, key))
-    return refs
 
 
 def _assert_fragment_shape(fragment: dict[str, Any]) -> None:
@@ -245,29 +204,89 @@ def test_runtime_fixtures_have_portable_fragment_shapes(path: Path) -> None:
 
 
 @pytest.mark.parametrize("path", _runtime_fixture_paths(), ids=lambda path: path.name)
-def test_open_choice_references_are_renderable(path: Path) -> None:
+def test_runtime_fixtures_pass_decision_legibility(path: Path) -> None:
     payload = _load_fixture(path)
-    fragments = payload["fragments"]
-    assert isinstance(fragments, list)
 
-    scenes = _renderable_ids_by_scene(fragments)
-    assert scenes, f"{path.name} must expose at least one scene"
+    result = LEGIBILITY.check_runtime_envelope(payload)
 
-    for fragment in fragments:
-        if not isinstance(fragment, dict) or fragment.get("fragment_type") != "choice":
-            continue
-        if fragment.get("available") is False:
-            continue
+    LEGIBILITY.assert_no_issues(result.issues)
 
-        refs = _collect_reference_ids(fragment.get("accepts", {}).get("constraints"))
-        if not refs:
-            continue
 
-        choice_uid = _fragment_uid(fragment)
-        scene = next((ids for ids in scenes if choice_uid in ids), None)
-        assert scene is not None, f"{path.name}: choice {choice_uid} is not in a scene"
-        for ref in refs:
-            assert ref in scene, f"{path.name}: choice {choice_uid} references hidden {ref}"
+def test_decision_legibility_reports_hidden_choice_references() -> None:
+    payload = {
+        "cursor_id": "fixture",
+        "step": 1,
+        "fragments": [
+            {
+                "uid": "scene",
+                "fragment_type": "group",
+                "group_type": "scene",
+                "member_ids": ["choice"],
+            },
+            {
+                "uid": "hidden-zone",
+                "fragment_type": "group",
+                "group_type": "zone",
+                "member_ids": [],
+            },
+            {
+                "uid": "choice",
+                "fragment_type": "choice",
+                "text": "Take one.",
+                "available": True,
+                "accepts": {
+                    "kind": "pieces",
+                    "constraints": {"target_zone_ref": "hidden-zone"},
+                },
+            },
+        ],
+    }
+
+    result = LEGIBILITY.check_runtime_envelope(payload)
+
+    assert [issue.ref_id for issue in result.issues] == ["hidden-zone"]
+    assert result.issues[0].choice_uid == "choice"
+    assert result.issues[0].reason == "referenced state is not renderable"
+
+
+def test_decision_legibility_accepts_visible_piece_domain_ids() -> None:
+    payload = {
+        "cursor_id": "fixture",
+        "step": 1,
+        "fragments": [
+            {
+                "uid": "scene",
+                "fragment_type": "group",
+                "group_type": "scene",
+                "member_ids": ["zone", "choice"],
+            },
+            {
+                "uid": "zone",
+                "fragment_type": "group",
+                "group_type": "zone",
+                "member_ids": ["piece-fragment"],
+            },
+            {
+                "uid": "piece-fragment",
+                "fragment_type": "piece",
+                "piece_id": "lamp",
+            },
+            {
+                "uid": "choice",
+                "fragment_type": "choice",
+                "text": "Use the lamp.",
+                "available": True,
+                "accepts": {
+                    "kind": "pieces",
+                    "piece_ids": ["lamp"],
+                },
+            },
+        ],
+    }
+
+    result = LEGIBILITY.check_runtime_envelope(payload)
+
+    assert result.issues == ()
 
 
 def test_command_hint_fixture_keeps_grammar_advisory() -> None:

--- a/engine/tests/conformance/test_widget_conformance_fixtures.py
+++ b/engine/tests/conformance/test_widget_conformance_fixtures.py
@@ -47,11 +47,12 @@ EXPECTED_PROPOSALS = {
 
 
 def _load_module(name: str, path: Path) -> ModuleType:
-    spec = importlib.util.spec_from_file_location(name, path)
+    module_name = f"{__name__}.{name}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
+    sys.modules[module_name] = module
     spec.loader.exec_module(module)
     return module
 
@@ -311,6 +312,80 @@ def test_decision_legibility_accepts_visible_piece_domain_ids() -> None:
     assert result.issues == ()
 
 
+def test_decision_legibility_reports_blocker_refs() -> None:
+    payload = {
+        "cursor_id": "fixture",
+        "step": 1,
+        "fragments": [
+            {
+                "uid": "scene",
+                "fragment_type": "group",
+                "group_type": "scene",
+                "member_ids": ["choice"],
+            },
+            {
+                "uid": "choice",
+                "fragment_type": "choice",
+                "text": "Unlock it.",
+                "available": True,
+                "blockers": [
+                    {
+                        "code": "missing_key",
+                        "message": "Needs the brass key.",
+                        "refs": ["hidden-key"],
+                    }
+                ],
+            },
+        ],
+    }
+
+    result = LEGIBILITY.check_runtime_envelope(payload)
+
+    assert [issue.ref_id for issue in result.issues] == ["hidden-key"]
+
+
+def test_decision_legibility_reports_place_edge_refs() -> None:
+    payload = {
+        "cursor_id": "fixture",
+        "step": 1,
+        "fragments": [
+            {
+                "uid": "scene",
+                "fragment_type": "group",
+                "group_type": "scene",
+                "member_ids": ["zone", "piece", "choice"],
+            },
+            {
+                "uid": "zone",
+                "fragment_type": "group",
+                "group_type": "zone",
+                "zone_id": "inventory",
+                "member_ids": ["piece"],
+            },
+            {
+                "uid": "piece",
+                "fragment_type": "piece",
+                "piece_id": "lamp",
+            },
+            {
+                "uid": "choice",
+                "fragment_type": "choice",
+                "text": "Move the lamp.",
+                "available": True,
+                "accepts": {
+                    "kind": "place",
+                    "source_zone_ref": "inventory",
+                    "edge_ref": "hidden-exit",
+                },
+            },
+        ],
+    }
+
+    result = LEGIBILITY.check_runtime_envelope(payload)
+
+    assert [issue.ref_id for issue in result.issues] == ["hidden-exit"]
+
+
 def test_input_parity_reports_unsubmittable_piece_choices() -> None:
     payload = {
         "cursor_id": "fixture",
@@ -387,6 +462,60 @@ def test_input_parity_reports_invalid_compose_parts() -> None:
     ]
 
 
+def test_input_parity_reports_negative_bounds() -> None:
+    payload = {
+        "cursor_id": "fixture",
+        "step": 1,
+        "fragments": [
+            {
+                "uid": "scene",
+                "fragment_type": "group",
+                "group_type": "scene",
+                "member_ids": ["zone", "piece", "choice"],
+            },
+            {
+                "uid": "zone",
+                "fragment_type": "group",
+                "group_type": "zone",
+                "zone_id": "inventory",
+                "member_ids": ["piece"],
+            },
+            {
+                "uid": "piece",
+                "fragment_type": "piece",
+                "piece_id": "lamp",
+            },
+            {
+                "uid": "choice",
+                "fragment_type": "choice",
+                "text": "Give supplies.",
+                "available": True,
+                "accepts": {
+                    "kind": "compose",
+                    "parts": [
+                        {"role": "amount", "accepts": {"kind": "quantity", "min": -1}},
+                        {
+                            "role": "item",
+                            "accepts": {
+                                "kind": "pieces",
+                                "target_zone_ref": "inventory",
+                                "max": -1,
+                            },
+                        },
+                    ],
+                },
+            },
+        ],
+    }
+
+    result = PARITY.check_runtime_envelope(payload)
+
+    assert [issue.reason for issue in result.issues] == [
+        "`min` must be non-negative",
+        "`max` must be non-negative",
+    ]
+
+
 def test_time_parity_reports_unreadable_pending_media() -> None:
     payload = {
         "cursor_id": "fixture",
@@ -413,6 +542,34 @@ def test_time_parity_reports_unreadable_pending_media() -> None:
     assert [issue.reason for issue in result.issues] == [
         "media is missing readable content",
         "ready media must resolve beyond rit",
+    ]
+
+
+@pytest.mark.parametrize("content", [{}, []], ids=["empty-object", "empty-list"])
+def test_time_parity_reports_empty_container_fallbacks(content: Any) -> None:
+    payload = {
+        "cursor_id": "fixture",
+        "step": 1,
+        "fragments": [
+            {
+                "uid": "scene",
+                "fragment_type": "group",
+                "group_type": "scene",
+                "member_ids": ["media"],
+            },
+            {
+                "uid": "media",
+                "fragment_type": "media",
+                "content": content,
+                "content_format": "url",
+            },
+        ],
+    }
+
+    result = TIME_PARITY.check_runtime_envelope(payload)
+
+    assert [issue.reason for issue in result.issues] == [
+        "media is missing readable content",
     ]
 
 

--- a/engine/tests/conformance/test_widget_conformance_fixtures.py
+++ b/engine/tests/conformance/test_widget_conformance_fixtures.py
@@ -23,6 +23,7 @@ FIXTURE_DIR = Path(__file__).parents[2] / "contrib" / "conformance" / "fixtures"
 PROPOSAL_DIR = Path(__file__).parents[2] / "contrib" / "conformance" / "proposals"
 LEGIBILITY_PATH = Path(__file__).parents[2] / "contrib" / "conformance" / "legibility.py"
 PARITY_PATH = Path(__file__).parents[2] / "contrib" / "conformance" / "parity.py"
+TIME_PARITY_PATH = Path(__file__).parents[2] / "contrib" / "conformance" / "time_parity.py"
 PROJECTED_STATE_FIXTURE = "projected_state_all_values.json"
 EXPECTED_FIXTURES = {
     "command_hints.json",
@@ -57,6 +58,7 @@ def _load_module(name: str, path: Path) -> ModuleType:
 
 LEGIBILITY = _load_module("legibility", LEGIBILITY_PATH)
 PARITY = _load_module("parity", PARITY_PATH)
+TIME_PARITY = _load_module("time_parity", TIME_PARITY_PATH)
 
 
 def _load_fixture(path: Path) -> dict[str, Any]:
@@ -223,6 +225,15 @@ def test_runtime_fixtures_pass_input_parity(path: Path) -> None:
     PARITY.assert_no_issues(result.issues)
 
 
+@pytest.mark.parametrize("path", _runtime_fixture_paths(), ids=lambda path: path.name)
+def test_runtime_fixtures_pass_time_parity(path: Path) -> None:
+    payload = _load_fixture(path)
+
+    result = TIME_PARITY.check_runtime_envelope(payload)
+
+    TIME_PARITY.assert_no_issues(result.issues)
+
+
 def test_decision_legibility_reports_hidden_choice_references() -> None:
     payload = {
         "cursor_id": "fixture",
@@ -373,6 +384,78 @@ def test_input_parity_reports_invalid_compose_parts() -> None:
         "duplicate role 'amount'",
         "missing role",
         "missing or unsupported accepts kind",
+    ]
+
+
+def test_time_parity_reports_unreadable_pending_media() -> None:
+    payload = {
+        "cursor_id": "fixture",
+        "step": 1,
+        "fragments": [
+            {
+                "uid": "scene",
+                "fragment_type": "group",
+                "group_type": "scene",
+                "member_ids": ["media"],
+            },
+            {
+                "uid": "media",
+                "fragment_type": "media",
+                "content": "",
+                "content_format": "rit",
+                "generation_status": "ready",
+            },
+        ],
+    }
+
+    result = TIME_PARITY.check_runtime_envelope(payload)
+
+    assert [issue.reason for issue in result.issues] == [
+        "media is missing readable content",
+        "ready media must resolve beyond rit",
+    ]
+
+
+def test_time_parity_accepts_roll_proposal_fallback() -> None:
+    payload = _load_fixture(PROPOSAL_DIR / "roll_fragment.json")
+
+    result = TIME_PARITY.check_runtime_envelope(payload)
+
+    TIME_PARITY.assert_no_issues(result.issues)
+
+
+def test_time_parity_reports_blocking_roll_rituals() -> None:
+    payload = {
+        "cursor_id": "fixture",
+        "step": 1,
+        "fragments": [
+            {
+                "uid": "scene",
+                "fragment_type": "group",
+                "group_type": "scene",
+                "member_ids": ["roll"],
+            },
+            {
+                "uid": "roll",
+                "fragment_type": "roll",
+                "label": "Fate",
+                "outcome": "fail",
+                "ritual_hints": {
+                    "duration_ms": True,
+                    "skip_label": "",
+                    "requires_completion": True,
+                },
+            },
+        ],
+    }
+
+    result = TIME_PARITY.check_runtime_envelope(payload)
+
+    assert [issue.reason for issue in result.issues] == [
+        "roll needs inputs or narrative for fallback",
+        "ritual duration_ms must be a non-negative integer",
+        "ritual skip_label must be readable when present",
+        "timing hint 'requires_completion' cannot be true",
     ]
 
 


### PR DESCRIPTION
## Summary
- Promote the conformance harness with legibility, parity, and multi-envelope sequence checks.
- Update widget conformance fixtures to reflect the current reconciliation matrix.
- Archive the v1.0 brand reference sheet and usage notes under docs as a non-canonical design reference.
- Ignore local `private/` scratch material in git.

## Testing
- Added and updated conformance tests for fixture coverage, sequence handling, legibility, and parity rules.
- Extended widget conformance assertions to match the current reference contract.
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive StoryTangl brand guidelines, usage rules, and a canonical brand sheet (with interactive “Tweaks” preview).
  * Added typography and palette assets and clarified archival/deployment rules for brand artifacts.
  * Updated design index to include new brand guidance.

* **Tests**
  * Added conformance tests validating decision legibility, input-parity, and timing/parity behaviors.

* **Chores**
  * Updated Git ignore to exclude the private/ directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->