### PR TITLE
Graduated penalty-matrix scoring (credentials)

### DIFF
--- a/engine/src/tangl/mechanics/games/__init__.py
+++ b/engine/src/tangl/mechanics/games/__init__.py
@@ -116,6 +116,8 @@ from .credentials_game import (
     CredentialsGameHandler,
     CredentialsMove,
     derive_disposition,
+    disposition_penalty,
+    DISPOSITION_PENALTY,
 )
 from .credentials_factory import (
     applicable_modes,

--- a/engine/src/tangl/mechanics/games/__init__.py
+++ b/engine/src/tangl/mechanics/games/__init__.py
@@ -190,6 +190,8 @@ __all__ = [
     "CredentialCase",
     "CredentialCaseResult",
     "derive_disposition",
+    "disposition_penalty",
+    "DISPOSITION_PENALTY",
     "ContrabandItem",
     "CredentialStatus",
     "CredentialToken",

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -173,6 +173,7 @@ class CredentialCaseResult(BaseModelPlus):
     chosen_disposition: CredentialDisposition
     expected_disposition: CredentialDisposition
     correct: bool
+    penalty: int = 0
     discovered_findings: dict[str, str] = Field(default_factory=dict)
     packet_findings: dict[str, str] = Field(default_factory=dict)
 
@@ -206,6 +207,31 @@ _DISPOSITION_SEVERITY: dict[CredentialDisposition, int] = {
 
 def _worse(a: CredentialDisposition, b: CredentialDisposition) -> CredentialDisposition:
     return a if _DISPOSITION_SEVERITY[a] >= _DISPOSITION_SEVERITY[b] else b
+
+
+# Graduated scoring: the cost of the chosen call given the correct one, over the
+# ordered allow -> deny -> arrest axis. One step off costs 2; two steps off
+# (allow <-> arrest) costs 5; correct costs 0. Arrest-when-wrong is always the
+# heavy 5, so the heavy hammer is appropriately high-stakes and deny is the
+# low-variance hedge for ambiguous calls. Penalties accumulate to a per-shift
+# failure threshold (the Papers Please citation model).
+# (The "+1 right-but-unjustified" evidence tax lands with the justification model
+# in B.3, where behavioral evidence -- a declined search, a bribe attempt --
+# also counts as justification.)
+_D = CredentialDisposition
+DISPOSITION_PENALTY: dict[CredentialDisposition, dict[CredentialDisposition, int]] = {
+    _D.PASS: {_D.PASS: 0, _D.DENY: 2, _D.ARREST: 5},
+    _D.DENY: {_D.PASS: 2, _D.DENY: 0, _D.ARREST: 5},
+    _D.ARREST: {_D.PASS: 5, _D.DENY: 2, _D.ARREST: 0},
+}
+
+
+def disposition_penalty(
+    expected: CredentialDisposition, chosen: CredentialDisposition
+) -> int:
+    """Penalty for choosing ``chosen`` when ``expected`` was correct."""
+
+    return DISPOSITION_PENALTY[expected][chosen]
 
 
 def _assess_credential(
@@ -368,8 +394,10 @@ class CredentialsGame(PickingGame):
         ]
     )
     allow_arrest: bool = True
-    # ``None`` means "every candidate must be correct" (the strict default).
-    pass_threshold: int | None = None
+    # The shift is lost when accumulated decision penalty exceeds this. 0 is the
+    # strict default (any wrong call ends the shift); a world raises it to make a
+    # more forgiving day. See DISPOSITION_PENALTY.
+    penalty_threshold: int = 0
     # The day's rules. Cases derive their disposition against this unless they
     # carry an authored ``correct_disposition`` override.
     restriction_map: Restrictions = Field(
@@ -477,10 +505,10 @@ class CredentialsGame(PickingGame):
         return sum(1 for result in self.case_results if result.correct)
 
     @property
-    def required_correct(self) -> int:
-        if self.pass_threshold is not None:
-            return self.pass_threshold
-        return self._total_cases()
+    def total_penalty(self) -> int:
+        """Accumulated decision penalty across the shift so far."""
+
+        return sum(result.penalty for result in self.case_results)
 
     # ----- picking-kernel surface (reads the active case) -------------------
     def get_visible_items(self) -> list[str]:
@@ -571,6 +599,8 @@ class CredentialsGame(PickingGame):
                 "credential_roster_size": self._total_cases(),
                 "credential_cases_remaining": self._total_cases() - len(self.case_results),
                 "credential_correct_count": self.correct_count,
+                "credential_total_penalty": self.total_penalty,
+                "credential_penalty_threshold": self.penalty_threshold,
                 "credential_shift_score": dict(self.score),
                 "credential_shift_complete": self.shift_complete,
             }
@@ -702,6 +732,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         chosen = CredentialDisposition(target)
         expected = game.expected_disposition(case)
         correct = chosen == expected
+        penalty = disposition_penalty(expected, chosen)
 
         game.case_results.append(
             CredentialCaseResult(
@@ -709,6 +740,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                 chosen_disposition=chosen,
                 expected_disposition=expected,
                 correct=correct,
+                penalty=penalty,
                 discovered_findings=dict(game.revealed_findings),
                 packet_findings=dict(game.packet_findings),
             )
@@ -716,6 +748,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
 
         detail["candidate"] = case.candidate_name
         detail["credential_stage"] = game.current_stage
+        detail["penalty"] = penalty
         if correct:
             game.score["player"] = game.score.get("player", 0) + 1
             detail["outcome"] = "correct_disposition"
@@ -846,11 +879,12 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
     # ----- lifecycle / projection ------------------------------------------
 
     def evaluate(self, game: CredentialsGame) -> GameResult:
-        """Own shift terminality: in process until the final candidate is decided."""
+        """Own shift terminality: in process until the final candidate is decided,
+        then win if accumulated penalty stayed within the threshold."""
 
         if not game.shift_complete:
             return GameResult.IN_PROCESS
-        if game.correct_count >= game.required_correct:
+        if game.total_penalty <= game.penalty_threshold:
             return GameResult.WIN
         return GameResult.LOSE
 

--- a/engine/tests/mechanics/games/test_credentials_game.py
+++ b/engine/tests/mechanics/games/test_credentials_game.py
@@ -146,16 +146,32 @@ class TestCredentialsCore:
         assert game.result is GameResult.LOSE
         assert game.correct_count == 1
 
-    def test_pass_threshold_allows_a_miss(self) -> None:
-        game, handler = _ready_game(pass_threshold=1)
+    def test_penalty_threshold_allows_a_miss(self) -> None:
+        # Edda should DENY; passing her is one step off (penalty 2). A threshold
+        # of 2 tolerates exactly that.
+        game, handler = _ready_game(penalty_threshold=2)
 
         handler.receive_move(game, ("inspect", "passport"))
-        handler.receive_move(game, ("decide", "pass"))  # wrong
+        handler.receive_move(game, ("decide", "pass"))  # wrong (deny expected) -> +2
         handler.receive_move(game, ("inspect", "passport"))
-        handler.receive_move(game, ("decide", "pass"))  # correct
+        handler.receive_move(game, ("decide", "pass"))  # correct -> +0
 
+        assert game.total_penalty == 2
         assert game.result is GameResult.WIN
         assert game.correct_count == 1
+
+    def test_arrest_when_wrong_is_a_grave_penalty(self) -> None:
+        # Arresting Edda (should DENY) is two steps off -> penalty 5, over the
+        # strict default threshold of 0.
+        game, handler = _ready_game()  # penalty_threshold defaults to 0
+        handler.receive_move(game, ("inspect", "passport"))
+        handler.receive_move(game, ("decide", "arrest"))  # deny expected -> +5
+
+        assert game.case_results[0].penalty == 5
+        handler.receive_move(game, ("inspect", "passport"))
+        handler.receive_move(game, ("decide", "pass"))  # Tomas correct
+        assert game.total_penalty == 5
+        assert game.result is GameResult.LOSE
 
     def test_terminal_routing_only_after_final_case(self) -> None:
         game, handler = _ready_game()

--- a/engine/tests/mechanics/games/test_credentials_scoring.py
+++ b/engine/tests/mechanics/games/test_credentials_scoring.py
@@ -1,0 +1,98 @@
+"""Tests for the graduated penalty-matrix scoring (CREDENTIALS_LOOP_DESIGN.md
+"Engine review" §2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tangl.mechanics.games import (
+    CredentialCase,
+    CredentialDisposition,
+    CredentialsGame,
+    CredentialsGameHandler,
+    disposition_penalty,
+)
+
+D = CredentialDisposition
+
+
+class TestPenaltyMatrix:
+    @pytest.mark.parametrize(
+        "expected,chosen,penalty",
+        [
+            (D.PASS, D.PASS, 0), (D.PASS, D.DENY, 2), (D.PASS, D.ARREST, 5),
+            (D.DENY, D.PASS, 2), (D.DENY, D.DENY, 0), (D.DENY, D.ARREST, 5),
+            (D.ARREST, D.PASS, 5), (D.ARREST, D.DENY, 2), (D.ARREST, D.ARREST, 0),
+        ],
+    )
+    def test_matrix(self, expected, chosen, penalty) -> None:
+        assert disposition_penalty(expected, chosen) == penalty
+
+    def test_arrest_when_wrong_is_always_heaviest(self) -> None:
+        # Reaching for arrest wrongly costs 5 whether the correct call was allow
+        # or deny -- the heavy hammer is uniformly high-stakes.
+        assert disposition_penalty(D.PASS, D.ARREST) == 5
+        assert disposition_penalty(D.DENY, D.ARREST) == 5
+
+    def test_deny_is_the_low_variance_hedge(self) -> None:
+        # For an ambiguous candidate (innocent vs guilty), denying caps the
+        # downside at 2 either way, while the alternatives risk 5.
+        assert disposition_penalty(D.PASS, D.DENY) == 2   # was innocent
+        assert disposition_penalty(D.ARREST, D.DENY) == 2  # was a criminal
+        # The risky alternatives: arrest an innocent (5), allow a criminal (5).
+        assert disposition_penalty(D.PASS, D.ARREST) == 5
+        assert disposition_penalty(D.ARREST, D.PASS) == 5
+
+
+def _game(threshold: int = 0) -> tuple[CredentialsGame, CredentialsGameHandler]:
+    roster = [
+        CredentialCase(candidate_name="A", correct_disposition=D.PASS),
+        CredentialCase(candidate_name="B", correct_disposition=D.DENY),
+        CredentialCase(candidate_name="C", correct_disposition=D.ARREST),
+    ]
+    game = CredentialsGame(roster=roster, penalty_threshold=threshold)
+    handler = CredentialsGameHandler()
+    handler.setup(game)
+    return game, handler
+
+
+def _decide(handler, game, disposition: str) -> None:
+    # reach packet stage then decide
+    inspect = handler.get_available_inspect_targets(game)
+    if inspect:
+        handler.receive_move(game, ("inspect", inspect[0]))
+    else:
+        game.current_stage = "packet"
+    handler.receive_move(game, ("decide", disposition))
+
+
+class TestShiftPenaltyAccumulation:
+    def test_perfect_shift_has_zero_penalty_and_wins(self) -> None:
+        game, handler = _game()
+        for call in ("pass", "deny", "arrest"):
+            _decide(handler, game, call)
+        assert game.total_penalty == 0
+        assert game.result.name == "WIN"
+
+    def test_penalty_accumulates_and_threshold_decides(self) -> None:
+        # Deny A (should pass, +2), deny B (+0), deny C (should arrest, +2) = 4.
+        game, handler = _game(threshold=3)
+        for _ in range(3):
+            _decide(handler, game, "deny")
+        assert game.total_penalty == 4
+        assert game.result.name == "LOSE"  # 4 > 3
+
+    def test_threshold_tolerates_within_budget(self) -> None:
+        game, handler = _game(threshold=4)
+        for _ in range(3):
+            _decide(handler, game, "deny")
+        assert game.total_penalty == 4
+        assert game.result.name == "WIN"  # 4 <= 4
+
+    def test_per_case_penalty_recorded(self) -> None:
+        game, handler = _game(threshold=10)
+        _decide(handler, game, "arrest")  # A should pass -> +5
+        _decide(handler, game, "deny")    # B correct -> +0
+        _decide(handler, game, "pass")    # C should arrest -> +5
+        assert [r.penalty for r in game.case_results] == [5, 0, 5]
+        assert game.total_penalty == 10


### PR DESCRIPTION
## Summary

Implements the **graduated penalty-matrix scoring** we settled in design — keeping the single `expected_disposition` and replacing the binary correct/incorrect shift outcome with a penalty over the ordered `allow → deny → arrest` axis, accumulated to a failure threshold (the Papers Please citation model).

```text
should allow   = { allow: 0,  deny: 2,  arrest: 5 }
should deny    = { allow: 2,  deny: 0,  arrest: 5 }
should arrest  = { allow: 5,  deny: 2,  arrest: 0 }
```

- `DISPOSITION_PENALTY` / `disposition_penalty(expected, chosen)`.
- `CredentialsGame.penalty_threshold` (default `0` strict; worlds raise it for a more forgiving day) replaces `pass_threshold`/`required_correct`.
- `total_penalty` accumulates across the shift; `evaluate` wins iff `total_penalty <= penalty_threshold`.
- `CredentialCaseResult.penalty` records the per-case cost; namespace exports `total_penalty` / `penalty_threshold`.

**Why it matters:** arrest-when-wrong is a flat **5**, so the heavy hammer is uniformly high-stakes and **deny is the low-variance hedge** (caps at 2) for an ambiguous candidate — which is the bluffing tension, for free, with no acceptable-set machinery.

## Scope

- The **+1 right-but-unjustified evidence tax is deferred** to land with the justification model in B.3 — "justified" gets richer there (a declined search or bribe attempt also counts as justification), so freezing it now would be premature. This PR is the settled core only.
- Pairs with the **attention/time budget** (per-shift clock, designed but not yet built) — together they produce the actual triage gameplay.

## Notes

- **Stacked on #262 (Phase B.2)** — this PR is targeted at `claude/credentials-phase-b2`; retarget to `main` once #262 merges.
- World/loader tests are unaffected (they play exact-correct → penalty 0 → win at the strict default).

## Test plan

- [x] New `test_credentials_scoring.py` — the full 3×3 matrix, arrest-always-heaviest, deny-is-the-hedge, and shift-level accumulation/threshold.
- [x] Reworked the old `pass_threshold` test to the penalty model; added an arrest-when-wrong-is-grave case.
- [x] Full sweep `engine/tests/{mechanics/games,loaders,service}`: 407 passed, 6 skipped.
- [ ] CI green.

Refs #246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
