### PR TITLE
Soft attention/time budget (credentials)

### DIFF
--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -781,18 +781,38 @@ does not yet model is the **pressure and ambiguity** that turn a correct
 rule-checker into a *game*. Two genuine engine-level additions (the rest is
 content/already-planned):
 
-### 1. Attention / time budget — the missing tension (high value)
+### 1. Attention / time budget — the missing tension (LANDED 2026-06-05)
 
-Mediation is currently **free**, so the dominant strategy is "run every probe on
-everyone" — which collapses the very judgment the disclosure discipline was
+Mediation was **free**, so the dominant strategy was "run every probe on
+everyone" — which collapsed the very judgment the disclosure discipline was
 protecting (you can't read the answer off the menu, but you *can* brute-force
 it). Papers Please's core tension is **scarcity**: you can't scrutinize everyone,
-so you triage on suspicion. A per-candidate or per-shift **budget** (inspection
-points / time) gives each inspect/mediate a cost and forces "who is worth a closer
-look?" This is the single highest-leverage addition; it is also what makes the
-already-built disclosure discipline *matter*, and what makes the concealed-
-contraband god's-eye rule *play* correctly (you deny the suspicious and sometimes
-miss, because you couldn't search everyone).
+so you triage on suspicion.
+
+**Shipped model — a soft per-shift time budget.** `CredentialsGame.time_budget`
+(None disables time pressure, the default). Every probe and decision costs time
+(`_MOVE_TIME_COST` / `_DECISION_TIME_COST`): a glance at a document or a
+date/seal check is cheap (1), verify-id and request-reissue cost 2, a **search**
+is expensive (3); passing/denying is quick (1) but an **arrest costs more** (3 —
+escort/paperwork, which also reinforces the matrix's "don't reach for arrest
+idly"). Time accrues per shift (`time_spent`). Time over the budget converts to
+penalty at `overtime_penalty_rate` and is folded into `total_penalty`, so going
+over the budget pushes you toward the failure threshold.
+
+**Soft, not a wall.** Actions are never blocked — you *can* go slow, but it costs
+you toward the LOSE line. The pressure is economic: investigate thoroughly and
+pay in time, or move fast and risk wrong calls. This is what makes the
+disclosure discipline *matter* (probing has a price now) and the
+concealed-contraband god's-eye rule *play* correctly (you can't afford to search
+everyone, so you deny the suspicious and sometimes miss).
+
+Costs are fixed defaults; the per-shift `time_budget` (and
+`overtime_penalty_rate`) are the tuning knobs. *Deferred:* the thoroughness
+slider (quick-vs-thorough search) and the reference-doc progression (checks get
+cheaper as you build your rulebook). A hard-clock / throughput variant (the
+shift *ends* when time runs out, leaving the queue unprocessed) is a possible
+later mode; the soft overtime model was chosen for v1 because it bolts directly
+onto the penalty accumulation with no early-termination machinery.
 
 ### 2. Graduated penalty scoring with a failure threshold (resolved 2026-06-04)
 

--- a/engine/src/tangl/mechanics/games/__init__.py
+++ b/engine/src/tangl/mechanics/games/__init__.py
@@ -118,6 +118,7 @@ from .credentials_game import (
     derive_disposition,
     disposition_penalty,
     DISPOSITION_PENALTY,
+    move_time_cost,
 )
 from .credentials_factory import (
     applicable_modes,
@@ -192,6 +193,7 @@ __all__ = [
     "derive_disposition",
     "disposition_penalty",
     "DISPOSITION_PENALTY",
+    "move_time_cost",
     "ContrabandItem",
     "CredentialStatus",
     "CredentialToken",

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -234,6 +234,35 @@ def disposition_penalty(
     return DISPOSITION_PENALTY[expected][chosen]
 
 
+# Time cost of each action, in shift-budget units. Cheap probes (a glance at a
+# document, a date/seal check) cost 1; verifying an id or requesting a reissue
+# costs 2; a search is expensive at 3. Decisions cost too: passing or denying is
+# quick, but an arrest takes longer (escort/paperwork) -- which also reinforces
+# the penalty matrix's "don't reach for arrest idly". Costs are fixed defaults
+# for now; the per-shift time_budget is the tuning knob.
+_MOVE_TIME_COST: dict[str, int] = {
+    "inspect": 1,
+    "request_document": 2,
+    "verify_id": 2,
+    "request_search": 3,
+    "request_disclosure": 1,
+    "request_relinquish": 1,
+}
+_DECISION_TIME_COST: dict[CredentialDisposition, int] = {
+    CredentialDisposition.PASS: 1,
+    CredentialDisposition.DENY: 1,
+    CredentialDisposition.ARREST: 3,
+}
+
+
+def move_time_cost(move: PickingMove) -> int:
+    """Time cost of one move (see ``_MOVE_TIME_COST`` / ``_DECISION_TIME_COST``)."""
+
+    if move.kind == "decide":
+        return _DECISION_TIME_COST.get(CredentialDisposition(move.target), 1)
+    return _MOVE_TIME_COST.get(move.kind, 1)
+
+
 def _assess_credential(
     token: CredentialToken | None,
     finding_status: dict[str, str] | None = None,
@@ -394,10 +423,16 @@ class CredentialsGame(PickingGame):
         ]
     )
     allow_arrest: bool = True
-    # The shift is lost when accumulated decision penalty exceeds this. 0 is the
-    # strict default (any wrong call ends the shift); a world raises it to make a
-    # more forgiving day. See DISPOSITION_PENALTY.
+    # The shift is lost when accumulated penalty exceeds this. 0 is the strict
+    # default (any wrong call ends the shift); a world raises it for a more
+    # forgiving day. Penalty = decision penalties (DISPOSITION_PENALTY) + overtime.
     penalty_threshold: int = 0
+    # Soft attention/time budget. None disables time pressure (the default).
+    # When set, every probe and decision costs time (see _MOVE_TIME_COST); time
+    # spent over the budget converts to penalty at overtime_penalty_rate. Going
+    # thorough costs time; going fast risks wrong calls.
+    time_budget: int | None = None
+    overtime_penalty_rate: int = 1
     # The day's rules. Cases derive their disposition against this unless they
     # carry an authored ``correct_disposition`` override.
     restriction_map: Restrictions = Field(
@@ -426,6 +461,12 @@ class CredentialsGame(PickingGame):
     )
     shift_complete: bool = Field(
         default=False,
+        json_schema_extra={"reset_field": True},
+    )
+    # Shift-level time spent on probes and decisions (not per-case; reset only on
+    # setup). Compared against time_budget for the overtime penalty.
+    time_spent: int = Field(
+        default=0,
         json_schema_extra={"reset_field": True},
     )
     # Mediation outcomes for the active case (Phase B.1): keys are an
@@ -505,10 +546,29 @@ class CredentialsGame(PickingGame):
         return sum(1 for result in self.case_results if result.correct)
 
     @property
-    def total_penalty(self) -> int:
-        """Accumulated decision penalty across the shift so far."""
+    def decision_penalty(self) -> int:
+        """Accumulated per-case decision penalty across the shift so far."""
 
         return sum(result.penalty for result in self.case_results)
+
+    @property
+    def overtime(self) -> int:
+        """Time spent over the budget (0 when no budget is set)."""
+
+        if self.time_budget is None:
+            return 0
+        return max(0, self.time_spent - self.time_budget)
+
+    @property
+    def overtime_penalty(self) -> int:
+        return self.overtime * self.overtime_penalty_rate
+
+    @property
+    def total_penalty(self) -> int:
+        """Decision penalties plus the overtime penalty, against which the
+        shift's failure threshold is judged."""
+
+        return self.decision_penalty + self.overtime_penalty
 
     # ----- picking-kernel surface (reads the active case) -------------------
     def get_visible_items(self) -> list[str]:
@@ -600,7 +660,11 @@ class CredentialsGame(PickingGame):
                 "credential_cases_remaining": self._total_cases() - len(self.case_results),
                 "credential_correct_count": self.correct_count,
                 "credential_total_penalty": self.total_penalty,
+                "credential_decision_penalty": self.decision_penalty,
                 "credential_penalty_threshold": self.penalty_threshold,
+                "credential_time_budget": self.time_budget,
+                "credential_time_spent": self.time_spent,
+                "credential_overtime": self.overtime,
                 "credential_shift_score": dict(self.score),
                 "credential_shift_complete": self.shift_complete,
             }
@@ -612,6 +676,12 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
     """Handler for an inspect-and-dispose checkpoint shift."""
 
     game_cls: ClassVar[type[Game]] = CredentialsGame
+
+    def resolve_round(self, game, player_move, opponent_move):
+        # Charge the move's time cost to the shift budget before resolving it.
+        # Soft budget: actions are never blocked; overtime converts to penalty.
+        game.time_spent += move_time_cost(self._normalize_move(player_move))
+        return super().resolve_round(game, player_move, opponent_move)
 
     def get_available_moves(self, game: CredentialsGame) -> list[CredentialsMove]:
         """Inspect + decide + (Phase B.1) mediation moves.

--- a/engine/tests/mechanics/games/test_credentials_budget.py
+++ b/engine/tests/mechanics/games/test_credentials_budget.py
@@ -1,0 +1,121 @@
+"""Tests for the soft attention/time budget (CREDENTIALS_LOOP_DESIGN.md
+"Engine review" §1).
+
+A per-shift budget; every probe and decision costs time; time spent over the
+budget converts to penalty toward the failure threshold. Actions are never
+blocked -- the pressure is economic (go thorough and pay in time, or go fast and
+risk wrong calls).
+"""
+
+from __future__ import annotations
+
+from tangl.mechanics.games import (
+    CredentialCase,
+    CredentialDisposition,
+    CredentialsGame,
+    CredentialsGameHandler,
+    CredentialsMove,
+    move_time_cost,
+)
+
+D = CredentialDisposition
+
+
+def _move(kind: str, target: str = "") -> CredentialsMove:
+    return CredentialsMove(kind=kind, target=target)
+
+
+class TestMoveCosts:
+    def test_tiered_costs(self) -> None:
+        assert move_time_cost(_move("inspect", "passport")) == 1
+        assert move_time_cost(_move("request_disclosure")) == 1
+        assert move_time_cost(_move("verify_id")) == 2
+        assert move_time_cost(_move("request_document", "work")) == 2
+        assert move_time_cost(_move("request_search")) == 3
+
+    def test_arrest_costs_more_than_a_quick_call(self) -> None:
+        assert move_time_cost(_move("decide", "pass")) == 1
+        assert move_time_cost(_move("decide", "deny")) == 1
+        assert move_time_cost(_move("decide", "arrest")) == 3
+
+
+def _game(**overrides) -> tuple[CredentialsGame, CredentialsGameHandler]:
+    roster = [
+        CredentialCase(candidate_name="A", correct_disposition=D.PASS),
+        CredentialCase(candidate_name="B", correct_disposition=D.PASS),
+    ]
+    game = CredentialsGame(roster=roster, **overrides)
+    handler = CredentialsGameHandler()
+    handler.setup(game)
+    return game, handler
+
+
+def _process(handler, game, call: str) -> None:
+    inspect = handler.get_available_inspect_targets(game)
+    if inspect:
+        handler.receive_move(game, ("inspect", inspect[0]))
+    else:
+        game.current_stage = "packet"
+    handler.receive_move(game, ("decide", call))
+
+
+class TestTimeAccrual:
+    def test_no_budget_means_no_overtime(self) -> None:
+        game, handler = _game()  # time_budget defaults to None
+        _process(handler, game, "pass")
+        _process(handler, game, "pass")
+        assert game.time_spent > 0  # time still accrues
+        assert game.overtime == 0
+        assert game.total_penalty == 0
+        assert game.result.name == "WIN"
+
+    def test_time_accrues_per_action(self) -> None:
+        game, handler = _game(time_budget=100)
+        handler.receive_move(game, ("inspect", "passport"))  # +1
+        handler.receive_move(game, ("request_search", ""))   # +3
+        assert game.time_spent == 4
+
+
+class TestOvertimePenalty:
+    def test_within_budget_no_penalty(self) -> None:
+        # Two candidates, inspect+pass each = 2 each = 4 total; budget 4 -> no overtime.
+        game, handler = _game(time_budget=4)
+        _process(handler, game, "pass")
+        _process(handler, game, "pass")
+        assert game.time_spent == 4
+        assert game.overtime == 0
+        assert game.total_penalty == 0
+        assert game.result.name == "WIN"
+
+    def test_overtime_converts_to_penalty_and_can_lose_a_clean_shift(self) -> None:
+        # Same correct play, but a stingy budget of 1 -> 3 overtime -> penalty 3,
+        # over the strict threshold 0, so even a flawless shift is lost on time.
+        game, handler = _game(time_budget=1)
+        _process(handler, game, "pass")
+        _process(handler, game, "pass")
+        assert game.decision_penalty == 0  # every call correct
+        assert game.overtime == 3
+        assert game.total_penalty == 3
+        assert game.result.name == "LOSE"
+
+    def test_overtime_rate_scales(self) -> None:
+        game, handler = _game(time_budget=2, overtime_penalty_rate=2)
+        _process(handler, game, "pass")  # 2
+        _process(handler, game, "pass")  # 4 total -> 2 over
+        assert game.overtime == 2
+        assert game.total_penalty == 4  # 2 over * rate 2
+
+    def test_threshold_can_absorb_some_overtime(self) -> None:
+        game, handler = _game(time_budget=2, penalty_threshold=3)
+        _process(handler, game, "pass")
+        _process(handler, game, "pass")  # 2 overtime -> penalty 2 <= 3
+        assert game.total_penalty == 2
+        assert game.result.name == "WIN"
+
+    def test_namespace_exposes_budget(self) -> None:
+        game, handler = _game(time_budget=5)
+        handler.receive_move(game, ("inspect", "passport"))
+        ns = game.to_namespace()
+        assert ns["credential_time_budget"] == 5
+        assert ns["credential_time_spent"] == 1
+        assert ns["credential_overtime"] == 0


### PR DESCRIPTION
## Summary

Adds the **attention/time budget** — the highest-leverage item from the engine review, and the thing that makes the disclosure discipline and the penalty matrix actually *bite*. Without it, mediation was free, so the optimal play was to probe everyone exhaustively, collapsing the triage the whole design was protecting.

Per the exhaustion fork we settled on: a **soft overtime** model (chosen over a hard clock because it bolts straight onto the penalty accumulation with no early-termination/throughput machinery).

- `CredentialsGame.time_budget` (**None disables time pressure — the default**, so nothing changes unless a world opts in) + `overtime_penalty_rate`.
- Every probe and decision costs time (`_MOVE_TIME_COST` / `_DECISION_TIME_COST`): a glance at a document or a date/seal check is cheap (1), verify-id / request-reissue cost 2, a **search** is expensive (3); pass/deny are quick (1) but an **arrest costs more** (3 — escort/paperwork, and it reinforces the matrix's "don't reach for arrest idly").
- `time_spent` accrues per shift; **overtime** (time over budget) converts to penalty at the rate and folds into `total_penalty`, so going slow pushes you toward the failure threshold.
- **Soft, not a wall:** actions are never blocked. The pressure is economic — investigate thoroughly and pay in time, or move fast and risk wrong calls.

## Why it matters

This is what makes the already-built pieces *play*: probing now has a price, so you can't afford to search everyone → you deny the suspicious and sometimes miss (the concealed-contraband god's-eye rule plays correctly), and the penalty matrix's "deny is the low-variance hedge" becomes the rational default under time pressure.

## Scope

- Costs are fixed defaults; the per-shift `time_budget` is the tuning knob.
- **Deferred:** thoroughness slider (quick-vs-thorough search), reference-doc progression (checks get cheaper as you build your rulebook), and a hard-clock/throughput variant.

## Test plan

- [x] New `test_credentials_budget.py` — tiered/arrest costs, per-action accrual, within-budget no-penalty, overtime-loses-a-clean-shift, rate scaling, threshold absorption, namespace exports.
- [x] No-budget default unchanged (existing scenarios accrue time but incur zero overtime).
- [x] Full sweep `engine/tests/{mechanics/games,loaders,service}`: 418 passed, 6 skipped.
- [ ] CI green.

Refs #246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
