### PR TITLE
Per-rule-set scoring config for the credentials shift

### DIFF
--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -844,11 +844,26 @@ costs that much: guessing right is fine but taxed, so gathering evidence (which
 costs budget, §1) is rewarded without being mandatory. It is **off by default**
 because it is regime-specific — a rule-of-law gate turns it on; an arrest-by-decree
 regime (§3) must leave it off, since arresting without evidence is the *norm*
-there. "Surfaced evidence" (`_has_surfaced_evidence`) = a revealed document/packet
-finding, an adverse `finding_status` (`confirmed`/`cleared`/`yielded`), or a logged
-declaration of contraband actually present. Justification will also include
-**behavioral** evidence once B.3 lands ("the smuggler tried to bribe his way out of
-a search" → grounds for arrest); `_EVIDENCE_FINDINGS` is the seam for that.
+there. A rejection is **justified** (`_rejection_is_justified`) if it is backed by
+either *surfaced* or *self-evident* evidence, and the tax errs toward justified so
+it never punishes a fair call:
+
+- *Surfaced* (`_has_surfaced_evidence`) — a revealed document/packet finding, an
+  adverse `finding_status` (`confirmed`/`cleared`/`yielded`, but **not** a clean
+  `search: cleared`, which turned nothing up), or a logged declaration of
+  contraband actually present.
+- *Self-evident* (`_has_visible_grounds`) — facts visible without investigation: a
+  credential the purpose plainly requires but the packet lacks, or openly
+  (non-concealed) contraband that is forbidden or plainly missing its permit. A
+  concealed item is not self-evident; a declared declaration-only item is allowed,
+  so neither counts.
+
+The tax keys off `correct` (not `penalty == 0`), so a custom matrix that tolerates
+a non-expected call at zero cost is never mistaken for a correct one, and it never
+fires on an allow (the point of an allow is that there is *no* adverse evidence).
+Justification will also grow **behavioral** evidence once B.3 lands ("the smuggler
+tried to bribe his way out of a search" → grounds for arrest); `_EVIDENCE_FINDINGS`
+is the seam for that.
 
 `derive_disposition` is unchanged; this was a refactor of the **decision scorer**
 (penalty lookup + accumulation + the evidence check) and the shift terminal

--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -855,7 +855,7 @@ a search" → grounds for arrest); `_EVIDENCE_FINDINGS` is the seam for that.
 condition (penalty-threshold instead of correct-count). `CredentialCaseResult`
 records the per-case `penalty` and an `unjustified` flag.
 
-### 3. Per-rule-set scoring + adversarial mediation (LANDED scoring 2026-06-05; degrade-events deferred)
+### 3. Per-rule-set scoring + malfeasance/doctoring (LANDED scoring 2026-06-05; malfeasance deferred)
 
 Scoring is **per rule set**, not a global constant. The penalty matrix is a
 per-game field (`penalty_matrix`, string-keyed by disposition value so it stays
@@ -880,17 +880,35 @@ There are **two independent ways to express such a regime**, and they compose:
   the existing factory machinery — "build legal, then degrade by target
   disposition" — pointed at a uniform target.
 
-**Adversarial / packet-degrading mediations (deferred).** The B.1/B.2 mediations
-are *clearing* (favorable: request_document, relinquish, disclosure). Their mirror
-image is a **degrade** transform that worsens the packet during play — lose a
-packet piece, smear a date to invalid, strip a seal — the corrupt-gatekeeper move
-that manufactures grounds *in the moment* rather than at generation. The transforms
-themselves already exist as `FailureMode`s (`MISSING_PERMIT` = lose a piece,
-`EXPIRED_ID`/`BAD_DATE` = invalidate a date); what is deferred is a **live event /
-move** that applies one mid-case and re-derives. Model it as the adversarial
-counterpart of `finding_status` (a `case_mutations` overlay so `advance_case` still
-resets cleanly and the underlying authored packet is untouched), gated behind a
-regime flag so only a corruption-flavored skin exposes it.
+**Malfeasance: doctoring evidence (deferred — opens its own design space).** The
+B.1/B.2 mediations are *clearing* and honest (request_document, relinquish,
+disclosure). Their counterpart is the player **doctoring evidence** — lose a piece,
+smear a date to invalid, strip or forge a seal — and that is a *malfeasance axis*,
+not merely a regime event. Two observations fix its shape:
+
+- It spans a **severity spectrum**. *Turning a blind eye* (don't investigate;
+  accept a bribe to pass someone) is the low, passive end — this is the Phase C
+  bribery/favoritism layer. *Actively doctoring the packet into false testimony*
+  (manufacturing or destroying a finding) is the high, active end. Both can point
+  **in favor of or against** the candidate. So Phase C bribery is the low-level
+  instance of the same spine, not a separate mechanic.
+- It is driven by the **no-evidence penalty**. Because `no_evidence_penalty` is a
+  scalar strike-cost, fabricating a justification is "just another step to keep
+  your strikes down." The balance question is therefore explicit and tunable:
+  **is having (or manufacturing) evidence worth more than the expected penalty for
+  getting caught at malfeasance?** A regime that prizes correct-seeming paperwork
+  makes doctoring rational; one that catches-and-punishes hard makes honest
+  investigation (paying budget, §1) the cheaper path.
+
+The transforms already exist as `FailureMode`s (`MISSING_PERMIT` = lose a piece,
+`EXPIRED_ID`/`BAD_DATE` = invalidate a date); what is deferred is the **live move**
+that applies one mid-case and re-derives, *plus* the catch/strike model that prices
+it (getting-caught probability, the malfeasance penalty, reputation). Model the
+mutation as the adversarial counterpart of `finding_status` (a `case_mutations`
+overlay so `advance_case` resets cleanly and the authored packet is untouched),
+gated behind a regime flag. Defer the whole malfeasance layer — it pulls in
+bribery, detection odds, and reputation at once — but build it as one axis with
+blind-eye/bribe at the bottom and false-testimony doctoring at the top.
 
 ### Generation: presentation vs. truth (confirmed)
 

--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -3,7 +3,9 @@
 **Status:** v1 LANDED (candidate-roster shift, 2026-05-21); Phase A LANDED
 (A.1 rules-derived dispositions, A.2 candidate factory, A.3 day-spec sampling +
 lazy offer roster, 2026-05-22); Phase B.1 LANDED (core mediation moves,
-2026-05-23); Phase B.2 LANDED (contraband mediation, 2026-06-04); Phases
+2026-05-23); Phase B.2 LANDED (contraband mediation, 2026-06-04); penalty-matrix
+scorer + soft time budget + per-rule-set scoring config (configurable
+`penalty_matrix`, `no_evidence_penalty` toggle) LANDED 2026-06-05; Phases
 B.3 (declines axis)/C/D designed below as overlays  
 **Scope:** the credentials / checkpoint interaction as a stacked picking-game
 composition inside `tangl.mechanics.games`  
@@ -814,7 +816,7 @@ shift *ends* when time runs out, leaving the queue unprocessed) is a possible
 later mode; the soft overtime model was chosen for v1 because it bolts directly
 onto the penalty accumulation with no early-termination machinery.
 
-### 2. Graduated penalty scoring with a failure threshold (resolved 2026-06-04)
+### 2. Graduated penalty scoring with a failure threshold (LANDED 2026-06-05)
 
 Keep the **single** `expected_disposition` (there is always one correct call).
 Replace the binary correct/incorrect score with a **penalty matrix** over the
@@ -836,16 +838,59 @@ caps the downside at 2 whether they turn out innocent (should-allow) or guilty
 matrix without any acceptable-set machinery. (The earlier "two-error /
 acceptable-set" sketch is superseded by this.)
 
-**+1 for right-but-unjustified.** Add a small penalty when the call is correct
-but unsupported by a revealed finding — guessing right is fine but taxed, so
-gathering evidence (which costs budget, §1) is rewarded without being mandatory.
-Justification includes **behavioral** evidence, not just documents: "the smuggler
-tried to bribe his way out of a search" justifies an arrest.
+**+1 for right-but-unjustified — a toggle (`no_evidence_penalty`, LANDED).** When
+> 0, a *correct* deny/arrest that the player never backed with surfaced evidence
+costs that much: guessing right is fine but taxed, so gathering evidence (which
+costs budget, §1) is rewarded without being mandatory. It is **off by default**
+because it is regime-specific — a rule-of-law gate turns it on; an arrest-by-decree
+regime (§3) must leave it off, since arresting without evidence is the *norm*
+there. "Surfaced evidence" (`_has_surfaced_evidence`) = a revealed document/packet
+finding, an adverse `finding_status` (`confirmed`/`cleared`/`yielded`), or a logged
+declaration of contraband actually present. Justification will also include
+**behavioral** evidence once B.3 lands ("the smuggler tried to bribe his way out of
+a search" → grounds for arrest); `_EVIDENCE_FINDINGS` is the seam for that.
 
-`derive_disposition` is unchanged; this is a refactor of the **decision scorer**
+`derive_disposition` is unchanged; this was a refactor of the **decision scorer**
 (penalty lookup + accumulation + the evidence check) and the shift terminal
 condition (penalty-threshold instead of correct-count). `CredentialCaseResult`
-records the per-case penalty.
+records the per-case `penalty` and an `unjustified` flag.
+
+### 3. Per-rule-set scoring + adversarial mediation (LANDED scoring 2026-06-05; degrade-events deferred)
+
+Scoring is **per rule set**, not a global constant. The penalty matrix is a
+per-game field (`penalty_matrix`, string-keyed by disposition value so it stays
+JSON-safe), defaulting to the standard rule-of-law matrix above. A world overrides
+it to score a different regime. The motivating example — **"arrest everyone, any
+non-arrest is a failure"** — is just a matrix where a non-arrest is a hard failure
+rather than a mild hedge:
+
+```text
+should arrest = { allow: 5, deny: 5, arrest: 0 }   # decree: only arrest is clean
+```
+
+There are **two independent ways to express such a regime**, and they compose:
+
+- **Decree via matrix** — set `expected_disposition` (or the matrix) so ARREST is
+  the only zero-penalty call even on *clean* packets. You arrest the innocent; the
+  regime, not the packet, defines correct. Leave `no_evidence_penalty` at 0.
+- **Manufactured grounds via generation** — author the shift with a skewed
+  `disposition_distribution` (e.g. `{ARREST: 1.0}`); `generate_roster`/`make_offer`
+  degrade every packet (FORGED / WRONG_HOLDER / CONCEALED, etc.) until it *derives*
+  to ARREST. The arrest is then "justified" by a real (planted) violation. This is
+  the existing factory machinery — "build legal, then degrade by target
+  disposition" — pointed at a uniform target.
+
+**Adversarial / packet-degrading mediations (deferred).** The B.1/B.2 mediations
+are *clearing* (favorable: request_document, relinquish, disclosure). Their mirror
+image is a **degrade** transform that worsens the packet during play — lose a
+packet piece, smear a date to invalid, strip a seal — the corrupt-gatekeeper move
+that manufactures grounds *in the moment* rather than at generation. The transforms
+themselves already exist as `FailureMode`s (`MISSING_PERMIT` = lose a piece,
+`EXPIRED_ID`/`BAD_DATE` = invalidate a date); what is deferred is a **live event /
+move** that applies one mid-case and re-derives. Model it as the adversarial
+counterpart of `finding_status` (a `case_mutations` overlay so `advance_case` still
+resets cleanly and the underlying authored packet is untouched), gated behind a
+regime flag so only a corruption-flavored skin exposes it.
 
 ### Generation: presentation vs. truth (confirmed)
 

--- a/engine/src/tangl/mechanics/games/__init__.py
+++ b/engine/src/tangl/mechanics/games/__init__.py
@@ -117,6 +117,7 @@ from .credentials_game import (
     CredentialsMove,
     derive_disposition,
     disposition_penalty,
+    default_penalty_matrix,
     DISPOSITION_PENALTY,
     move_time_cost,
 )
@@ -192,6 +193,7 @@ __all__ = [
     "CredentialCaseResult",
     "derive_disposition",
     "disposition_penalty",
+    "default_penalty_matrix",
     "DISPOSITION_PENALTY",
     "move_time_cost",
     "ContrabandItem",

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -174,6 +174,9 @@ class CredentialCaseResult(BaseModelPlus):
     expected_disposition: CredentialDisposition
     correct: bool
     penalty: int = 0
+    # True when the call was correct but unbacked by surfaced evidence and the
+    # no_evidence_penalty toggle was on (the "justify your disposition" tax fired).
+    unjustified: bool = False
     discovered_findings: dict[str, str] = Field(default_factory=dict)
     packet_findings: dict[str, str] = Field(default_factory=dict)
 
@@ -218,20 +221,40 @@ def _worse(a: CredentialDisposition, b: CredentialDisposition) -> CredentialDisp
 # (The "+1 right-but-unjustified" evidence tax lands with the justification model
 # in B.3, where behavioral evidence -- a declined search, a bribe attempt --
 # also counts as justification.)
-_D = CredentialDisposition
-DISPOSITION_PENALTY: dict[CredentialDisposition, dict[CredentialDisposition, int]] = {
-    _D.PASS: {_D.PASS: 0, _D.DENY: 2, _D.ARREST: 5},
-    _D.DENY: {_D.PASS: 2, _D.DENY: 0, _D.ARREST: 5},
-    _D.ARREST: {_D.PASS: 5, _D.DENY: 2, _D.ARREST: 0},
+# String-keyed (disposition .value) so it is a plain JSON-serializable structure
+# a world can override per rule set. The default is the standard rule-of-law
+# matrix; a regime could supply, e.g., {"arrest": {"pass": 5, "deny": 5,
+# "arrest": 0}} to make any non-arrest a hard failure.
+DISPOSITION_PENALTY: dict[str, dict[str, int]] = {
+    "pass": {"pass": 0, "deny": 2, "arrest": 5},
+    "deny": {"pass": 2, "deny": 0, "arrest": 5},
+    "arrest": {"pass": 5, "deny": 2, "arrest": 0},
 }
 
 
-def disposition_penalty(
-    expected: CredentialDisposition, chosen: CredentialDisposition
-) -> int:
-    """Penalty for choosing ``chosen`` when ``expected`` was correct."""
+def default_penalty_matrix() -> dict[str, dict[str, int]]:
+    """A fresh copy of the standard penalty matrix (for per-game defaults)."""
 
-    return DISPOSITION_PENALTY[expected][chosen]
+    return {expected: dict(row) for expected, row in DISPOSITION_PENALTY.items()}
+
+
+def disposition_penalty(
+    expected: CredentialDisposition,
+    chosen: CredentialDisposition,
+    matrix: dict[str, dict[str, int]] | None = None,
+) -> int:
+    """Penalty for choosing ``chosen`` when ``expected`` was correct, under
+    ``matrix`` (the standard matrix by default)."""
+
+    return (matrix or DISPOSITION_PENALTY)[expected.value][chosen.value]
+
+
+# finding_status values that represent *surfaced* evidence -- an investigation
+# that turned a problem up ("confirmed"), repaired a mitigatable one ("cleared"),
+# or recovered contraband ("yielded"). A plain "verified" (checked, sound) is not
+# adverse evidence, so it is excluded. Behavioral evidence (a declined search, a
+# bribe attempt) extends this set in Phase B.3.
+_EVIDENCE_FINDINGS = frozenset({"confirmed", "cleared", "yielded"})
 
 
 # Time cost of each action, in shift-budget units. Cheap probes (a glance at a
@@ -425,8 +448,18 @@ class CredentialsGame(PickingGame):
     allow_arrest: bool = True
     # The shift is lost when accumulated penalty exceeds this. 0 is the strict
     # default (any wrong call ends the shift); a world raises it for a more
-    # forgiving day. Penalty = decision penalties (DISPOSITION_PENALTY) + overtime.
+    # forgiving day. Penalty = decision penalties + overtime.
     penalty_threshold: int = 0
+    # Scoring is per rule set. The penalty matrix (keyed by disposition value)
+    # is overridable so a regime can score differently -- e.g. "arrest everyone,
+    # any non-arrest fails". no_evidence_penalty is the toggle for the "justify
+    # your disposition" tax: when > 0, a *correct* deny/arrest that is not backed
+    # by a revealed finding costs that much (off by default; a decree regime that
+    # needs no evidence leaves it at 0).
+    penalty_matrix: dict[str, dict[str, int]] = Field(
+        default_factory=default_penalty_matrix
+    )
+    no_evidence_penalty: int = 0
     # Soft attention/time budget. None disables time pressure (the default).
     # When set, every probe and decision costs time (see _MOVE_TIME_COST); time
     # spent over the budget converts to penalty at overtime_penalty_rate. Going
@@ -662,6 +695,7 @@ class CredentialsGame(PickingGame):
                 "credential_total_penalty": self.total_penalty,
                 "credential_decision_penalty": self.decision_penalty,
                 "credential_penalty_threshold": self.penalty_threshold,
+                "credential_no_evidence_penalty": self.no_evidence_penalty,
                 "credential_time_budget": self.time_budget,
                 "credential_time_spent": self.time_spent,
                 "credential_overtime": self.overtime,
@@ -792,6 +826,25 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         game.current_stage = "packet"
         return RoundResult.CONTINUE
 
+    def _has_surfaced_evidence(self, game: CredentialsGame) -> bool:
+        """Whether the player surfaced any adverse evidence for the active case.
+
+        Backs the no_evidence_penalty toggle: a correct rejection is "justified"
+        only if the player actually turned something up -- a revealed document or
+        packet finding, an adverse finding_status, or a logged declaration of
+        contraband that is actually present.
+        """
+
+        if game.revealed_findings or game.packet_findings:
+            return True
+        fs = game.finding_status
+        if any(value in _EVIDENCE_FINDINGS for value in fs.values()):
+            return True
+        # A logged disclosure counts only when there was something to declare.
+        if fs.get("disclosure") in ("declared", "too_late") and game.active_case.get_contraband():
+            return True
+        return False
+
     def resolve_decision(
         self,
         game: CredentialsGame,
@@ -802,7 +855,21 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         chosen = CredentialDisposition(target)
         expected = game.expected_disposition(case)
         correct = chosen == expected
-        penalty = disposition_penalty(expected, chosen)
+        # Scoring is per rule set: the penalty matrix is the game's, not a global.
+        penalty = disposition_penalty(expected, chosen, game.penalty_matrix)
+
+        # The "justify your disposition" tax (opt-in, off by default): a *correct*
+        # rejection that the player never backed with surfaced evidence still
+        # costs no_evidence_penalty. A decree regime that needs no evidence leaves
+        # the toggle at 0; a rule-of-law regime sets it to make profiling cost.
+        unjustified = (
+            penalty == 0
+            and game.no_evidence_penalty > 0
+            and chosen in (CredentialDisposition.DENY, CredentialDisposition.ARREST)
+            and not self._has_surfaced_evidence(game)
+        )
+        if unjustified:
+            penalty += game.no_evidence_penalty
 
         game.case_results.append(
             CredentialCaseResult(
@@ -811,6 +878,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                 expected_disposition=expected,
                 correct=correct,
                 penalty=penalty,
+                unjustified=unjustified,
                 discovered_findings=dict(game.revealed_findings),
                 packet_findings=dict(game.packet_findings),
             )
@@ -819,6 +887,8 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         detail["candidate"] = case.candidate_name
         detail["credential_stage"] = game.current_stage
         detail["penalty"] = penalty
+        if unjustified:
+            detail["unjustified"] = True
         if correct:
             game.score["player"] = game.score.get("player", 0) + 1
             detail["outcome"] = "correct_disposition"

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -244,9 +244,16 @@ def disposition_penalty(
     matrix: dict[str, dict[str, int]] | None = None,
 ) -> int:
     """Penalty for choosing ``chosen`` when ``expected`` was correct, under
-    ``matrix`` (the standard matrix by default)."""
+    ``matrix`` (the standard matrix by default).
 
-    return (matrix or DISPOSITION_PENALTY)[expected.value][chosen.value]
+    A custom matrix may be *partial* -- a regime can override just the rows/cells
+    that differ from the standard (e.g. only the ``"arrest"`` row) and any missing
+    expected-row or chosen-cell falls back to the standard matrix.
+    """
+
+    m = matrix or DISPOSITION_PENALTY
+    row = m.get(expected.value, DISPOSITION_PENALTY[expected.value])
+    return row.get(chosen.value, DISPOSITION_PENALTY[expected.value][chosen.value])
 
 
 # finding_status values that represent *surfaced* evidence -- an investigation
@@ -826,23 +833,66 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         game.current_stage = "packet"
         return RoundResult.CONTINUE
 
-    def _has_surfaced_evidence(self, game: CredentialsGame) -> bool:
-        """Whether the player surfaced any adverse evidence for the active case.
+    def _rejection_is_justified(self, game: CredentialsGame) -> bool:
+        """Whether a deny/arrest on the active case is backed by evidence -- either
+        surfaced by the player's investigation or self-evidently visible. Backs the
+        no_evidence_penalty toggle (only an *unjustified* correct rejection is
+        taxed), and errs toward "justified" so the tax never punishes a fair call.
+        """
 
-        Backs the no_evidence_penalty toggle: a correct rejection is "justified"
-        only if the player actually turned something up -- a revealed document or
-        packet finding, an adverse finding_status, or a logged declaration of
-        contraband that is actually present.
+        return self._has_surfaced_evidence(game) or self._has_visible_grounds(game)
+
+    def _has_surfaced_evidence(self, game: CredentialsGame) -> bool:
+        """Adverse evidence the player turned up: a revealed document/packet
+        finding, an adverse finding_status, or a logged declaration of contraband
+        actually present.
         """
 
         if game.revealed_findings or game.packet_findings:
             return True
         fs = game.finding_status
-        if any(value in _EVIDENCE_FINDINGS for value in fs.values()):
+        for key, value in fs.items():
+            if value not in _EVIDENCE_FINDINGS:
+                continue
+            # A *clean* search ("search": "cleared") turned nothing up -- it is
+            # not adverse evidence and must not suppress the tax on an unrelated
+            # unsurfaced issue.
+            if key == "search" and value == "cleared":
+                continue
             return True
         # A logged disclosure counts only when there was something to declare.
         if fs.get("disclosure") in ("declared", "too_late") and game.active_case.get_contraband():
             return True
+        return False
+
+    def _has_visible_grounds(self, game: CredentialsGame) -> bool:
+        """Self-evident grounds for a rejection -- facts visible without any
+        investigation: a credential the purpose plainly requires but the packet
+        does not hold, or openly (non-concealed) contraband that is forbidden or
+        plainly missing its permit. A concealed item is *not* self-evident, and a
+        declared declaration-only item is allowed (not grounds), so neither counts.
+        """
+
+        case = game.active_case
+        rules = game.restriction_map
+        region = case.get_region()
+
+        purpose = case.get_purpose()
+        plevel = rules.level_for(region, purpose, RestrictionLevel.ANONYMOUS)
+        if plevel is not RestrictionLevel.FORBIDDEN:
+            if plevel.requires_id and case.id_status() is None:
+                return True
+            if plevel.requires_permit and case.credential_for(purpose) is None:
+                return True
+
+        for item in case.get_contraband():
+            if item.concealed:
+                continue  # a hidden item's grounds are not self-evident
+            clevel = rules.level_for(region, item.indication, RestrictionLevel.FORBIDDEN)
+            if clevel is RestrictionLevel.FORBIDDEN:
+                return True  # openly forbidden goods
+            if clevel.requires_permit and case.credential_for(item.indication) is None:
+                return True  # visible item, plainly missing its permit
         return False
 
     def resolve_decision(
@@ -859,14 +909,16 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         penalty = disposition_penalty(expected, chosen, game.penalty_matrix)
 
         # The "justify your disposition" tax (opt-in, off by default): a *correct*
-        # rejection that the player never backed with surfaced evidence still
-        # costs no_evidence_penalty. A decree regime that needs no evidence leaves
+        # rejection that is backed by neither surfaced nor self-evident evidence
+        # still costs no_evidence_penalty. Keyed off ``correct`` (not penalty == 0)
+        # so a custom matrix that tolerates a non-expected call at zero cost is not
+        # mistaken for a correct one. A decree regime that needs no evidence leaves
         # the toggle at 0; a rule-of-law regime sets it to make profiling cost.
         unjustified = (
-            penalty == 0
+            correct
             and game.no_evidence_penalty > 0
             and chosen in (CredentialDisposition.DENY, CredentialDisposition.ARREST)
-            and not self._has_surfaced_evidence(game)
+            and not self._rejection_is_justified(game)
         )
         if unjustified:
             penalty += game.no_evidence_penalty

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -879,11 +879,12 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
 
         purpose = case.get_purpose()
         plevel = rules.level_for(region, purpose, RestrictionLevel.ANONYMOUS)
-        if plevel is not RestrictionLevel.FORBIDDEN:
-            if plevel.requires_id and case.id_status() is None:
-                return True
-            if plevel.requires_permit and case.credential_for(purpose) is None:
-                return True
+        if plevel is RestrictionLevel.FORBIDDEN:
+            return True  # the stated purpose is itself disallowed -- self-evident
+        if plevel.requires_id and case.id_status() is None:
+            return True
+        if plevel.requires_permit and case.credential_for(purpose) is None:
+            return True
 
         for item in case.get_contraband():
             if item.concealed:

--- a/engine/tests/mechanics/games/test_credentials_scoring_config.py
+++ b/engine/tests/mechanics/games/test_credentials_scoring_config.py
@@ -37,6 +37,7 @@ RULES = Restrictions.from_map(
             IND.TRAVEL: L.WITH_ID,
             IND.WEAPON: L.WITH_PERMIT,
             IND.DRUGS: L.FORBIDDEN,
+            IND.WORK: L.FORBIDDEN,  # the purpose itself is disallowed today
         }
     }
 )
@@ -76,6 +77,18 @@ def _missing_id_case(name: str = "Cleo") -> CredentialCase:
         purpose=IND.TRAVEL,
         presented_documents={"passport": "(none presented)"},
         id_card=None,
+        packet=[],
+    )
+
+
+def _forbidden_purpose_case(name: str = "Eve") -> CredentialCase:
+    # Valid id, but the stated purpose (WORK) is forbidden today -> expected DENY;
+    # the purpose itself is the visible ground, nothing to inspect.
+    return CredentialCase(
+        candidate_name=name,
+        purpose=IND.WORK,
+        presented_documents={"passport": "An id."},
+        id_card=_id(),
         packet=[],
     )
 
@@ -265,6 +278,16 @@ class TestEvidenceTaxEdgeCases:
         # No id presented for a WITH_ID purpose: the absence is visible, so a deny
         # is justified without any inspection -- not taxed.
         game, handler = _game([_missing_id_case()], no_evidence_penalty=1)
+        _decide(handler, game, "deny")
+        result = game.case_results[-1]
+        assert result.correct is True
+        assert result.unjustified is False
+        assert result.penalty == 0
+
+    def test_forbidden_purpose_is_self_evident(self) -> None:
+        # The stated purpose is disallowed today; denying needs no inspection.
+        game, handler = _game([_forbidden_purpose_case()], no_evidence_penalty=1)
+        assert game.expected_disposition(game.active_case) is D.DENY
         _decide(handler, game, "deny")
         result = game.case_results[-1]
         assert result.correct is True

--- a/engine/tests/mechanics/games/test_credentials_scoring_config.py
+++ b/engine/tests/mechanics/games/test_credentials_scoring_config.py
@@ -11,6 +11,7 @@ Two regimes exercise the generality:
 from __future__ import annotations
 
 from tangl.mechanics.games import (
+    ContrabandItem,
     CredentialCase,
     CredentialDisposition,
     CredentialStatus,
@@ -31,7 +32,13 @@ IND = Indication
 L = RestrictionLevel
 
 RULES = Restrictions.from_map(
-    {Region.LOCAL: {IND.TRAVEL: L.WITH_ID, IND.WEAPON: L.WITH_PERMIT}}
+    {
+        Region.LOCAL: {
+            IND.TRAVEL: L.WITH_ID,
+            IND.WEAPON: L.WITH_PERMIT,
+            IND.DRUGS: L.FORBIDDEN,
+        }
+    }
 )
 
 
@@ -62,14 +69,39 @@ def _bad_id_case(name: str = "Boris") -> CredentialCase:
     )
 
 
-def _game(roster, **overrides):
+def _missing_id_case(name: str = "Cleo") -> CredentialCase:
+    # WITH_ID purpose but no id at all -> expected DENY; the absence is visible.
+    return CredentialCase(
+        candidate_name=name,
+        purpose=IND.TRAVEL,
+        presented_documents={"passport": "(none presented)"},
+        id_card=None,
+        packet=[],
+    )
+
+
+def _declared_drugs_case(name: str = "Dmitri") -> CredentialCase:
+    # Openly carried (non-concealed) forbidden goods -> expected DENY; visible.
+    return CredentialCase(
+        candidate_name=name,
+        purpose=IND.TRAVEL,
+        presented_documents={"passport": "An id."},
+        id_card=_id(),
+        packet=[],
+        possessions=[ContrabandItem(indication=IND.DRUGS)],
+    )
+
+
+def _game(
+    roster: list[CredentialCase], **overrides: object
+) -> tuple[CredentialsGame, CredentialsGameHandler]:
     game = CredentialsGame(roster=roster, restriction_map=RULES, **overrides)
     handler = CredentialsGameHandler()
     handler.setup(game)
     return game, handler
 
 
-def _decide(handler, game, call: str) -> None:
+def _decide(handler: CredentialsGameHandler, game: CredentialsGame, call: str) -> None:
     handler.receive_move(game, ("decide", call))
 
 
@@ -99,21 +131,25 @@ class TestDefaultMatrix:
 # --------------------------------------------------------------------------- #
 # a decree regime overrides the matrix
 # --------------------------------------------------------------------------- #
-class TestDecreeRegime:
-    """'Arrest everyone, any non-arrest is a failure.'"""
+def _decree_matrix() -> dict[str, dict[str, int]]:
+    """A fresh 'arrest everyone' matrix: a non-arrest is a hard failure."""
 
-    DECREE = {
+    return {
         "pass": {"pass": 0, "deny": 2, "arrest": 5},
         "deny": {"pass": 2, "deny": 0, "arrest": 5},
         # under decree a non-arrest is a hard failure, not a mild hedge
         "arrest": {"pass": 5, "deny": 5, "arrest": 0},
     }
 
+
+class TestDecreeRegime:
+    """'Arrest everyone, any non-arrest is a failure.'"""
+
     def test_non_arrest_is_a_hard_failure(self) -> None:
         # A candidate whose expected call is ARREST, denied -> decree penalty 5.
         case = _bad_id_case()
         case.correct_disposition = D.ARREST  # the regime's expectation
-        game, handler = _game([case], penalty_matrix=self.DECREE, penalty_threshold=0)
+        game, handler = _game([case], penalty_matrix=_decree_matrix(), penalty_threshold=0)
         _decide(handler, game, "deny")
         assert game.case_results[-1].penalty == 5
         assert game.result.name == "LOSE"
@@ -121,7 +157,7 @@ class TestDecreeRegime:
     def test_arrest_is_clean_under_decree(self) -> None:
         case = _bad_id_case()
         case.correct_disposition = D.ARREST
-        game, handler = _game([case], penalty_matrix=self.DECREE)
+        game, handler = _game([case], penalty_matrix=_decree_matrix())
         _decide(handler, game, "arrest")
         assert game.case_results[-1].penalty == 0
         assert game.result.name == "WIN"
@@ -131,10 +167,28 @@ class TestDecreeRegime:
         # unbacked correct arrest is not taxed.
         case = _bad_id_case()
         case.correct_disposition = D.ARREST
-        game, handler = _game([case], penalty_matrix=self.DECREE)
+        game, handler = _game([case], penalty_matrix=_decree_matrix())
         _decide(handler, game, "arrest")  # no inspection at all
         assert game.case_results[-1].unjustified is False
         assert game.case_results[-1].penalty == 0
+
+    def test_partial_matrix_overrides_only_named_cells(self) -> None:
+        # A regime can supply just the row it wants to change; missing rows/cells
+        # fall back to the standard matrix.
+        partial = {"arrest": {"pass": 5, "deny": 5, "arrest": 0}}
+        case = _bad_id_case()
+        case.correct_disposition = D.ARREST
+        game, handler = _game([case], penalty_matrix=partial)
+        _decide(handler, game, "deny")  # overridden cell -> 5
+        assert game.case_results[-1].penalty == 5
+
+    def test_partial_matrix_falls_back_for_unspecified_rows(self) -> None:
+        # The "deny" row is unspecified, so a wrong call against a should-deny
+        # candidate uses the standard penalty (deny->arrest = 5).
+        partial = {"arrest": {"pass": 5, "deny": 5, "arrest": 0}}
+        game, handler = _game([_bad_id_case()], penalty_matrix=partial)  # expected DENY
+        _decide(handler, game, "arrest")
+        assert game.case_results[-1].penalty == 5  # standard deny->arrest
 
 
 # --------------------------------------------------------------------------- #
@@ -176,7 +230,7 @@ class TestEvidenceTax:
 
     def test_wrong_call_is_not_double_charged(self) -> None:
         # A wrong call already carries matrix penalty; the evidence tax only fires
-        # on correct (penalty == 0) rejections, so a wrong deny is unaffected.
+        # on *correct* rejections, so a wrong deny is unaffected.
         game, handler = _game([_clean_case()], no_evidence_penalty=1)
         _decide(handler, game, "deny")  # expected PASS -> wrong
         result = game.case_results[-1]
@@ -192,3 +246,57 @@ class TestEvidenceTax:
     def test_namespace_exposes_toggle(self) -> None:
         game, _ = _game([_clean_case()], no_evidence_penalty=2)
         assert game.to_namespace()["credential_no_evidence_penalty"] == 2
+
+
+class TestEvidenceTaxEdgeCases:
+    """Special-handling cases for what counts as evidence."""
+
+    def test_clean_search_does_not_count_as_evidence(self) -> None:
+        # A clean search turned nothing up; it must not suppress the tax on an
+        # unrelated unsurfaced issue (the expired id).
+        game, handler = _game([_bad_id_case()], no_evidence_penalty=1)
+        handler.receive_move(game, ("request_search", ""))  # clean -> "cleared"
+        assert game.finding_status.get("search") == "cleared"
+        _decide(handler, game, "deny")
+        assert game.case_results[-1].unjustified is True
+        assert game.case_results[-1].penalty == 1
+
+    def test_missing_required_credential_is_self_evident(self) -> None:
+        # No id presented for a WITH_ID purpose: the absence is visible, so a deny
+        # is justified without any inspection -- not taxed.
+        game, handler = _game([_missing_id_case()], no_evidence_penalty=1)
+        _decide(handler, game, "deny")
+        result = game.case_results[-1]
+        assert result.correct is True
+        assert result.unjustified is False
+        assert result.penalty == 0
+
+    def test_openly_declared_forbidden_contraband_is_self_evident(self) -> None:
+        # Visibly-carried forbidden goods justify a deny on their face -- not taxed.
+        game, handler = _game([_declared_drugs_case()], no_evidence_penalty=1)
+        assert game.expected_disposition(game.active_case) is D.DENY
+        _decide(handler, game, "deny")
+        result = game.case_results[-1]
+        assert result.unjustified is False
+        assert result.penalty == 0
+
+    def test_concealed_contraband_is_not_self_evident(self) -> None:
+        # A *concealed* item is hidden: denying without searching is unjustified.
+        case = _declared_drugs_case()
+        case.possessions = [ContrabandItem(indication=IND.DRUGS, concealed=True)]
+        game, handler = _game([case], no_evidence_penalty=1)
+        assert game.expected_disposition(game.active_case) is D.ARREST  # smuggling
+        _decide(handler, game, "arrest")  # correct, but blind
+        assert game.case_results[-1].unjustified is True
+
+    def test_tax_keys_off_correct_not_zero_penalty(self) -> None:
+        # A lenient matrix tolerates a deny of a clean candidate at zero cost. The
+        # call is *wrong* (expected PASS), so the evidence tax must not fire even
+        # though the matrix penalty is 0.
+        lenient = {"pass": {"pass": 0, "deny": 0, "arrest": 5}}
+        game, handler = _game([_clean_case()], penalty_matrix=lenient, no_evidence_penalty=1)
+        _decide(handler, game, "deny")  # expected PASS -> wrong, but tolerated
+        result = game.case_results[-1]
+        assert result.correct is False
+        assert result.unjustified is False
+        assert result.penalty == 0  # tolerated, and not taxed

--- a/engine/tests/mechanics/games/test_credentials_scoring_config.py
+++ b/engine/tests/mechanics/games/test_credentials_scoring_config.py
@@ -1,0 +1,194 @@
+"""Tests for per-rule-set scoring configuration (CREDENTIALS_LOOP_DESIGN.md
+"Engine review" §2): the penalty matrix is a per-game knob, and the
+no_evidence_penalty toggle taxes correct-but-unbacked rejections.
+
+Two regimes exercise the generality:
+  * a rule-of-law gate that wants dispositions justified by evidence; and
+  * a decree regime ("arrest everyone, any non-arrest fails") whose penalty
+    matrix makes deny/pass hard failures and leaves the evidence toggle off.
+"""
+
+from __future__ import annotations
+
+from tangl.mechanics.games import (
+    CredentialCase,
+    CredentialDisposition,
+    CredentialStatus,
+    CredentialToken,
+    CredentialsGame,
+    CredentialsGameHandler,
+    Indication,
+    Region,
+    Restrictions,
+    RestrictionLevel,
+    default_penalty_matrix,
+    disposition_penalty,
+)
+
+D = CredentialDisposition
+S = CredentialStatus
+IND = Indication
+L = RestrictionLevel
+
+RULES = Restrictions.from_map(
+    {Region.LOCAL: {IND.TRAVEL: L.WITH_ID, IND.WEAPON: L.WITH_PERMIT}}
+)
+
+
+def _id(status: S = S.VALID) -> CredentialToken:
+    return CredentialToken(indication=IND.TRAVEL, status=status)
+
+
+def _clean_case(name: str = "Ada") -> CredentialCase:
+    return CredentialCase(
+        candidate_name=name,
+        purpose=IND.TRAVEL,
+        presented_documents={"passport": "An id."},
+        id_card=_id(),
+        packet=[],
+    )
+
+
+def _bad_id_case(name: str = "Boris") -> CredentialCase:
+    # Expired id -> WITH_ID requirement unmet -> expected DENY. The expiry is a
+    # hidden fact, so inspecting the passport surfaces the evidence for the deny.
+    return CredentialCase(
+        candidate_name=name,
+        purpose=IND.TRAVEL,
+        presented_documents={"passport": "A worn id."},
+        hidden_facts={"passport": "The expiry date has slipped past."},
+        id_card=_id(S.EXPIRED),
+        packet=[],
+    )
+
+
+def _game(roster, **overrides):
+    game = CredentialsGame(roster=roster, restriction_map=RULES, **overrides)
+    handler = CredentialsGameHandler()
+    handler.setup(game)
+    return game, handler
+
+
+def _decide(handler, game, call: str) -> None:
+    handler.receive_move(game, ("decide", call))
+
+
+# --------------------------------------------------------------------------- #
+# default matrix as a per-game field
+# --------------------------------------------------------------------------- #
+class TestDefaultMatrix:
+    def test_default_matrix_is_the_standard(self) -> None:
+        game = CredentialsGame()
+        assert game.penalty_matrix == default_penalty_matrix()
+        assert game.penalty_matrix["pass"]["arrest"] == 5
+        assert game.penalty_matrix["deny"]["pass"] == 2
+
+    def test_default_factory_is_not_shared(self) -> None:
+        a = CredentialsGame()
+        b = CredentialsGame()
+        a.penalty_matrix["pass"]["deny"] = 99
+        assert b.penalty_matrix["pass"]["deny"] == 2  # independent copies
+
+    def test_helper_accepts_an_explicit_matrix(self) -> None:
+        decree = {"arrest": {"pass": 5, "deny": 5, "arrest": 0}}
+        assert disposition_penalty(D.ARREST, D.DENY, decree) == 5
+        # default unchanged
+        assert disposition_penalty(D.ARREST, D.DENY) == 2
+
+
+# --------------------------------------------------------------------------- #
+# a decree regime overrides the matrix
+# --------------------------------------------------------------------------- #
+class TestDecreeRegime:
+    """'Arrest everyone, any non-arrest is a failure.'"""
+
+    DECREE = {
+        "pass": {"pass": 0, "deny": 2, "arrest": 5},
+        "deny": {"pass": 2, "deny": 0, "arrest": 5},
+        # under decree a non-arrest is a hard failure, not a mild hedge
+        "arrest": {"pass": 5, "deny": 5, "arrest": 0},
+    }
+
+    def test_non_arrest_is_a_hard_failure(self) -> None:
+        # A candidate whose expected call is ARREST, denied -> decree penalty 5.
+        case = _bad_id_case()
+        case.correct_disposition = D.ARREST  # the regime's expectation
+        game, handler = _game([case], penalty_matrix=self.DECREE, penalty_threshold=0)
+        _decide(handler, game, "deny")
+        assert game.case_results[-1].penalty == 5
+        assert game.result.name == "LOSE"
+
+    def test_arrest_is_clean_under_decree(self) -> None:
+        case = _bad_id_case()
+        case.correct_disposition = D.ARREST
+        game, handler = _game([case], penalty_matrix=self.DECREE)
+        _decide(handler, game, "arrest")
+        assert game.case_results[-1].penalty == 0
+        assert game.result.name == "WIN"
+
+    def test_decree_leaves_no_evidence_toggle_off(self) -> None:
+        # Arresting-by-decree needs no evidence; the toggle defaults to 0 so an
+        # unbacked correct arrest is not taxed.
+        case = _bad_id_case()
+        case.correct_disposition = D.ARREST
+        game, handler = _game([case], penalty_matrix=self.DECREE)
+        _decide(handler, game, "arrest")  # no inspection at all
+        assert game.case_results[-1].unjustified is False
+        assert game.case_results[-1].penalty == 0
+
+
+# --------------------------------------------------------------------------- #
+# no_evidence_penalty toggle
+# --------------------------------------------------------------------------- #
+class TestEvidenceTax:
+    def test_off_by_default(self) -> None:
+        game, handler = _game([_bad_id_case()])
+        assert game.no_evidence_penalty == 0
+        _decide(handler, game, "deny")  # correct, but no inspection
+        assert game.case_results[-1].penalty == 0
+        assert game.case_results[-1].unjustified is False
+
+    def test_correct_unbacked_deny_is_taxed(self) -> None:
+        game, handler = _game([_bad_id_case()], no_evidence_penalty=1, penalty_threshold=0)
+        _decide(handler, game, "deny")  # correct call, no evidence surfaced
+        result = game.case_results[-1]
+        assert result.correct is True
+        assert result.unjustified is True
+        assert result.penalty == 1
+        assert game.result.name == "LOSE"  # tax pushed over the strict threshold
+
+    def test_backed_deny_is_not_taxed(self) -> None:
+        game, handler = _game([_bad_id_case()], no_evidence_penalty=1)
+        handler.receive_move(game, ("inspect", "passport"))  # surfaces the expiry
+        _decide(handler, game, "deny")
+        result = game.case_results[-1]
+        assert result.unjustified is False
+        assert result.penalty == 0
+        assert game.result.name == "WIN"
+
+    def test_correct_pass_is_never_taxed(self) -> None:
+        # Waving a clean candidate through needs no evidence -- only rejections do.
+        game, handler = _game([_clean_case()], no_evidence_penalty=1)
+        _decide(handler, game, "pass")
+        result = game.case_results[-1]
+        assert result.unjustified is False
+        assert result.penalty == 0
+
+    def test_wrong_call_is_not_double_charged(self) -> None:
+        # A wrong call already carries matrix penalty; the evidence tax only fires
+        # on correct (penalty == 0) rejections, so a wrong deny is unaffected.
+        game, handler = _game([_clean_case()], no_evidence_penalty=1)
+        _decide(handler, game, "deny")  # expected PASS -> wrong
+        result = game.case_results[-1]
+        assert result.correct is False
+        assert result.unjustified is False
+        assert result.penalty == 2  # pure matrix penalty, no +tax
+
+    def test_tax_rate_scales(self) -> None:
+        game, handler = _game([_bad_id_case()], no_evidence_penalty=3, penalty_threshold=10)
+        _decide(handler, game, "deny")
+        assert game.case_results[-1].penalty == 3
+
+    def test_namespace_exposes_toggle(self) -> None:
+        game, _ = _game([_clean_case()], no_evidence_penalty=2)
+        assert game.to_namespace()["credential_no_evidence_penalty"] == 2


### PR DESCRIPTION
Makes the credentials shift **scoring per rule set** rather than a hardcoded
global, and adds the deferred evidence tax as an opt-in toggle. Builds directly
on the penalty-matrix scorer (#263) and soft time budget (#264).

## What changed

- **`penalty_matrix` is a per-game field** (string-keyed by disposition value so
  it stays JSON-safe for the VM `value_hash`), defaulting to the standard
  rule-of-law matrix. A world overrides it to score a different regime. The
  motivating example — **"arrest everyone, any non-arrest is a failure"** — is
  just a matrix where a non-arrest is a hard failure rather than a mild hedge:
  `{ arrest: { allow: 5, deny: 5, arrest: 0 } }`.
- **`no_evidence_penalty` toggle** (off by default): a *correct* deny/arrest that
  the player never backed with surfaced evidence costs that much — the "justify
  your disposition" tax, finally landing the +1 that was deferred from the
  scorer. It's regime-specific: a rule-of-law gate turns it on; an
  arrest-by-decree regime leaves it off (arresting without evidence is the *norm*
  there). `CredentialCaseResult` gains an `unjustified` flag; the namespace
  exposes `credential_no_evidence_penalty`.
- `disposition_penalty()` takes an optional matrix; `default_penalty_matrix()`
  backs the per-game default. `_has_surfaced_evidence()` reads revealed/packet
  findings, adverse `finding_status`, and logged contraband declarations;
  `_EVIDENCE_FINDINGS` is the seam where B.3 behavioral evidence (declined search,
  bribe attempt) will extend justification.

`derive_disposition` is unchanged — this is all decision-scorer.

## Two ways to express a decree regime (they compose)

- **Decree via matrix** — ARREST is the only zero-penalty call even on clean
  packets; you arrest the innocent.
- **Manufactured grounds via generation** — skew the roster
  `disposition_distribution` to `{ARREST: 1.0}` and the existing factory degrades
  every packet (FORGED/WRONG_HOLDER/CONCEALED…) until it *derives* to ARREST.

The genuinely new piece the design discussion raised — **live packet-degrading
mediations** (lose a piece / smear a date *mid-case*, the corrupt-gatekeeper
mirror of the clearing mediations) — is captured as deferred in the design doc
(§3); the transforms already exist as `FailureMode`s, what's deferred is a live
event/move that applies one and re-derives.

## Tests

New `test_credentials_scoring_config.py` (13): default-matrix-as-field +
non-shared factory copies, the decree regime (non-arrest hard-fails, arrest is
clean, evidence toggle stays off), and the evidence tax (off by default, correct
unbacked deny taxed, backed deny not taxed, correct pass never taxed, wrong call
not double-charged, rate scaling, namespace). Full games suite green
(263 passed, 4 skipped); credential-related cross-suite green (319 passed).

Doc: `CREDENTIALS_LOOP_DESIGN.md` §2 marked LANDED, new §3 for per-rule-set
scoring + the adversarial-mediation deferral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-game customizable penalty matrices for disposition scoring.
  * Optional evidence-justification tax (configurable) that can penalize correct deny/arrest decisions lacking surfaced or self-evident justification; per-case results now record penalty and an "unjustified" marker.

* **Tests**
  * Expanded test coverage for penalty-matrix behavior and nuanced evidence/tax edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->