### PR TITLE
B.2.1: CRIMINAL contraband tier (per-se crime, no rescue)

### DIFF
--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
@@ -1,0 +1,358 @@
+# Credential Mechanic — Design Note
+
+**Status:** PLANNED (design precedes code; this doc stakes the intended shape)
+**Scope:** the *global* credential mechanic — `Credential → Document → Media`,
+with carrier/bearer binding — that the credentials checkpoint **game**
+(`tangl.mechanics.games.credentials_game`) becomes one consumer of.
+**Relation to other docs:**
+- `tangl.mechanics.games.CREDENTIALS_LOOP_DESIGN.md` — the *game* layer (roster
+  shift, restriction map, disposition derivation, mediation). This note is its
+  global-mechanic counterpart; the game points *up* to here.
+- `tangl.media.MEDIA_DESIGN.md` — the spec→adapt→create→provision pipeline this
+  builds on.
+- `tangl.mechanics.presence` (`look/look.py`) — the bearer-portrait projection
+  this *adopts* (see below).
+- Supersedes the scratch `media/.../credforge.py` (`CredentialMediaSpec` /
+  `CredentialForge`), which predates the mature media pipeline.
+
+---
+
+## 1 · Why this is global, not game-specific
+
+The credentials *game* is one skin. The primitives underneath it are a reusable
+pattern that recurs well outside a checkpoint: the player's own papers in
+inventory, an NPC flashing a badge, an access-gated door, a comp tier, a hall
+pass. Those primitives currently live inside the games package
+(`credentials_enums.py`); promoting them to `tangl.mechanics.credentials` (a
+sibling of `presence`, `demographics`, `progression`) was always the intended
+shape.
+
+The pattern is a **projection chain**:
+
+```text
+Credential   (abstract attestation: issuer, indication, validity)
+  → Document  (carrier form: id_card / permit / ticket)
+     → Media  (visible card: frame + seal + text + bearer portrait)
+```
+
+with **carrier binding** threaded through every layer.
+
+---
+
+## 2 · The three layers
+
+### Credential
+An attestation: issuer / indication (purpose or contraband) / validity status.
+This is today's `CredentialToken` (`VALID` / `MISSING_SEAL` / `EXPIRED` /
+`FORGED` / `WRONG_HOLDER`).
+
+### Document — the carrier form
+A credential rendered as a concrete document type. Two carrier modes:
+
+- **Self-carrying** — an *id card* identifies its own holder; the bearer *is* the
+  carrier.
+- **Carrier-bound by reference** — a *permit* references an id; the binding is the
+  `holder_matches` axis, and a broken binding is `WRONG_HOLDER`. ("Carrier-bound
+  id" = the permit-references-id relationship.)
+
+### Media — the visible card
+A `CredentialCardSpec(MediaSpec)` composes the card: frame + seal(issuer,
+validity) + text(name, indication, dates) + **bearer portrait**. Built on the
+existing `MediaSpec` two-phase `adapt → create` contract, resolved through
+`MediaSpecProvisioner`, attached as a `MediaFragment` on the document's
+`PieceFragment` (which Bridge.1 already emits). Content-addressed → dedupe +
+caching + reproducibility (adapted-spec hash) for free.
+
+---
+
+## 3 · Bearer binding adopts the presence projection (the load-bearing idea)
+
+The bearer's photo is **not a credential concept**. It is the *presence system's
+portrait of whoever the credential names as bearer*. Presence already exposes
+exactly this seam:
+
+- `HasSimpleLook.adapt_look_media_spec(media_role=...) -> LookMediaPayload`
+  (`presence/look/look.py`) — any `HasLook` entity projects its appearance into a
+  media payload.
+- `Look.media_traits()` / `trait_tokens()` and the demographic enums
+  (`HairColor`, `SkinTone`, ...) are the shared vernacular.
+
+So:
+
+```text
+id_photo  =  bearer.adapt_look_media_spec(media_role="id_photo")
+```
+
+**Division of ownership:** credentials owns the *card* (frame, seal, layout,
+text); presence owns the *portrait*. The credential mechanic never generates a
+face — it asks the bearer's presence for one.
+
+This makes discrepancy rendering fall out for free:
+
+- **valid** → bind the *true bearer's* look.
+- **`WRONG_HOLDER`** → bind a *different* entity's look (or a mismatched
+  demographic), so the photo doesn't match the declared identity — a thing the
+  player can *spot*.
+
+This is the visual arm of the **build-correct-then-degrade** factory the game
+already has: the same `degrade` step that sets a token's status drives which look
+the card binds. The credential mechanic reads token status; it does not maintain
+a parallel error flag.
+
+---
+
+## 3a · Everything reduces to compiling a pile of RITs
+
+The whole media side collapses to one operation: **compose a recipe of RITs
+(background, frame, seal/overlay, text layer, optional portrait) into one
+composite RIT (or resolve to an existing one that already fills the need).**
+
+- **Non-presence-bound credentials** (permit, ticket — no portrait) compose
+  *strictly from SVG content templates + backgrounds + seals/overlays*. Each
+  layer is an SVG-rendered or static RIT, composited into one card.
+- **Presence-bound credentials** (id card) differ in exactly *one* extra step:
+  first **acquire a suitable presence projection** for the document — an
+  id-portrait-style close-up. Once that portrait RIT exists, the case **reduces
+  to the non-presence case**: it is just one more RIT in the pile.
+
+So credentials' media is a *degenerate composition* — a few fixed layers, no
+inventory. That is why it can be the **simple first consumer** that proves the
+composition pipeline before the full paperdoll system needs it.
+
+### The real shape: RIT registries + composition strategies
+
+Neither existing forge is the right tool, and both are legacy:
+
+- `svg_forge` is built for **inventorying and assembling parts out of a catalog
+  SVG** (`SvgSourceManager` → named `SvgGroup`s), not for compositing a handful of
+  independent SVG/RIT wrappers.
+- `raster_forge` is a stub whose intended job — the **avatar paperdoll
+  assembler** (layer body + outfit + ornaments from the `presence` wearable/outfit
+  stack) — is poorly named; it is really a **file/resource forge**, not a raster
+  one.
+
+The unifying target is to refactor both into **RIT registries + composition
+strategies**:
+
+- **Each layer/part is its own mini-RIT** — a catalog SVG's groups, a seal, a
+  rendered text block, a background, a portrait are all RITs, indexed in a
+  registry. (This generalizes `MediaResourceRegistry` + `SvgSourceManager` into
+  one notion: everything is a RIT.)
+- **A composition strategy** combines selected RITs into a new composite RIT —
+  SVG-assembly, raster-paste, etc. are interchangeable strategies behind one
+  interface. (This generalizes `SvgGroup` assembly and the PIL paste into one.)
+- **The composite is itself a RIT** — content-addressed, reused on identical
+  recipe, and it rides the existing `MediaFragment` journal path unchanged.
+
+A `MediaSpec` is then exactly the user's "functional description of RIT
+manipulation and composition": *select mini-RITs from registries + apply a
+strategy → composite RIT, or resolve to an existing one.*
+
+**Credentials is the degenerate consumer** of this — a few fixed layers, one
+strategy, no inventory management. The avatar paperdoll system is the rich
+consumer (large wearable inventories, many layers). They share the registry +
+strategy framework; credentials is the simplest thing that proves it.
+
+**The one hard rule:** route through the media framework — `MediaSpec →
+MediaSpecProvisioner → MediaRIT → MediaFragment`. The journal-integration path for
+a *single produced RIT already exists* (a handler emits `MediaFragment(content=
+rit)`; the service dereferences it), and a composite is just a RIT, so it rides
+the same path. The genuine gap is only the *composition framework* (registries +
+strategies). If credentials hand-rolls its own composition **and** its own journal
+emission outside this, we duplicate exactly the plumbing paperdolls also need.
+
+> **Dependency, flagged:** the registry + strategy refactor is a **media-subsystem
+> design decision**, not a credentials one. Credentials should *consume* it, not
+> drive a big media refactor on its own schedule. Phase D therefore depends on at
+> least a minimal composition-strategy surface existing; worth its own media-layer
+> design note / issue rather than being smuggled in through this mechanic.
+
+### Acquiring the portrait RIT (three modes)
+
+The id-portrait can be specified:
+
+1. **Directly** — a given portrait RIT.
+2. **By properties → selection** — demographic/look properties select from a
+   range of pre-created assets (the world portrait pool).
+3. **By properties → dynamic generation** — `comfy_forge` / `stable_forge`
+   generate from the look descriptor.
+
+A richer variant of (3) drives the **side-by-side presentation**: pre-render
+everyone's base portraits once, then send a base portrait *as an img2img/
+controlnet reference* to re-generate the candidate's appearance **today** —
+slightly different hairstyle, expression, and current clothing — for the live
+figure standing at the counter. The card carries the *official* portrait; the
+candidate standing there is a today-variation of the *same base presence*. That
+makes the compare-the-photo-to-the-face interaction literal.
+
+---
+
+## 3b · Advanced: presence-degradation mediation (deferred)
+
+Once the card photo and the live candidate are both presence projections, a
+mismatch is a **presence diff**, and severity depends on whether the mismatched
+trait is *mutable*:
+
+- **Mutable mismatch** (hair color/style, expression, clothing) — the card shows
+  blonde hair, the candidate is now brunette; they claim they recently dyed it.
+  Probably **OK** if nothing else is wrong — clearable by claim, because hair is
+  legitimately changeable.
+- **Immutable mismatch** (facial bone structure / identity) — the card's face
+  does not match the candidate's *and* the hair differs; the dyed-hair claim is a
+  cover for a **false id** → deny / arrest.
+
+So the holder-match check graduates: a same-base-identity / mutable-trait
+difference is mitigatable; a different-base-identity difference is a crime, no
+matter what claim accompanies it. This needs presence to distinguish **base
+identity** (immutable) from **mutable presentation** — advanced presence
+degradation, and a game-layer mediation outcome (a presence-aware extension of
+B.2). Deferred; noted here because it is the reason the presence projection must
+separate identity from presentation.
+
+---
+
+## 4 · Default projections + the override model ("template for the template")
+
+`tangl.mechanics.credentials` ships **default projections** so a bare credential
+renders a working card with no world-specific authoring:
+
+- a default card frame (SVG primitives),
+- a small seal set (valid / wrong / missing variants, SVG),
+- a default text/date layout,
+- a placeholder portrait silhouette (when no bearer look is available).
+
+A world or game **overrides by data, not code**: region names, seal designs,
+permit/indication catalog, card styling are provided as configuration, and the
+default projection machinery consumes them as guidance. The credentials demo game
+supplies its regions, seals, and permit types; the machinery "just does its
+thing." This is the *template for the template* — engine defaults prove the
+projection and are the copy-and-reskin starting point (Lethesford University →
+any institution).
+
+---
+
+## 5 · Media policy: three tiers, raster stays out of the engine repo
+
+Same `MediaDep`, three provisioning tiers:
+
+1. **Engine SVG defaults** — deterministic, repo-safe, `FAST_SYNC` via
+   `svg_forge` (frame/seal/text as SVG; portrait an `<image>` ref). The test and
+   conformance path.
+2. **World pre-rendered portrait pool** — a world's compile / first-run / setup
+   step generates ~N portraits matching a demographic distribution into the
+   **world media directory** (distributed with the world, content-addressed,
+   deduped). Raster here is fine — it is *not* in the engine repo.
+3. **Runtime gen-AI portrait** — optional `comfy_forge` / `stable_forge`
+   generation into **story-scope** inventory (ASYNC; soft-dependency, so the
+   card frame renders immediately and the portrait fills in).
+
+**Raster / LFS guidance.** "No raster in the engine repo" is test/demo hygiene
+(stray PNGs get LFS'd and confuse non-LFS install patterns), not dogma. It is
+waivable per-case with an explicit, documented LFS exception or a fallback. When
+a skin has *a lot* of vector media, the CarWars precedent applies: commit SVG
+under LFS and reverse the policy deliberately. The rule is really "no
+*unmanaged* raster."
+
+---
+
+## 6 · Disclosure discipline carries over
+
+The card renders the candidate's **presentation**: a forged seal draws a subtly
+wrong seal, a wrong-holder card draws a mismatched portrait, an expired card
+shows a past date. These are *visible to a careful look* — but the *finding*
+("this seal is forged") is revealed only by inspecting. The image is the visual
+analog of `presented_documents` (visible) vs. `hidden_facts` (revealed on
+inspection). The card must **not** flag "FORGED" in red; the player must notice.
+Same discipline already enforced on the move menu and info channels.
+
+---
+
+## 6a · Media is enrichment — prose carries the floor
+
+Media is a **soft dependency** (MEDIA_DESIGN): the journal text is the primary
+artifact, and the widget vocab's CLI-floor rule requires every interaction be
+reachable by a text client. So a "visual" discrepancy cannot live *only* in
+pixels. The resolution is that **the discrepancy lives in the structured truth,
+not in any one rendering channel**: a portrait mismatch is a difference in the
+`Look` data and the token status, and presence already projects that truth to
+*both* channels —
+
+- **prose** via `Look.describe()` / `trait_tokens()`,
+- **media** via `adapt_look_media_spec()`.
+
+MEDIA_DESIGN frames these as symmetric output dimensions of one adapted intent.
+So a wrong-holder card is, for a text client, a **prose look-diff**: the id reads
+"a fair-skinned woman, blonde, neutral"; the traveler at the counter reads "a
+fair-skinned woman, dark hair." The player compares two *descriptions* exactly as
+a rich client compares two *faces*. The discrepancy is reachable at the CLI
+floor; the image merely makes the comparison nicer.
+
+**The honest caveat (a real, non-blocking weak spot).** Images allow a
+discrepancy to be *present but missable* — you can simply fail to look closely at
+a faintly-wrong seal. Prose struggles to be both faithful and missable: "the
+seal's color is slightly off" already half-states the finding, where an image
+just shows the seal and lets you not notice. So a class of **subtle visual
+discrepancies** (fine seal tells, micro-expression, print-quality cues) renders
+weakly on non-visual clients — it tends to either leak or become unspottable.
+Mitigations, none of which block the media work:
+
+- author the prose to give the **raw observation, not the judgment** (describe
+  the seal's full visible detail neutrally; let the player decide), preserving
+  missability;
+- let a skin **select failure modes by client profile** — lean on coarse,
+  text-faithful discrepancies (missing seal, wrong region name, expired date,
+  whole-identity mismatch) for CLI-floor play, and reserve the subtle-visual
+  modes as enrichment that rich clients reward.
+
+In short: most credential discrepancies are structured and project cleanly to
+prose; a minority are genuinely visual-first and are simply *better* with media —
+worth naming, not worth gating the media work on.
+
+---
+
+## 7 · Staged plan (media spec is the forcing function)
+
+0. **(Media-layer prerequisite, separate track.)** A minimal **RIT registry +
+   composition-strategy** surface, replacing the legacy `svg_forge`/`raster_forge`
+   shape (§3a). Owned by media, not credentials; Phase D consumes it.
+1. **`CredentialCardSpec`** as a `MediaSpec`, built *on the media framework*
+   (`MediaSpec` → `MediaSpecProvisioner` → `MediaRIT` → `MediaFragment`) and the
+   composition surface from (0) — **not** a hand-rolled composition or journal
+   path. It reads a credential's status + carrier binding to render discrepancies,
+   and calls presence's `adapt_look_media_spec(media_role="id_photo")` for the
+   bearer portrait. The genuine *second consumer* of the credential primitives and
+   the *simplest consumer* of the composition framework.
+2. **Extract primitives** (`Credential`, `Document`, carrier binding) from
+   `games/credentials_enums.py` into `tangl.mechanics.credentials` — justified by
+   that second consumer, not on spec.
+3. **Re-point the game** at the promoted primitives; the game adds its overrides
+   (regions, seals, permits).
+4. **Default assets** land alongside (1) so the projection is provable from day
+   one.
+
+Steps 1–4 keep the merged game working; nothing is a big-bang refactor. Step 0 is
+the one genuine dependency, and it is a media-subsystem concern in its own right.
+
+---
+
+## 8 · Open questions
+
+- **Portrait pool keying.** Demographic descriptor → portrait identity mapping for
+  the world pre-render pool (so `WRONG_HOLDER` can deterministically bind a
+  *different* pool entry, and so a base portrait can be re-used as the img2img
+  reference for the side-by-side live figure). Likely a `demographics`-driven key.
+- **Where bearer identity lives for procedural candidates.** A sampled candidate
+  has no `HasLook` entity yet; the factory may need to materialize a minimal
+  presence (a `Look`) per candidate so the card can bind a portrait — and so the
+  base-identity-vs-mutable-presentation split (§3b) has somewhere to live.
+- **RIT registry + composition-strategy surface (media-layer, §3a step 0).** The
+  one genuine dependency. Unifies the legacy `svg_forge` catalog-assembler and the
+  `raster_forge`/file-forge stub into registries of mini-RITs + interchangeable
+  composition strategies producing a composite RIT. Recipe/spec format (layer list
+  + transforms + strategy + content-addressing) is the open piece. Paperdoll-
+  driven; credentials is the degenerate validating consumer, not the driver.
+  Deserves its own media-subsystem design note / issue.
+- **Journal integration of composed media.** The single-RIT path exists
+  (`MediaFragment(content=rit)` → service deref). Confirm a composite RIT rides
+  the same path unchanged (it should — a composite is just a RIT), so neither
+  credentials nor paperdolls invent a second journal channel.

--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -704,6 +704,16 @@ levels (from the restriction map for that indication):
   severity the deferred *planting* malfeasance move aims for: a discovered criminal
   good is what launders a shadow-blacklist arrest into "arrest with reason."
 
+`RestrictionLevel` is shared by purpose and contraband rules, so two corners are
+pinned for "weird but legal" authored configs: a **CRIMINAL purpose** (e.g.
+`{WORK: CRIMINAL}`) derives ARREST (the stated purpose is itself a crime; the
+purpose branch special-cases it like FORBIDDEN→DENY), and a **WITH_ID contraband**
+good is routed through `_assess_requirement` (class `"credentialed"`, = needs a
+permit and/or id) rather than treated as merely declarable, so its bearer-id check
+is not bypassed. `build_valid` keeps raising only for criminal/forbidden
+*contraband* (a caller asking to add a disallowed good); a criminal/forbidden
+*purpose* is left to derive its inherent ARREST/DENY, which the roster relies on.
+
 And **concealment is itself the violation** — concealing *any* contraband is a
 problem, independent of whether it would have been permitted. The disclosure /
 search distinction decides severity:

--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -5,7 +5,8 @@
 lazy offer roster, 2026-05-22); Phase B.1 LANDED (core mediation moves,
 2026-05-23); Phase B.2 LANDED (contraband mediation, 2026-06-04); penalty-matrix
 scorer + soft time budget + per-rule-set scoring config (configurable
-`penalty_matrix`, `no_evidence_penalty` toggle) LANDED 2026-06-05; Phases
+`penalty_matrix`, `no_evidence_penalty` toggle) LANDED 2026-06-05; B.2.1 CRIMINAL
+contraband tier (per-se crime, no rescue, per-rule-set) LANDED 2026-06-05; Phases
 B.3 (declines axis)/C/D designed below as overlays  
 **Scope:** the credentials / checkpoint interaction as a stacked picking-game
 composition inside `tangl.mechanics.games`  
@@ -684,12 +685,24 @@ computes a base disposition; Phase C composes the override on top.
 
 The matrix collapses once you see that **contraband is, by definition, what must
 be declared.** If concealment doesn't matter for an item, it simply isn't
-contraband — there is no fourth "ignored" category. So contraband has exactly
-three levels (from the restriction map for that indication):
+contraband — there is no fourth "ignored" category. So contraband has these
+levels (from the restriction map for that indication):
 
 - **declaration-only** (anonymous / id level) — allowed *if declared*.
 - **permit-required** (with-permit level) — declared *and* a valid permit.
-- **forbidden** — denied regardless.
+- **forbidden** — denied regardless (but *relinquishable* — surrender it and the
+  candidate walks).
+- **criminal** (`RestrictionLevel.CRIMINAL`, LANDED B.2.1 2026-06-05) — a **per-se
+  crime**: mere possession arrests, and **neither declaring nor surrendering it
+  rescues** (you cannot relinquish your way out of trafficking — heroin, slaves, a
+  case of counterfeit). `_contraband_class` returns `"criminal"` and
+  `_assess_contraband` short-circuits to ARREST before any rescue path. This is the
+  arrestible-severity *forbidden* sits below: which goods are criminal is **per
+  rule set** — a permissive regime simply maps the same good down to a lower level,
+  and a privileged-origin **whitelist** exemption (Phase C overlay above
+  `derive_disposition`) is the only thing that bends it back. It is also the target
+  severity the deferred *planting* malfeasance move aims for: a discovered criminal
+  good is what launders a shadow-blacklist arrest into "arrest with reason."
 
 And **concealment is itself the violation** — concealing *any* contraband is a
 problem, independent of whether it would have been permitted. The disclosure /

--- a/engine/src/tangl/mechanics/games/credentials_enums.py
+++ b/engine/src/tangl/mechanics/games/credentials_enums.py
@@ -58,10 +58,17 @@ CONTRABAND = frozenset({Indication.WEAPON, Indication.DRUGS, Indication.SECRETS}
 class RestrictionLevel(Enum):
     """How permissive the rule is for an indication, most to least restrictive.
 
-    ``forbidden -> with_permit (req id) -> with_id -> anonymous``. A day's
-    authored rule change is a delta along this axis for some indication.
+    ``criminal -> forbidden -> with_permit (req id) -> with_id -> anonymous``. A
+    day's authored rule change is a delta along this axis for some indication.
+
+    ``criminal`` and ``forbidden`` differ for *contraband*: a forbidden good can
+    be relinquished (declared -> deny, surrender -> pass), but a criminal good is
+    a per-se crime -- mere possession arrests, and neither declaring nor
+    surrendering it rescues. Which goods are criminal is per rule set: a
+    permissive regime simply maps the same good down to a lower level.
     """
 
+    CRIMINAL = "criminal"          # possession is itself a crime; always arrest
     FORBIDDEN = "forbidden"        # never; no valid credential exists
     WITH_PERMIT = "with_permit"    # requires a permit (which itself requires id)
     WITH_ID = "with_id"            # requires a valid bearer id

--- a/engine/src/tangl/mechanics/games/credentials_factory.py
+++ b/engine/src/tangl/mechanics/games/credentials_factory.py
@@ -76,9 +76,9 @@ def build_valid(
 
     for c_ind in contraband:
         c_level = restrictions.level_for(region, c_ind, RestrictionLevel.FORBIDDEN)
-        if c_level is RestrictionLevel.FORBIDDEN:
+        if c_level in (RestrictionLevel.CRIMINAL, RestrictionLevel.FORBIDDEN):
             raise ValueError(
-                f"Cannot build a valid case with forbidden contraband: "
+                f"Cannot build a valid case with criminal/forbidden contraband: "
                 f"{c_ind.value} in {region.value}."
             )
         if c_level.requires_permit:

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -349,6 +349,8 @@ def _assess_requirement(
 def _contraband_class(level: RestrictionLevel) -> str:
     """Classify a contraband indication's rule (Phase B.2)."""
 
+    if level is RestrictionLevel.CRIMINAL:
+        return "criminal"  # per-se crime; possession arrests, no rescue
     if level is RestrictionLevel.FORBIDDEN:
         return "forbidden"
     if level.requires_permit:
@@ -372,6 +374,13 @@ def _assess_contraband(
 
     fs = finding_status or {}
     cls = _contraband_class(level)
+    if cls == "criminal":
+        # Per-se crime: mere possession is the offense. Declaring or surrendering
+        # it does not rescue (you cannot relinquish your way out of trafficking).
+        # A permissive regime that tolerates the good simply maps it below
+        # CRIMINAL. (A privileged-origin whitelist exemption is a Phase C overlay
+        # applied above derive_disposition, not here.)
+        return CredentialDisposition.ARREST
     # disclosure declares all concealed goods; a bare un-concealed item is
     # already declared. The contraband's permit (when one is required) lives in
     # the packet keyed by indication, so its standing is assessed by
@@ -890,8 +899,8 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             if item.concealed:
                 continue  # a hidden item's grounds are not self-evident
             clevel = rules.level_for(region, item.indication, RestrictionLevel.FORBIDDEN)
-            if clevel is RestrictionLevel.FORBIDDEN:
-                return True  # openly forbidden goods
+            if clevel in (RestrictionLevel.CRIMINAL, RestrictionLevel.FORBIDDEN):
+                return True  # openly criminal / forbidden goods
             if clevel.requires_permit and case.credential_for(item.indication) is None:
                 return True  # visible item, plainly missing its permit
         return False

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -353,9 +353,11 @@ def _contraband_class(level: RestrictionLevel) -> str:
         return "criminal"  # per-se crime; possession arrests, no rescue
     if level is RestrictionLevel.FORBIDDEN:
         return "forbidden"
-    if level.requires_permit:
-        return "permit_required"
-    return "declaration_only"  # allowed if declared (anonymous / id level)
+    if level.requires_permit or level.requires_id:
+        # Needs a valid permit and/or bearer id: route through _assess_requirement
+        # so the id is actually checked (a WITH_ID good is not merely declarable).
+        return "credentialed"
+    return "declaration_only"  # anonymous level: allowed once declared
 
 
 def _assess_contraband(
@@ -392,7 +394,7 @@ def _assess_contraband(
             return CredentialDisposition.PASS  # voluntarily surrendered
         if cls == "forbidden":
             return CredentialDisposition.DENY  # declared forbidden -> relinquish/deny
-        if cls == "permit_required":
+        if cls == "credentialed":
             return _assess_requirement(case, item.indication, level, fs)
         return CredentialDisposition.PASS  # declaration-only, declared -> allow
 
@@ -401,10 +403,10 @@ def _assess_contraband(
         return CredentialDisposition.ARREST  # smuggling forbidden goods
     if cls == "declaration_only":
         return CredentialDisposition.DENY  # concealed declarable goods
-    # permit-required, concealed:
+    # credentialed (permit and/or id required), concealed:
     if _assess_requirement(case, item.indication, level, fs) is CredentialDisposition.PASS:
-        return CredentialDisposition.DENY  # had a valid permit but concealed it (Q1)
-    return CredentialDisposition.ARREST  # smuggling unpermitted goods
+        return CredentialDisposition.DENY  # had a valid credential but concealed it (Q1)
+    return CredentialDisposition.ARREST  # smuggling un-credentialed goods
 
 
 def derive_disposition(
@@ -426,7 +428,11 @@ def derive_disposition(
 
     purpose = case.get_purpose()
     level = restrictions.level_for(region, purpose, RestrictionLevel.ANONYMOUS)
-    if level is RestrictionLevel.FORBIDDEN:
+    if level is RestrictionLevel.CRIMINAL:
+        # The stated purpose is itself a crime (RestrictionLevel is shared by
+        # purpose and contraband rules) -- e.g. an authored {WORK: CRIMINAL} regime.
+        worst = _worse(worst, CredentialDisposition.ARREST)
+    elif level is RestrictionLevel.FORBIDDEN:
         worst = _worse(worst, CredentialDisposition.DENY)  # purpose not allowed
     else:
         worst = _worse(worst, _assess_requirement(case, purpose, level, finding_status))
@@ -888,8 +894,8 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
 
         purpose = case.get_purpose()
         plevel = rules.level_for(region, purpose, RestrictionLevel.ANONYMOUS)
-        if plevel is RestrictionLevel.FORBIDDEN:
-            return True  # the stated purpose is itself disallowed -- self-evident
+        if plevel in (RestrictionLevel.CRIMINAL, RestrictionLevel.FORBIDDEN):
+            return True  # the stated purpose is itself criminal/disallowed -- self-evident
         if plevel.requires_id and case.id_status() is None:
             return True
         if plevel.requires_permit and case.credential_for(purpose) is None:

--- a/engine/tests/mechanics/games/test_credentials_contraband.py
+++ b/engine/tests/mechanics/games/test_credentials_contraband.py
@@ -209,3 +209,79 @@ class TestForgedDocumentIsAlwaysACrime:
         # renewal); a merely-invalid unused permit is not a crime.
         case = _case(packet=[_permit(IND.WEAPON, S.EXPIRED)])
         assert _derive(case) is D.PASS
+
+
+# drugs as a per-se crime in THIS regime; a permissive regime maps it lower.
+CRIMINAL_RULES = Restrictions.from_map(
+    {Region.LOCAL: {IND.TRAVEL: L.WITH_ID, IND.DRUGS: L.CRIMINAL}}
+)
+
+
+def _derive_crim(case: CredentialCase, fs: dict | None = None) -> CredentialDisposition:
+    return derive_disposition(case, CRIMINAL_RULES, fs)
+
+
+class TestCriminalContrabandTier:
+    """A CRIMINAL good is a per-se crime: possession arrests, no rescue (B.2.1)."""
+
+    def test_declared_criminal_arrests(self) -> None:
+        assert _derive_crim(_case(ContrabandItem(indication=IND.DRUGS))) is D.ARREST
+
+    def test_concealed_criminal_arrests(self) -> None:
+        case = _case(ContrabandItem(indication=IND.DRUGS, concealed=True))
+        assert _derive_crim(case) is D.ARREST
+
+    def test_relinquish_does_not_rescue_criminal(self) -> None:
+        case = _case(ContrabandItem(indication=IND.DRUGS))  # declared
+        assert _derive_crim(case, {"relinquish": "yielded"}) is D.ARREST
+
+    def test_disclose_and_relinquish_do_not_rescue_smuggled_criminal(self) -> None:
+        case = _case(ContrabandItem(indication=IND.DRUGS, concealed=True))
+        fs = {"disclosure": "declared", "relinquish": "yielded"}
+        assert _derive_crim(case, fs) is D.ARREST
+
+    def test_per_rule_set_contrast(self) -> None:
+        # Same declared good: relinquishable to PASS under FORBIDDEN (module RULES),
+        # but a per-se arrest under CRIMINAL -- the criminality is regime data.
+        case = _case(ContrabandItem(indication=IND.DRUGS))
+        assert _derive(case, {"relinquish": "yielded"}) is D.PASS
+        assert _derive_crim(case, {"relinquish": "yielded"}) is D.ARREST
+
+
+class TestCriminalSelfEvidence:
+    """How the criminal tier interacts with the no_evidence_penalty tax."""
+
+    def _game(self, *possessions):
+        game = CredentialsGame(
+            roster=[_case(*possessions)],
+            restriction_map=CRIMINAL_RULES,
+            no_evidence_penalty=1,
+        )
+        handler = CredentialsGameHandler()
+        handler.setup(game)
+        return game, handler
+
+    def test_visible_criminal_is_self_evident_arrest(self) -> None:
+        # Openly carried criminal goods justify an arrest on their face.
+        game, handler = self._game(ContrabandItem(indication=IND.DRUGS))
+        assert game.expected_disposition(game.active_case) is D.ARREST
+        handler.receive_move(game, ("decide", "arrest"))
+        result = game.case_results[-1]
+        assert result.unjustified is False
+        assert result.penalty == 0
+
+    def test_concealed_criminal_blind_arrest_is_taxed(self) -> None:
+        # Smuggled criminal goods are hidden: arresting without searching is a
+        # blind (if correct) call, so the tax fires.
+        game, handler = self._game(ContrabandItem(indication=IND.DRUGS, concealed=True))
+        assert game.expected_disposition(game.active_case) is D.ARREST
+        handler.receive_move(game, ("decide", "arrest"))  # no search
+        assert game.case_results[-1].unjustified is True
+
+    def test_concealed_criminal_after_search_is_justified(self) -> None:
+        game, handler = self._game(ContrabandItem(indication=IND.DRUGS, concealed=True))
+        handler.receive_move(game, ("request_search", ""))  # confirms concealment
+        handler.receive_move(game, ("decide", "arrest"))
+        result = game.case_results[-1]
+        assert result.unjustified is False
+        assert result.penalty == 0

--- a/engine/tests/mechanics/games/test_credentials_contraband.py
+++ b/engine/tests/mechanics/games/test_credentials_contraband.py
@@ -285,3 +285,43 @@ class TestCriminalSelfEvidence:
         result = game.case_results[-1]
         assert result.unjustified is False
         assert result.penalty == 0
+
+
+# RestrictionLevel is shared by purpose and contraband rules; these pin the
+# matrix corners for "weird but legal" authored configs.
+PURPOSE_CRIMINAL_RULES = Restrictions.from_map({Region.LOCAL: {IND.WORK: L.CRIMINAL}})
+# A good allowed only with a valid bearer id, under an anonymous purpose so the id
+# is not otherwise required -- isolates the contraband's own id check.
+ID_CONTRABAND_RULES = Restrictions.from_map(
+    {Region.LOCAL: {IND.TRAVEL: L.ANONYMOUS, IND.SECRETS: L.WITH_ID}}
+)
+
+
+class TestSharedRestrictionLevelEdges:
+    def test_criminal_purpose_arrests(self) -> None:
+        # The stated purpose is itself a crime -> arrest (not a fall-through PASS).
+        case = CredentialCase(
+            purpose=IND.WORK,
+            presented_documents={"passport": "An id."},
+            id_card=_id(),
+        )
+        assert derive_disposition(case, PURPOSE_CRIMINAL_RULES) is D.ARREST
+
+    def test_with_id_contraband_does_not_bypass_the_id_check(self) -> None:
+        # A WITH_ID good is not merely declarable: a declared one with no id denies.
+        no_id = CredentialCase(
+            purpose=IND.TRAVEL,
+            presented_documents={"passport": "(none)"},
+            id_card=None,
+            possessions=[ContrabandItem(indication=IND.SECRETS)],
+        )
+        assert derive_disposition(no_id, ID_CONTRABAND_RULES) is D.DENY
+
+    def test_with_id_contraband_allows_with_a_valid_id(self) -> None:
+        with_id = CredentialCase(
+            purpose=IND.TRAVEL,
+            presented_documents={"passport": "An id."},
+            id_card=_id(),
+            possessions=[ContrabandItem(indication=IND.SECRETS)],
+        )
+        assert derive_disposition(with_id, ID_CONTRABAND_RULES) is D.PASS


### PR DESCRIPTION
Adds a contraband severity **above `FORBIDDEN`** for goods whose mere possession
is a crime — heroin, trafficking, a case of counterfeit — distinct from
relinquishable forbidden goods. This is the smallest piece of the malfeasance
arc: it's the **arrestible target** the deferred planting / shadow-blacklist move
will aim for ("discover" a planted criminal good → an arrest *with reason*).

## Model

A new `RestrictionLevel.CRIMINAL` at the most-restrictive end of the axis
(`criminal → forbidden → with_permit → with_id → anonymous`). The difference is
only for *contraband*:

| tier | declared | concealed | relinquish/disclosure rescues? |
|---|---|---|---|
| `FORBIDDEN` | DENY | ARREST | **yes** → PASS |
| **`CRIMINAL`** | ARREST | ARREST | **no** — possession is the crime |

- `_contraband_class` returns `"criminal"`; `_assess_contraband` short-circuits to
  ARREST **before** any rescue path, so neither `request_disclosure` nor
  `request_relinquish` saves it.
- **Per rule set**: which goods are criminal is regime data — a permissive regime
  maps the same good *down* to a lower level. (A privileged-origin **whitelist**
  exemption stays a Phase C overlay above `derive_disposition`, not baked here.)
- `_has_visible_grounds`: openly carried criminal goods are **self-evident** arrest
  grounds (no `no_evidence_penalty` tax); a *smuggled* (concealed) criminal good
  still needs a search to justify the arrest, so a blind arrest is taxed.
- `build_valid` now also rejects CRIMINAL contraband, preserving the
  `build_valid → derives-PASS` round-trip invariant.

## Tests (+8)

`TestCriminalContrabandTier` (derive-level: declared/concealed arrest; relinquish
and disclose-then-relinquish do **not** rescue; the per-rule-set contrast — same
declared drugs relinquish→PASS under FORBIDDEN, →ARREST under CRIMINAL) and
`TestCriminalSelfEvidence` (visible criminal = self-evident/not taxed; concealed
criminal blind-arrest = taxed; concealed criminal after a search = justified).

Full games suite green (279 passed, 4 skipped); credential cross-suite green
(332 passed). Doc: B.2.1 subsection + status line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated restriction level documentation with clarified explanations of contraband severity progression.

* **New Features**
  * Introduced a new "criminal" contraband tier where possession triggers arrest regardless of declaration or relinquishment status.

* **Tests**
  * Added test coverage for criminal contraband behavior and evidence penalty system interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->