### PR TITLE
Phase C: whitelist/blacklist override — compose + cover (no new code)

### DIFF
--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -6,8 +6,10 @@ lazy offer roster, 2026-05-22); Phase B.1 LANDED (core mediation moves,
 2026-05-23); Phase B.2 LANDED (contraband mediation, 2026-06-04); penalty-matrix
 scorer + soft time budget + per-rule-set scoring config (configurable
 `penalty_matrix`, `no_evidence_penalty` toggle) LANDED 2026-06-05; B.2.1 CRIMINAL
-contraband tier (per-se crime, no rescue, per-rule-set) LANDED 2026-06-05; Phases
-B.3 (declines axis)/C/D designed below as overlays  
+contraband tier (per-se crime, no rescue, per-rule-set) LANDED 2026-06-05; Phase C
+whitelist/blacklist override (data flags clamping `expected_disposition`; overt vs
+shadow = the tax toggle) LANDED 2026-06-06; B.3 (declines axis) + the malfeasance
+layer (bribe/plant/invalidate) designed below as overlays  
 **Scope:** the credentials / checkpoint interaction as a stacked picking-game
 composition inside `tangl.mechanics.games`  
 **Background sources:** `docs/src/notes/CREDENTIALS_INTERACTION.md`,
@@ -758,15 +760,35 @@ arrest↔deny) layers on top of all of it.
 
 ## Phase C: context and haggling
 
-Whitelist / blacklist are already wired through `expected_disposition` and
-`_packet_finding`; Phase C only needs authored cases that set the flags plus
-journal flavor. Bribe / threat is another move kind (`accept_bribe` /
-`refuse_bribe`) plus additive shift tallies (`reputation`, `coin`) updated in
-resolution and exported to namespace; richer endings are then authored as extra
-POSTREQS edges keyed on `credential_*` predicates -- no engine change. The
-`ScreeningRound` narrative-override idea from the (dropped) `screening.py`
-(`on_invalid_seal`, `on_allow`, ...) is worth reviving as per-finding journal
-flavor.
+**Whitelist / blacklist — LANDED 2026-06-06 (was always data, not a subsystem).**
+The override is `whitelist`/`blacklist` flags on the case feeding
+`expected_disposition`: whitelist clamps the expected call **down** to PASS
+(the sponsored carrier waved through even with per-se-criminal goods), blacklist
+clamps it **up** to ARREST (wanted by name; DENY if `allow_arrest` is off). It is
+authored data propagated by the roster (`ScenarioOffer.whitelist/blacklist` →
+`materialize`), with `_packet_finding` flavor; an origin-scoped whitelist is just
+"set the flag for those origins" at authoring — no engine set needed. This is the
+parsimonious shape; nothing to build, only compositions to cover.
+
+**Overt vs shadow blacklist is the `no_evidence_penalty` toggle, not new code.**
+A blacklisted *clean* candidate derives ARREST via the override but has no surfaced
+or self-evident grounds, so:
+- *overt* (tax off, `no_evidence_penalty == 0`) — the name is authorization; the
+  arrest is free.
+- *shadow* (tax on, `> 0`) — the bare name-arrest reads as `unjustified`, which is
+  exactly the pressure to manufacture cover (plant a CRIMINAL good and "discover"
+  it → arrest *with reason*). The planting itself is the deferred malfeasance layer.
+
+**Deferred — fold into the malfeasance layer, do NOT build piecemeal.** Bribe /
+favoritism (`bribe_offer` exists only as a narrative data seam today) is the
+*passive, low* pole of the one malfeasance axis (turning a blind eye), and
+origin-bends-severity (a privileged origin overlooks *some* crimes — a graduated
+bend rather than a hard PASS clamp) is the same family. Building `accept_bribe` or
+a partial severity-bend now would fragment a layer that wants to ship as one thing
+(blind-eye/bribe at the bottom, doctoring/false-testimony at the top, inventory +
+catch-strike pricing throughout). The `ScreeningRound` narrative-override idea from
+the dropped `screening.py` (`on_invalid_seal`, `on_allow`, …) is still worth
+reviving as per-finding journal flavor when that lands.
 
 ---
 

--- a/engine/tests/mechanics/games/test_credentials_overrides.py
+++ b/engine/tests/mechanics/games/test_credentials_overrides.py
@@ -40,6 +40,9 @@ RULES = Restrictions.from_map(
 )
 
 
+# --------------------------------------------------------------------------- #
+# fixtures / helpers
+# --------------------------------------------------------------------------- #
 def _id(status: S = S.VALID) -> CredentialToken:
     return CredentialToken(indication=IND.TRAVEL, status=status)
 
@@ -64,13 +67,18 @@ def _smuggler(**kw) -> CredentialCase:
     )
 
 
-def _game(case: CredentialCase, **kw):
+def _game(
+    case: CredentialCase, **kw
+) -> tuple[CredentialsGame, CredentialsGameHandler]:
     game = CredentialsGame(roster=[case], restriction_map=RULES, **kw)
     handler = CredentialsGameHandler()
     handler.setup(game)
     return game, handler
 
 
+# --------------------------------------------------------------------------- #
+# test classes
+# --------------------------------------------------------------------------- #
 class TestWhitelist:
     def test_whitelist_clamps_a_criminal_packet_to_pass(self) -> None:
         # The sponsored-carrier exemption: even per-se-criminal goods are waved

--- a/engine/tests/mechanics/games/test_credentials_overrides.py
+++ b/engine/tests/mechanics/games/test_credentials_overrides.py
@@ -1,0 +1,125 @@
+"""Phase C: whitelist / blacklist identity overrides.
+
+The override is *data*, not a subsystem: `whitelist`/`blacklist` flags on the case
+feed `expected_disposition` (whitelist clamps down to PASS, blacklist clamps up to
+ARREST), layered above `derive_disposition`. These tests pin the compositions with
+the layers added since the override was first wired -- the CRIMINAL contraband
+tier and the no_evidence_penalty tax -- and show that the **overt vs shadow
+blacklist** distinction is the existing tax toggle, not new code:
+
+  * overt blacklist (arrest by name) -- the name is authorization; tax off.
+  * shadow blacklist (arrest *with reason*) -- tax on, so a bare name-arrest of a
+    clean candidate reads as unjustified, which is the pressure to manufacture
+    cover (the deferred planting malfeasance layer).
+"""
+
+from __future__ import annotations
+
+from tangl.mechanics.games import (
+    ContrabandItem,
+    CredentialCase,
+    CredentialDisposition,
+    CredentialStatus,
+    CredentialToken,
+    CredentialsGame,
+    CredentialsGameHandler,
+    Indication,
+    Region,
+    Restrictions,
+    RestrictionLevel,
+    derive_disposition,
+)
+
+D = CredentialDisposition
+S = CredentialStatus
+IND = Indication
+L = RestrictionLevel
+
+RULES = Restrictions.from_map(
+    {Region.LOCAL: {IND.TRAVEL: L.WITH_ID, IND.DRUGS: L.CRIMINAL}}
+)
+
+
+def _id(status: S = S.VALID) -> CredentialToken:
+    return CredentialToken(indication=IND.TRAVEL, status=status)
+
+
+def _clean(**kw) -> CredentialCase:
+    return CredentialCase(
+        purpose=IND.TRAVEL,
+        presented_documents={"passport": "An id."},
+        id_card=_id(),
+        **kw,
+    )
+
+
+def _smuggler(**kw) -> CredentialCase:
+    # Carries concealed criminal goods -> derives ARREST on its own.
+    return CredentialCase(
+        purpose=IND.TRAVEL,
+        presented_documents={"passport": "An id."},
+        id_card=_id(),
+        possessions=[ContrabandItem(indication=IND.DRUGS, concealed=True)],
+        **kw,
+    )
+
+
+def _game(case: CredentialCase, **kw):
+    game = CredentialsGame(roster=[case], restriction_map=RULES, **kw)
+    handler = CredentialsGameHandler()
+    handler.setup(game)
+    return game, handler
+
+
+class TestWhitelist:
+    def test_whitelist_clamps_a_criminal_packet_to_pass(self) -> None:
+        # The sponsored-carrier exemption: even per-se-criminal goods are waved
+        # through (the whitelist overlay sits above derive_disposition).
+        case = _smuggler(whitelist=True)
+        assert derive_disposition(case, RULES) is D.ARREST  # the packet is criminal
+        game, _ = _game(case)
+        assert game.expected_disposition(case) is D.PASS  # ...but sponsored -> pass
+
+    def test_whitelisted_pass_is_never_taxed(self) -> None:
+        game, handler = _game(_smuggler(whitelist=True), no_evidence_penalty=1)
+        handler.receive_move(game, ("decide", "pass"))
+        result = game.case_results[-1]
+        assert result.correct is True
+        assert result.unjustified is False
+        assert result.penalty == 0
+
+
+class TestBlacklist:
+    def test_blacklist_escalates_a_clean_packet_to_arrest(self) -> None:
+        case = _clean(blacklist=True)
+        assert derive_disposition(case, RULES) is D.PASS  # nothing wrong
+        game, _ = _game(case)
+        assert game.expected_disposition(case) is D.ARREST  # ...but wanted -> arrest
+
+    def test_blacklist_without_arrest_falls_back_to_deny(self) -> None:
+        game, _ = _game(_clean(blacklist=True), allow_arrest=False)
+        assert game.expected_disposition(game.active_case) is D.DENY
+
+
+class TestOvertVsShadowBlacklist:
+    """Same blacklisted clean candidate; the regime's tax toggle is the only
+    difference between an overt and a shadow blacklist."""
+
+    def test_overt_blacklist_arrest_is_free(self) -> None:
+        # Tax off: the name on the list is authorization enough.
+        game, handler = _game(_clean(blacklist=True), no_evidence_penalty=0)
+        handler.receive_move(game, ("decide", "arrest"))
+        result = game.case_results[-1]
+        assert result.correct is True
+        assert result.unjustified is False
+        assert result.penalty == 0
+
+    def test_shadow_blacklist_arrest_is_taxed(self) -> None:
+        # Tax on: a clean candidate has no surfaced or self-evident grounds, so a
+        # bare name-arrest is unjustified -- the pressure to manufacture cover.
+        game, handler = _game(_clean(blacklist=True), no_evidence_penalty=1)
+        handler.receive_move(game, ("decide", "arrest"))
+        result = game.case_results[-1]
+        assert result.correct is True
+        assert result.unjustified is True
+        assert result.penalty == 1


### PR DESCRIPTION
**Phase C's whitelist/blacklist was already built as data** — flags on the case
feeding `expected_disposition` (whitelist clamps the expected call *down* to PASS,
blacklist *up* to ARREST), propagated by the roster (`ScenarioOffer` →
`materialize`), with `_packet_finding` flavor. Reinventing it as a "Phase C
feature" would be exactly the metastasis we want to avoid. So this PR adds **no new
code** — it pins the compositions with the layers added since the override was
first wired, and records one nice result.

## What's covered

- **whitelist clamps even a per-se-`CRIMINAL` packet to PASS** — the
  sponsored-carrier exemption, sitting above `derive_disposition`.
- **blacklist escalates a clean packet to ARREST** (DENY when `allow_arrest` is
  off).
- **overt vs shadow blacklist is the `no_evidence_penalty` toggle, not new code.**
  A blacklisted *clean* candidate derives ARREST via the override but has no
  surfaced or self-evident grounds, so:
  - *overt* (tax off): the name is authorization — the arrest is free;
  - *shadow* (tax on): the bare name-arrest reads as `unjustified` — which is the
    pressure to manufacture cover (plant a CRIMINAL good and "discover" it). The
    planting itself is the deferred malfeasance layer.

## Explicitly deferred (don't build piecemeal)

`bribe_offer` exists only as a narrative data seam, and bribe/favoritism +
origin-bends-severity belong to the **one malfeasance axis** (blind-eye/bribe at
the bottom → doctoring/false-testimony at the top, inventory + catch-strike pricing
throughout). Building `accept_bribe` or a partial severity-bend now would fragment
a layer that should ship as one thing.

## Tests

`test_credentials_overrides.py` (+6). Full games suite green (288 passed, 4
skipped). Doc: Phase C marked LANDED + the overt/shadow note + status line.

Next: the **start-to-finish simplification review** — sweep the credentials code
for mechanics that could fall back to a core concept or be data variants rather
than new features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated design documentation for credential override mechanics.

* **New Features**
  * Added whitelist and blacklist credential override system with distinct handling modes.
  * Introduced evidence penalty toggle to differentiate restriction visibility levels.

* **Tests**
  * Added comprehensive test coverage for credential override functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->