### PR TITLE
Credentials cleanup: dedup dead state + enumerate the finding vocab

### DIFF
--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -1226,6 +1226,8 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             outcome = notes.get("outcome")
             if outcome == "id_verified_problem":
                 line = "The id does not match the bearer."
+            elif outcome == "id_verified_not_applicable":
+                line = "There is no id to verify."
             else:
                 line = "The id matches the bearer."
             return [
@@ -1258,6 +1260,12 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                 ContentFragment(content=line),
             ]
         if action == "request_relinquish":
+            if notes.get("outcome") == "request_relinquish_not_applicable":
+                return [
+                    ContentFragment(
+                        content="You look for contraband to have surrendered, but there is none."
+                    ),
+                ]
             return [
                 ContentFragment(content="You direct the candidate to surrender the contraband."),
                 ContentFragment(content="They hand it over and step back, lighter."),

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -256,12 +256,44 @@ def disposition_penalty(
     return row.get(chosen.value, DISPOSITION_PENALTY[expected.value][chosen.value])
 
 
+class Finding:
+    """finding_status *values* (Phase B mediation outcomes). Plain-string
+    constants (not an Enum) so finding_status stays a JSON-serializable
+    ``dict[str, str]`` for the VM value_hash and round-trips through persistence."""
+
+    CLEARED = "cleared"      # a mitigatable problem was found and repaired
+    VERIFIED = "verified"    # checked and sound -- no adverse evidence
+    CONFIRMED = "confirmed"  # an adverse fact confirmed (crime / concealment)
+    DECLARED = "declared"    # contraband voluntarily disclosed
+    TOO_LATE = "too_late"    # disclosure after a confirming search; no rescue
+    YIELDED = "yielded"      # contraband surrendered
+
+
+class FindingKey:
+    """finding_status *keys* with a fixed name (the others are an indication
+    value -- a permit keyed by the good it covers)."""
+
+    ID = "id"
+    SEARCH = "search"
+    DISCLOSURE = "disclosure"
+    RELINQUISH = "relinquish"
+
+
+class ContrabandClass:
+    """How a contraband indication's restriction level is handled (B.2)."""
+
+    CRIMINAL = "criminal"
+    FORBIDDEN = "forbidden"
+    CREDENTIALED = "credentialed"  # needs a valid permit and/or bearer id
+    DECLARATION_ONLY = "declaration_only"
+
+
 # finding_status values that represent *surfaced* evidence -- an investigation
-# that turned a problem up ("confirmed"), repaired a mitigatable one ("cleared"),
-# or recovered contraband ("yielded"). A plain "verified" (checked, sound) is not
-# adverse evidence, so it is excluded. Behavioral evidence (a declined search, a
-# bribe attempt) extends this set in Phase B.3.
-_EVIDENCE_FINDINGS = frozenset({"confirmed", "cleared", "yielded"})
+# that turned a problem up (CONFIRMED), repaired a mitigatable one (CLEARED), or
+# recovered contraband (YIELDED). A plain VERIFIED (checked, sound) is not adverse
+# evidence, so it is excluded. Behavioral evidence (a declined search, a bribe
+# attempt) extends this set in Phase B.3.
+_EVIDENCE_FINDINGS = frozenset({Finding.CONFIRMED, Finding.CLEARED, Finding.YIELDED})
 
 
 # Time cost of each action, in shift-budget units. Cheap probes (a glance at a
@@ -305,7 +337,7 @@ def _assess_credential(
         return CredentialDisposition.ARREST  # forged; crimes not mediatable in B.1
     # Mitigatable (missing seal / bad date / expired): Phase B.1 mediation can
     # clear it via ``request_document``; check the per-case finding_status.
-    if finding_status and finding_status.get(token.indication.value) == "cleared":
+    if finding_status and finding_status.get(token.indication.value) == Finding.CLEARED:
         return CredentialDisposition.PASS
     return CredentialDisposition.DENY
 
@@ -322,7 +354,7 @@ def _assess_id(
     if status.is_crime:
         return CredentialDisposition.ARREST  # fake / wrong-holder id
     # Mitigatable id (expired / bad date): cleared by future id-mediation.
-    if finding_status and finding_status.get("id") == "cleared":
+    if finding_status and finding_status.get(FindingKey.ID) == Finding.CLEARED:
         return CredentialDisposition.PASS
     return CredentialDisposition.DENY
 
@@ -350,14 +382,14 @@ def _contraband_class(level: RestrictionLevel) -> str:
     """Classify a contraband indication's rule (Phase B.2)."""
 
     if level is RestrictionLevel.CRIMINAL:
-        return "criminal"  # per-se crime; possession arrests, no rescue
+        return ContrabandClass.CRIMINAL  # per-se crime; possession arrests, no rescue
     if level is RestrictionLevel.FORBIDDEN:
-        return "forbidden"
+        return ContrabandClass.FORBIDDEN
     if level.requires_permit or level.requires_id:
         # Needs a valid permit and/or bearer id: route through _assess_requirement
         # so the id is actually checked (a WITH_ID good is not merely declarable).
-        return "credentialed"
-    return "declaration_only"  # anonymous level: allowed once declared
+        return ContrabandClass.CREDENTIALED
+    return ContrabandClass.DECLARATION_ONLY  # anonymous level: allowed once declared
 
 
 def _assess_contraband(
@@ -376,7 +408,7 @@ def _assess_contraband(
 
     fs = finding_status or {}
     cls = _contraband_class(level)
-    if cls == "criminal":
+    if cls == ContrabandClass.CRIMINAL:
         # Per-se crime: mere possession is the offense. Declaring or surrendering
         # it does not rescue (you cannot relinquish your way out of trafficking).
         # A permissive regime that tolerates the good simply maps it below
@@ -387,21 +419,21 @@ def _assess_contraband(
     # already declared. The contraband's permit (when one is required) lives in
     # the packet keyed by indication, so its standing is assessed by
     # _assess_requirement -- the same machinery as a purpose permit.
-    declared = (not item.concealed) or fs.get("disclosure") == "declared"
+    declared = (not item.concealed) or fs.get(FindingKey.DISCLOSURE) == Finding.DECLARED
 
     if declared:
-        if fs.get("relinquish") == "yielded":
+        if fs.get(FindingKey.RELINQUISH) == Finding.YIELDED:
             return CredentialDisposition.PASS  # voluntarily surrendered
-        if cls == "forbidden":
+        if cls == ContrabandClass.FORBIDDEN:
             return CredentialDisposition.DENY  # declared forbidden -> relinquish/deny
-        if cls == "credentialed":
+        if cls == ContrabandClass.CREDENTIALED:
             return _assess_requirement(case, item.indication, level, fs)
         return CredentialDisposition.PASS  # declaration-only, declared -> allow
 
     # Concealed and not disclosed: concealment is the violation.
-    if cls == "forbidden":
+    if cls == ContrabandClass.FORBIDDEN:
         return CredentialDisposition.ARREST  # smuggling forbidden goods
-    if cls == "declaration_only":
+    if cls == ContrabandClass.DECLARATION_ONLY:
         return CredentialDisposition.DENY  # concealed declarable goods
     # credentialed (permit and/or id required), concealed:
     if _assess_requirement(case, item.indication, level, fs) is CredentialDisposition.PASS:
@@ -461,12 +493,6 @@ class CredentialsGame(PickingGame):
     # on arrival (Phase A.3), and `offers` is the source of truth instead of
     # `roster`. See credentials_roster.py.
     offers: list["ScenarioOffer"] = Field(default_factory=list)
-    checkpoint_rules: list[str] = Field(
-        default_factory=lambda: [
-            "Travelers need a valid passport.",
-            "This route also requires a travel permit.",
-        ]
-    )
     allow_arrest: bool = True
     # The shift is lost when accumulated penalty exceeds this. 0 is the strict
     # default (any wrong call ends the shift); a world raises it for a more
@@ -525,9 +551,10 @@ class CredentialsGame(PickingGame):
         json_schema_extra={"reset_field": True},
     )
     # Mediation outcomes for the active case (Phase B.1): keys are an
-    # indication's value (a permit), or "id", or "search". Values are
-    # "cleared" / "confirmed". Reset by advance_case so each candidate starts
-    # with a clean slate.
+    # indication's value (a permit) or a fixed ``FindingKey`` (id / search /
+    # disclosure / relinquish); values are ``Finding`` constants. Kept as plain
+    # ``dict[str, str]`` so it stays JSON-serializable for the VM value_hash.
+    # Reset by advance_case so each candidate starts with a clean slate.
     finding_status: dict[str, str] = Field(
         default_factory=dict,
         json_schema_extra={"reset_field": True},
@@ -671,7 +698,7 @@ class CredentialsGame(PickingGame):
     def advance_case(self) -> None:
         """Reset per-case working state and step to the next candidate.
 
-        Never touches roster, checkpoint rules, threshold, score, or
+        Never touches roster, rules, threshold, score, or
         ``case_results``. Sets ``shift_complete`` instead of letting
         ``case_index`` run past the roster, so
         :meth:`CredentialsGameHandler.evaluate` owns shift terminality.
@@ -703,7 +730,6 @@ class CredentialsGame(PickingGame):
                 "credential_stage": self.current_stage,
                 "credential_packet_findings": dict(self.packet_findings),
                 "credential_num_packet_findings": len(self.packet_findings),
-                "credential_checkpoint_rules": list(self.checkpoint_rules),
                 "credential_allow_arrest": self.allow_arrest,
                 "credential_disposition": (
                     self.disposition.value if self.disposition is not None else None
@@ -721,7 +747,6 @@ class CredentialsGame(PickingGame):
                 "credential_time_budget": self.time_budget,
                 "credential_time_spent": self.time_spent,
                 "credential_overtime": self.overtime,
-                "credential_shift_score": dict(self.score),
                 "credential_shift_complete": self.shift_complete,
             }
         )
@@ -764,24 +789,24 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                 continue
             moves.append(CredentialsMove(kind="request_document", target=key))
         # verify_id: offer whenever an id is presented and not yet verified.
-        if case.id_card is not None and "id" not in game.finding_status:
+        if case.id_card is not None and FindingKey.ID not in game.finding_status:
             moves.append(CredentialsMove(kind="verify_id", target=""))
         # request_search: single move, once per case.
-        if "search" not in game.finding_status:
+        if FindingKey.SEARCH not in game.finding_status:
             moves.append(CredentialsMove(kind="request_search", target=""))
         # request_disclosure (B.2): "anything to declare?" -- always offerable
         # (asking reveals nothing the menu shouldn't), once per case.
-        if "disclosure" not in game.finding_status:
+        if FindingKey.DISCLOSURE not in game.finding_status:
             moves.append(CredentialsMove(kind="request_disclosure", target=""))
         # request_relinquish (B.2): offer when the candidate has *declared*
         # contraband to surrender (visible, or disclosed via request_disclosure).
-        if "relinquish" not in game.finding_status and self._has_declared_contraband(game):
+        if FindingKey.RELINQUISH not in game.finding_status and self._has_declared_contraband(game):
             moves.append(CredentialsMove(kind="request_relinquish", target=""))
         return moves
 
     @staticmethod
     def _has_declared_contraband(game: CredentialsGame) -> bool:
-        disclosed = game.finding_status.get("disclosure") == "declared"
+        disclosed = game.finding_status.get(FindingKey.DISCLOSURE) == Finding.DECLARED
         return any(
             (not item.concealed) or disclosed for item in game.active_case.get_contraband()
         )
@@ -869,14 +894,17 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         for key, value in fs.items():
             if value not in _EVIDENCE_FINDINGS:
                 continue
-            # A *clean* search ("search": "cleared") turned nothing up -- it is
-            # not adverse evidence and must not suppress the tax on an unrelated
+            # A *clean* search (SEARCH: CLEARED) turned nothing up -- it is not
+            # adverse evidence and must not suppress the tax on an unrelated
             # unsurfaced issue.
-            if key == "search" and value == "cleared":
+            if key == FindingKey.SEARCH and value == Finding.CLEARED:
                 continue
             return True
         # A logged disclosure counts only when there was something to declare.
-        if fs.get("disclosure") in ("declared", "too_late") and game.active_case.get_contraband():
+        if (
+            fs.get(FindingKey.DISCLOSURE) in (Finding.DECLARED, Finding.TOO_LATE)
+            and game.active_case.get_contraband()
+        ):
             return True
         return False
 
@@ -1012,13 +1040,13 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             return RoundResult.CONTINUE
 
         if permit.status.is_crime:
-            game.finding_status[indication_value] = "confirmed"
+            game.finding_status[indication_value] = Finding.CONFIRMED
             detail["outcome"] = "request_document_confirmed"
         elif permit.status.is_valid:
-            game.finding_status[indication_value] = "verified"
+            game.finding_status[indication_value] = Finding.VERIFIED
             detail["outcome"] = "request_document_verified"
         else:
-            game.finding_status[indication_value] = "cleared"
+            game.finding_status[indication_value] = Finding.CLEARED
             detail["outcome"] = "request_document_cleared"
         detail["target_indication"] = indication_value
         return RoundResult.CONTINUE
@@ -1031,13 +1059,13 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         # verify_id answers only "does the id match the bearer?". It discloses a
         # holder mismatch (a crime) but never mechanically repairs a stale id --
         # an expired or mis-dated id stays a deny until a future id-reissue move
-        # (B.2). So it records "verified" / "confirmed", never "cleared".
+        # (B.2). So it records VERIFIED / CONFIRMED, never CLEARED.
         status = game.active_case.id_status()
         if status is CredentialStatus.WRONG_HOLDER:
-            game.finding_status["id"] = "confirmed"
+            game.finding_status[FindingKey.ID] = Finding.CONFIRMED
             detail["outcome"] = "id_verified_problem"
         else:
-            game.finding_status["id"] = "verified"
+            game.finding_status[FindingKey.ID] = Finding.VERIFIED
             detail["outcome"] = "id_verified_clean"
         return RoundResult.CONTINUE
 
@@ -1048,11 +1076,11 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
     ) -> RoundResult:
         concealed = [item for item in game.active_case.get_contraband() if item.concealed]
         if concealed:
-            game.finding_status["search"] = "confirmed"
+            game.finding_status[FindingKey.SEARCH] = Finding.CONFIRMED
             detail["outcome"] = "search_found_concealment"
             detail["concealed"] = [item.indication.value for item in concealed]
         else:
-            game.finding_status["search"] = "cleared"
+            game.finding_status[FindingKey.SEARCH] = Finding.CLEARED
             detail["outcome"] = "search_clean"
         return RoundResult.CONTINUE
 
@@ -1069,12 +1097,12 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         # records "too_late" (which derive does not treat as declared) rather
         # than "declared".
         concealed = [item for item in game.active_case.get_contraband() if item.concealed]
-        if concealed and game.finding_status.get("search") == "confirmed":
-            game.finding_status["disclosure"] = "too_late"
+        if concealed and game.finding_status.get(FindingKey.SEARCH) == Finding.CONFIRMED:
+            game.finding_status[FindingKey.DISCLOSURE] = Finding.TOO_LATE
             detail["outcome"] = "disclosure_too_late"
             detail["declared"] = [item.indication.value for item in concealed]
         else:
-            game.finding_status["disclosure"] = "declared"
+            game.finding_status[FindingKey.DISCLOSURE] = Finding.DECLARED
             if concealed:
                 detail["outcome"] = "disclosure_declared"
                 detail["declared"] = [item.indication.value for item in concealed]
@@ -1088,7 +1116,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         detail: dict[str, object],
     ) -> RoundResult:
         # The candidate surrenders declared contraband, clearing the violation.
-        game.finding_status["relinquish"] = "yielded"
+        game.finding_status[FindingKey.RELINQUISH] = Finding.YIELDED
         detail["outcome"] = "relinquished"
         return RoundResult.CONTINUE
 

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -1061,6 +1061,9 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         # an expired or mis-dated id stays a deny until a future id-reissue move
         # (B.2). So it records VERIFIED / CONFIRMED, never CLEARED.
         status = game.active_case.id_status()
+        if status is None:  # off-menu safety; the menu offers this only with an id
+            detail["outcome"] = "id_verified_not_applicable"
+            return RoundResult.CONTINUE
         if status is CredentialStatus.WRONG_HOLDER:
             game.finding_status[FindingKey.ID] = Finding.CONFIRMED
             detail["outcome"] = "id_verified_problem"
@@ -1116,6 +1119,12 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         detail: dict[str, object],
     ) -> RoundResult:
         # The candidate surrenders declared contraband, clearing the violation.
+        # Off-menu safety: with nothing declared to surrender, record nothing --
+        # else a spurious YIELDED would count as surfaced evidence and suppress
+        # the no_evidence_penalty on an unrelated rejection.
+        if not self._has_declared_contraband(game):
+            detail["outcome"] = "request_relinquish_not_applicable"
+            return RoundResult.CONTINUE
         game.finding_status[FindingKey.RELINQUISH] = Finding.YIELDED
         detail["outcome"] = "relinquished"
         return RoundResult.CONTINUE

--- a/engine/tests/mechanics/games/test_credentials_contraband.py
+++ b/engine/tests/mechanics/games/test_credentials_contraband.py
@@ -338,9 +338,16 @@ class TestMediationOffMenuSafety:
         handler.setup(game)
         return game, handler
 
+    @staticmethod
+    def _journal_text(handler: CredentialsGameHandler, game: CredentialsGame) -> str:
+        frags = handler.get_journal_fragments(game) or []
+        return " ".join(
+            f.content for f in frags if isinstance(getattr(f, "content", None), str)
+        )
+
     def test_verify_id_with_no_id_records_nothing(self) -> None:
         # No id presented (missing-id deny); verifying off-menu must not record a
-        # bogus "id verified clean".
+        # bogus "id verified clean" -- in state or in the prose.
         case = CredentialCase(
             purpose=IND.TRAVEL,
             presented_documents={"passport": "(none)"},
@@ -349,6 +356,7 @@ class TestMediationOffMenuSafety:
         game, handler = self._game(case)
         handler.receive_move(game, ("verify_id", ""))
         assert "id" not in game.finding_status
+        assert "matches the bearer" not in self._journal_text(handler, game)
 
     def test_relinquish_with_no_contraband_does_not_fake_evidence(self) -> None:
         # An off-menu relinquish on a clean packet must not record YIELDED -- else
@@ -363,6 +371,7 @@ class TestMediationOffMenuSafety:
         game, handler = self._game(case, no_evidence_penalty=1)
         handler.receive_move(game, ("request_relinquish", ""))
         assert "relinquish" not in game.finding_status
+        assert "hand it over" not in self._journal_text(handler, game)
 
         handler.receive_move(game, ("decide", "deny"))  # correct, but unbacked
         result = game.case_results[-1]

--- a/engine/tests/mechanics/games/test_credentials_contraband.py
+++ b/engine/tests/mechanics/games/test_credentials_contraband.py
@@ -325,3 +325,47 @@ class TestSharedRestrictionLevelEdges:
             possessions=[ContrabandItem(indication=IND.SECRETS)],
         )
         assert derive_disposition(with_id, ID_CONTRABAND_RULES) is D.PASS
+
+
+class TestMediationOffMenuSafety:
+    """Mediation moves are menu-gated, but receive_move does not revalidate, so
+    each resolver guards its own precondition (matching _resolve_request_document).
+    """
+
+    def _game(self, case: CredentialCase, **kw):
+        game = CredentialsGame(roster=[case], restriction_map=RULES, **kw)
+        handler = CredentialsGameHandler()
+        handler.setup(game)
+        return game, handler
+
+    def test_verify_id_with_no_id_records_nothing(self) -> None:
+        # No id presented (missing-id deny); verifying off-menu must not record a
+        # bogus "id verified clean".
+        case = CredentialCase(
+            purpose=IND.TRAVEL,
+            presented_documents={"passport": "(none)"},
+            id_card=None,
+        )
+        game, handler = self._game(case)
+        handler.receive_move(game, ("verify_id", ""))
+        assert "id" not in game.finding_status
+
+    def test_relinquish_with_no_contraband_does_not_fake_evidence(self) -> None:
+        # An off-menu relinquish on a clean packet must not record YIELDED -- else
+        # it would count as surfaced evidence and suppress the tax on an unrelated
+        # rejection (here, an expired-id deny).
+        case = CredentialCase(
+            purpose=IND.TRAVEL,
+            presented_documents={"passport": "A worn id."},
+            id_card=_id(S.EXPIRED),
+            possessions=[],
+        )
+        game, handler = self._game(case, no_evidence_penalty=1)
+        handler.receive_move(game, ("request_relinquish", ""))
+        assert "relinquish" not in game.finding_status
+
+        handler.receive_move(game, ("decide", "deny"))  # correct, but unbacked
+        result = game.case_results[-1]
+        assert result.correct is True
+        assert result.unjustified is True  # not falsely justified by the relinquish
+        assert result.penalty == 1

--- a/engine/tests/mechanics/games/test_credentials_game.py
+++ b/engine/tests/mechanics/games/test_credentials_game.py
@@ -202,15 +202,19 @@ class TestCredentialsCore:
         assert opening["credential_cases_remaining"] == 2
         assert opening["credential_correct_count"] == 0
         assert opening["credential_shift_complete"] is False
-        assert opening["credential_shift_score"] == {"player": 0, "opponent": 0}
+        # Correct/incorrect counts come from the base game's player/opponent score
+        # (no credentials-specific duplicate of it).
+        assert opening["player_score"] == 0
+        assert opening["opponent_score"] == 0
 
         handler.receive_move(game, ("inspect", "passport"))
-        handler.receive_move(game, ("decide", "deny"))
+        handler.receive_move(game, ("decide", "deny"))  # first case is a correct deny
 
         mid = game.to_namespace()
         assert mid["credential_case_number"] == 2
         assert mid["credential_cases_remaining"] == 1
         assert mid["credential_correct_count"] == 1
+        assert mid["player_score"] == 1
         assert mid["credential_candidate_name"] == "Tomas Vey"
 
 


### PR DESCRIPTION
The low-risk slice of the simplification review (findings A, B, C, 6). **No
behavior change** — pure dedup + naming. Full games suite green (288), credential
cross-suite green (341).

## Dedup / dead state

- **Drop `checkpoint_rules`** — a parallel human-readable rule list maintained
  beside `restriction_map`, read by *nothing* (no world, test, or journal; the
  story-info channel already renders rules from `restriction_map`). Field + the
  `credential_checkpoint_rules` namespace key removed.
- **Drop the `credential_shift_score` export** — it duplicated the base game's
  `player_score`/`opponent_score` (which credentials already increments). The
  penalty model is authoritative for win/lose; the score is just the
  correct/incorrect count, which the base export already carries. (Test updated to
  assert on the base `player_score`.)

## Enumerate (single source of the finding vocabulary)

Replaced the scattered magic strings — which were typed as bare literals across
`derive`, the five `_resolve_*` methods, `_has_surfaced_evidence`, and the move
menu — with three named constant namespaces:

- `Finding` — `cleared/verified/confirmed/declared/too_late/yielded` (finding_status values)
- `FindingKey` — `id/search/disclosure/relinquish` (the fixed keys)
- `ContrabandClass` — `criminal/forbidden/credentialed/declaration_only` (the `_contraband_class` dispatch)

Kept as **plain-string constants, not Enums**, deliberately: `finding_status` is a
`dict[str, str]` that gets JSON-serialized for the VM `value_hash` and round-trips
through persistence, so the stored values must stay plain strings (the same
constraint that flattened the restriction map and string-keyed the penalty matrix).
The constants give the single-source / typo-safety benefit with zero serialization
risk.

Deferred (the more ambitious findings, as agreed): the per-move declarative
descriptor (collapsing the parallel availability/dispatch/label/prose switches) and
the narrative-vs-structured case duality — both are design discussions before a
diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated credential game to use structured/typed outcomes for mediation and evidence evaluation
  * Removed a deprecated checkpoint field from exported game state
  * Improved handling of mediation moves so cleared searches and disclosure/relinquish flows don't produce spurious adverse evidence

* **Tests**
  * Added tests covering namespace/progress updates and off-menu mediation safety to prevent false evidence or unjustified decisions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->