### PR TITLE
Reconcile backend fragment contracts with widget DTOs

### DIFF
--- a/apps/cli/src/tangl/cli/controllers/story_controller.py
+++ b/apps/cli/src/tangl/cli/controllers/story_controller.py
@@ -1,15 +1,27 @@
 from __future__ import annotations
 
 import argparse
-from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, Mapping
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID
 
 from cmd2 import CommandSet, with_argparser, with_default_category
 
+from tangl.service.response import ProjectedState, RuntimeEnvelope
+
 
 if TYPE_CHECKING:
     from ..app import StoryTanglCLI
+
+
+@dataclass(frozen=True)
+class _CachedChoice:
+    edge_id: UUID
+    label: str
+    available: bool
+    unavailable_reason: str | None
+    accepts: dict[str, Any] | None
 
 
 @with_default_category("Story")
@@ -20,8 +32,8 @@ class StoryController(CommandSet):
 
     def __init__(self) -> None:
         super().__init__()
-        self._current_story_update: list[Any] = []
-        self._current_choices: list[SimpleNamespace] = []
+        self._current_story_update: list[dict[str, Any]] = []
+        self._current_choices: list[_CachedChoice] = []
         self._current_metadata: dict[str, Any] = {}
 
     # ------------------------------------------------------------------
@@ -45,96 +57,109 @@ class StoryController(CommandSet):
             )
         )
 
-    def _load_choices_from_fragments(self) -> list[SimpleNamespace]:
-        """Extract choices from fragment stream (from blocks or loose)."""
+    def _load_choices_from_fragments(self) -> list[_CachedChoice]:
+        """Extract actionable choices from the canonical fragment DTO stream."""
 
-        choices: list[SimpleNamespace] = []
-
-        def read(source: Any, key: str, default: Any = None) -> Any:
-            if isinstance(source, Mapping):
-                return source.get(key, default)
-            return getattr(source, key, default)
-
+        choices: list[_CachedChoice] = []
         for fragment in self._current_story_update:
-            ftype = read(fragment, "fragment_type")
+            if fragment.get("fragment_type") != "choice":
+                continue
 
-            if ftype == "block":
-                embedded = read(fragment, "choices") or []
-                for choice_frag in embedded:
-                    edge_id = (
-                        read(choice_frag, "edge_id")
-                        or read(choice_frag, "source_id")
-                        or read(choice_frag, "uid")
-                    )
-                    label = (
-                        read(choice_frag, "label")
-                        or read(choice_frag, "content", "")
-                        or read(choice_frag, "text", "")
-                        or read(choice_frag, "source_label", "")
-                    )
-                    active = read(choice_frag, "active", True)
-                    reason = read(choice_frag, "unavailable_reason")
+            edge_id = fragment.get("edge_id")
+            if edge_id is None:
+                continue
 
-                    if edge_id:
-                        choices.append(
-                            SimpleNamespace(
-                                edge_id=UUID(str(edge_id)),
-                                label=label.replace("_", " "),
-                                active=active,
-                                unavailable_reason=reason,
-                            )
-                        )
-
-            elif ftype == "choice":
-                edge_id = (
-                    read(fragment, "edge_id")
-                    or read(fragment, "source_id")
-                    or read(fragment, "uid")
+            accepts = fragment.get("accepts")
+            choices.append(
+                _CachedChoice(
+                    edge_id=UUID(str(edge_id)),
+                    label=str(fragment.get("text") or "choice"),
+                    available=bool(fragment.get("available", True)),
+                    unavailable_reason=fragment.get("unavailable_reason"),
+                    accepts=dict(accepts) if isinstance(accepts, dict) else None,
                 )
-                label = (
-                    read(fragment, "label")
-                    or read(fragment, "content", "")
-                    or read(fragment, "text", "")
-                    or read(fragment, "source_label", "")
-                )
-                active = read(fragment, "active", True)
-                reason = read(fragment, "unavailable_reason")
-
-                if edge_id:
-                    choices.append(
-                        SimpleNamespace(
-                            edge_id=UUID(str(edge_id)),
-                            label=label.replace("_", " "),
-                            active=active,
-                            unavailable_reason=reason,
-                        )
-                    )
+            )
 
         return choices
 
     def _call_service(self, method_name: str, **params: Any) -> Any:
         return self._cmd.call_service(method_name, **params)
 
-    def _apply_runtime_envelope(self, envelope: Any) -> None:
-        payload = envelope.to_dto() if hasattr(envelope, "to_dto") else None
-        metadata = (
-            payload.get("metadata")
-            if isinstance(payload, Mapping)
-            else getattr(envelope, "metadata", None)
-        ) or {}
-        if not isinstance(metadata, Mapping):
-            metadata = {}
-        self._current_metadata = dict(metadata)
-        ledger_id_value = metadata.get("ledger_id")
+    def _apply_runtime_envelope(self, envelope: RuntimeEnvelope) -> None:
+        payload = envelope.to_dto()
+        self._current_metadata = payload.get("metadata", {})
+        ledger_id_value = self._current_metadata.get("ledger_id")
         if ledger_id_value is not None:
             self._cmd.set_ledger(UUID(str(ledger_id_value)))
-        fragments = (
-            payload.get("fragments")
-            if isinstance(payload, Mapping)
-            else getattr(envelope, "fragments", [])
-        )
-        self._current_story_update = list(fragments or [])
+        self._current_story_update = payload["fragments"]
         self._current_choices = self._load_choices_from_fragments()
+
+    @staticmethod
+    def _choice_payload(
+        choice: _CachedChoice,
+        values: list[str],
+        raw_payload: str | None,
+    ) -> dict[str, Any] | None:
+        """Build one documented choice payload from CLI input."""
+
+        if raw_payload is not None:
+            if values:
+                raise ValueError("Use positional values or --payload, not both.")
+            try:
+                payload = json.loads(raw_payload)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Invalid JSON payload: {exc.msg}") from exc
+            if not isinstance(payload, dict):
+                raise ValueError("--payload must decode to a JSON object.")
+            return payload
+
+        accepts = choice.accepts
+        kind = accepts.get("kind", "pick") if accepts is not None else "pick"
+        if kind == "pick":
+            if values:
+                raise ValueError("This choice does not accept an input value.")
+            return {}
+
+        if kind in {"text", "raw_command"}:
+            text = " ".join(values).strip()
+            required = kind == "raw_command" or bool(accepts.get("required", True))
+            if required and not text:
+                raise ValueError(f"This choice requires {kind.replace('_', ' ')} input.")
+            return {"text": text}
+
+        if kind == "quantity":
+            if len(values) != 1:
+                raise ValueError("This choice requires one integer quantity.")
+            try:
+                quantity = int(values[0])
+            except ValueError as exc:
+                raise ValueError("Quantity must be an integer.") from exc
+
+            minimum = accepts.get("min")
+            maximum = accepts.get("max")
+            step = accepts.get("step", 1)
+            if isinstance(minimum, int) and quantity < minimum:
+                raise ValueError(f"Quantity must be at least {minimum}.")
+            if isinstance(maximum, int) and quantity > maximum:
+                raise ValueError(f"Quantity must be at most {maximum}.")
+            if isinstance(step, int) and step > 1:
+                origin = minimum if isinstance(minimum, int) else 0
+                if (quantity - origin) % step:
+                    raise ValueError(f"Quantity must advance in steps of {step}.")
+            return {"quantity": quantity}
+
+        if kind == "pieces":
+            minimum = accepts.get("min", 1)
+            maximum = accepts.get("max", 1)
+            if isinstance(minimum, int) and len(values) < minimum:
+                raise ValueError(f"Select at least {minimum} piece(s).")
+            if isinstance(maximum, int) and len(values) > maximum:
+                raise ValueError(f"Select at most {maximum} piece(s).")
+            return {"piece_ids": values}
+
+        raise ValueError(
+            f"{kind} input requires an explicit JSON object via --payload."
+        )
 
     # ------------------------------------------------------------------
     # commands
@@ -153,7 +178,7 @@ class StoryController(CommandSet):
         if args.label:
             kwargs["story_label"] = args.label
 
-        result = self._call_service("create_story", **kwargs)
+        result = cast(RuntimeEnvelope, self._call_service("create_story", **kwargs))
         self._apply_runtime_envelope(result)
 
         title = args.world_id
@@ -173,21 +198,28 @@ class StoryController(CommandSet):
         if not self._require_story_context():
             return
 
-        result = self._call_service("get_story_update", limit=10)
+        result = cast(RuntimeEnvelope, self._call_service("get_story_update", limit=10))
         self._apply_runtime_envelope(result)
         self._render_current_story_update()
 
     choose_parser = argparse.ArgumentParser()
     choose_parser.add_argument("action", type=int, help="Choice number to execute")
+    choose_parser.add_argument(
+        "values",
+        nargs="*",
+        help="Text, quantity, or piece identifiers required by the choice",
+    )
+    choose_parser.add_argument(
+        "--payload",
+        help="Explicit JSON object for place, compose, or extension choices",
+    )
 
     @with_argparser(choose_parser)
     def do_do(self, args: argparse.Namespace) -> None:
         if not self._require_story_context():
             return
 
-        active_choices = [
-            choice for choice in self._current_choices if getattr(choice, "active", True)
-        ]
+        active_choices = [choice for choice in self._current_choices if choice.available]
         if not active_choices:
             self._cmd.poutput("No cached choices. Run `story` to refresh choices first.")
             return
@@ -198,9 +230,19 @@ class StoryController(CommandSet):
             return
 
         choice = active_choices[index - 1]
-        result = self._call_service(
-            "resolve_choice",
-            edge_id=choice.edge_id,
+        try:
+            choice_payload = self._choice_payload(choice, args.values, args.payload)
+        except ValueError as exc:
+            self._cmd.poutput(str(exc))
+            return
+
+        result = cast(
+            RuntimeEnvelope,
+            self._call_service(
+                "resolve_choice",
+                edge_id=choice.edge_id,
+                choice_payload=choice_payload,
+            ),
         )
         self._apply_runtime_envelope(result)
         self._render_current_story_update()
@@ -266,14 +308,5 @@ class StoryController(CommandSet):
         if not self._require_story_context():
             return
 
-        info = self._call_service("get_story_info")
-        if hasattr(info, "to_dto"):
-            payload = info.to_dto()
-        elif hasattr(info, "model_dump"):
-            payload = info.model_dump()
-        elif isinstance(info, dict):
-            payload = info
-        else:
-            payload = {"info": str(info)}
-
-        self._cmd.emit_terminal(self._cmd.terminal_renderer.projected_state(payload))
+        info = cast(ProjectedState, self._call_service("get_story_info"))
+        self._cmd.emit_terminal(self._cmd.terminal_renderer.projected_state(info.to_dto()))

--- a/apps/cli/src/tangl/cli/controllers/story_controller.py
+++ b/apps/cli/src/tangl/cli/controllers/story_controller.py
@@ -61,7 +61,7 @@ class StoryController(CommandSet):
             if ftype == "block":
                 embedded = read(fragment, "choices") or []
                 for choice_frag in embedded:
-                    uid = (
+                    edge_id = (
                         read(choice_frag, "edge_id")
                         or read(choice_frag, "source_id")
                         or read(choice_frag, "uid")
@@ -75,10 +75,10 @@ class StoryController(CommandSet):
                     active = read(choice_frag, "active", True)
                     reason = read(choice_frag, "unavailable_reason")
 
-                    if uid:
+                    if edge_id:
                         choices.append(
                             SimpleNamespace(
-                                uid=UUID(str(uid)),
+                                edge_id=UUID(str(edge_id)),
                                 label=label.replace("_", " "),
                                 active=active,
                                 unavailable_reason=reason,
@@ -86,7 +86,7 @@ class StoryController(CommandSet):
                         )
 
             elif ftype == "choice":
-                uid = (
+                edge_id = (
                     read(fragment, "edge_id")
                     or read(fragment, "source_id")
                     or read(fragment, "uid")
@@ -100,10 +100,10 @@ class StoryController(CommandSet):
                 active = read(fragment, "active", True)
                 reason = read(fragment, "unavailable_reason")
 
-                if uid:
+                if edge_id:
                     choices.append(
                         SimpleNamespace(
-                            uid=UUID(str(uid)),
+                            edge_id=UUID(str(edge_id)),
                             label=label.replace("_", " "),
                             active=active,
                             unavailable_reason=reason,
@@ -200,7 +200,7 @@ class StoryController(CommandSet):
         choice = active_choices[index - 1]
         result = self._call_service(
             "resolve_choice",
-            edge_id=choice.uid,
+            edge_id=choice.edge_id,
         )
         self._apply_runtime_envelope(result)
         self._render_current_story_update()

--- a/apps/cli/src/tangl/cli/controllers/story_controller.py
+++ b/apps/cli/src/tangl/cli/controllers/story_controller.py
@@ -267,7 +267,9 @@ class StoryController(CommandSet):
             return
 
         info = self._call_service("get_story_info")
-        if hasattr(info, "model_dump"):
+        if hasattr(info, "to_dto"):
+            payload = info.to_dto()
+        elif hasattr(info, "model_dump"):
             payload = info.model_dump()
         elif isinstance(info, dict):
             payload = info

--- a/apps/cli/src/tangl/cli/controllers/story_controller.py
+++ b/apps/cli/src/tangl/cli/controllers/story_controller.py
@@ -50,25 +50,30 @@ class StoryController(CommandSet):
 
         choices: list[SimpleNamespace] = []
 
+        def read(source: Any, key: str, default: Any = None) -> Any:
+            if isinstance(source, Mapping):
+                return source.get(key, default)
+            return getattr(source, key, default)
+
         for fragment in self._current_story_update:
-            ftype = getattr(fragment, "fragment_type", None)
+            ftype = read(fragment, "fragment_type")
 
             if ftype == "block":
-                embedded = getattr(fragment, "choices", None) or []
+                embedded = read(fragment, "choices") or []
                 for choice_frag in embedded:
                     uid = (
-                        getattr(choice_frag, "edge_id", None)
-                        or getattr(choice_frag, "source_id", None)
-                        or getattr(choice_frag, "uid", None)
+                        read(choice_frag, "edge_id")
+                        or read(choice_frag, "source_id")
+                        or read(choice_frag, "uid")
                     )
                     label = (
-                        getattr(choice_frag, "label", None)
-                        or getattr(choice_frag, "content", "")
-                        or getattr(choice_frag, "text", "")
-                        or getattr(choice_frag, "source_label", "")
+                        read(choice_frag, "label")
+                        or read(choice_frag, "content", "")
+                        or read(choice_frag, "text", "")
+                        or read(choice_frag, "source_label", "")
                     )
-                    active = getattr(choice_frag, "active", True)
-                    reason = getattr(choice_frag, "unavailable_reason", None)
+                    active = read(choice_frag, "active", True)
+                    reason = read(choice_frag, "unavailable_reason")
 
                     if uid:
                         choices.append(
@@ -82,18 +87,18 @@ class StoryController(CommandSet):
 
             elif ftype == "choice":
                 uid = (
-                    getattr(fragment, "edge_id", None)
-                    or getattr(fragment, "source_id", None)
-                    or getattr(fragment, "uid", None)
+                    read(fragment, "edge_id")
+                    or read(fragment, "source_id")
+                    or read(fragment, "uid")
                 )
                 label = (
-                    getattr(fragment, "label", None)
-                    or getattr(fragment, "content", "")
-                    or getattr(fragment, "text", "")
-                    or getattr(fragment, "source_label", "")
+                    read(fragment, "label")
+                    or read(fragment, "content", "")
+                    or read(fragment, "text", "")
+                    or read(fragment, "source_label", "")
                 )
-                active = getattr(fragment, "active", True)
-                reason = getattr(fragment, "unavailable_reason", None)
+                active = read(fragment, "active", True)
+                reason = read(fragment, "unavailable_reason")
 
                 if uid:
                     choices.append(
@@ -111,14 +116,24 @@ class StoryController(CommandSet):
         return self._cmd.call_service(method_name, **params)
 
     def _apply_runtime_envelope(self, envelope: Any) -> None:
-        metadata = getattr(envelope, "metadata", None) or {}
+        payload = envelope.to_dto() if hasattr(envelope, "to_dto") else None
+        metadata = (
+            payload.get("metadata")
+            if isinstance(payload, Mapping)
+            else getattr(envelope, "metadata", None)
+        ) or {}
         if not isinstance(metadata, Mapping):
             metadata = {}
         self._current_metadata = dict(metadata)
         ledger_id_value = metadata.get("ledger_id")
         if ledger_id_value is not None:
             self._cmd.set_ledger(UUID(str(ledger_id_value)))
-        self._current_story_update = list(getattr(envelope, "fragments", []) or [])
+        fragments = (
+            payload.get("fragments")
+            if isinstance(payload, Mapping)
+            else getattr(envelope, "fragments", [])
+        )
+        self._current_story_update = list(fragments or [])
         self._current_choices = self._load_choices_from_fragments()
 
     # ------------------------------------------------------------------

--- a/apps/cli/src/tangl/cli/rendering.py
+++ b/apps/cli/src/tangl/cli/rendering.py
@@ -123,7 +123,8 @@ class PlainTerminalRenderer:
         for choice in choices:
             label = _choice_label(choice)
             if _choice_active(choice):
-                lines.append(f"{active_index}. {label}")
+                hint = _choice_input_hint(choice)
+                lines.append(f"{active_index}. {label}{f' {hint}' if hint else ''}")
                 active_index += 1
                 continue
 
@@ -254,6 +255,10 @@ def _plain_fragment_lines(fragment: Any) -> list[str]:
     if ftype == "user_event":
         event_type = _read(fragment, "event_type") or "event"
         return [f"* {event_type}: {_fragment_text(fragment)}"]
+    if ftype == "piece":
+        piece_id = _read(fragment, "piece_id")
+        label = _fragment_text(fragment)
+        return [f"[{piece_id}] {label}" if piece_id else label]
 
     text = _fragment_text(fragment)
     return [text] if text else []
@@ -280,6 +285,11 @@ def _rich_fragment_renderables(fragment: Any) -> list[Any]:
     if ftype == "user_event":
         event_type = _read(fragment, "event_type") or "event"
         return [_rich_text(f"‹ {event_type} › {_fragment_text(fragment)}", style="italic dim")]
+    if ftype == "piece":
+        piece_id = _read(fragment, "piece_id")
+        label = _fragment_text(fragment)
+        text = f"[{piece_id}] {label}" if piece_id else label
+        return [_rich_text(text)]
 
     content_format = _read(fragment, "content_format")
     text = _fragment_text(fragment)
@@ -310,7 +320,7 @@ def _rich_choices(choices: list[Any], *, no_choices_text: str = "No available ch
     for choice in choices:
         label = _choice_label(choice)
         if _choice_active(choice):
-            table.add_row(str(active_index), label, "")
+            table.add_row(str(active_index), label, _choice_input_hint(choice))
             active_index += 1
             continue
 
@@ -628,8 +638,36 @@ def _choice_label(choice: Any) -> str:
 
 
 def _choice_active(choice: Any) -> bool:
-    active = _read(choice, "active", True)
-    return bool(active)
+    available = _read(choice, "available")
+    if available is not None:
+        return bool(available)
+    return bool(_read(choice, "active", True))
+
+
+def _choice_input_hint(choice: Any) -> str:
+    accepts = _read(choice, "accepts")
+    if not isinstance(accepts, Mapping):
+        return ""
+
+    kind = accepts.get("kind")
+    if kind == "quantity":
+        bounds = "-".join(
+            str(value)
+            for value in (accepts.get("min"), accepts.get("max"))
+            if value is not None
+        )
+        unit = f" {accepts['unit']}" if accepts.get("unit") else ""
+        return f"<quantity{f' {bounds}' if bounds else ''}{unit}>"
+    if kind == "pieces":
+        minimum = accepts.get("min", 1)
+        maximum = accepts.get("max", 1)
+        count = str(minimum) if minimum == maximum else f"{minimum}-{maximum}"
+        return f"<piece ids: {count}>"
+    if kind in {"text", "raw_command"}:
+        return f"<{str(kind).replace('_', ' ')}>"
+    if kind not in {None, "pick"}:
+        return f"<{kind}: --payload JSON>"
+    return ""
 
 
 def _read(source: Any, key: str, default: Any = None) -> Any:

--- a/apps/cli/tests/test_cli_rendering.py
+++ b/apps/cli/tests/test_cli_rendering.py
@@ -41,9 +41,18 @@ def test_rich_renderer_exports_envelope_text() -> None:
                 event_type="shift_bell",
                 content="Ten minutes remain.",
             ),
+            {
+                "fragment_type": "piece",
+                "piece_id": "permit-7",
+                "content": "Gate permit",
+            },
         ],
         choices=[
-            SimpleNamespace(label="Verify ID", active=True),
+            {
+                "label": "Verify ID",
+                "available": True,
+                "accepts": {"kind": "pieces", "min": 1, "max": 1},
+            },
             SimpleNamespace(
                 label="Allow passage",
                 active=False,
@@ -67,7 +76,9 @@ def test_rich_renderer_exports_envelope_text() -> None:
     assert "permit-9472.jpg" in transcript
     assert "permit_expiry" in transcript
     assert "shift_bell" in transcript
+    assert "[permit-7] Gate permit" in transcript
     assert "Verify ID" in transcript
+    assert "piece ids: 1" in transcript
     assert "Allow passage" in transcript
     assert "Permit expired" in transcript
     assert "/m Map" in transcript

--- a/apps/cli/tests/test_cli_story_controller.py
+++ b/apps/cli/tests/test_cli_story_controller.py
@@ -9,7 +9,13 @@ import cmd2
 from tangl.cli.controllers.story_controller import StoryController
 from tangl.cli.rendering import PlainTerminalRenderer
 from tangl.journal.fragments import ChoiceFragment, ContentFragment
-from tangl.service.response import RuntimeEnvelope
+from tangl.service.response import (
+    KvListValue,
+    KvRow,
+    ProjectedSection,
+    ProjectedState,
+    RuntimeEnvelope,
+)
 
 # This uses a test-app to focus on the StoryController
 
@@ -199,3 +205,28 @@ def test_status_renders_projected_sections_generically(story_controller: StoryCo
     assert "Cursor: Dark Forest" in output
     assert "Flags:" in output
     assert "torch_lit, met_guide" in output
+
+
+def test_status_uses_projected_state_dto(
+    story_controller: StoryController,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli = story_controller._cmd
+    state = ProjectedState(
+        sections=[
+            ProjectedSection(
+                section_id="session",
+                title="Session",
+                kind="stats",
+                value=KvListValue(items=[KvRow(key="Step", value=4)]),
+            )
+        ]
+    )
+    monkeypatch.setattr(cli, "call_service", lambda *_args, **_kwargs: state)
+    cli.outputs.clear()
+
+    story_controller.do_status()
+
+    output = "\n".join(cli.outputs)
+    assert "Session:" in output
+    assert "Step: 4" in output

--- a/apps/cli/tests/test_cli_story_controller.py
+++ b/apps/cli/tests/test_cli_story_controller.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
 from uuid import UUID, uuid4
 
-import pytest
 import cmd2
+import pytest
 
 from tangl.cli.controllers.story_controller import StoryController
 from tangl.cli.rendering import PlainTerminalRenderer
-from tangl.journal.fragments import ChoiceFragment, ContentFragment
+from tangl.journal.fragments import ChoiceFragment, ContentFragment, PieceFragment
 from tangl.service.response import (
+    BadgeListValue,
     KvListValue,
     KvRow,
     ProjectedSection,
@@ -17,7 +17,9 @@ from tangl.service.response import (
     RuntimeEnvelope,
 )
 
+
 # This uses a test-app to focus on the StoryController
+
 
 class RecordingCLI(cmd2.Cmd):
     def __init__(self) -> None:
@@ -31,7 +33,7 @@ class RecordingCLI(cmd2.Cmd):
         self.story_controller = StoryController()
         self.register_command_set(self.story_controller)
 
-    def poutput(self, message: object, *, end: str = "\n", **_: object) -> None:
+    def poutput(self, message: object, *, end: str = "\n", **_: object) -> None:  # noqa: ARG002
         self.outputs.append(str(message))
 
     def emit_terminal(self, renderables: list[object]) -> None:
@@ -43,55 +45,43 @@ class RecordingCLI(cmd2.Cmd):
     def call_service(self, method_name: str, /, **params: object) -> object:
         self.calls.append((method_name, params))
         if method_name in {"create_story", "get_story_update"}:
-            return SimpleNamespace(
+            return RuntimeEnvelope(
                 metadata={"ledger_id": str(self.ledger_id)},
                 fragments=[
-                    SimpleNamespace(
-                        fragment_type="block",
-                        content="start",
-                        choices=[
-                            SimpleNamespace(
-                                fragment_type="choice",
-                                uid=self.edge_id,
-                                source_id=self.edge_id,
-                                label="Go",
-                                active=True,
-                            )
-                        ],
+                    ContentFragment(content="start"),
+                    ChoiceFragment(
+                        edge_id=self.edge_id,
+                        text="Go",
                     ),
                 ],
             )
         if method_name == "resolve_choice":
-            return SimpleNamespace(
+            return RuntimeEnvelope(
                 metadata={"ledger_id": str(self.ledger_id)},
-                fragments=[SimpleNamespace(content="moved")],
+                fragments=[ContentFragment(content="moved")],
             )
         if method_name == "get_story_info":
-            return {
-                "sections": [
-                    {
-                        "section_id": "session",
-                        "title": "Session",
-                        "kind": "stats",
-                        "value": {
-                            "value_type": "kv_list",
-                            "items": [
-                                {"key": "Cursor", "value": "Dark Forest"},
-                                {"key": "Step", "value": 0},
-                            ],
-                        },
-                    },
-                    {
-                        "section_id": "flags",
-                        "title": "Flags",
-                        "kind": "custom_metrics",
-                        "value": {
-                            "value_type": "badges",
-                            "items": ["torch_lit", "met_guide"],
-                        },
-                    },
+            return ProjectedState(
+                sections=[
+                    ProjectedSection(
+                        section_id="session",
+                        title="Session",
+                        kind="stats",
+                        value=KvListValue(
+                            items=[
+                                KvRow(key="Cursor", value="Dark Forest"),
+                                KvRow(key="Step", value=0),
+                            ]
+                        ),
+                    ),
+                    ProjectedSection(
+                        section_id="flags",
+                        title="Flags",
+                        kind="custom_metrics",
+                        value=BadgeListValue(items=["torch_lit", "met_guide"]),
+                    ),
                 ]
-            }
+            )
         if method_name == "drop_story":
             return {
                 "status": "dropped",
@@ -106,6 +96,7 @@ class RecordingCLI(cmd2.Cmd):
 def story_controller() -> StoryController:
     cli = RecordingCLI()
     return cli.story_controller
+
 
 def test_story_command_fetches_journal_and_choices(story_controller: StoryController) -> None:
     story_controller.do_story()
@@ -122,6 +113,7 @@ def test_do_command_resolves_choice(story_controller: StoryController) -> None:
     assert resolve_calls
     _, params = resolve_calls[-1]
     assert params["edge_id"] == cli.edge_id
+    assert params["choice_payload"] == {}
 
 
 def test_cli_applies_runtime_envelope_dto_projection(
@@ -155,24 +147,24 @@ def test_cli_applies_runtime_envelope_dto_projection(
 
 def test_cli_shows_locked_choices_with_reason(story_controller: StoryController) -> None:
     cli = story_controller._cmd
-    locked_fragment = SimpleNamespace(
-        fragment_type="choice",
-        content="Open vault",
-        active=False,
-        unavailable_reason="Requires keycard",
-        uid=uuid4(),
-    )
-    active_fragment = SimpleNamespace(
-        fragment_type="choice",
-        content="Go north",
-        active=True,
-        uid=uuid4(),
+    story_controller._apply_runtime_envelope(
+        RuntimeEnvelope(
+            fragments=[
+                ChoiceFragment(
+                    edge_id=uuid4(),
+                    text="Open vault",
+                    available=False,
+                    unavailable_reason="Requires keycard",
+                ),
+                ChoiceFragment(
+                    edge_id=uuid4(),
+                    text="Go north",
+                ),
+            ]
+        )
     )
 
     cli.outputs.clear()
-    story_controller._current_story_update = [locked_fragment, active_fragment]
-    story_controller._current_choices = story_controller._load_choices_from_fragments()
-
     story_controller._render_current_story_update()
 
     output = "\n".join(cli.outputs)
@@ -180,10 +172,105 @@ def test_cli_shows_locked_choices_with_reason(story_controller: StoryController)
     assert "x) Open vault [locked: Requires keycard]" in output
 
 
+def test_do_command_submits_quantity_payload(story_controller: StoryController) -> None:
+    cli = story_controller._cmd
+    story_controller._apply_runtime_envelope(
+        RuntimeEnvelope(
+            fragments=[
+                ChoiceFragment(
+                    edge_id=cli.edge_id,
+                    text="Take tokens",
+                    accepts={"kind": "quantity", "min": 1, "max": 3},
+                )
+            ]
+        )
+    )
+
+    story_controller.do_do("1 2")
+
+    _, params = [call for call in cli.calls if call[0] == "resolve_choice"][-1]
+    assert params["choice_payload"] == {"quantity": 2}
+
+
+def test_do_command_submits_piece_payload(story_controller: StoryController) -> None:
+    cli = story_controller._cmd
+    story_controller._apply_runtime_envelope(
+        RuntimeEnvelope(
+            fragments=[
+                PieceFragment(
+                    piece_id="permit-7",
+                    piece_kind="document",
+                    content="Gate permit",
+                ),
+                ChoiceFragment(
+                    edge_id=cli.edge_id,
+                    text="Inspect a document",
+                    accepts={"kind": "pieces", "min": 1, "max": 1},
+                ),
+            ]
+        )
+    )
+
+    story_controller.do_do("1 permit-7")
+
+    _, params = [call for call in cli.calls if call[0] == "resolve_choice"][-1]
+    assert params["choice_payload"] == {"piece_ids": ["permit-7"]}
+
+
+def test_do_command_rejects_invalid_quantity(story_controller: StoryController) -> None:
+    cli = story_controller._cmd
+    story_controller._apply_runtime_envelope(
+        RuntimeEnvelope(
+            fragments=[
+                ChoiceFragment(
+                    edge_id=cli.edge_id,
+                    text="Take tokens",
+                    accepts={"kind": "quantity", "min": 1, "max": 3},
+                )
+            ]
+        )
+    )
+    calls_before = len(cli.calls)
+
+    story_controller.do_do("1 4")
+
+    assert len(cli.calls) == calls_before
+    assert cli.outputs[-1] == "Quantity must be at most 3."
+
+
+def test_do_command_accepts_explicit_compose_payload(
+    story_controller: StoryController,
+) -> None:
+    cli = story_controller._cmd
+    story_controller._apply_runtime_envelope(
+        RuntimeEnvelope(
+            fragments=[
+                ChoiceFragment(
+                    edge_id=cli.edge_id,
+                    text="Give coins",
+                    accepts={
+                        "kind": "compose",
+                        "parts": [
+                            {
+                                "role": "amount",
+                                "accepts": {"kind": "quantity", "min": 1},
+                            }
+                        ],
+                    },
+                )
+            ]
+        )
+    )
+
+    story_controller.do_do("""1 --payload '{"parts":{"amount":{"quantity":2}}}'""")
+
+    _, params = [call for call in cli.calls if call[0] == "resolve_choice"][-1]
+    assert params["choice_payload"] == {"parts": {"amount": {"quantity": 2}}}
+
+
 def test_drop_story_invokes_service_and_clears_context(story_controller: StoryController) -> None:
     cli = story_controller._cmd
-    story_controller._current_story_update = [SimpleNamespace(content="previous")]
-    story_controller._current_choices = [SimpleNamespace(edge_id=cli.edge_id, label="Go")]
+    story_controller.do_story()
     cli.outputs.clear()
 
     story_controller.do_drop_story("--archive")

--- a/apps/cli/tests/test_cli_story_controller.py
+++ b/apps/cli/tests/test_cli_story_controller.py
@@ -129,11 +129,17 @@ def test_cli_applies_runtime_envelope_dto_projection(
 ) -> None:
     cli = story_controller._cmd
     edge_id = uuid4()
+    fragment_uid = uuid4()
     envelope = RuntimeEnvelope(
         metadata={"ledger_id": str(cli.ledger_id)},
         fragments=[
             ContentFragment(content="start", step=3),
-            ChoiceFragment(edge_id=edge_id, text="Go north", step=3),
+            ChoiceFragment(
+                uid=fragment_uid,
+                edge_id=edge_id,
+                text="Go north",
+                step=3,
+            ),
         ],
     )
 
@@ -142,7 +148,8 @@ def test_cli_applies_runtime_envelope_dto_projection(
     assert story_controller._current_story_update[0]["content"] == "start"
     assert "seq" not in story_controller._current_story_update[0]
     assert "step" not in story_controller._current_story_update[0]
-    assert story_controller._current_choices[0].uid == edge_id
+    assert story_controller._current_story_update[1]["uid"] == str(fragment_uid)
+    assert story_controller._current_choices[0].edge_id == edge_id
     assert story_controller._current_choices[0].label == "Go north"
 
 
@@ -176,7 +183,7 @@ def test_cli_shows_locked_choices_with_reason(story_controller: StoryController)
 def test_drop_story_invokes_service_and_clears_context(story_controller: StoryController) -> None:
     cli = story_controller._cmd
     story_controller._current_story_update = [SimpleNamespace(content="previous")]
-    story_controller._current_choices = [SimpleNamespace(uid=cli.edge_id, label="Go")]
+    story_controller._current_choices = [SimpleNamespace(edge_id=cli.edge_id, label="Go")]
     cli.outputs.clear()
 
     story_controller.do_drop_story("--archive")

--- a/apps/cli/tests/test_cli_story_controller.py
+++ b/apps/cli/tests/test_cli_story_controller.py
@@ -8,6 +8,8 @@ import cmd2
 
 from tangl.cli.controllers.story_controller import StoryController
 from tangl.cli.rendering import PlainTerminalRenderer
+from tangl.journal.fragments import ChoiceFragment, ContentFragment
+from tangl.service.response import RuntimeEnvelope
 
 # This uses a test-app to focus on the StoryController
 
@@ -114,6 +116,28 @@ def test_do_command_resolves_choice(story_controller: StoryController) -> None:
     assert resolve_calls
     _, params = resolve_calls[-1]
     assert params["edge_id"] == cli.edge_id
+
+
+def test_cli_applies_runtime_envelope_dto_projection(
+    story_controller: StoryController,
+) -> None:
+    cli = story_controller._cmd
+    edge_id = uuid4()
+    envelope = RuntimeEnvelope(
+        metadata={"ledger_id": str(cli.ledger_id)},
+        fragments=[
+            ContentFragment(content="start", step=3),
+            ChoiceFragment(edge_id=edge_id, text="Go north", step=3),
+        ],
+    )
+
+    story_controller._apply_runtime_envelope(envelope)
+
+    assert story_controller._current_story_update[0]["content"] == "start"
+    assert "seq" not in story_controller._current_story_update[0]
+    assert "step" not in story_controller._current_story_update[0]
+    assert story_controller._current_choices[0].uid == edge_id
+    assert story_controller._current_choices[0].label == "Go north"
 
 
 def test_cli_shows_locked_choices_with_reason(story_controller: StoryController) -> None:

--- a/apps/server/src/tangl/rest/routers/story_router.py
+++ b/apps/server/src/tangl/rest/routers/story_router.py
@@ -437,7 +437,7 @@ async def get_story_info(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=_bad_request_detail(exc)) from exc
 
-    payload = result.to_dto() if hasattr(result, "to_dto") else _serialize(result)
+    payload = result.to_dto()
     if _profile_has(render_profile, "html"):
         payload = _transform_text_fields(payload)
     return payload

--- a/apps/server/src/tangl/rest/routers/story_router.py
+++ b/apps/server/src/tangl/rest/routers/story_router.py
@@ -10,7 +10,7 @@ from markdown_it import MarkdownIt
 from pydantic import BaseModel, ConfigDict
 
 from tangl.config import get_story_media_dir, get_sys_media_dir, settings
-from tangl.journal.fragments import MediaFragment
+from tangl.journal.fragments import MediaFragment, fragment_to_dto
 from tangl.rest.dependencies_gateway import (
     get_service_manager,
     get_user_locks,
@@ -210,7 +210,7 @@ def _serialize_fragment(
     if isinstance(fragment, MediaFragment):
         return None
     if hasattr(fragment, "model_dump"):
-        return _serialize(fragment.model_dump(mode="python"))
+        return _serialize(fragment_to_dto(fragment))
     if hasattr(fragment, "unstructure"):
         return _serialize(fragment.unstructure())
     return {"fragment_type": "unknown", "content": str(fragment)}
@@ -223,7 +223,8 @@ def _serialize_runtime_envelope(
 ) -> dict[str, Any]:
     profile_tokens = _normalize_profile_tokens(render_profile)
     media_profile = _media_render_profile(profile_tokens)
-    metadata = dict(envelope.metadata or {})
+    envelope_payload = envelope.to_dto()
+    metadata = dict(envelope_payload.get("metadata") or {})
     world_id = str(metadata["world_id"]) if metadata.get("world_id") is not None else None
     story_id = str(metadata["ledger_id"]) if metadata.get("ledger_id") is not None else None
     world_media_root = _resolve_world_media_root(world_id)
@@ -245,12 +246,8 @@ def _serialize_runtime_envelope(
             fragments.append(payload)
 
     payload = {
-        "cursor_id": envelope.cursor_id,
-        "step": envelope.step,
+        **envelope_payload,
         "fragments": _normalize_choice_labels_in_fragments(fragments),
-        "last_redirect": envelope.last_redirect,
-        "redirect_trace": envelope.redirect_trace,
-        "metadata": metadata,
     }
     serialized = _serialize(payload)
     if "html" in profile_tokens:

--- a/apps/server/src/tangl/rest/routers/story_router.py
+++ b/apps/server/src/tangl/rest/routers/story_router.py
@@ -437,7 +437,7 @@ async def get_story_info(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=_bad_request_detail(exc)) from exc
 
-    payload = _serialize(result)
+    payload = result.to_dto() if hasattr(result, "to_dto") else _serialize(result)
     if _profile_has(render_profile, "html"):
         payload = _transform_text_fields(payload)
     return payload

--- a/apps/server/src/tangl/rest/routers/story_router.py
+++ b/apps/server/src/tangl/rest/routers/story_router.py
@@ -148,10 +148,6 @@ def _normalize_choice_labels_in_fragments(fragments: list[dict[str, Any]]) -> li
 
     def _normalize_choice_data(choice: dict[str, Any]) -> dict[str, Any]:
         normalized = dict(choice)
-        if normalized.get("edge_id"):
-            normalized["uid"] = normalized["edge_id"]
-        if normalized.get("source_id") and "uid" not in normalized:
-            normalized["uid"] = normalized["source_id"]
         if normalized.get("source_label") and not normalized.get("label"):
             normalized["label"] = normalized["source_label"]
         if normalized.get("text") and not normalized.get("label"):

--- a/apps/server/tests/helpers_server/json_fragment_helpers.py
+++ b/apps/server/tests/helpers_server/json_fragment_helpers.py
@@ -6,14 +6,12 @@ def extract_choices_from_fragments(fragments: list[dict]) -> list[dict]:
 
     def _normalize(choice: dict) -> dict:
         normalized = dict(choice)
-        if "edge_id" in normalized:
-            normalized["uid"] = normalized["edge_id"]
-        elif "source_id" in normalized:
-            normalized["uid"] = normalized["source_id"]
-        elif "uid" in normalized:
-            normalized["uid"] = normalized["uid"]
         if "source_label" in normalized and not normalized.get("label"):
             normalized["label"] = normalized["source_label"]
+        if "text" in normalized and not normalized.get("label"):
+            normalized["label"] = normalized["text"]
+        if "content" in normalized and not normalized.get("label"):
+            normalized["label"] = normalized["content"]
         return normalized
 
     for fragment in fragments:

--- a/apps/server/tests/test_multi_world_switching.py
+++ b/apps/server/tests/test_multi_world_switching.py
@@ -274,7 +274,8 @@ def test_multi_world_switching_flow(
     assert isinstance(step_before, int)
 
     first_choice_frag = choices_one[0]
-    first_choice = first_choice_frag.get("uid") or first_choice_frag.get("source_id")
+    first_choice = first_choice_frag.get("edge_id")
+    assert isinstance(first_choice, str)
     choose_resp = client.post("story/do", json={"edge_id": first_choice}, headers=headers)
     assert choose_resp.status_code == 200
     choice_step = choose_resp.json()["step"]
@@ -324,7 +325,8 @@ def test_multi_world_switching_flow(
     third_choices = extract_choices_from_fragments(fragments_three)
     assert len(third_choices) == 1
 
-    continue_choice = third_choices[0].get("uid") or third_choices[0].get("source_id")
+    continue_choice = third_choices[0].get("edge_id")
+    assert isinstance(continue_choice, str)
     continue_resp = client.post("story/do", json={"edge_id": continue_choice}, headers=headers)
     assert continue_resp.status_code == 200
 

--- a/apps/server/tests/test_story_branching_endpoints.py
+++ b/apps/server/tests/test_story_branching_endpoints.py
@@ -60,6 +60,12 @@ def _find_choice(choices: list[dict[str, object]], keyword: str) -> dict[str, ob
     raise AssertionError(f"Choice containing '{keyword}' not found: {choices}")
 
 
+def _edge_id(choice: dict[str, object]) -> object:
+    edge_id = choice.get("edge_id")
+    assert edge_id is not None
+    return edge_id
+
+
 def test_branching_story_left_path_rest(branching_story_client: tuple[TestClient, dict[str, str]]) -> None:
     client, headers = branching_story_client
 
@@ -78,7 +84,7 @@ def test_branching_story_left_path_rest(branching_story_client: tuple[TestClient
     assert len(choices) == 3
 
     left_choice = _find_choice(choices, "left")
-    resolve_left = client.post("story/do", json={"edge_id": left_choice["uid"]}, headers=headers)
+    resolve_left = client.post("story/do", json={"edge_id": _edge_id(left_choice)}, headers=headers)
     assert resolve_left.status_code == 200
 
     update_two = client.get(
@@ -106,7 +112,7 @@ def test_branching_story_enter_cave_rest(branching_story_client: tuple[TestClien
 
     choices = extract_choices_from_fragments(fragments)
     right_choice = _find_choice(choices, "right")
-    resolve_right = client.post("story/do", json={"edge_id": right_choice["uid"]}, headers=headers)
+    resolve_right = client.post("story/do", json={"edge_id": _edge_id(right_choice)}, headers=headers)
     assert resolve_right.status_code == 200
 
     second_update = client.get(
@@ -125,7 +131,7 @@ def test_branching_story_enter_cave_rest(branching_story_client: tuple[TestClien
     assert _find_choice(choices_two, "back")
 
     enter_choice = _find_choice(choices_two, "enter")
-    resolve_enter = client.post("story/do", json={"edge_id": enter_choice["uid"]}, headers=headers)
+    resolve_enter = client.post("story/do", json={"edge_id": _edge_id(enter_choice)}, headers=headers)
     assert resolve_enter.status_code == 200
 
     third_update = client.get(
@@ -148,7 +154,7 @@ def test_branching_story_backtrack_rest(branching_story_client: tuple[TestClient
     first_update = client.get("story/update", headers=headers).json()
     first_choices = extract_choices_from_fragments(first_update["fragments"])
     right_choice = _find_choice(first_choices, "right")
-    first_resolve = client.post("story/do", json={"edge_id": right_choice["uid"]}, headers=headers)
+    first_resolve = client.post("story/do", json={"edge_id": _edge_id(right_choice)}, headers=headers)
     assert first_resolve.status_code == 200
     first_step = first_resolve.json()["step"]
 
@@ -159,7 +165,7 @@ def test_branching_story_backtrack_rest(branching_story_client: tuple[TestClient
     ).json()
     second_choices = extract_choices_from_fragments(second_update["fragments"])
     back_choice = _find_choice(second_choices, "back")
-    resolve_back = client.post("story/do", json={"edge_id": back_choice["uid"]}, headers=headers)
+    resolve_back = client.post("story/do", json={"edge_id": _edge_id(back_choice)}, headers=headers)
     assert resolve_back.status_code == 200
     back_step = resolve_back.json()["step"]
 

--- a/apps/server/tests/test_story_linear_endpoints.py
+++ b/apps/server/tests/test_story_linear_endpoints.py
@@ -57,6 +57,12 @@ def _fragment_has_html_content(fragments: list[dict[str, object]]) -> bool:
     return any("<p>" in str(fragment.get("content", "")) for fragment in fragments)
 
 
+def _edge_id(choice: dict[str, object]) -> object:
+    edge_id = choice.get("edge_id")
+    assert edge_id is not None
+    return edge_id
+
+
 def test_linear_story_rest_flow(linear_story_client: tuple[TestClient, dict[str, str]]) -> None:
     client, headers = linear_story_client
 
@@ -72,7 +78,7 @@ def test_linear_story_rest_flow(linear_story_client: tuple[TestClient, dict[str,
     choices = extract_choices_from_fragments(fragments)
     assert choices, "Expected an initial choice to be available"
 
-    first_choice = choices[0].get("uid") or choices[0].get("source_id")
+    first_choice = _edge_id(choices[0])
     resolve_first = client.post("story/do", json={"edge_id": first_choice}, headers=headers)
     assert resolve_first.status_code == 200
     first_step = resolve_first.json()["step"]
@@ -93,7 +99,7 @@ def test_linear_story_rest_flow(linear_story_client: tuple[TestClient, dict[str,
     choices_two = extract_choices_from_fragments(fragments_two)
     assert choices_two, "Expected a continuation choice after the middle block"
 
-    second_choice = choices_two[0].get("uid") or choices_two[0].get("source_id")
+    second_choice = _edge_id(choices_two[0])
     resolve_second = client.post("story/do", json={"edge_id": second_choice}, headers=headers)
     assert resolve_second.status_code == 200
     second_step = resolve_second.json()["step"]
@@ -138,8 +144,7 @@ def test_linear_story_do_supports_html_render_profile(
 
     update = client.get("story/update", headers=headers)
     assert update.status_code == 200
-    first_choice = extract_choices_from_fragments(update.json()["fragments"])[0].get("uid")
-    assert first_choice is not None
+    first_choice = _edge_id(extract_choices_from_fragments(update.json()["fragments"])[0])
 
     resolve = client.post(
         "story/do",

--- a/apps/server/tests/test_story_runtime_endpoints.py
+++ b/apps/server/tests/test_story_runtime_endpoints.py
@@ -377,6 +377,8 @@ def test_story_update_preserves_choice_fragment_uid_and_edge_id(
     assert isinstance(choice.get("edge_id"), str)
     assert choice["uid"] != choice["edge_id"]
     assert choice["label"] == "Continue"
+    assert "seq" not in choice
+    assert "step" not in choice
 
     resolved = client.post(
         "story/do",

--- a/apps/server/tests/test_story_runtime_endpoints.py
+++ b/apps/server/tests/test_story_runtime_endpoints.py
@@ -23,9 +23,32 @@ from tangl.utils.hash_secret import key_for_secret, uuid_for_secret
 from tangl.vm.runtime.ledger import Ledger
 
 
-def _write_story_bundle(root: Path, *, with_projector: bool = False) -> str:
+def _write_story_bundle(
+    root: Path,
+    *,
+    with_projector: bool = False,
+    with_choice_payload_hints: bool = False,
+) -> str:
     world_dir = root / "story_demo"
     world_dir.mkdir()
+    action_lines = [
+        "          - text: Continue",
+        "            successor: end",
+    ]
+    if with_choice_payload_hints:
+        action_lines.extend(
+            [
+                "            accepts:",
+                "              kind: quantity",
+                "              min: 1",
+                "              max: 3",
+                "              unit: ration",
+                "            ui_hints:",
+                "              hotkey: b",
+                "              source_kind: market",
+                "              contribution: purchase",
+            ]
+        )
     (world_dir / "world.yaml").write_text(
         "\n".join(
             [
@@ -49,8 +72,7 @@ def _write_story_bundle(root: Path, *, with_projector: bool = False) -> str:
                 "      start:",
                 "        content: Start",
                 "        actions:",
-                "          - text: Continue",
-                "            successor: end",
+                *action_lines,
                 "      end:",
                 "        content: End",
             ]
@@ -164,6 +186,32 @@ def _first_choice_fragment(payload: dict[str, object]) -> dict[str, object]:
 @pytest.fixture()
 def story_client(tmp_path: Path, monkeypatch) -> tuple[TestClient, dict[str, str], str]:
     world_label = _write_story_bundle(tmp_path)
+    monkeypatch.setattr("tangl.service.world_registry.get_world_dirs", lambda: [tmp_path])
+
+    reset_service_state_for_testing()
+    reset_service_manager_for_testing()
+    World.clear_instances()
+    service_manager = get_service_manager()
+    secret = settings.client.secret
+    user_id = uuid_for_secret(secret)
+    user = User(uid=user_id)
+    user.set_secret(secret)
+    service_manager.persistence.save(user)
+
+    client = TestClient(app, base_url="http://test/api/v2/")
+    headers = {"X-API-Key": key_for_secret(secret)}
+    try:
+        yield client, headers, world_label
+    finally:
+        client.close()
+        World.clear_instances()
+        reset_service_manager_for_testing()
+        reset_service_state_for_testing()
+
+
+@pytest.fixture()
+def payload_story_client(tmp_path: Path, monkeypatch) -> tuple[TestClient, dict[str, str], str]:
+    world_label = _write_story_bundle(tmp_path, with_choice_payload_hints=True)
     monkeypatch.setattr("tangl.service.world_registry.get_world_dirs", lambda: [tmp_path])
 
     reset_service_state_for_testing()
@@ -336,6 +384,39 @@ def test_story_update_preserves_choice_fragment_uid_and_edge_id(
         headers=headers,
     )
     assert resolved.status_code == 200
+
+
+def test_story_update_preserves_choice_payload_contracts(
+    payload_story_client: tuple[TestClient, dict[str, str], str],
+) -> None:
+    client, headers, world_label = payload_story_client
+
+    create = client.post(
+        "story/story/create",
+        params={"world_id": world_label, "init_mode": "EAGER"},
+        headers=headers,
+    )
+    assert create.status_code == 200
+
+    update = client.get("story/update", headers=headers)
+    assert update.status_code == 200
+    choice = _first_choice_fragment(update.json())
+
+    assert choice["accepts"] == {
+        "kind": "quantity",
+        "required": True,
+        "min": 1,
+        "max": 3,
+        "step": 1,
+        "unit": "ration",
+        "cost_previews": [],
+    }
+    assert choice["ui_hints"] == {
+        "hotkey": "b",
+        "source_kind": "market",
+        "contribution": "purchase",
+        "cost_previews": [],
+    }
 
 
 def test_story_info_returns_403_when_endpoint_is_restricted_for_non_privileged_user(

--- a/apps/server/tests/test_story_runtime_endpoints.py
+++ b/apps/server/tests/test_story_runtime_endpoints.py
@@ -152,6 +152,15 @@ def _session_value(payload: dict[str, object], key: str) -> object | None:
     return None
 
 
+def _first_choice_fragment(payload: dict[str, object]) -> dict[str, object]:
+    fragments = payload.get("fragments")
+    assert isinstance(fragments, list)
+    for fragment in fragments:
+        if isinstance(fragment, dict) and fragment.get("fragment_type") == "choice":
+            return fragment
+    raise AssertionError(f"No choice fragment found in {fragments}")
+
+
 @pytest.fixture()
 def story_client(tmp_path: Path, monkeypatch) -> tuple[TestClient, dict[str, str], str]:
     world_label = _write_story_bundle(tmp_path)
@@ -298,6 +307,35 @@ def test_story_rest_envelope_flow(
     dropped = drop.json()
     assert dropped.get("status") == "ok"
     assert dropped.get("dropped_ledger_id")
+
+
+def test_story_update_preserves_choice_fragment_uid_and_edge_id(
+    story_client: tuple[TestClient, dict[str, str], str],
+) -> None:
+    client, headers, world_label = story_client
+
+    create = client.post(
+        "story/story/create",
+        params={"world_id": world_label, "init_mode": "EAGER"},
+        headers=headers,
+    )
+    assert create.status_code == 200
+
+    update = client.get("story/update", headers=headers)
+    assert update.status_code == 200
+    choice = _first_choice_fragment(update.json())
+
+    assert isinstance(choice.get("uid"), str)
+    assert isinstance(choice.get("edge_id"), str)
+    assert choice["uid"] != choice["edge_id"]
+    assert choice["label"] == "Continue"
+
+    resolved = client.post(
+        "story/do",
+        json={"edge_id": choice["edge_id"]},
+        headers=headers,
+    )
+    assert resolved.status_code == 200
 
 
 def test_story_info_returns_403_when_endpoint_is_restricted_for_non_privileged_user(

--- a/docs/src/design/index.rst
+++ b/docs/src/design/index.rst
@@ -56,6 +56,7 @@ See also
    traversal/notes-sinks
 
    service/SERVICE_DESIGN
+   service/BACKEND_FRAGMENT_RECONCILIATION
    service/RESPONSE_TYPES
    service/FRAGMENT_STREAM_CONTRACT
 

--- a/docs/src/design/service/BACKEND_FRAGMENT_RECONCILIATION.md
+++ b/docs/src/design/service/BACKEND_FRAGMENT_RECONCILIATION.md
@@ -1,0 +1,91 @@
+# Backend Fragment Contract Reconciliation
+
+Status: active reconciliation note.
+
+StoryTangl has two related but separate output surfaces:
+
+- the **service/backend Python API**, consumed directly by Python clients such as
+  cmd2, Rich, Tk, and in-process tools;
+- the **FastAPI REST server**, which transcribes those Python objects to and
+  from HTTP JSON.
+
+The service/backend API is the contract owner for runtime widget-shaped data.
+The REST server is intentionally thin: authentication, request routing,
+transport serialization, HTTP error mapping, and transport-adjacent media
+dereferencing. It should not invent a second fragment model or merge fragments
+back into legacy display blocks.
+
+## Target Shape
+
+Service story-session methods return typed Python objects:
+
+| Service method | Python return |
+| --- | --- |
+| `create_story` | `RuntimeEnvelope` |
+| `resolve_choice` | `RuntimeEnvelope` |
+| `get_story_update` | `RuntimeEnvelope` |
+| `get_story_info` | `ProjectedState` |
+| acknowledgement-only methods | `RuntimeInfo` |
+
+`RuntimeEnvelope.fragments` is an ordered list of independent `BaseFragment`
+instances. A choice's fragment `uid` identifies the renderable choice fragment;
+its `edge_id` identifies the action to submit back to `resolve_choice`. These
+identities must remain distinct.
+
+## Responsibility Split
+
+Backend/service responsibilities:
+
+- Return typed Python `RuntimeEnvelope`, `ProjectedState`, and `RuntimeInfo`
+  objects.
+- Preserve independent fragments and fragment `uid`s.
+- Populate action-facing `ChoiceFragment.edge_id`, `accepts`, `ui_hints`,
+  availability, and blockers.
+- Populate advisory envelope metadata such as `info_affordances`,
+  `info_state`, `world_id`, `ledger_id`, and command grammar hints.
+- Validate submitted choice payloads during action resolution.
+
+REST responsibilities:
+
+- Parse HTTP request bodies and query params into service-call arguments.
+- Enforce authentication and service-method access policy.
+- Serialize typed Python response objects into JSON-safe payloads.
+- Apply explicitly requested render profiles such as `html` text conversion.
+- Apply transport-adjacent media policies, such as RIT placeholder or media
+  server URL conversion.
+- Preserve service-owned identities and semantic fields while adding only
+  harmless compatibility aliases such as `label`.
+
+REST must not:
+
+- rewrite a choice fragment `uid` to equal its `edge_id`;
+- collapse sibling fragments into a `block` payload;
+- require clients to submit fragment `uid` when the contract says `edge_id`;
+- create backend semantics from presentation-only hints.
+
+## Current Status
+
+The service layer already returns Python-native `RuntimeEnvelope` objects for
+story creation, updates, and choice resolution. The first pinned backend
+contract test now asserts that a simple story emits sibling content and choice
+fragments, not a legacy block, and that `uid` and `edge_id` stay separate.
+
+The REST layer still performs JSON serialization manually because it owns HTTP
+transport concerns such as media profiles and optional markdown-to-HTML
+conversion. That is acceptable as long as the serializer remains a transcription
+boundary and keeps service semantics intact.
+
+## Diagnostic Fixtures And Transcripts
+
+Diagnostic transcripts should be generated only after backend output can be
+captured as a real `RuntimeEnvelope` stream. The durable source of truth should
+be:
+
+```text
+backend emitted RuntimeEnvelope
+  -> canonical JSON fixture
+  -> CLI/Rich/web rendered transcript
+```
+
+Until that path is real for a world/demo, transcript-like prose and UI mockups
+remain design references rather than regression baselines.

--- a/docs/src/design/service/BACKEND_FRAGMENT_RECONCILIATION.md
+++ b/docs/src/design/service/BACKEND_FRAGMENT_RECONCILIATION.md
@@ -69,6 +69,11 @@ The service layer already returns Python-native `RuntimeEnvelope` objects for
 story creation, updates, and choice resolution. The first pinned backend
 contract test now asserts that a simple story emits sibling content and choice
 fragments, not a legacy block, and that `uid` and `edge_id` stay separate.
+Additional contract tests pin the authored `Action.accepts` and `Action.ui_hints`
+path through service envelopes and REST JSON. These are UI-facing intent
+contracts, even when the engine's internal vocabulary also uses fields named
+`kind`; any future service adapter that maps UI intent onto engine mechanics
+should be explicit and narrow rather than handled by the REST serializer.
 
 The REST layer still performs JSON serialization manually because it owns HTTP
 transport concerns such as media profiles and optional markdown-to-HTML

--- a/docs/src/design/service/BACKEND_FRAGMENT_RECONCILIATION.md
+++ b/docs/src/design/service/BACKEND_FRAGMENT_RECONCILIATION.md
@@ -74,8 +74,10 @@ path through service envelopes and REST JSON. These are UI-facing intent
 contracts, even when the engine's internal vocabulary also uses fields named
 `kind`; any future service adapter that maps UI intent onto engine mechanics
 should be explicit and narrow rather than handled by the REST serializer.
-Remote Python clients rehydrate those REST payloads into the same typed fragment
-models used by in-process clients.
+Direct `RuntimeEnvelope` serialization preserves concrete fragment subclass
+fields, so in-process Python clients, diagnostic fixture generation, REST
+serialization, and remote Python rehydration all operate on the same
+widget-shaped payload surface.
 The same pattern applies to `ProjectedState`: service methods own the typed
 section/value model, REST serializes it, and remote Python clients decode it
 back into typed projected-state values.

--- a/docs/src/design/service/BACKEND_FRAGMENT_RECONCILIATION.md
+++ b/docs/src/design/service/BACKEND_FRAGMENT_RECONCILIATION.md
@@ -83,8 +83,9 @@ The reference CLI stores runtime updates from `RuntimeEnvelope.to_dto()` before
 rendering, while still accepting lightweight object-shaped stubs in tests and
 diagnostic harnesses.
 The same pattern applies to `ProjectedState`: service methods own the typed
-section/value model, REST serializes it, and remote Python clients decode it
-back into typed projected-state values.
+section/value model, `ProjectedState.to_dto()` emits the client-facing
+`value_type` discriminated DTO surface, REST and CLI use that projection, and
+remote Python clients decode it back into typed projected-state values.
 
 The REST layer starts from `RuntimeEnvelope.to_dto()` and keeps any remaining
 manual shaping limited to HTTP-adjacent concerns: media profiles, optional

--- a/docs/src/design/service/BACKEND_FRAGMENT_RECONCILIATION.md
+++ b/docs/src/design/service/BACKEND_FRAGMENT_RECONCILIATION.md
@@ -74,6 +74,8 @@ path through service envelopes and REST JSON. These are UI-facing intent
 contracts, even when the engine's internal vocabulary also uses fields named
 `kind`; any future service adapter that maps UI intent onto engine mechanics
 should be explicit and narrow rather than handled by the REST serializer.
+Remote Python clients rehydrate those REST payloads into the same typed fragment
+models used by in-process clients.
 
 The REST layer still performs JSON serialization manually because it owns HTTP
 transport concerns such as media profiles and optional markdown-to-HTML

--- a/docs/src/design/service/BACKEND_FRAGMENT_RECONCILIATION.md
+++ b/docs/src/design/service/BACKEND_FRAGMENT_RECONCILIATION.md
@@ -76,6 +76,9 @@ contracts, even when the engine's internal vocabulary also uses fields named
 should be explicit and narrow rather than handled by the REST serializer.
 Remote Python clients rehydrate those REST payloads into the same typed fragment
 models used by in-process clients.
+The same pattern applies to `ProjectedState`: service methods own the typed
+section/value model, REST serializes it, and remote Python clients decode it
+back into typed projected-state values.
 
 The REST layer still performs JSON serialization manually because it owns HTTP
 transport concerns such as media profiles and optional markdown-to-HTML

--- a/docs/src/design/service/BACKEND_FRAGMENT_RECONCILIATION.md
+++ b/docs/src/design/service/BACKEND_FRAGMENT_RECONCILIATION.md
@@ -83,10 +83,11 @@ The same pattern applies to `ProjectedState`: service methods own the typed
 section/value model, REST serializes it, and remote Python clients decode it
 back into typed projected-state values.
 
-The REST layer still performs JSON serialization manually because it owns HTTP
-transport concerns such as media profiles and optional markdown-to-HTML
-conversion. That is acceptable as long as the serializer remains a transcription
-boundary and keeps service semantics intact.
+The REST layer starts from `RuntimeEnvelope.to_dto()` and keeps any remaining
+manual shaping limited to HTTP-adjacent concerns: media profiles, optional
+markdown-to-HTML conversion, and harmless compatibility aliases such as
+`choice.label`. That is acceptable as long as the serializer remains a
+transcription boundary and keeps service semantics intact.
 
 ## Diagnostic Fixtures And Transcripts
 

--- a/docs/src/design/service/BACKEND_FRAGMENT_RECONCILIATION.md
+++ b/docs/src/design/service/BACKEND_FRAGMENT_RECONCILIATION.md
@@ -87,6 +87,37 @@ section/value model, `ProjectedState.to_dto()` emits the client-facing
 `value_type` discriminated DTO surface, REST and CLI use that projection, and
 remote Python clients decode it back into typed projected-state values.
 
+The credentials demo now provides the first real mechanic-to-widget vertical
+slice. Entering its `HasGame` block asks the game handler for a current-state
+projection before any round has completed. The handler emits a candidate
+`PieceFragment`, a packet `GroupFragment(group_type="zone")`, and document
+`PieceFragment` members alongside the block's authored prose and provisioned
+choices. `ServiceManager.resolve_choice()` returns those same typed siblings in
+the `RuntimeEnvelope`, and `RuntimeEnvelope.to_dto()` preserves their identities,
+zone references, structured properties, and text fallbacks. The engine-side
+field is named `piece_kind` because `kind` is reserved for constructor-form
+persistence; fragment DTO metadata maps it to and from the widget contract's
+`kind` key.
+
+The same slice exercises input in the reverse direction. The credentials game
+provisions one `ChoiceFragment(accepts.kind="pieces")` targeting the packet
+zone. `GameHandler` owns the small generic hooks that declare a move's
+`Accepts` contract and resolve submitted widget data into an engine move.
+Selecting a document's `piece_id` therefore becomes the existing credentials
+inspection move before rule evaluation; malformed or stale selections fail at
+that mechanics boundary. `Action` preserves the nested accepts discriminator
+through graph snapshots, while service and REST remain generic. The test in
+`engine/tests/integration/test_credentials_widget_flow.py` pins the complete
+path.
+
+Nim provides the second use of the same hooks for bounded integer input.
+`get_available_moves()` remains the rules-facing list of legal takes, while
+`get_provisioned_moves()` projects those moves as one
+`ChoiceFragment(accepts.kind="quantity")`. The submitted quantity is validated
+against the current heap and resolved back to the ordinary integer move before
+the round runs. This distinction keeps client action aggregation out of the
+mechanics API and is the intended pattern for future “how many?” interactions.
+
 The REST layer starts from `RuntimeEnvelope.to_dto()` and keeps any remaining
 manual shaping limited to HTTP-adjacent concerns: media profiles, optional
 markdown-to-HTML conversion, and harmless compatibility aliases such as

--- a/docs/src/design/service/BACKEND_FRAGMENT_RECONCILIATION.md
+++ b/docs/src/design/service/BACKEND_FRAGMENT_RECONCILIATION.md
@@ -79,6 +79,9 @@ pathway, preserving concrete fragment subclass fields while omitting
 transport-only stream bookkeeping. In-process Python clients, diagnostic
 fixture generation, REST serialization, and remote Python rehydration all
 operate on that same widget-shaped payload surface.
+The reference CLI stores runtime updates from `RuntimeEnvelope.to_dto()` before
+rendering, while still accepting lightweight object-shaped stubs in tests and
+diagnostic harnesses.
 The same pattern applies to `ProjectedState`: service methods own the typed
 section/value model, REST serializes it, and remote Python clients decode it
 back into typed projected-state values.

--- a/docs/src/design/service/BACKEND_FRAGMENT_RECONCILIATION.md
+++ b/docs/src/design/service/BACKEND_FRAGMENT_RECONCILIATION.md
@@ -74,10 +74,11 @@ path through service envelopes and REST JSON. These are UI-facing intent
 contracts, even when the engine's internal vocabulary also uses fields named
 `kind`; any future service adapter that maps UI intent onto engine mechanics
 should be explicit and narrow rather than handled by the REST serializer.
-Direct `RuntimeEnvelope` serialization preserves concrete fragment subclass
-fields, so in-process Python clients, diagnostic fixture generation, REST
-serialization, and remote Python rehydration all operate on the same
-widget-shaped payload surface.
+`RuntimeEnvelope.to_dto()` projects fragments through the journal fragment DTO
+pathway, preserving concrete fragment subclass fields while omitting
+transport-only stream bookkeeping. In-process Python clients, diagnostic
+fixture generation, REST serialization, and remote Python rehydration all
+operate on that same widget-shaped payload surface.
 The same pattern applies to `ProjectedState`: service methods own the typed
 section/value model, REST serializes it, and remote Python clients decode it
 back into typed projected-state values.

--- a/docs/src/design/service/BACKEND_FRAGMENT_RECONCILIATION.md
+++ b/docs/src/design/service/BACKEND_FRAGMENT_RECONCILIATION.md
@@ -87,6 +87,18 @@ boundary and keeps service semantics intact.
 
 ## Diagnostic Fixtures And Transcripts
 
+`engine/contrib/conformance/backend_widget_demo.py` now generates the first
+backend-emitted diagnostic payloads:
+
+- `engine/contrib/conformance/diagnostics/backend_widget_contract_runtime.json`
+- `engine/contrib/conformance/diagnostics/backend_widget_contract_projected_state.json`
+
+These are not canonical conformance fixtures yet. They prove that the current
+service layer can emit a real widget-shaped `RuntimeEnvelope` and
+`ProjectedState` covering content, typed choices, `accepts`, `ui_hints`,
+`metadata.info_affordances`, `metadata.info_state`, and generic projected-state
+values.
+
 Diagnostic transcripts should be generated only after backend output can be
 captured as a real `RuntimeEnvelope` stream. The durable source of truth should
 be:

--- a/docs/src/design/service/FRAGMENT_STREAM_CONTRACT.md
+++ b/docs/src/design/service/FRAGMENT_STREAM_CONTRACT.md
@@ -33,7 +33,7 @@ clients and remote managers can degrade safely.
 RuntimeEnvelope
   cursor_id: UUID | null
   step: int | null
-  fragments: list[BaseFragment]
+  fragments: list[BaseFragment]  # serialized as concrete fragment payloads
   last_redirect: dict | null
   redirect_trace: list[dict]
   metadata: dict
@@ -43,9 +43,11 @@ RuntimeEnvelope
 directly. Acknowledgement-only operations such as `drop_story` return
 `RuntimeInfo`.
 
-`fragments` are ordered for reading and replay. A fragment's `uid` is also a
-stable reference target within the envelope and across later update/delete
-control fragments.
+`fragments` are ordered for reading and replay. The Python type is rooted at
+`BaseFragment`, but direct `RuntimeEnvelope` serialization preserves concrete
+fragment fields such as `ChoiceFragment.edge_id`, `accepts`, and `ui_hints`.
+A fragment's `uid` is also a stable reference target within the envelope and
+across later update/delete control fragments.
 
 ## Fragment Registry Model
 

--- a/docs/src/design/service/FRAGMENT_STREAM_CONTRACT.md
+++ b/docs/src/design/service/FRAGMENT_STREAM_CONTRACT.md
@@ -44,10 +44,13 @@ directly. Acknowledgement-only operations such as `drop_story` return
 `RuntimeInfo`.
 
 `fragments` are ordered for reading and replay. The Python type is rooted at
-`BaseFragment`, but direct `RuntimeEnvelope` serialization preserves concrete
-fragment fields such as `ChoiceFragment.edge_id`, `accepts`, and `ui_hints`.
-A fragment's `uid` is also a stable reference target within the envelope and
-across later update/delete control fragments.
+`BaseFragment`, while `RuntimeEnvelope.to_dto()` projects each fragment through
+the journal fragment DTO pathway. That pathway uses `fragment_type` as the
+transport discriminator, preserves concrete fields such as
+`ChoiceFragment.edge_id`, `accepts`, and `ui_hints`, and omits stream
+bookkeeping selected by `dto_exclude` field metadata. A fragment's `uid` is also
+a stable reference target within the envelope and across later update/delete
+control fragments.
 
 ## Fragment Registry Model
 

--- a/docs/src/design/service/RESPONSE_TYPES.md
+++ b/docs/src/design/service/RESPONSE_TYPES.md
@@ -35,7 +35,7 @@ metadata.
 
 **Characteristics:**
 - Carries `cursor_id`, `step`, redirect metadata, and service metadata
-- Carries concrete fragment models through a `BaseFragment`-typed stream
+- Carries concrete fragment DTOs through a `BaseFragment`-typed stream
 - The client renders fragments directly through a registry/shell model
 - Unknown fragment types are valid extension points and must survive transport
 

--- a/docs/src/design/service/RESPONSE_TYPES.md
+++ b/docs/src/design/service/RESPONSE_TYPES.md
@@ -57,6 +57,7 @@ See `FRAGMENT_STREAM_CONTRACT.md` for the detailed client-facing contract.
 **Characteristics:**
 - Read-only (MethodType.READ)
 - Returns structured metadata (not narrative)
+- `ProjectedState.to_dto()` preserves `value_type` discriminators for clients
 - Idempotent queries
 
 ---

--- a/docs/src/design/service/RESPONSE_TYPES.md
+++ b/docs/src/design/service/RESPONSE_TYPES.md
@@ -35,7 +35,7 @@ metadata.
 
 **Characteristics:**
 - Carries `cursor_id`, `step`, redirect metadata, and service metadata
-- Carries `fragments: list[BaseFragment]`
+- Carries concrete fragment models through a `BaseFragment`-typed stream
 - The client renders fragments directly through a registry/shell model
 - Unknown fragment types are valid extension points and must survive transport
 

--- a/docs/src/design/story/STORYTANGL_WIDGET_VOCAB.md
+++ b/docs/src/design/story/STORYTANGL_WIDGET_VOCAB.md
@@ -571,7 +571,7 @@ port sketches.
 
 ```python
 class ContentFragment(BaseFragment):
-    fragment_type: str | Enum = "content"
+    fragment_type: Literal["content"] = "content"
     content: Any = None              # usually str; may be richer
     source_id: UUID | None = None
     content_format: str | None = Field(None, alias="format")  # md/plain/html
@@ -599,10 +599,9 @@ class AttributedFragment(ContentFragment):
     media: str
 ```
 
-Note the `alias="type"` on `fragment_type` — the wire shape may use
-either `fragment_type: "attributed"` or `type: "attributed"`. Clients
-MUST accept both. (This is a legacy-compat surface; future fragment
-types should not introduce aliases.)
+The canonical fragment DTO shape uses `fragment_type: "attributed"`.
+The local model may accept the older `type` alias while hydrating internal
+objects, but reference clients should not emit or require the alias.
 
 | | |
 |---|---|
@@ -619,7 +618,7 @@ types should not introduce aliases.)
 
 ```python
 class MediaFragment(ContentFragment):
-    fragment_type: str = "media"
+    fragment_type: Literal["media"] = "media"
     content: Pathlike | bytes | str | dict | MediaRIT
     content_format: Literal["url", "data", "xml", "json", "rit"]
     media_role: str | None = None       # see below

--- a/docs/src/design/story/WIDGET_CONTRACT_RECONCILIATION.md
+++ b/docs/src/design/story/WIDGET_CONTRACT_RECONCILIATION.md
@@ -83,8 +83,8 @@ surface is small enough to settle with its immediate neighbors.
 
 | Surface | Spec tier | Reference UI | Engine backend | Plan |
 |---|---|---|---|---|
-| Typed `PiecesAccepts` (was `tokens`) | P1 | done (kind `pieces` + typed TS shape) | done (`Accepts` union) | expand conformance cases only as new widgets land |
-| Typed `PickAccepts`, `TextAccepts`, `QuantityAccepts`, `RawCommandAccepts` | P1 | done | done (`Accepts` union) | keep legacy web `payload_type` path as local UI compatibility until fixtures stop using it |
+| Typed `PiecesAccepts` (was `tokens`) | P1 | done (kind `pieces` + typed TS shape) | done (`Accepts` union + credentials mechanic-to-service flow) | expand conformance cases only as new widgets land |
+| Typed `PickAccepts`, `TextAccepts`, `QuantityAccepts`, `RawCommandAccepts` | P1 | done | done (`Accepts` union; Nim quantity flow) | keep legacy web `payload_type` path as local UI compatibility until fixtures stop using it |
 | Typed `PlaceAccepts` (including optional `edge_ref`) | P1 | partial (`edge_ref` not rendered) | done (`Accepts` union) | add `edge_ref` fixture when route/network MVP lands |
 | Typed `ComposeAccepts` | P1 | partial (web nested renderer + CLI/Tk inspection fixture) | done (`Accepts` union) | harden layout and add broader part combinations as worlds emit them |
 | Typed `UIHints` | P1 | partial (documented + ad-hoc keys) | done (`UIHints`, extra-allow) | tighten named fields when more worlds use them |
@@ -109,12 +109,12 @@ question in the spec).
 
 | Surface | Spec tier | Reference UI | Engine backend | Plan |
 |---|---|---|---|---|
-| `PieceFragment` (core shape) | P2 | partial (basic web widget + carwars wireframes) | partial (untyped equivalent) | engine PR: typed `PieceFragment` with required `hints.label_text` |
+| `PieceFragment` (core shape) | P2 | partial (basic web widget + carwars wireframes) | done (typed; credentials mechanic-to-service flow) | keep P2 until a second bundle exercises the same shape |
 | `PieceFragment.realized` + `cost` (offers) | P2 | done in carwars catalog fixtures | not_started | engine PR for typed lifecycle; bundle MVP needed for shop semantics |
 | `PieceFragment.owner` | P2 (proposal fixture) | not_started | not_started | wait for multi-cursor MVP |
 | `PieceFragment.position` | P2 (proposal fixture) | not_started | not_started | wait for grid/hex bundle MVP (Patchwork, Carcassonne) |
 | `PieceFragment.available` + `unavailable_reason` | P2 | done | not_started | engine PR with `PieceFragment` graduation |
-| `group_type="zone"` with `ZoneConstraints` | P2 | partial (basic web widget + carwars wireframes) | not_started | engine PR: typed `GroupFragment.constraints`; bundle MVP for capacity |
+| `group_type="zone"` with `ZoneConstraints` | P2 | partial (basic web widget + carwars wireframes) | partial (credentials packet zone; constraints untyped) | type constraints when a bundle needs capacity or placement rules |
 | `ZoneLayoutHints` (orientation, fan, grid, hex, graph, floorplan) | P2 | partial (orientation/grid/fan) | not_started | engine PR; render-port catches up as needed |
 | `GraphLayout.edges` (first-class adjacencies with UIDs) | P2 (proposal fixture) | not_started | not_started | wait for network/route bundle MVP (Ticket-to-Ride-shaped) |
 | `PlaceAccepts.edge_ref` fixture coverage | P2 pressure fixture | not_started | not_started | P1 typed field exists in the target; graph-route fixture remains gated on a route/network MVP |

--- a/docs/src/design/story/WIDGET_CONTRACT_RECONCILIATION.md
+++ b/docs/src/design/story/WIDGET_CONTRACT_RECONCILIATION.md
@@ -188,6 +188,7 @@ graduations and as the regression suite for cross-port parity.
 | `engine/contrib/conformance/test_conformance.py` | pytest harness binding fixtures + ports | not_started | wire into CI |
 | `engine/contrib/conformance/fixtures/*.json` | canonical envelopes per surface | partial (Tier S + current P1 fixtures) | keep promoting proposal fixtures as implementation lands |
 | `engine/contrib/conformance/proposals/*.json` | forward-compatible proposal envelopes | partial | current set covers carwars garage, piece realization, place accepts, record KvRow, roll fragment, and one UUID-shaped v1.5 wireframe interpretation sample; CLI/Tk can inspect them without promotion |
+| `engine/contrib/conformance/diagnostics/*.json` | backend-emitted service payloads | initial | non-gating proof that `ServiceManager` can emit widget-shaped `RuntimeEnvelope` and `ProjectedState`; promote only after ports/harness agree |
 | webapp Vitest conformance suite | webapp DOM matches expected for each fixture | not_started | written from fixtures; webapp regression mechanism |
 
 ---
@@ -197,6 +198,29 @@ graduations and as the regression suite for cross-port parity.
 A short log of what changed across recent spec / UI / engine releases.
 Each entry names which layer moved and what the consequence is for the
 others.
+
+### 2026-06 — backend fragment-contract audit (L2/L3 update)
+
+- Pinned service-created runtime envelopes as independent fragments rather
+  than legacy display blocks. **Impact:** choice fragment `uid` and action
+  `edge_id` are distinct and both survive REST serialization.
+- Pinned authored `Action.accepts` and `Action.ui_hints` through
+  `ServiceManager`, REST JSON, and remote Python-client hydration.
+  **Impact:** generic clients can depend on typed payload contracts without
+  REST inventing a second fragment model.
+- Pinned `ProjectedState` remote hydration for `kind`, `kinds`, and opaque
+  `query` routing. **Impact:** info-channel sections remain typed for Python
+  clients while REST stays a transcription boundary.
+- Added backend-emitted diagnostics under
+  `engine/contrib/conformance/diagnostics/`. **Impact:** the current backend
+  can now generate a real widget-shaped `RuntimeEnvelope` plus
+  `ProjectedState`; these remain diagnostic until promoted into canonical
+  fixtures and conformance gates.
+- Documented the service/REST responsibility split in
+  `docs/src/design/service/BACKEND_FRAGMENT_RECONCILIATION.md`. **Impact:**
+  backend/service owns typed widget-shaped Python payloads; FastAPI handles
+  auth, routing, JSON transcription, render profiles, and media transport
+  policy.
 
 ### 2026-05 — spec v1.5 (L1 update only)
 

--- a/engine/contrib/conformance/README.md
+++ b/engine/contrib/conformance/README.md
@@ -27,6 +27,13 @@ fragment registry: media placeholders update in place, pieces move between
 zones, stale offers or fallback fragments can be deleted, and open choices keep
 their referenced state renderable after each envelope.
 
+`diagnostics/` contains JSON payloads generated from the real service/backend
+path. These files are not gating conformance fixtures. They are the first proof
+that the current backend can emit widget-shaped `RuntimeEnvelope` and
+`ProjectedState` payloads before a genre demo depends on the widget framework.
+Regenerate them with
+`poetry run python engine/contrib/conformance/backend_widget_demo.py`.
+
 `legibility.py` contains the first promoted conformance harness. It is a
 JSON-only decision-legibility check: after applying update/delete controls, each
 available choice must be renderable in the current scene shell and any

--- a/engine/contrib/conformance/backend_widget_demo.py
+++ b/engine/contrib/conformance/backend_widget_demo.py
@@ -210,8 +210,7 @@ def build_demo_payloads() -> tuple[dict[str, Any], dict[str, Any]]:
         )
         projected = manager.get_story_info(user_id=user.uid)
 
-        runtime_payload = envelope.model_dump(mode="json", by_alias=True, exclude_none=True)
-        _strip_volatile_fragment_fields(runtime_payload)
+        runtime_payload = envelope.to_dto()
         projected_payload = projected.model_dump(mode="json", by_alias=True, exclude_none=True)
         return _normalize_uuids(runtime_payload), _normalize_uuids(projected_payload)
     finally:
@@ -235,19 +234,6 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, indent=2, sort_keys=False) + "\n",
         encoding="utf-8",
     )
-
-
-def _strip_volatile_fragment_fields(payload: dict[str, Any]) -> None:
-    fragments = payload.get("fragments")
-    if not isinstance(fragments, list):
-        return
-    for fragment in fragments:
-        if not isinstance(fragment, dict):
-            continue
-        fragment.pop("seq", None)
-        fragment.pop("step", None)
-        if fragment.get("tags") == []:
-            fragment.pop("tags")
 
 
 def _normalize_uuids(payload: Any) -> Any:

--- a/engine/contrib/conformance/backend_widget_demo.py
+++ b/engine/contrib/conformance/backend_widget_demo.py
@@ -210,7 +210,8 @@ def build_demo_payloads() -> tuple[dict[str, Any], dict[str, Any]]:
         )
         projected = manager.get_story_info(user_id=user.uid)
 
-        runtime_payload = _runtime_envelope_payload(envelope)
+        runtime_payload = envelope.model_dump(mode="json", by_alias=True, exclude_none=True)
+        _strip_volatile_fragment_fields(runtime_payload)
         projected_payload = projected.model_dump(mode="json", by_alias=True, exclude_none=True)
         return _normalize_uuids(runtime_payload), _normalize_uuids(projected_payload)
     finally:
@@ -236,24 +237,17 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
     )
 
 
-def _runtime_envelope_payload(envelope: Any) -> dict[str, Any]:
-    return {
-        "cursor_id": str(envelope.cursor_id) if envelope.cursor_id is not None else None,
-        "step": envelope.step,
-        "fragments": [_fragment_payload(fragment) for fragment in envelope.fragments],
-        "last_redirect": envelope.last_redirect,
-        "redirect_trace": list(envelope.redirect_trace),
-        "metadata": dict(envelope.metadata),
-    }
-
-
-def _fragment_payload(fragment: Any) -> dict[str, Any]:
-    payload = fragment.model_dump(mode="json", by_alias=True, exclude_none=True)
-    payload.pop("seq", None)
-    payload.pop("step", None)
-    if payload.get("tags") == []:
-        payload.pop("tags")
-    return payload
+def _strip_volatile_fragment_fields(payload: dict[str, Any]) -> None:
+    fragments = payload.get("fragments")
+    if not isinstance(fragments, list):
+        return
+    for fragment in fragments:
+        if not isinstance(fragment, dict):
+            continue
+        fragment.pop("seq", None)
+        fragment.pop("step", None)
+        if fragment.get("tags") == []:
+            fragment.pop("tags")
 
 
 def _normalize_uuids(payload: Any) -> Any:

--- a/engine/contrib/conformance/backend_widget_demo.py
+++ b/engine/contrib/conformance/backend_widget_demo.py
@@ -1,0 +1,279 @@
+"""Generate backend-emitted widget contract diagnostics.
+
+The saved diagnostics in this directory are deliberately not canonical
+conformance fixtures. They prove that the current service layer can emit
+widget-shaped data before a genre demo, such as CarWars, tries to consume it.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+from uuid import NAMESPACE_URL, UUID, uuid5
+
+from tangl.persistence import PersistenceManagerFactory
+from tangl.service import (
+    BadgeListValue,
+    InfoAffordance,
+    ItemListValue,
+    KvListValue,
+    KvRow,
+    ProjectedItem,
+    ProjectedSection,
+    ProjectedState,
+    ScalarValue,
+    ServiceManager,
+    TableValue,
+)
+from tangl.service.user.user import User
+from tangl.story import InitMode, World
+from tangl.vm.runtime.frame import PhaseCtx
+from tangl.vm.runtime.ledger import Ledger
+
+
+DIAGNOSTIC_DIR = Path(__file__).parent / "diagnostics"
+RUNTIME_FIXTURE = DIAGNOSTIC_DIR / "backend_widget_contract_runtime.json"
+PROJECTED_FIXTURE = DIAGNOSTIC_DIR / "backend_widget_contract_projected_state.json"
+
+_UUID_PATTERN = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+class _WidgetDemoProjector:
+    """Project generic widget-contract state without bundle-specific concepts."""
+
+    def project(self, *, ledger: Ledger) -> ProjectedState:
+        return ProjectedState(
+            sections=[
+                ProjectedSection(
+                    section_id="session",
+                    title="Session",
+                    kind="stats",
+                    value=KvListValue(
+                        items=[
+                            KvRow(key="Cursor", value=ledger.cursor.label),
+                            KvRow(key="Step", value=ledger.step),
+                        ],
+                    ),
+                ),
+                ProjectedSection(
+                    section_id="supplies",
+                    title="Supplies",
+                    kind="resource",
+                    value=KvListValue(
+                        items=[
+                            KvRow(key="Rations", value=2, max=6, hint="bar"),
+                            KvRow(key="Coin", value=14, unit="silver"),
+                        ],
+                    ),
+                ),
+                ProjectedSection(
+                    section_id="inventory",
+                    title="Inventory",
+                    kind="inventory",
+                    value=ItemListValue(
+                        items=[
+                            ProjectedItem(label="Lantern", detail="half-oil", tags=["light"]),
+                            ProjectedItem(label="Road map", tags=["route"]),
+                        ],
+                    ),
+                ),
+                ProjectedSection(
+                    section_id="watch",
+                    title="Watch",
+                    kind="roster",
+                    value=TableValue(
+                        columns=["Name", "Role"],
+                        rows=[["Mira", "Scout"], ["Tovin", "Guard"]],
+                    ),
+                ),
+                ProjectedSection(
+                    section_id="conditions",
+                    title="Conditions",
+                    kind="tags",
+                    value=BadgeListValue(items=["rain", "night"]),
+                ),
+                ProjectedSection(
+                    section_id="danger",
+                    title="Danger",
+                    kind="status",
+                    value=ScalarValue(value="low"),
+                ),
+            ],
+        )
+
+
+def _script_data() -> dict[str, object]:
+    return {
+        "label": "widget_contract_demo",
+        "metadata": {
+            "title": "Widget Contract Demo",
+            "author": "StoryTangl",
+            "start_at": "intro.start",
+        },
+        "scenes": {
+            "intro": {
+                "blocks": {
+                    "start": {
+                        "content": "The road forks under cold rain.",
+                        "actions": [
+                            {
+                                "text": "Buy rations.",
+                                "successor": "market",
+                                "accepts": {
+                                    "kind": "quantity",
+                                    "min": 1,
+                                    "max": 3,
+                                    "unit": "ration",
+                                },
+                                "ui_hints": {
+                                    "hotkey": "b",
+                                    "source_kind": "market",
+                                    "contribution": "purchase",
+                                },
+                            },
+                            {
+                                "text": "Name the mule.",
+                                "successor": "market",
+                                "accepts": {
+                                    "kind": "text",
+                                    "placeholder": "Buttercup",
+                                },
+                                "ui_hints": {
+                                    "hotkey": "n",
+                                    "source_kind": "stable",
+                                    "contribution": "rename",
+                                },
+                            },
+                        ],
+                    },
+                    "market": {
+                        "content": "The quartermaster marks the ledger.",
+                    },
+                },
+            },
+        },
+    }
+
+
+def _advertise_info_channels(
+    caller: object,
+    *,
+    ctx: PhaseCtx,
+) -> list[InfoAffordance]:
+    _ = (caller, ctx)
+    return [
+        InfoAffordance(
+            kind="inventory",
+            label="Inventory",
+            shortcuts=["i", "inv"],
+            query={"kinds": ["inventory"]},
+        ),
+        InfoAffordance(
+            kind="map",
+            label="Map",
+            shortcuts=["m"],
+            query={"kinds": ["map"], "format": "text"},
+        ),
+    ]
+
+
+def build_demo_payloads() -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return normalized JSON-ready RuntimeEnvelope and ProjectedState payloads."""
+
+    World.clear_instances()
+    try:
+        persistence = PersistenceManagerFactory.native_in_mem()
+        manager = ServiceManager(persistence)
+        user = User(label="widget-contract-user")
+        persistence.save(user)
+
+        world = World.from_script_data(
+            script_data=_script_data(),
+            story_info_projector=_WidgetDemoProjector(),
+        )
+        world.dispatch.register(
+            _advertise_info_channels,
+            task="advertise_info_channels",
+        )
+
+        envelope = manager.create_story(
+            user_id=user.uid,
+            world_id=world.label,
+            world=world,
+            init_mode=InitMode.EAGER.value,
+            story_label="widget_contract_story",
+        )
+        projected = manager.get_story_info(user_id=user.uid)
+
+        runtime_payload = _runtime_envelope_payload(envelope)
+        projected_payload = projected.model_dump(mode="json", by_alias=True, exclude_none=True)
+        return _normalize_uuids(runtime_payload), _normalize_uuids(projected_payload)
+    finally:
+        World.clear_instances()
+
+
+def write_demo_payloads(directory: Path = DIAGNOSTIC_DIR) -> tuple[Path, Path]:
+    """Write the current backend-emitted diagnostic payloads."""
+
+    runtime_payload, projected_payload = build_demo_payloads()
+    directory.mkdir(parents=True, exist_ok=True)
+    runtime_path = directory / RUNTIME_FIXTURE.name
+    projected_path = directory / PROJECTED_FIXTURE.name
+    _write_json(runtime_path, runtime_payload)
+    _write_json(projected_path, projected_payload)
+    return runtime_path, projected_path
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _runtime_envelope_payload(envelope: Any) -> dict[str, Any]:
+    return {
+        "cursor_id": str(envelope.cursor_id) if envelope.cursor_id is not None else None,
+        "step": envelope.step,
+        "fragments": [_fragment_payload(fragment) for fragment in envelope.fragments],
+        "last_redirect": envelope.last_redirect,
+        "redirect_trace": list(envelope.redirect_trace),
+        "metadata": dict(envelope.metadata),
+    }
+
+
+def _fragment_payload(fragment: Any) -> dict[str, Any]:
+    payload = fragment.model_dump(mode="json", by_alias=True, exclude_none=True)
+    payload.pop("seq", None)
+    payload.pop("step", None)
+    if payload.get("tags") == []:
+        payload.pop("tags")
+    return payload
+
+
+def _normalize_uuids(payload: Any) -> Any:
+    seen: dict[str, str] = {}
+
+    def normalize(value: Any) -> Any:
+        if isinstance(value, dict):
+            return {key: normalize(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [normalize(item) for item in value]
+        if isinstance(value, str) and _UUID_PATTERN.fullmatch(value):
+            if value not in seen:
+                seen[value] = str(uuid5(NAMESPACE_URL, f"storytangl-widget-demo:{len(seen) + 1}"))
+            return seen[value]
+        return value
+
+    return normalize(payload)
+
+
+if __name__ == "__main__":
+    runtime_path, projected_path = write_demo_payloads()
+    print(runtime_path)
+    print(projected_path)

--- a/engine/contrib/conformance/backend_widget_demo.py
+++ b/engine/contrib/conformance/backend_widget_demo.py
@@ -211,7 +211,7 @@ def build_demo_payloads() -> tuple[dict[str, Any], dict[str, Any]]:
         projected = manager.get_story_info(user_id=user.uid)
 
         runtime_payload = envelope.to_dto()
-        projected_payload = projected.model_dump(mode="json", by_alias=True, exclude_none=True)
+        projected_payload = projected.to_dto()
         return _normalize_uuids(runtime_payload), _normalize_uuids(projected_payload)
     finally:
         World.clear_instances()

--- a/engine/contrib/conformance/diagnostics/README.md
+++ b/engine/contrib/conformance/diagnostics/README.md
@@ -1,0 +1,16 @@
+# Backend-Emitted Diagnostics
+
+This directory contains diagnostic JSON generated from the service/backend path.
+These files are not gating conformance fixtures yet. They prove what the current
+backend can emit as real `RuntimeEnvelope` and `ProjectedState` payloads before
+genre demos such as CarWars rely on the widget framework.
+
+Regenerate with:
+
+```bash
+poetry run python engine/contrib/conformance/backend_widget_demo.py
+```
+
+Promotion rule: move a diagnostic payload into `fixtures/` only after the
+backend shape, reference ports, and conformance harness agree that it should be
+part of the portable client floor.

--- a/engine/contrib/conformance/diagnostics/backend_widget_contract_projected_state.json
+++ b/engine/contrib/conformance/diagnostics/backend_widget_contract_projected_state.json
@@ -1,0 +1,109 @@
+{
+  "sections": [
+    {
+      "section_id": "session",
+      "title": "Session",
+      "kind": "stats",
+      "value": {
+        "value_type": "kv_list",
+        "items": [
+          {
+            "key": "Cursor",
+            "value": "start"
+          },
+          {
+            "key": "Step",
+            "value": 1
+          }
+        ]
+      }
+    },
+    {
+      "section_id": "supplies",
+      "title": "Supplies",
+      "kind": "resource",
+      "value": {
+        "value_type": "kv_list",
+        "items": [
+          {
+            "key": "Rations",
+            "value": 2,
+            "max": 6,
+            "hint": "bar"
+          },
+          {
+            "key": "Coin",
+            "value": 14,
+            "unit": "silver"
+          }
+        ]
+      }
+    },
+    {
+      "section_id": "inventory",
+      "title": "Inventory",
+      "kind": "inventory",
+      "value": {
+        "value_type": "item_list",
+        "items": [
+          {
+            "label": "Lantern",
+            "detail": "half-oil",
+            "tags": [
+              "light"
+            ]
+          },
+          {
+            "label": "Road map",
+            "tags": [
+              "route"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "section_id": "watch",
+      "title": "Watch",
+      "kind": "roster",
+      "value": {
+        "value_type": "table",
+        "columns": [
+          "Name",
+          "Role"
+        ],
+        "rows": [
+          [
+            "Mira",
+            "Scout"
+          ],
+          [
+            "Tovin",
+            "Guard"
+          ]
+        ]
+      }
+    },
+    {
+      "section_id": "conditions",
+      "title": "Conditions",
+      "kind": "tags",
+      "value": {
+        "value_type": "badges",
+        "items": [
+          "rain",
+          "night"
+        ]
+      }
+    },
+    {
+      "section_id": "danger",
+      "title": "Danger",
+      "kind": "status",
+      "value": {
+        "value_type": "scalar",
+        "value": "low"
+      }
+    }
+  ]
+}

--- a/engine/contrib/conformance/diagnostics/backend_widget_contract_runtime.json
+++ b/engine/contrib/conformance/diagnostics/backend_widget_contract_runtime.json
@@ -54,7 +54,6 @@
       }
     }
   ],
-  "last_redirect": null,
   "redirect_trace": [],
   "metadata": {
     "info_affordances": [

--- a/engine/contrib/conformance/diagnostics/backend_widget_contract_runtime.json
+++ b/engine/contrib/conformance/diagnostics/backend_widget_contract_runtime.json
@@ -1,0 +1,102 @@
+{
+  "cursor_id": "04b7d8af-0d53-56df-bdfe-7d5e8bb521b5",
+  "step": 1,
+  "fragments": [
+    {
+      "uid": "93d7085a-d4e5-5d1a-92f2-27f107a2b0aa",
+      "fragment_type": "content",
+      "content": "The road forks under cold rain.",
+      "source_id": "04b7d8af-0d53-56df-bdfe-7d5e8bb521b5"
+    },
+    {
+      "uid": "a6f1367a-2dcf-549f-badd-4c609b7e284c",
+      "fragment_type": "choice",
+      "content": "Buy rations.",
+      "edge_id": "2850fcc1-11b5-5333-a32f-c7dad8b8ef79",
+      "text": "Buy rations.",
+      "available": true,
+      "active": true,
+      "accepts": {
+        "kind": "quantity",
+        "required": true,
+        "min": 1,
+        "max": 3,
+        "step": 1,
+        "unit": "ration",
+        "cost_previews": []
+      },
+      "ui_hints": {
+        "hotkey": "b",
+        "source_kind": "market",
+        "contribution": "purchase",
+        "cost_previews": []
+      }
+    },
+    {
+      "uid": "4a8267ad-2196-5311-8e39-825941b0ce4c",
+      "fragment_type": "choice",
+      "content": "Name the mule.",
+      "edge_id": "82231e85-74af-51b5-81b0-fc8bd7235ac9",
+      "text": "Name the mule.",
+      "available": true,
+      "active": true,
+      "accepts": {
+        "kind": "text",
+        "required": true,
+        "placeholder": "Buttercup",
+        "validators": []
+      },
+      "ui_hints": {
+        "hotkey": "n",
+        "source_kind": "stable",
+        "contribution": "rename",
+        "cost_previews": []
+      }
+    }
+  ],
+  "last_redirect": null,
+  "redirect_trace": [],
+  "metadata": {
+    "info_affordances": [
+      {
+        "kind": "inventory",
+        "label": "Inventory",
+        "shortcuts": [
+          "i",
+          "inv"
+        ],
+        "query": {
+          "kinds": [
+            "inventory"
+          ]
+        }
+      },
+      {
+        "kind": "map",
+        "label": "Map",
+        "shortcuts": [
+          "m"
+        ],
+        "query": {
+          "kinds": [
+            "map"
+          ],
+          "format": "text"
+        }
+      }
+    ],
+    "info_state": {
+      "version": 1,
+      "dirty_kinds": [
+        "inventory",
+        "map"
+      ],
+      "available_kinds": [
+        "inventory",
+        "map"
+      ]
+    },
+    "world_id": "widget_contract_demo",
+    "ledger_id": "c59747d5-53a8-5617-9a4f-4aaeda16adc8"
+  }
+}

--- a/engine/src/tangl/core/bases.py
+++ b/engine/src/tangl/core/bases.py
@@ -414,7 +414,12 @@ class HasOrder(BaseModelPlus):
         >>> assert h < i < j
     """
 
-    seq: int = Field(None, init=False, validate_default=True)
+    seq: int = Field(
+        None,
+        init=False,
+        validate_default=True,
+        json_schema_extra={"dto_exclude": True},
+    )
     _seq: ClassVar[int] = time.time_ns()  # initialize to something strictly larger than the previous run
 
     @classmethod

--- a/engine/src/tangl/journal/fragments.py
+++ b/engine/src/tangl/journal/fragments.py
@@ -8,6 +8,7 @@ compatibility.
 from __future__ import annotations
 
 from base64 import b64encode
+from collections.abc import Mapping
 from enum import Enum
 from typing import Any, Literal
 from uuid import UUID
@@ -47,7 +48,7 @@ class ContentFragment(BaseFragment):
     the composing cursor or source of the new composite instead.
     """
 
-    fragment_type: str | Enum = "content"
+    fragment_type: Literal["content"] = "content"
     content: Any = None
     source_id: UUID | None = None
     content_format: str | None = Field(None, alias="format")
@@ -216,7 +217,7 @@ class MediaFragment(ContentFragment, extra="allow"):
     staging_hints: StagingHints | None = None
     media_role: str | None = None
     scope: str | None = "world"
-    fragment_type: str = "media"
+    fragment_type: Literal["media"] = "media"
 
     @field_serializer("content")
     def _encode_binary_content(self, content: Any) -> str:
@@ -248,6 +249,69 @@ class BlockFragment(ContentFragment):
     choices: list[ChoiceFragment] = Field(default_factory=list)
 
 
+_FRAGMENT_DTO_TYPES: dict[str, type[BaseFragment]] = {
+    "attributed": AttributedFragment,
+    "block": BlockFragment,
+    "choice": ChoiceFragment,
+    "content": ContentFragment,
+    "delete": ControlFragment,
+    "dialog": DialogFragment,
+    "group": GroupFragment,
+    "kv": KvFragment,
+    "media": MediaFragment,
+    "piece": PieceFragment,
+    "update": ControlFragment,
+    "user_event": UserEventFragment,
+}
+
+
+def fragment_to_dto(
+    fragment: BaseFragment,
+    *,
+    exclude: set[str] | None = None,
+) -> UnstructuredData:
+    """Return the client DTO projection of a journal fragment.
+
+    DTO projection is distinct from :meth:`unstructure`: it is JSON-safe,
+    keyed by ``fragment_type``, and selected through ``dto_exclude`` field
+    metadata rather than persistence's constructor-form ``kind`` path.
+    """
+
+    exclude_fields = set(fragment._match_fields(dto_exclude=True))
+    if exclude is not None:
+        exclude_fields.update(exclude)
+    payload = fragment.model_dump(
+        mode="json",
+        by_alias=True,
+        exclude_none=True,
+        exclude=exclude_fields,
+    )
+    payload.pop("step", None)
+    if payload.get("type") == payload.get("fragment_type"):
+        payload.pop("type")
+    if payload.get("tags") == []:
+        payload.pop("tags")
+    return payload
+
+
+def fragment_from_dto(payload: object) -> BaseFragment:
+    """Hydrate a fragment DTO, preserving unknown extension fragments."""
+
+    if not isinstance(payload, Mapping):
+        return BaseFragment(fragment_type="unknown", content=payload)
+
+    raw_fragment = dict(payload)
+    fragment_type = raw_fragment.get("fragment_type")
+    if not isinstance(fragment_type, str) or not fragment_type:
+        return BaseFragment(fragment_type="unknown", content=raw_fragment)
+
+    fragment_model = _FRAGMENT_DTO_TYPES.get(fragment_type)
+    if fragment_model is None:
+        return BaseFragment(fragment_type=fragment_type, content=raw_fragment)
+
+    return fragment_model.model_validate(raw_fragment)
+
+
 __all__ = [
     "AttributedFragment",
     "BlockFragment",
@@ -266,4 +330,6 @@ __all__ = [
     "StagingHints",
     "UIHints",
     "UserEventFragment",
+    "fragment_from_dto",
+    "fragment_to_dto",
 ]

--- a/engine/src/tangl/journal/fragments.py
+++ b/engine/src/tangl/journal/fragments.py
@@ -13,7 +13,7 @@ from enum import Enum
 from typing import Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_serializer, model_validator
 
 from tangl.core import BaseFragment, Registry, Selector
 from tangl.journal.intent import Accepts, KvRow, UIHints
@@ -85,14 +85,20 @@ class PieceFragment(BaseFragment, extra="allow"):
     same piece in place as it changes state or moves between zones. ``zone_ref``
     names the containing ``group_type="zone"`` fragment. ``properties`` carries
     per-kind structured data (a candidate's declared purpose, a permit's expiry,
-    ...). Graduates the typed shape tracked as the ``PieceFragment`` row in
+    ...). Python uses ``piece_kind`` because constructor-form persistence reserves
+    ``kind`` for the model class; DTO projection exposes it as contract field
+    ``kind``. Graduates the typed shape tracked as the ``PieceFragment`` row in
     ``WIDGET_CONTRACT_RECONCILIATION.md``; matches the existing conformance
     fixture shape.
     """
 
     fragment_type: Literal["piece"] = "piece"
     piece_id: str
-    kind: str | None = None
+    piece_kind: str = Field(
+        ...,
+        validation_alias=AliasChoices("piece_kind", "kind"),
+        json_schema_extra={"dto": True, "dto_alias": "kind"},
+    )
     display_state: str | None = None
     zone_ref: UUID | None = None
     properties: dict[str, Any] = Field(default_factory=dict)
@@ -291,6 +297,10 @@ def fragment_to_dto(
         payload.pop("type")
     if payload.get("tags") == []:
         payload.pop("tags")
+    for field_name in fragment._match_fields(dto=True):
+        dto_alias = type(fragment).model_fields[field_name].json_schema_extra["dto_alias"]
+        if field_name in payload:
+            payload[dto_alias] = payload.pop(field_name)
     return payload
 
 
@@ -309,6 +319,10 @@ def fragment_from_dto(payload: object) -> BaseFragment:
     if fragment_model is None:
         return BaseFragment(fragment_type=fragment_type, content=raw_fragment)
 
+    for field_name in fragment_model._match_fields(dto=True):
+        dto_alias = fragment_model.model_fields[field_name].json_schema_extra["dto_alias"]
+        if dto_alias in raw_fragment:
+            raw_fragment[field_name] = raw_fragment.pop(dto_alias)
     return fragment_model.model_validate(raw_fragment)
 
 

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
 from tangl.core import BaseFragment
 from tangl.core.bases import BaseModelPlus
+from tangl.journal.intent import PieceConstraints, PiecesAccepts, PickAccepts
 from tangl.journal.fragments import (
     ContentFragment,
     GroupFragment,
@@ -53,10 +54,15 @@ from .picking_game import PickingGame, PickingGameHandler, PickingMove
 # into the seed so distinct credentials blocks in one journal (e.g. a scheduled
 # and a randomized shift) never collide on a shared global fragment id.
 _PIECE_NS = uuid.UUID("b7c3f6e2-1d4a-4c9b-9f2e-7a6d5c4b3a21")
+_DOCUMENT_SELECTOR_TARGET = "__document_piece__"
 
 
 def _piece_uid(game_uid: uuid.UUID, case_index: int, key: str) -> uuid.UUID:
     return uuid.uuid5(_PIECE_NS, f"credentials:{game_uid}:{case_index}:{key}")
+
+
+def _document_piece_id(case_index: int, label: str) -> str:
+    return f"{case_index}:{label}"
 
 
 def _document_kind(label: str) -> str:
@@ -804,6 +810,25 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             moves.append(CredentialsMove(kind="request_relinquish", target=""))
         return moves
 
+    def get_provisioned_moves(self, game: CredentialsGame) -> list[CredentialsMove]:
+        moves = list(self.get_available_moves(game))
+        document_moves = [
+            move
+            for move in moves
+            if move.kind == "inspect" and move.target in game.presented_documents
+        ]
+        moves = [
+            move
+            for move in moves
+            if move.kind != "inspect" or move.target not in game.presented_documents
+        ]
+        if document_moves:
+            moves.insert(
+                0,
+                CredentialsMove(kind="inspect", target=_DOCUMENT_SELECTOR_TARGET),
+            )
+        return moves
+
     @staticmethod
     def _has_declared_contraband(game: CredentialsGame) -> bool:
         disclosed = game.finding_status.get(FindingKey.DISCLOSURE) == Finding.DECLARED
@@ -826,6 +851,8 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
 
     def get_move_label(self, game: CredentialsGame, move: CredentialsMove) -> str:
         if move.kind == "inspect":
+            if move.target == _DOCUMENT_SELECTOR_TARGET:
+                return "Inspect a document"
             if move.target in game.active_case.packet_hidden_facts:
                 return f"Review {move.target}"
             return f"Inspect {move.target}"
@@ -840,6 +867,48 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         if move.kind == "request_relinquish":
             return "Have the contraband surrendered"
         return f"Choose {move.target}"
+
+    def get_move_accepts(
+        self,
+        game: CredentialsGame,
+        move: CredentialsMove,
+    ) -> PiecesAccepts | PickAccepts:
+        if move.kind == "inspect" and move.target == _DOCUMENT_SELECTOR_TARGET:
+            return PiecesAccepts(
+                constraints=PieceConstraints(
+                    target_zone_ref=str(
+                        _piece_uid(game.uid, game.case_index, "packet"),
+                    ),
+                ),
+            )
+        return PickAccepts()
+
+    def resolve_move_payload(
+        self,
+        game: CredentialsGame,
+        move: CredentialsMove,
+        payload: dict[str, object],
+    ) -> CredentialsMove:
+        move = self._normalize_move(move)
+        if move.kind != "inspect" or move.target != _DOCUMENT_SELECTOR_TARGET:
+            return move
+
+        piece_ids = payload.get("piece_ids")
+        if not isinstance(piece_ids, list) or len(piece_ids) != 1:
+            raise ValueError("Inspect a document requires exactly one piece_id")
+
+        selected_piece_id = piece_ids[0]
+        if not isinstance(selected_piece_id, str):
+            raise ValueError("Document piece_id must be a string")
+        target_by_piece_id = {
+            _document_piece_id(game.case_index, target): target
+            for target in self.get_available_inspect_targets(game)
+            if target in game.presented_documents
+        }
+        target = target_by_piece_id.get(selected_piece_id)
+        if target is None:
+            raise ValueError(f"Document piece is not inspectable: {selected_piece_id}")
+        return CredentialsMove(kind="inspect", target=target)
 
     def resolve_inspection(
         self,
@@ -1169,7 +1238,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
     def get_journal_fragments(self, game: CredentialsGame) -> list[BaseFragment] | None:
         last_round = game.last_round
         if last_round is None:
-            return []
+            return [] if game.shift_complete else self._candidate_fragments(game)
 
         move = self._normalize_move(last_round.player_move)
         prose = self._prose_fragments(game, last_round, move.kind, move.target, last_round.notes or {})
@@ -1315,7 +1384,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         candidate = PieceFragment(
             uid=_piece_uid(game.uid, idx, "candidate"),
             piece_id=f"candidate-{idx}",
-            kind="candidate",
+            piece_kind="candidate",
             content=case.candidate_name,
             properties={
                 "declared_purpose": case.get_purpose().value,
@@ -1332,8 +1401,8 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             doc_pieces.append(
                 PieceFragment(
                     uid=doc_uid,
-                    piece_id=f"{idx}:{label}",
-                    kind=_document_kind(label),
+                    piece_id=_document_piece_id(idx, label),
+                    piece_kind=_document_kind(label),
                     content=description,
                     zone_ref=packet_uid,
                     hints=PresentationHints(label_text=label),

--- a/engine/src/tangl/mechanics/games/handler.py
+++ b/engine/src/tangl/mechanics/games/handler.py
@@ -19,6 +19,7 @@ from .strategies import opponent_strategies, scoring_strategies
 
 if TYPE_CHECKING:
     from tangl.core import BaseFragment
+    from tangl.journal.intent import Accepts
 
 GameT = TypeVar("GameT", bound=Game)
 
@@ -108,6 +109,26 @@ class GameHandler(ABC, Generic[GameT]):
 
         move_value = getattr(move, "value", move)
         return f"Play {move_value}"
+
+    def get_provisioned_moves(self, game: GameT) -> list[Move]:
+        """Return the moves represented as client-facing actions."""
+
+        return self.get_available_moves(game)
+
+    def get_move_accepts(self, game: GameT, move: Move) -> Accepts | None:
+        """Return the client input contract for a move action."""
+
+        return None
+
+    def resolve_move_payload(
+        self,
+        game: GameT,
+        move: Move,
+        payload: dict[str, Any],
+    ) -> Move:
+        """Resolve submitted widget data into the engine move."""
+
+        return move
 
     def build_round_notes(
         self,

--- a/engine/src/tangl/mechanics/games/handlers.py
+++ b/engine/src/tangl/mechanics/games/handlers.py
@@ -49,7 +49,7 @@ def _build_game_actions(cursor: HasGame) -> list[Any]:
     from tangl.story import Action
 
     actions: list[Action] = []
-    for move in cursor.game_handler.get_available_moves(cursor.game):
+    for move in cursor.game_handler.get_provisioned_moves(cursor.game):
         actions.append(
             Action(
                 graph=cursor.graph,
@@ -57,6 +57,7 @@ def _build_game_actions(cursor: HasGame) -> list[Any]:
                 successor_id=cursor.uid,
                 label=cursor.game_handler.get_move_label(cursor.game, move),
                 payload={"move": move},
+                accepts=cursor.game_handler.get_move_accepts(cursor.game, move),
                 tags={"dynamic", "fanout", "game"},
             )
         )
@@ -161,15 +162,16 @@ def provision_game_moves(
     """
     Provision self-loop :class:`~tangl.story.episode.action.Action` choices for moves.
 
-    When the game is READY, the handler queries available moves from the
-    game handler and returns one :class:`~tangl.story.episode.action.Action`
-    per move. Each action is a self-loop with the move stored in ``payload``
-    for later processing during :data:`~tangl.vm.resolution_phase.ResolutionPhase.UPDATE`.
+    When the game is READY, the handler queries client-facing provisioned moves
+    from the game handler and returns one
+    :class:`~tangl.story.episode.action.Action` per move. Each action is a
+    self-loop with the move stored in ``payload`` for later processing during
+    :data:`~tangl.vm.resolution_phase.ResolutionPhase.UPDATE`.
 
     Returns
     -------
     list[Action]
-        One action per available move, or an empty list when the game is not
+        One action per provisioned move, or an empty list when the game is not
         accepting player input.
     """
 
@@ -198,7 +200,7 @@ def provision_game_moves(
     if cursor.game.phase != GamePhase.READY:
         return None if runtime_planning else []
 
-    moves = cursor.game_handler.get_available_moves(cursor.game)
+    moves = cursor.game_handler.get_provisioned_moves(cursor.game)
 
     if not moves:
         logger.warning("No available moves at %s despite READY phase", cursor.get_label())
@@ -227,7 +229,8 @@ def process_game_move(
     """
     Apply the player's selected move through the game handler.
 
-    Extracts ``move`` from the selected action payload, forwards it to
+    Extracts ``move`` from the selected action payload, resolves any submitted
+    widget data through the game handler, then forwards the concrete move to
     :meth:`~tangl.mechanics.games.handler.GameHandler.receive_move`, and
     records round/game outcomes in ``cursor.locals`` for downstream JOURNAL
     and CONTEXT phases.
@@ -252,6 +255,7 @@ def process_game_move(
     if move is None:
         logger.warning("Selected edge missing move payload at %s", cursor.get_label())
         return None
+    move = cursor.game_handler.resolve_move_payload(cursor.game, move, payload)
 
     if cursor.game.phase != GamePhase.READY:
         logger.warning(
@@ -328,11 +332,6 @@ def generate_game_journal(
     if not isinstance(cursor, HasGame):
         return []
 
-    last_round = cursor.locals.get("last_round")
-    if not last_round:
-        logger.debug("No last_round available for journal at %s", cursor.get_label())
-        return []
-
     custom_fragments = cursor.game_handler.get_journal_fragments(cursor.game)
     if custom_fragments is not None:
         logger.debug(
@@ -341,6 +340,11 @@ def generate_game_journal(
             cursor.get_label(),
         )
         return custom_fragments
+
+    last_round = cursor.locals.get("last_round")
+    if not last_round:
+        logger.debug("No last_round available for journal at %s", cursor.get_label())
+        return []
 
     fragments: list[ContentFragment] = []
 

--- a/engine/src/tangl/mechanics/games/nim_game.py
+++ b/engine/src/tangl/mechanics/games/nim_game.py
@@ -11,12 +11,15 @@ from typing import ClassVar
 
 from pydantic import Field
 
+from tangl.journal.intent import QuantityAccepts
 from tangl.journal.fragments import ContentFragment
 
 from .enums import RoundResult
 from .game import Game
 from .handler import GameHandler
 from .strategies import opponent_strategies
+
+_QUANTITY_SELECTOR_MOVE = 0
 
 
 class NimGame(Game[int]):
@@ -75,9 +78,39 @@ class NimGameHandler(GameHandler[NimGame]):
     def get_available_moves(self, game: NimGame) -> list[int]:
         return game.get_available_moves()
 
+    def get_provisioned_moves(self, game: NimGame) -> list[int]:
+        return [_QUANTITY_SELECTOR_MOVE] if game.get_available_moves() else []
+
     def get_move_label(self, game: NimGame, move: int) -> str:
+        if move == _QUANTITY_SELECTOR_MOVE:
+            return "Take tokens"
         noun = "token" if move == 1 else "tokens"
         return f"Take {move} {noun}"
+
+    def get_move_accepts(self, game: NimGame, move: int) -> QuantityAccepts | None:
+        if move != _QUANTITY_SELECTOR_MOVE:
+            return None
+        return QuantityAccepts(
+            min=game.min_take,
+            max=min(game.max_take, game.heap_size),
+            unit="token",
+        )
+
+    def resolve_move_payload(
+        self,
+        game: NimGame,
+        move: int,
+        payload: dict[str, object],
+    ) -> int:
+        if move != _QUANTITY_SELECTOR_MOVE:
+            return move
+
+        quantity = payload.get("quantity")
+        if isinstance(quantity, bool) or not isinstance(quantity, int):
+            raise ValueError("Take tokens requires an integer quantity")
+        if quantity not in game.get_available_moves():
+            raise ValueError(f"Invalid token quantity: {quantity}")
+        return quantity
 
     def resolve_round(
         self,

--- a/engine/src/tangl/service/remote_service_manager.py
+++ b/engine/src/tangl/service/remote_service_manager.py
@@ -15,18 +15,7 @@ import requests
 from pydantic import ValidationError as PydanticValidationError
 
 from tangl.core import BaseFragment
-from tangl.journal.fragments import (
-    AttributedFragment,
-    BlockFragment,
-    ChoiceFragment,
-    ContentFragment,
-    ControlFragment,
-    DialogFragment,
-    GroupFragment,
-    KvFragment,
-    MediaFragment,
-    UserEventFragment,
-)
+from tangl.journal.fragments import fragment_from_dto
 from tangl.media.media_resource import MediaResourceInventoryTag as MediaRIT
 from tangl.persistence import PersistenceManager
 from tangl.type_hints import Identifier, UnstructuredData
@@ -64,21 +53,6 @@ _STANDARD_RUNTIME_INFO_FIELDS = {
     "step",
     "details",
 }
-_KNOWN_FRAGMENT_TYPES: dict[str, type[BaseFragment]] = {
-    "attributed": AttributedFragment,
-    "block": BlockFragment,
-    "choice": ChoiceFragment,
-    "content": ContentFragment,
-    "delete": ControlFragment,
-    "dialog": DialogFragment,
-    "group": GroupFragment,
-    "kv": KvFragment,
-    "media": MediaFragment,
-    "update": ControlFragment,
-    "user_event": UserEventFragment,
-}
-
-
 class RemoteServiceManager(ServiceManager):
     """Service-manager adapter that fulfills calls through the REST API."""
 
@@ -250,21 +224,12 @@ class RemoteServiceManager(ServiceManager):
             raise ServiceError(f"Remote service returned invalid {label} payload") from exc
 
     def _decode_fragment(self, payload: object) -> BaseFragment:
-        if not isinstance(payload, Mapping):
-            return BaseFragment(fragment_type="unknown", content=payload)
-
-        raw_fragment = dict(payload)
-        fragment_type = raw_fragment.get("fragment_type")
-        if not isinstance(fragment_type, str) or not fragment_type:
-            return BaseFragment(fragment_type="unknown", content=raw_fragment)
-
-        fragment_model = _KNOWN_FRAGMENT_TYPES.get(fragment_type)
-        if fragment_model is None:
-            return BaseFragment(fragment_type=fragment_type, content=raw_fragment)
-
         try:
-            return fragment_model.model_validate(raw_fragment)
+            return fragment_from_dto(payload)
         except PydanticValidationError as exc:
+            fragment_type = (
+                payload.get("fragment_type") if isinstance(payload, Mapping) else "unknown"
+            )
             raise ServiceError(
                 f"Remote service returned invalid {fragment_type} fragment payload",
             ) from exc

--- a/engine/src/tangl/service/response.py
+++ b/engine/src/tangl/service/response.py
@@ -21,7 +21,12 @@ from pydantic import (
 from tangl.core import BaseFragment
 from tangl.info import __url__
 from tangl.journal.intent import KvRow, PrimitiveValue
-from tangl.journal.fragments import KvFragment, MediaFragment, PresentationHints
+from tangl.journal.fragments import (
+    KvFragment,
+    MediaFragment,
+    PresentationHints,
+    fragment_to_dto,
+)
 from tangl.service.user.user import User
 
 
@@ -88,6 +93,25 @@ class RuntimeEnvelope(InfoModel):
     last_redirect: dict[str, Any] | None = None
     redirect_trace: list[dict[str, Any]] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
+
+    def to_dto(self) -> dict[str, Any]:
+        """Return the transport DTO projection for client-facing envelopes."""
+
+        base_payload = self.model_dump(
+            mode="json",
+            by_alias=True,
+            exclude_none=True,
+            exclude={"fragments"},
+        )
+        payload: dict[str, Any] = {}
+        for field_name in ("cursor_id", "step"):
+            if field_name in base_payload:
+                payload[field_name] = base_payload[field_name]
+        payload["fragments"] = [fragment_to_dto(fragment) for fragment in self.fragments]
+        for field_name in ("last_redirect", "redirect_trace", "metadata"):
+            if field_name in base_payload:
+                payload[field_name] = base_payload[field_name]
+        return payload
 
 
 JsonValue: TypeAlias = PydanticJsonValue

--- a/engine/src/tangl/service/response.py
+++ b/engine/src/tangl/service/response.py
@@ -328,6 +328,11 @@ class ProjectedState(InfoModel):
 
     sections: list[ProjectedSection] = Field(default_factory=list)
 
+    def to_dto(self) -> dict[str, Any]:
+        """Return the transport DTO projection for projected-state clients."""
+
+        return self.model_dump(mode="json", by_alias=True, exclude_none=True)
+
 
 def coerce_runtime_info(value: Any) -> RuntimeInfo | None:
     """Best-effort coercion from runtime-like payloads to ``RuntimeInfo``."""

--- a/engine/src/tangl/service/response.py
+++ b/engine/src/tangl/service/response.py
@@ -12,6 +12,7 @@ from pydantic import (
     ConfigDict,
     Field,
     JsonValue as PydanticJsonValue,
+    SerializeAsAny,
     ValidationError,
     field_serializer,
     model_validator,
@@ -83,7 +84,7 @@ class RuntimeEnvelope(InfoModel):
 
     cursor_id: UUID | None = None
     step: int | None = None
-    fragments: list[BaseFragment] = Field(default_factory=list)
+    fragments: list[SerializeAsAny[BaseFragment]] = Field(default_factory=list)
     last_redirect: dict[str, Any] | None = None
     redirect_trace: list[dict[str, Any]] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)

--- a/engine/src/tangl/service/response.py
+++ b/engine/src/tangl/service/response.py
@@ -106,11 +106,9 @@ class RuntimeEnvelope(InfoModel):
         payload: dict[str, Any] = {}
         for field_name in ("cursor_id", "step"):
             if field_name in base_payload:
-                payload[field_name] = base_payload[field_name]
+                payload[field_name] = base_payload.pop(field_name)
         payload["fragments"] = [fragment_to_dto(fragment) for fragment in self.fragments]
-        for field_name in ("last_redirect", "redirect_trace", "metadata"):
-            if field_name in base_payload:
-                payload[field_name] = base_payload[field_name]
+        payload.update(base_payload)
         return payload
 
 

--- a/engine/src/tangl/story/episode/action.py
+++ b/engine/src/tangl/story/episode/action.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from pydantic import field_serializer
+
 from tangl.journal.intent import Accepts, UIHints
 from tangl.vm import ResolutionPhase, TraversableEdge
 
@@ -25,6 +27,12 @@ class Action(TraversableEdge):
     accepts: Accepts | None = None
     ui_hints: UIHints | None = None
     journal_text: str | None = None
+
+    @field_serializer("accepts")
+    def _serialize_accepts(self, accepts: Accepts | None) -> dict[str, Any] | None:
+        if accepts is None:
+            return None
+        return accepts.model_dump(mode="python", by_alias=True, exclude_none=True)
 
     @classmethod
     def trigger_phase_from_activation(cls, activation: str | None) -> ResolutionPhase | None:

--- a/engine/tests/conformance/test_backend_widget_demo.py
+++ b/engine/tests/conformance/test_backend_widget_demo.py
@@ -1,0 +1,85 @@
+"""Backend-emitted widget-contract diagnostics."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from tangl.service.response import ProjectedState, RuntimeEnvelope
+
+
+ROOT = Path(__file__).parents[3]
+CONFORMANCE_DIR = ROOT / "engine" / "contrib" / "conformance"
+BACKEND_DEMO_PATH = CONFORMANCE_DIR / "backend_widget_demo.py"
+REFERENCE_PATH = CONFORMANCE_DIR / "reference_port.py"
+DIAGNOSTIC_DIR = CONFORMANCE_DIR / "diagnostics"
+RUNTIME_PATH = DIAGNOSTIC_DIR / "backend_widget_contract_runtime.json"
+PROJECTED_PATH = DIAGNOSTIC_DIR / "backend_widget_contract_projected_state.json"
+
+
+def _load_module(name: str, path: Path) -> ModuleType:
+    module_name = f"{__name__}.{name}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+BACKEND_DEMO = _load_module("backend_widget_demo", BACKEND_DEMO_PATH)
+REFERENCE_PORT = _load_module("reference_port", REFERENCE_PATH)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as payload_file:
+        payload = json.load(payload_file)
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_backend_widget_diagnostics_match_generator() -> None:
+    runtime_payload, projected_payload = BACKEND_DEMO.build_demo_payloads()
+
+    assert _load_json(RUNTIME_PATH) == runtime_payload
+    assert _load_json(PROJECTED_PATH) == projected_payload
+
+
+def test_backend_widget_diagnostics_validate_as_service_contracts() -> None:
+    runtime_payload = _load_json(RUNTIME_PATH)
+    projected_payload = _load_json(PROJECTED_PATH)
+
+    RuntimeEnvelope.model_validate(runtime_payload)
+    ProjectedState.model_validate(projected_payload)
+
+    choices = [
+        fragment
+        for fragment in runtime_payload["fragments"]
+        if fragment.get("fragment_type") == "choice"
+    ]
+    assert len(choices) == 2
+    assert choices[0]["uid"] != choices[0]["edge_id"]
+    assert choices[0]["accepts"]["kind"] == "quantity"
+    assert choices[0]["ui_hints"]["source_kind"] == "market"
+    assert choices[1]["accepts"]["kind"] == "text"
+    assert runtime_payload["metadata"]["info_state"]["available_kinds"] == [
+        "inventory",
+        "map",
+    ]
+
+
+def test_backend_widget_diagnostics_render_in_reference_port() -> None:
+    runtime_output = "\n".join(REFERENCE_PORT.render_fixture(_load_json(RUNTIME_PATH)))
+    projected_output = "\n".join(REFERENCE_PORT.render_fixture(_load_json(PROJECTED_PATH)))
+
+    assert "The road forks under cold rain." in runtime_output
+    assert "b) Buy rations. <quantity 1-3 ration>" in runtime_output
+    assert "n) Name the mule. <text: Buttercup>" in runtime_output
+    assert "? Inventory: /info inventory (shortcuts: /i, /inv)" in runtime_output
+    assert "Supplies:\n  Rations: 2" in projected_output
+    assert "Mira | Scout" in projected_output

--- a/engine/tests/conformance/test_widget_conformance_fixtures.py
+++ b/engine/tests/conformance/test_widget_conformance_fixtures.py
@@ -666,11 +666,11 @@ def test_credentials_shift_fixture_round_trips_through_typed_models() -> None:
 
     # Candidate + document pieces validate as typed PieceFragments.
     candidate = PieceFragment.model_validate(by_uid["00000000-0000-4000-8000-000000000603"])
-    assert candidate.kind == "candidate"
+    assert candidate.piece_kind == "candidate"
     assert candidate.properties["declared_purpose"] == "work"
 
     permit = PieceFragment.model_validate(by_uid["00000000-0000-4000-8000-000000000606"])
-    assert permit.kind == "permit"
+    assert permit.piece_kind == "permit"
     assert str(permit.zone_ref) == "00000000-0000-4000-8000-000000000604"
 
     # Packet zone validates as a typed GroupFragment carrying its zone_role.

--- a/engine/tests/integration/test_credentials_widget_flow.py
+++ b/engine/tests/integration/test_credentials_widget_flow.py
@@ -1,0 +1,134 @@
+"""Credentials widget projection through the service runtime envelope."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tangl.core import Selector
+from tangl.journal.fragments import (
+    ChoiceFragment,
+    ContentFragment,
+    GroupFragment,
+    PieceFragment,
+)
+from tangl.loaders import WorldBundle
+from tangl.loaders.compiler import WorldCompiler
+from tangl.persistence import PersistenceManagerFactory
+from tangl.service.service_manager import ServiceManager
+from tangl.service.user.user import User
+from tangl.story import Action, InitMode
+from tangl.vm import Ledger
+
+
+def _credential_gate_root() -> Path:
+    return Path(__file__).resolve().parents[3] / "worlds" / "credential_gate"
+
+
+def _action(ledger: Ledger, text: str) -> Action:
+    return next(
+        action
+        for action in ledger.cursor.edges_out(
+            Selector(has_kind=Action, trigger_phase=None),
+        )
+        if action.text == text or action.label == text
+    )
+
+
+def test_credentials_packet_reaches_service_envelope_as_typed_widgets() -> None:
+    persistence = PersistenceManagerFactory.native_in_mem()
+    user = User(label="credentials-widget-user")
+    persistence.save(user)
+    manager = ServiceManager(persistence)
+    world = WorldCompiler().compile(WorldBundle.load(_credential_gate_root()))
+
+    created = manager.create_story(
+        user_id=user.uid,
+        world_id=world.label,
+        world=world,
+        init_mode=InitMode.EAGER.value,
+        story_label="credentials_widget_flow",
+    )
+    ledger = persistence.load(user.current_ledger_id)
+    assert isinstance(ledger, Ledger)
+
+    entered = manager.resolve_choice(
+        user_id=user.uid,
+        edge_id=_action(ledger, "Work the scheduled shift").uid,
+    )
+
+    pieces = [
+        fragment for fragment in entered.fragments if isinstance(fragment, PieceFragment)
+    ]
+    packet = next(
+        fragment
+        for fragment in entered.fragments
+        if isinstance(fragment, GroupFragment) and fragment.zone_role == "packet"
+    )
+    candidate = next(
+        fragment for fragment in pieces if fragment.piece_kind == "candidate"
+    )
+    documents = [fragment for fragment in pieces if fragment.zone_ref == packet.uid]
+
+    assert candidate.content == "Tomas Vey"
+    assert candidate.presentation_hints.label_text == "Tomas Vey"
+    assert documents
+    assert set(packet.member_ids) == {fragment.uid for fragment in documents}
+    assert any(isinstance(fragment, ContentFragment) for fragment in entered.fragments)
+    inspect_choice = next(
+        fragment
+        for fragment in entered.fragments
+        if isinstance(fragment, ChoiceFragment) and fragment.text == "Inspect a document"
+    )
+    assert inspect_choice.edge_id is not None
+    assert inspect_choice.accepts is not None
+    assert inspect_choice.accepts.kind == "pieces"
+    assert inspect_choice.accepts.constraints is not None
+    assert inspect_choice.accepts.constraints.target_zone_ref == str(packet.uid)
+
+    dto = entered.to_dto()
+    piece_payloads = [
+        fragment for fragment in dto["fragments"] if fragment["fragment_type"] == "piece"
+    ]
+    packet_payload = next(
+        fragment
+        for fragment in dto["fragments"]
+        if fragment["fragment_type"] == "group" and fragment["zone_role"] == "packet"
+    )
+    inspect_payload = next(
+        fragment
+        for fragment in dto["fragments"]
+        if fragment["fragment_type"] == "choice"
+        and fragment["text"] == "Inspect a document"
+    )
+
+    assert {fragment["uid"] for fragment in piece_payloads if "zone_ref" in fragment} == set(
+        packet_payload["member_ids"],
+    )
+    assert all(fragment["content"] for fragment in piece_payloads)
+    assert all(fragment["hints"]["label_text"] for fragment in piece_payloads)
+    assert inspect_payload["accepts"] == {
+        "kind": "pieces",
+        "min": 1,
+        "max": 1,
+        "constraints": {"target_zone_ref": packet_payload["uid"]},
+    }
+
+    passport = next(
+        fragment
+        for fragment in documents
+        if fragment.presentation_hints.label_text == "passport"
+    )
+    inspected = manager.resolve_choice(
+        user_id=user.uid,
+        edge_id=inspect_choice.edge_id,
+        choice_payload={"piece_ids": [passport.piece_id]},
+    )
+
+    assert any(
+        isinstance(fragment, ContentFragment)
+        and "inspect the passport" in str(fragment.content).lower()
+        for fragment in inspected.fragments
+    )
+    persisted = persistence.load(user.current_ledger_id)
+    assert isinstance(persisted, Ledger)
+    assert persisted.cursor.game.inspected_documents == ["passport"]

--- a/engine/tests/journal/test_content_fragment.py
+++ b/engine/tests/journal/test_content_fragment.py
@@ -12,10 +12,9 @@ from tangl.journal.ux import ControlFragment
 def test_content_fragment_creation():
     # Test basic fragment creation
     fragment = ContentFragment(
-        fragment_type="test",
-        content="Test content"
+        content="Test content",
     )
-    assert fragment.fragment_type == "test"
+    assert fragment.fragment_type == "content"
     assert fragment.content == "Test content"
     assert fragment.uid is not None
     assert isinstance(fragment.uid, UUID)
@@ -23,13 +22,12 @@ def test_content_fragment_creation():
 def test_fragment_serialization():
     # Test that fragments serialize correctly
     fragment = ContentFragment(
-        fragment_type="test",
         label="test_label",
         content="Test content",
-        format="plain"
+        format="plain",
     )
     data = fragment.model_dump()
-    assert data["fragment_type"] == "test"
+    assert data["fragment_type"] == "content"
     assert data["label"] == "test_label"
     assert data["content"] == "Test content"
     assert data["format"] == "plain"

--- a/engine/tests/journal/test_fragment_dto.py
+++ b/engine/tests/journal/test_fragment_dto.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from tangl.core import BaseFragment
+from tangl.journal.fragments import (
+    AttributedFragment,
+    ChoiceFragment,
+    ContentFragment,
+    PieceFragment,
+    fragment_from_dto,
+    fragment_to_dto,
+)
+
+
+def test_fragment_to_dto_omits_stream_bookkeeping() -> None:
+    fragment = ChoiceFragment(
+        edge_id=uuid4(),
+        text="Take the brass lamp.",
+        step=4,
+    )
+
+    payload = fragment_to_dto(fragment)
+
+    assert payload["fragment_type"] == "choice"
+    assert payload["text"] == "Take the brass lamp."
+    assert "seq" not in payload
+    assert "step" not in payload
+    assert "tags" not in payload
+
+
+def test_fragment_to_dto_preserves_piece_kind() -> None:
+    fragment = PieceFragment(
+        piece_id="permit-a17",
+        kind="document",
+        content="Permit A17",
+    )
+
+    payload = fragment_to_dto(fragment)
+
+    assert payload["fragment_type"] == "piece"
+    assert payload["kind"] == "document"
+
+
+def test_fragment_to_dto_omits_redundant_type_alias() -> None:
+    fragment = AttributedFragment(
+        content="Keep moving.",
+        who="guide",
+        how="whispers",
+        media="",
+    )
+
+    payload = fragment_to_dto(fragment)
+
+    assert payload["fragment_type"] == "attributed"
+    assert "type" not in payload
+
+
+def test_fragment_from_dto_hydrates_known_fragment() -> None:
+    edge_id = UUID("00000000-0000-4000-8000-000000000111")
+
+    fragment = fragment_from_dto(
+        {
+            "fragment_type": "choice",
+            "edge_id": str(edge_id),
+            "text": "Continue.",
+        }
+    )
+
+    assert isinstance(fragment, ChoiceFragment)
+    assert fragment.edge_id == edge_id
+    assert fragment.text == "Continue."
+
+
+def test_fragment_from_dto_preserves_unknown_fragment_payload() -> None:
+    fragment = fragment_from_dto({"fragment_type": "future_card", "foo": "bar"})
+
+    assert isinstance(fragment, BaseFragment)
+    assert fragment.fragment_type == "future_card"
+    assert fragment.content == {"fragment_type": "future_card", "foo": "bar"}
+
+
+def test_known_fragment_dto_validation_stays_strict() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        fragment_from_dto({"fragment_type": "piece", "content": "missing id"})
+
+    assert "piece_id" in str(exc_info.value)
+
+
+def test_typed_content_fragment_rejects_extension_discriminator() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        ContentFragment(fragment_type="custom_card", content="Use BaseFragment instead")
+
+    assert "content" in str(exc_info.value)

--- a/engine/tests/journal/test_fragment_dto.py
+++ b/engine/tests/journal/test_fragment_dto.py
@@ -1,3 +1,9 @@
+"""Tests for client-facing fragment DTO projection and hydration.
+
+Coverage includes bookkeeping omission, typed fragment round trips, aliases,
+unknown-fragment fallback, and discriminator validation.
+"""
+
 from __future__ import annotations
 
 from uuid import UUID, uuid4

--- a/engine/tests/journal/test_fragment_dto.py
+++ b/engine/tests/journal/test_fragment_dto.py
@@ -35,7 +35,7 @@ def test_fragment_to_dto_omits_stream_bookkeeping() -> None:
 def test_fragment_to_dto_preserves_piece_kind() -> None:
     fragment = PieceFragment(
         piece_id="permit-a17",
-        kind="document",
+        piece_kind="document",
         content="Permit A17",
     )
 
@@ -43,6 +43,21 @@ def test_fragment_to_dto_preserves_piece_kind() -> None:
 
     assert payload["fragment_type"] == "piece"
     assert payload["kind"] == "document"
+    assert "piece_kind" not in payload
+
+
+def test_fragment_from_dto_maps_piece_kind_to_engine_field() -> None:
+    fragment = fragment_from_dto(
+        {
+            "fragment_type": "piece",
+            "piece_id": "permit-a17",
+            "kind": "document",
+            "content": "Permit A17",
+        }
+    )
+
+    assert isinstance(fragment, PieceFragment)
+    assert fragment.piece_kind == "document"
 
 
 def test_fragment_to_dto_omits_redundant_type_alias() -> None:

--- a/engine/tests/journal/test_piece_fragment.py
+++ b/engine/tests/journal/test_piece_fragment.py
@@ -9,7 +9,11 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from tangl.journal.fragments import PieceFragment, PresentationHints
+from tangl.journal.fragments import (
+    PieceFragment,
+    PresentationHints,
+    fragment_to_dto,
+)
 
 
 def test_piece_fragment_serializes_to_fixture_shape() -> None:
@@ -18,14 +22,14 @@ def test_piece_fragment_serializes_to_fixture_shape() -> None:
     piece = PieceFragment(
         uid=uid,
         piece_id="lamp",
-        kind="item",
+        piece_kind="item",
         content="brass lamp",
         display_state="available",
         zone_ref=zone,
         hints=PresentationHints(label_text="brass lamp"),
     )
 
-    data = piece.model_dump(mode="json", by_alias=True, exclude_none=True)
+    data = fragment_to_dto(piece)
 
     assert data["fragment_type"] == "piece"
     assert data["piece_id"] == "lamp"
@@ -39,7 +43,7 @@ def test_piece_fragment_serializes_to_fixture_shape() -> None:
 def test_piece_fragment_carries_properties_for_richer_kinds() -> None:
     piece = PieceFragment(
         piece_id="candidate-0",
-        kind="candidate",
+        piece_kind="candidate",
         content="Bek Tarsus",
         properties={"declared_purpose": "merchant", "declared_origin": "Kalden"},
         hints=PresentationHints(label_text="Bek Tarsus (merchant)"),
@@ -48,5 +52,18 @@ def test_piece_fragment_carries_properties_for_richer_kinds() -> None:
     data = piece.model_dump(mode="json", by_alias=True, exclude_none=True)
 
     assert data["properties"]["declared_purpose"] == "merchant"
-    assert data["kind"] == "candidate"
+    assert data["piece_kind"] == "candidate"
     assert data["hints"]["label_text"] == "Bek Tarsus (merchant)"
+
+
+def test_piece_kind_survives_constructor_form_round_trip() -> None:
+    piece = PieceFragment(
+        piece_id="candidate-0",
+        piece_kind="candidate",
+        content="Bek Tarsus",
+    )
+
+    restored = PieceFragment.structure(piece.unstructure())
+
+    assert isinstance(restored, PieceFragment)
+    assert restored.piece_kind == "candidate"

--- a/engine/tests/loaders/test_credential_gate_world.py
+++ b/engine/tests/loaders/test_credential_gate_world.py
@@ -32,7 +32,16 @@ def _choose(ledger: Ledger, label: str) -> None:
     action = next(
         a for a in _actions(ledger) if a.label == label or a.text == label
     )
-    ledger.resolve_choice(action.uid, choice_payload=action.payload)
+    ledger.resolve_choice(action.uid)
+
+
+def _inspect(ledger: Ledger, target: str) -> None:
+    action = next(a for a in _actions(ledger) if a.label == "Inspect a document")
+    game = ledger.cursor.game
+    ledger.resolve_choice(
+        action.uid,
+        choice_payload={"piece_ids": [f"{game.case_index}:{target}"]},
+    )
 
 
 class TestCredentialGateWorld:
@@ -60,15 +69,15 @@ class TestCredentialGateWorld:
         assert ledger.cursor.label == "standard_challenge"
 
         # The authored roster: Tomas (pass), Edda (deny), Goran (arrest).
-        _choose(ledger, "Inspect passport")
+        _inspect(ledger, "passport")
         _choose(ledger, "Choose pass")
         assert ledger.cursor.label == "standard_challenge"  # still mid-shift
 
-        _choose(ledger, "Inspect passport")
+        _inspect(ledger, "passport")
         _choose(ledger, "Choose deny")
         assert ledger.cursor.label == "standard_challenge"
 
-        _choose(ledger, "Inspect passport")
+        _inspect(ledger, "passport")
         _choose(ledger, "Choose arrest")
 
         assert ledger.cursor.label == "victory"
@@ -102,15 +111,8 @@ class TestCredentialGateWorld:
 
         for _ in range(total):
             target = game.expected_disposition(game.active_case).value
-            # Action.label is Optional[str] (story-authored actions can have
-            # label=None and surface their text via .text instead); guard the
-            # None case before .startswith.
-            inspect = next(
-                a
-                for a in _actions(ledger)
-                if a.label and a.label.startswith(("Inspect", "Review"))
-            )
-            ledger.resolve_choice(inspect.uid, choice_payload=inspect.payload)
+            inspect_target = next(iter(game.presented_documents))
+            _inspect(ledger, inspect_target)
             _choose(ledger, f"Choose {target}")
 
         assert ledger.cursor.label == "victory"

--- a/engine/tests/mechanics/games/test_credentials_fragments.py
+++ b/engine/tests/mechanics/games/test_credentials_fragments.py
@@ -45,14 +45,29 @@ def _by_type(fragments, kind):
 
 
 class TestStructuredEmission:
+    def test_initial_projection_emits_candidate_packet_and_documents(self) -> None:
+        game, handler = _game()
+
+        frags = handler.get_journal_fragments(game)
+
+        assert any(
+            isinstance(fragment, PieceFragment) and fragment.piece_kind == "candidate"
+            for fragment in frags
+        )
+        assert any(
+            isinstance(fragment, GroupFragment) and fragment.zone_role == "packet"
+            for fragment in frags
+        )
+        assert not _by_type(frags, ContentFragment)
+
     def test_inspect_emits_candidate_packet_and_documents(self) -> None:
         game, handler = _game()
         handler.receive_move(game, ("inspect", "passport"))
         frags = handler.get_journal_fragments(game)
 
         pieces = _by_type(frags, PieceFragment)
-        candidate = [p for p in pieces if p.kind == "candidate"]
-        docs = [p for p in pieces if p.kind != "candidate"]
+        candidate = [p for p in pieces if p.piece_kind == "candidate"]
+        docs = [p for p in pieces if p.piece_kind != "candidate"]
 
         assert candidate and candidate[0].content == "Edda Marrow"
         assert candidate[0].properties["declared_purpose"]  # populated
@@ -86,10 +101,18 @@ class TestStructuredEmission:
     def test_candidate_uid_is_stable_across_rounds(self) -> None:
         game, handler = _game()
         handler.receive_move(game, ("inspect", "passport"))
-        first = [p for p in _by_type(handler.get_journal_fragments(game), PieceFragment) if p.kind == "candidate"][0]
+        first = [
+            p
+            for p in _by_type(handler.get_journal_fragments(game), PieceFragment)
+            if p.piece_kind == "candidate"
+        ][0]
 
         handler.receive_move(game, ("inspect", "work permit"))
-        second = [p for p in _by_type(handler.get_journal_fragments(game), PieceFragment) if p.kind == "candidate"][0]
+        second = [
+            p
+            for p in _by_type(handler.get_journal_fragments(game), PieceFragment)
+            if p.piece_kind == "candidate"
+        ][0]
 
         assert first.uid == second.uid  # same candidate -> in-place update
 
@@ -104,7 +127,7 @@ class TestStructuredEmission:
         def candidate_uid(handler, game):
             return [
                 p for p in _by_type(handler.get_journal_fragments(game), PieceFragment)
-                if p.kind == "candidate"
+                if p.piece_kind == "candidate"
             ][0].uid
 
         assert candidate_uid(handler_a, game_a) != candidate_uid(handler_b, game_b)
@@ -128,5 +151,7 @@ class TestStructuredEmission:
         handler.receive_move(game, ("decide", "deny"))
 
         frags = handler.get_journal_fragments(game)
-        candidate = [p for p in _by_type(frags, PieceFragment) if p.kind == "candidate"]
+        candidate = [
+            p for p in _by_type(frags, PieceFragment) if p.piece_kind == "candidate"
+        ]
         assert candidate and candidate[0].content == "Tomas Vey"

--- a/engine/tests/mechanics/games/test_credentials_game.py
+++ b/engine/tests/mechanics/games/test_credentials_game.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from tangl.core import Graph
 from tangl.mechanics.games import GameResult, HasGame
 from tangl.mechanics.games.credentials_game import (
@@ -78,6 +80,49 @@ class TestCredentialsCore:
 
         assert result.name == "CONTINUE"
         assert "packet consistency" in game.packet_findings
+
+    def test_document_inspection_is_one_piece_selector_move(self) -> None:
+        game, handler = _ready_game()
+
+        inspect_moves = [
+            move for move in handler.get_provisioned_moves(game) if move.kind == "inspect"
+        ]
+
+        assert len(inspect_moves) == 1
+        assert handler.get_move_label(game, inspect_moves[0]) == "Inspect a document"
+        accepts = handler.get_move_accepts(game, inspect_moves[0])
+        assert accepts.kind == "pieces"
+        assert accepts.constraints is not None
+        assert accepts.constraints.target_zone_ref
+
+    def test_piece_payload_resolves_to_document_inspection(self) -> None:
+        game, handler = _ready_game()
+        selector = next(
+            move for move in handler.get_provisioned_moves(game) if move.kind == "inspect"
+        )
+
+        resolved = handler.resolve_move_payload(
+            game,
+            selector,
+            {"piece_ids": ["0:passport"]},
+        )
+
+        assert resolved.kind == "inspect"
+        assert resolved.target == "passport"
+
+    def test_stale_document_piece_payload_is_rejected(self) -> None:
+        game, handler = _ready_game()
+        selector = next(
+            move for move in handler.get_provisioned_moves(game) if move.kind == "inspect"
+        )
+        handler.receive_move(game, ("inspect", "passport"))
+
+        with pytest.raises(ValueError, match="not inspectable"):
+            handler.resolve_move_payload(
+                game,
+                selector,
+                {"piece_ids": ["0:passport"]},
+            )
 
     def test_arrest_move_can_be_disabled(self) -> None:
         game, handler = _ready_game(allow_arrest=False)
@@ -227,9 +272,23 @@ class TestCredentialsIntegration:
     def _labels(self, ledger: Ledger) -> set[str]:
         return {a.label for a in self._actions(ledger)}
 
-    def _choose(self, ledger: Ledger, label: str) -> None:
+    def _choose(
+        self,
+        ledger: Ledger,
+        label: str,
+        *,
+        choice_payload: dict[str, object] | None = None,
+    ) -> None:
         action = next(a for a in self._actions(ledger) if a.label == label)
-        ledger.resolve_choice(action.uid, choice_payload=action.payload)
+        ledger.resolve_choice(action.uid, choice_payload=choice_payload)
+
+    def _inspect(self, ledger: Ledger, target: str) -> None:
+        game = ledger.cursor.game
+        self._choose(
+            ledger,
+            "Inspect a document",
+            choice_payload={"piece_ids": [f"{game.case_index}:{target}"]},
+        )
 
     def test_walk_full_roster_to_victory(self) -> None:
         graph = Graph(label="credential_shift")
@@ -258,18 +317,18 @@ class TestCredentialsIntegration:
         ledger.resolve_choice(intro_to_checkpoint.uid)
 
         # Candidate 1 (Edda) -> deny.
-        self._choose(ledger, "Inspect passport")
+        self._inspect(ledger, "passport")
         self._choose(ledger, "Choose deny")
 
         # Stale move cleanup: the desk now shows candidate 2's documents only.
         labels = self._labels(ledger)
-        assert "Inspect passport" in labels
+        assert "Inspect a document" in labels
         assert "Inspect baggage" not in labels  # belonged to candidate 1
         assert not any(label.startswith("Choose ") for label in labels)  # must inspect first
         assert ledger.cursor_id == block.uid  # still mid-shift
 
         # Candidate 2 (Tomas) -> pass, completing the shift.
-        self._choose(ledger, "Inspect passport")
+        self._inspect(ledger, "passport")
         self._choose(ledger, "Choose pass")
 
         assert ledger.cursor_id == victory.uid

--- a/engine/tests/mechanics/games/test_game_handlers.py
+++ b/engine/tests/mechanics/games/test_game_handlers.py
@@ -141,7 +141,7 @@ class TestProvisioningHandler:
         assert all(action.successor_id == game_block.uid for action in actions)
         assert all(
             action.payload == {"move": move}
-            for action, move in zip(actions, ["win", "lose", "draw"])
+            for action, move in zip(actions, ["win", "lose", "draw"], strict=True)
         )
 
     def test_provisioning_replaces_previous_dynamic_game_actions(

--- a/engine/tests/mechanics/games/test_game_handlers.py
+++ b/engine/tests/mechanics/games/test_game_handlers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from tangl.core import Graph
+from tangl.journal.intent import PieceConstraints, PiecesAccepts
 from tangl.mechanics.games import Game, GameHandler, GamePhase, GameResult, RoundResult, HasGame
 from tangl.story import Action, Block
 from tangl.mechanics.games.handlers import (
@@ -138,7 +139,10 @@ class TestProvisioningHandler:
         assert all(isinstance(action, Action) for action in actions)
         assert all(action.predecessor_id == game_block.uid for action in actions)
         assert all(action.successor_id == game_block.uid for action in actions)
-        assert all(action.payload == {"move": move} for action, move in zip(actions, ["win", "lose", "draw"]))
+        assert all(
+            action.payload == {"move": move}
+            for action, move in zip(actions, ["win", "lose", "draw"])
+        )
 
     def test_provisioning_replaces_previous_dynamic_game_actions(
         self,
@@ -167,6 +171,26 @@ class TestProvisioningHandler:
         actions = provision_game_moves(game_block, ctx=ctx)
 
         assert actions == []
+
+    def test_typed_accepts_survives_graph_snapshot(
+        self,
+        game_graph: Graph,
+        game_block: GameBlock,
+    ) -> None:
+        action = Action(
+            graph=game_graph,
+            predecessor_id=game_block.uid,
+            successor_id=game_block.uid,
+            accepts=PiecesAccepts(
+                constraints=PieceConstraints(target_zone_ref="packet"),
+            ),
+        )
+
+        restored = Graph.structure(game_graph.unstructure()).get(action.uid)
+
+        assert isinstance(restored, Action)
+        assert restored.accepts is not None
+        assert restored.accepts.kind == "pieces"
 
 
 class TestUpdateHandler:

--- a/engine/tests/mechanics/games/test_nim_game.py
+++ b/engine/tests/mechanics/games/test_nim_game.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from tangl.core import Graph
 from tangl.mechanics.games import HasGame
 from tangl.mechanics.games.nim_game import NimGame, NimGameHandler
@@ -57,6 +59,16 @@ class TestNimCore:
         assert ns["nim_heap_size"] == 5
         assert ns["nim_max_take"] == 3
 
+    def test_quantity_payload_resolves_to_legal_take(self) -> None:
+        game = NimGame(opening_heap_size=2, max_take=3)
+        handler = NimGameHandler()
+        handler.setup(game)
+        selector = handler.get_provisioned_moves(game)[0]
+
+        assert handler.resolve_move_payload(game, selector, {"quantity": 2}) == 2
+        with pytest.raises(ValueError, match="Invalid token quantity"):
+            handler.resolve_move_payload(game, selector, {"quantity": 3})
+
 
 class TestNimIntegration:
     """VM and HasGame integration tests for nim."""
@@ -73,11 +85,11 @@ class TestNimIntegration:
 
         actions = provision_game_moves(block, ctx=ctx)
 
-        assert [action.label for action in actions] == [
-            "Take 1 token",
-            "Take 2 tokens",
-            "Take 3 tokens",
-        ]
+        assert [action.label for action in actions] == ["Take tokens"]
+        assert actions[0].accepts is not None
+        assert actions[0].accepts.kind == "quantity"
+        assert actions[0].accepts.min == 1
+        assert actions[0].accepts.max == 3
 
     def test_nim_routes_to_victory(self) -> None:
         graph = Graph(label="nim_flow")
@@ -106,12 +118,12 @@ class TestNimIntegration:
         ledger = Ledger.from_graph(graph=graph, entry_id=intro.uid)
         ledger.resolve_choice(intro_to_heap.uid)
 
-        take_one = next(
+        take = next(
             action
             for action in ledger.cursor.edges_out()
-            if isinstance(action, Action) and action.payload and action.payload["move"] == 1
+            if isinstance(action, Action) and action.label == "Take tokens"
         )
-        ledger.resolve_choice(take_one.uid, choice_payload=take_one.payload)
+        ledger.resolve_choice(take.uid, choice_payload={"quantity": 1})
 
         assert ledger.cursor_id == victory.uid
         content = " ".join(getattr(fragment, "content", "") for fragment in ledger.get_journal())

--- a/engine/tests/media/test_media_fragment.py
+++ b/engine/tests/media/test_media_fragment.py
@@ -7,7 +7,6 @@ from tangl.journal.media import MediaFragment, StagingHints
 def test_media_fragment_with_url():
     # Test media fragment with URL
     fragment = MediaFragment(
-        fragment_type="image",
         content="https://example.com/image.jpg",
         content_type="image",
         content_format="url",
@@ -17,7 +16,8 @@ def test_media_fragment_with_url():
             media_transition="fade_in"
         )
     )
-    assert fragment.fragment_type == "image"
+    assert fragment.fragment_type == "media"
+    assert fragment.content_type.value == "image"
     assert fragment.content == "https://example.com/image.jpg"
     assert fragment.content_format == "url"
     assert fragment.staging_hints.media_shape == "landscape"

--- a/engine/tests/service/response/test_projected_state.py
+++ b/engine/tests/service/response/test_projected_state.py
@@ -101,6 +101,19 @@ def test_projected_state_round_trips_through_model_dump_and_validate() -> None:
     assert restored == state
 
 
+def test_projected_state_to_dto_preserves_value_discriminators() -> None:
+    state = _fixture()
+
+    payload = state.to_dto()
+    restored = ProjectedState.model_validate(payload)
+
+    assert payload["sections"][0]["value"]["value_type"] == "kv_list"
+    assert payload["sections"][1]["hints"]["style_name"] == "sidebar"
+    assert payload["sections"][2]["value"]["value_type"] == "table"
+    assert payload["sections"][4]["value"]["value_type"] == "scalar"
+    assert restored == state
+
+
 def test_projected_state_preserves_section_order() -> None:
     state = _fixture()
 

--- a/engine/tests/service/response/test_runtime_envelope.py
+++ b/engine/tests/service/response/test_runtime_envelope.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from tangl.journal.fragments import ChoiceFragment, ContentFragment
+from tangl.service.response import RuntimeEnvelope
+
+
+def test_runtime_envelope_model_dump_preserves_fragment_subclass_fields() -> None:
+    edge_id = uuid4()
+    envelope = RuntimeEnvelope(
+        cursor_id=uuid4(),
+        step=1,
+        fragments=[
+            ContentFragment(content="Start"),
+            ChoiceFragment(
+                edge_id=edge_id,
+                text="Buy rations.",
+                accepts={
+                    "kind": "quantity",
+                    "min": 1,
+                    "max": 3,
+                    "unit": "ration",
+                },
+                ui_hints={"hotkey": "b", "source_kind": "market"},
+            ),
+        ],
+    )
+
+    payload = envelope.model_dump(mode="json", by_alias=True, exclude_none=True)
+    choice = payload["fragments"][1]
+
+    assert choice["fragment_type"] == "choice"
+    assert choice["edge_id"] == str(edge_id)
+    assert choice["text"] == "Buy rations."
+    assert choice["accepts"]["kind"] == "quantity"
+    assert choice["accepts"]["unit"] == "ration"
+    assert choice["ui_hints"]["hotkey"] == "b"
+    assert choice["ui_hints"]["source_kind"] == "market"

--- a/engine/tests/service/response/test_runtime_envelope.py
+++ b/engine/tests/service/response/test_runtime_envelope.py
@@ -6,6 +6,10 @@ from tangl.journal.fragments import ChoiceFragment, ContentFragment
 from tangl.service.response import RuntimeEnvelope
 
 
+class ExtendedRuntimeEnvelope(RuntimeEnvelope):
+    diagnostic_id: str
+
+
 def test_runtime_envelope_model_dump_preserves_fragment_subclass_fields() -> None:
     edge_id = uuid4()
     envelope = RuntimeEnvelope(
@@ -63,3 +67,16 @@ def test_runtime_envelope_to_dto_uses_fragment_dto_projection() -> None:
     assert "seq" not in choice
     assert "step" not in choice
     assert "tags" not in choice
+
+
+def test_runtime_envelope_to_dto_preserves_public_envelope_fields() -> None:
+    envelope = ExtendedRuntimeEnvelope(
+        step=0,
+        diagnostic_id="trace-7",
+        fragments=[ContentFragment(content="Start")],
+    )
+
+    payload = envelope.to_dto()
+
+    assert payload["step"] == 0
+    assert payload["diagnostic_id"] == "trace-7"

--- a/engine/tests/service/response/test_runtime_envelope.py
+++ b/engine/tests/service/response/test_runtime_envelope.py
@@ -37,3 +37,29 @@ def test_runtime_envelope_model_dump_preserves_fragment_subclass_fields() -> Non
     assert choice["accepts"]["unit"] == "ration"
     assert choice["ui_hints"]["hotkey"] == "b"
     assert choice["ui_hints"]["source_kind"] == "market"
+
+
+def test_runtime_envelope_to_dto_uses_fragment_dto_projection() -> None:
+    envelope = RuntimeEnvelope(
+        cursor_id=uuid4(),
+        step=1,
+        fragments=[
+            ContentFragment(content="Start", step=1),
+            ChoiceFragment(
+                edge_id=uuid4(),
+                text="Buy rations.",
+                accepts={"kind": "quantity", "min": 1, "max": 3},
+                step=1,
+            ),
+        ],
+    )
+
+    payload = envelope.to_dto()
+    choice = payload["fragments"][1]
+
+    assert choice["fragment_type"] == "choice"
+    assert choice["text"] == "Buy rations."
+    assert choice["accepts"]["kind"] == "quantity"
+    assert "seq" not in choice
+    assert "step" not in choice
+    assert "tags" not in choice

--- a/engine/tests/service/test_remote_service_manager.py
+++ b/engine/tests/service/test_remote_service_manager.py
@@ -16,6 +16,7 @@ import requests
 from tangl.core import BaseFragment
 from tangl.journal.fragments import BlockFragment, ChoiceFragment
 from tangl.persistence import PersistenceManagerFactory
+from tangl.service import KvListValue, ProjectedState, TableValue
 from tangl.service.bootstrap import build_service_manager
 from tangl.service.exceptions import AccessDeniedError, InvalidOperationError, ServiceError
 from tangl.service.remote_service_manager import RemoteServiceManager
@@ -344,6 +345,67 @@ class TestRemoteResponseHydration:
         assert choice.ui_hints is not None
         assert choice.ui_hints.hotkey == "b"
         assert choice.ui_hints.source_kind == "market"
+
+    def test_story_info_decodes_projected_state_contracts(self) -> None:
+        user_id = uuid4()
+        payload = {
+            "sections": [
+                {
+                    "section_id": "stats",
+                    "title": "Stats",
+                    "kind": "status",
+                    "value": {
+                        "value_type": "kv_list",
+                        "items": [
+                            {
+                                "key": "Health",
+                                "value": 9,
+                                "max": 12,
+                                "hint": "bar",
+                            }
+                        ],
+                    },
+                },
+                {
+                    "section_id": "matrix",
+                    "title": "Matrix",
+                    "kind": "map",
+                    "value": {
+                        "value_type": "table",
+                        "columns": ["Room", "Seen"],
+                        "rows": [["Hall", True]],
+                    },
+                },
+            ],
+        }
+        session = RecordingSession([StubResponse(200, payload)])
+        manager = RemoteServiceManager(
+            "https://example.test/api/v2",
+            api_key="bound-key",
+            session=session,
+        )
+        manager._bound_user_id = user_id
+
+        state = manager.get_story_info(
+            user_id=user_id,
+            kind="status",
+            kinds=["map", "inventory"],
+            query={"kinds": ["map"], "format": "table"},
+        )
+
+        assert isinstance(state, ProjectedState)
+        assert isinstance(state.sections[0].value, KvListValue)
+        assert state.sections[0].value.items[0].key == "Health"
+        assert state.sections[0].value.items[0].hint == "bar"
+        assert isinstance(state.sections[1].value, TableValue)
+        assert state.sections[1].value.rows == [["Hall", True]]
+        assert session.calls[0]["url"] == "https://example.test/api/v2/story/info"
+        assert session.calls[0]["params"] == {
+            "kind": "status",
+            "kinds": "map,inventory",
+            "query": '{"kinds": ["map"], "format": "table"}',
+            "render_profile": "raw",
+        }
 
     def test_unknown_fragment_payloads_survive_remote_decode(self) -> None:
         user_id = uuid4()

--- a/engine/tests/service/test_remote_service_manager.py
+++ b/engine/tests/service/test_remote_service_manager.py
@@ -296,6 +296,55 @@ class TestRemoteResponseHydration:
             "render_profile": "raw",
         }
 
+    def test_story_update_decodes_choice_payload_contracts(self) -> None:
+        user_id = uuid4()
+        payload = {
+            "cursor_id": str(uuid4()),
+            "step": 3,
+            "fragments": [
+                {
+                    "fragment_type": "choice",
+                    "edge_id": str(uuid4()),
+                    "text": "Buy rations",
+                    "available": True,
+                    "accepts": {
+                        "kind": "quantity",
+                        "required": True,
+                        "min": 1,
+                        "max": 3,
+                        "step": 1,
+                        "unit": "ration",
+                        "cost_previews": [],
+                    },
+                    "ui_hints": {
+                        "hotkey": "b",
+                        "source_kind": "market",
+                        "contribution": "purchase",
+                        "cost_previews": [],
+                    },
+                }
+            ],
+            "metadata": {},
+        }
+        session = RecordingSession([StubResponse(200, payload)])
+        manager = RemoteServiceManager(
+            "https://example.test/api/v2",
+            api_key="bound-key",
+            session=session,
+        )
+        manager._bound_user_id = user_id
+
+        envelope = manager.get_story_update(user_id=user_id)
+
+        choice = envelope.fragments[0]
+        assert isinstance(choice, ChoiceFragment)
+        assert choice.accepts is not None
+        assert choice.accepts.kind == "quantity"
+        assert choice.accepts.unit == "ration"
+        assert choice.ui_hints is not None
+        assert choice.ui_hints.hotkey == "b"
+        assert choice.ui_hints.source_kind == "market"
+
     def test_unknown_fragment_payloads_survive_remote_decode(self) -> None:
         user_id = uuid4()
         payload = {

--- a/engine/tests/service/test_service_manager.py
+++ b/engine/tests/service/test_service_manager.py
@@ -22,7 +22,21 @@ from tangl.story.episode import Action
 from tangl.vm.runtime.ledger import Ledger
 
 
-def _story_script() -> dict[str, object]:
+def _story_script(*, with_choice_payload_hints: bool = False) -> dict[str, object]:
+    action: dict[str, object] = {"text": "Continue", "successor": "end"}
+    if with_choice_payload_hints:
+        action["accepts"] = {
+            "kind": "quantity",
+            "min": 1,
+            "max": 3,
+            "unit": "ration",
+        }
+        action["ui_hints"] = {
+            "hotkey": "b",
+            "source_kind": "market",
+            "contribution": "purchase",
+        }
+
     return {
         "label": "svc_manager_world",
         "metadata": {
@@ -35,7 +49,7 @@ def _story_script() -> dict[str, object]:
                 "blocks": {
                     "start": {
                         "content": "Start",
-                        "actions": [{"text": "Continue", "successor": "end"}],
+                        "actions": [action],
                     },
                     "end": {
                         "content": "End",
@@ -183,6 +197,44 @@ def test_story_envelope_keeps_fragments_independent_from_actions(
     assert payload["uid"] == str(choice.uid)
     assert payload["edge_id"] == str(edge.uid)
     assert payload["uid"] != payload["edge_id"]
+
+
+def test_story_envelope_preserves_choice_payload_contracts(
+    manager: ServiceManager,
+    user: User,
+) -> None:
+    world = World.from_script_data(script_data=_story_script(with_choice_payload_hints=True))
+    created = manager.create_story(
+        user_id=user.uid,
+        world_id=world.label,
+        world=world,
+        init_mode=InitMode.EAGER.value,
+        story_label="svc_manager_story_choice_contracts",
+    )
+
+    assert isinstance(created, RuntimeEnvelope)
+    choice = next(fragment for fragment in created.fragments if isinstance(fragment, ChoiceFragment))
+    assert choice.accepts is not None
+    assert choice.accepts.kind == "quantity"
+    assert choice.ui_hints is not None
+    assert choice.ui_hints.hotkey == "b"
+
+    payload = choice.model_dump(mode="json", by_alias=True, exclude_none=True)
+    assert payload["accepts"] == {
+        "kind": "quantity",
+        "required": True,
+        "min": 1,
+        "max": 3,
+        "step": 1,
+        "unit": "ration",
+        "cost_previews": [],
+    }
+    assert payload["ui_hints"] == {
+        "hotkey": "b",
+        "source_kind": "market",
+        "contribution": "purchase",
+        "cost_previews": [],
+    }
 
 
 def test_create_story_passes_user_namespace_to_world_override(

--- a/engine/tests/service/test_service_manager.py
+++ b/engine/tests/service/test_service_manager.py
@@ -7,6 +7,7 @@ from uuid import UUID
 import pytest
 
 from tangl.core import BaseFragment, Selector
+from tangl.journal.fragments import BlockFragment, ChoiceFragment, ContentFragment
 from tangl.persistence import PersistenceManagerFactory
 from tangl.service.response import ProjectedState, RuntimeEnvelope, RuntimeInfo, UserInfo, WorldInfo
 from tangl.service.service_manager import ServiceManager
@@ -147,6 +148,41 @@ def test_story_methods_return_typed_runtime_payloads(
 
     projected = manager.get_story_info(user_id=user.uid)
     assert isinstance(projected, ProjectedState)
+
+
+def test_story_envelope_keeps_fragments_independent_from_actions(
+    manager: ServiceManager,
+    persistence,
+    user: User,
+) -> None:
+    world = World.from_script_data(script_data=_story_script())
+    created = manager.create_story(
+        user_id=user.uid,
+        world_id=world.label,
+        world=world,
+        init_mode=InitMode.EAGER.value,
+        story_label="svc_manager_story_fragments",
+    )
+
+    assert isinstance(created, RuntimeEnvelope)
+    assert not any(isinstance(fragment, BlockFragment) for fragment in created.fragments)
+    assert any(isinstance(fragment, ContentFragment) for fragment in created.fragments)
+
+    ledger = persistence[user.current_ledger_id]
+    assert isinstance(ledger, Ledger)
+    edge = _first_choice_edge(ledger)
+    choice = next(fragment for fragment in created.fragments if isinstance(fragment, ChoiceFragment))
+
+    assert choice.uid != edge.uid
+    assert choice.edge_id == edge.uid
+    assert choice.text == "Continue"
+    assert choice.available is True
+
+    payload = choice.model_dump(mode="json", by_alias=True, exclude_none=True)
+    assert payload["fragment_type"] == "choice"
+    assert payload["uid"] == str(choice.uid)
+    assert payload["edge_id"] == str(edge.uid)
+    assert payload["uid"] != payload["edge_id"]
 
 
 def test_create_story_passes_user_namespace_to_world_override(


### PR DESCRIPTION
## Summary

- establish canonical fragment, runtime-envelope, and projected-state DTO projections shared by service, REST, CLI, remote clients, and diagnostics
- preserve independent fragment identity and action `edge_id` while carrying typed `accepts`, UI hints, pieces, zones, and projected-state values
- add real mechanic-to-widget vertical slices for credentials piece selection and bounded Nim quantity input
- add backend-emitted diagnostic fixtures and update the widget/backend reconciliation notes

## Review focus

- DTO field selection and round-trip behavior in `tangl.journal.fragments` and `tangl.service.response`
- the service/REST responsibility boundary
- generic game move provisioning and payload resolution hooks
- credentials and Nim integration coverage

This intentionally does not implement the remaining Blocker, Interpretation, grammar, roll, or richer zone-layout rows. Those remain follow-up reconciliation slices tracked in #235.

## Verification

- `poetry run pytest engine/tests apps/cli/tests apps/server/tests`
  - 2585 passed, 66 skipped, 10 xfailed
- `poetry run sphinx-build -W --keep-going -b html docs/src /tmp/storytangl-backend-contract-docs`
- `python -m compileall` across touched Python packages
- `git diff --check`
- incremental CodeRabbit review from original base `e08e6cc0`; substantive identity/test issues addressed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Typed input contracts and clearer input hints for choices (quantity, piece selectors, text), plus piece fragment display in CLI.
  * Choices now expose structured accepts/ui_hints so clients can render input widgets.

* **Bug Fixes**
  * Stabilized choice/action identity and choice availability semantics so routing and availability behave consistently.
  * Status/reporting now emits projected state payloads reliably.

* **Documentation**
  * Added backend fragment reconciliation, widget vocabulary, response contract updates, and diagnostic payloads.

* **Tests**
  * Expanded tests and diagnostics validating fragment DTOs, choice payload contracts, and end-to-end widget flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->