### PR TITLE
Reconcile cardinal docs with the open-link planning vocabulary (#268 item C)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -326,8 +326,9 @@ link** — fixed endpoint + `Requirement` for the open endpoint + policy — is 
 planning primitive, and every dynamic mechanism is a coordinate in its planning
 matrix. That doc also owns the dynamic-action-projection vocabulary, the filled
 audit table, and the pipeline ordering used across design docs:
-binding/admission → live availability → projection → submission → backend
-validation → mutation → journal output.
+binding/admission → projection → live availability → submission → backend
+validation → mutation → journal output (use-time availability is filtered
+*after* projection, never folded into binding).
 
 - **Requirement** — a `Selector` with provision policy and authored-path
   metadata

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -319,13 +319,24 @@ Creates `Frame` instances to execute one resolution cycle.
 ### Provisioning (`vm/provision/`)
 
 The system that resolves "what does this node need?" into concrete graph
-entities.
+entities. The conceptual model is canonical in
+[docs/src/design/planning/AFFORDANCE_MODEL.md](docs/src/design/planning/AFFORDANCE_MODEL.md)
+("Open Links: Requirement-Bearing Edges and the Planning Matrix"): the **open
+link** — fixed endpoint + `Requirement` for the open endpoint + policy — is the
+planning primitive, and every dynamic mechanism is a coordinate in its planning
+matrix. That doc also owns the dynamic-action-projection vocabulary, the filled
+audit table, and the pipeline ordering used across design docs:
+binding/admission → live availability → projection → submission → backend
+validation → mutation → journal output.
 
 - **Requirement** — a `Selector` with provision policy and authored-path
   metadata
-- **Dependency** — an edge carrying a requirement
-- **Affordance** — optional resource attachment
-- **Fanout** — an edge that dynamically generates child edges
+- **Dependency** — an open link with the requester fixed and the provider
+  endpoint open (addressed pull; a hard dependency blocks until bound)
+- **Affordance** — the same open-link object with the provider fixed and the
+  context endpoint open (broadcast offer; no taker means no failure)
+- **Fanout** — a cardinality/rule-generation mode that produces many open
+  links; not a third peer of dependency/affordance
 - **Provisioners** — strategies that generate `ProvisionOffer`s:
   Find, Template, Token, InlineTemplate, Stub, UpdateClone
 - **Resolver** — gather offers → filter → rank → bind

--- a/docs/src/design/glossary.md
+++ b/docs/src/design/glossary.md
@@ -68,11 +68,13 @@ use these terms, they mean *exactly* what's defined here.
 > filled audit table.
 
 The canonical pipeline ordering, used consistently across design docs:
-**binding/admission → live availability → projection → submission → backend
+**binding/admission → projection → live availability → submission → backend
 validation → mutation → journal output**. Binding answers "can this
-relationship be formed?"; live availability answers "can this bound
-relationship be used now?" — the model doc's "Availability is after binding"
-section is the source of truth for that distinction.
+relationship be formed?"; projection turns a bound link into the `Action` that
+carries its predicates; live availability — a use-time filter applied *after*
+binding and projection — answers "can this bound relationship be used now?" The
+model doc's "Availability is after binding" section is the source of truth for
+that distinction.
 
 | Term | Metaphor | Definition | Implementation |
 |------|----------|------------|----------------|

--- a/docs/src/design/glossary.md
+++ b/docs/src/design/glossary.md
@@ -60,6 +60,33 @@ use these terms, they mean *exactly* what's defined here.
 | **Narrative debt** | technical debt | Provisioned concept not yet introduced to the reader via journal | Bound dependency with no journal coverage |
 | **Narrative credit** | foreshadowing | Concept introduced in journal before any structural need requires it | Namespace-published, no dependency yet |
 
+## Open Links and Projection
+
+> Canonical model: [Open Links: Requirement-Bearing Edges and the Planning
+> Matrix](planning/AFFORDANCE_MODEL.md). The entries below are the shared
+> vocabulary; the model doc owns the definitions, the planning matrix, and the
+> filled audit table.
+
+The canonical pipeline ordering, used consistently across design docs:
+**binding/admission → live availability → projection → submission → backend
+validation → mutation → journal output**. Binding answers "can this
+relationship be formed?"; live availability answers "can this bound
+relationship be used now?" — the model doc's "Availability is after binding"
+section is the source of truth for that distinction.
+
+| Term | Metaphor | Definition | Implementation |
+|------|----------|------------|----------------|
+| **Open link** | binding site | The planning primitive: a relationship represented before both endpoints are known — fixed endpoint + `Requirement` (open endpoint) + policy. Not a broken edge; the basic unit of work in the provisioner | `Edge + HasRequirement` (`vm.provision.requirement`) |
+| **Dependency** | addressed pull | Open link with the requester fixed and the provider endpoint open. A hard dependency is consumer-side pressure: if it cannot bind, the frontier blocks and provisioning is driven to make a provider exist | `vm.provision.Dependency` |
+| **Affordance** | broadcast offer | The same open-link object with the provider fixed and the context endpoint open. Provider-side availability: if no taker, nothing is offered and nothing fails | `vm.provision.Affordance` |
+| **Fanout** | edge generator | A cardinality/rule-generation mode that produces many open links — not a third peer of dependency/affordance | `vm.provision.Fanout` + `Resolver.resolve_fanout` |
+| **Scoped contribution** | open mic | Cross-domain pattern: a concept visible in the current scope contributes a phase-appropriate artifact (action, info affordance, journal fragment, modifier, redirect) | Pattern, not a class; sandbox's `SandboxInteraction` is its sandbox authoring form |
+| **Dynamic action projection** | JIT menu build | Phase-local creation of ordinary `Action` edges from a scoped source coordinate, with explicit admission, payload, availability, projection, and cleanup. A named pattern, deliberately not one shared implementation | `project_menu_affordances`, `_project_sandbox_interaction`, game move provisioning, … |
+| **Self-fanout** | REPL loop | A re-entrant game block re-projecting its currently available moves as self-loop actions until a terminal state routes outward. Conceptual coordinate; implemented as a local projector by design | `HasGame` move provisioning (`mechanics/games/handlers.py`) |
+| **Cleanup ownership** | tag-scoped GC | Which projector may delete a generated action: a compound key of source-node scoping (the owner's `edges_out`) plus a discriminator tag set. The tag contract is **mutual non-subsumption** — a subset antichain — not set disjointness, since families intentionally share tags like `dynamic` | Audit table in the model doc; invariant tests in `engine/tests/mechanics/test_sandbox_architecture.py` |
+| **Interaction request** | form submission | Conceptual name for the client-to-backend submission of a backend-issued interaction id plus collected payload. The wire field remains `edge_id`; renaming it is deferred pending a concrete client/compat need | `DirectEdgeRequest(edge_id, payload)` via `resolve_choice` |
+| **Projection provenance** | audit stamp | Additive, non-authoritative lifecycle metadata recording which projector emitted a generated edge and why. Diagnostic only — never legality authority | Discriminator tags; sandbox source fields currently ride in `ui_hints` (normalization tracked in issue #268) |
+
 ## Dispatch and Behavior
 
 | Term | Metaphor | Definition | Implementation |

--- a/docs/src/design/planning/AFFORDANCE_MODEL.md
+++ b/docs/src/design/planning/AFFORDANCE_MODEL.md
@@ -15,6 +15,8 @@ immediate refactor** — do not build it yet.
 `tangl.story.episode`, `tangl.mechanics.sandbox`
 
 See also:
+[glossary.md](../glossary.md) ("Open Links and Projection") for the shared
+vocabulary table these terms anchor,
 [PROVISIONING.md](PROVISIONING.md) for how open endpoints are bound,
 [HUB_FANOUT.md](../story/HUB_FANOUT.md) and
 [SANDBOX_FANOUT_DESIGN.md](../../notes/SANDBOX_FANOUT_DESIGN.md) for the

--- a/docs/src/design/planning/PLANNING_DESIGN.md
+++ b/docs/src/design/planning/PLANNING_DESIGN.md
@@ -1,9 +1,16 @@
-> **⚠️ Stale document.** This doc references `engine/src/tangl/vm/dispatch/planning.py`,
-> which no longer exists. Planning dispatch is now in `tangl.vm.dispatch` and resolution
-> logic is in `tangl.vm.provision.resolver`. The authoritative architecture docs are
-> `engine/src/tangl/vm/VM_DESIGN.md` (provisioning section) and
-> `engine/src/tangl/vm/provision/SCOPE_MATCHING_DESIGN.md` (scope matching). This file
-> is retained for historical context only.
+> **⚠️ Stale document — superseded.** This doc teaches v3.7 planning vocabulary
+> and references `engine/src/tangl/vm/dispatch/planning.py`, which no longer
+> exists. **The current planning model is
+> [AFFORDANCE_MODEL.md](AFFORDANCE_MODEL.md)** ("Open Links: Requirement-Bearing
+> Edges and the Planning Matrix", CANONICAL): the open link as the planning
+> primitive, the dependency/affordance duality, the planning matrix, and the
+> filled audit table. Do not use this file's vocabulary in new docs, code, or
+> issues. Implementation references: `engine/src/tangl/vm/VM_DESIGN.md`
+> (provisioning section) and
+> `engine/src/tangl/vm/provision/SCOPE_MATCHING_DESIGN.md` (scope matching);
+> planning dispatch is now in `tangl.vm.dispatch` and resolution logic in
+> `tangl.vm.provision.resolver`. This file is retained for historical context
+> only.
 
 # Planning & Provisioning System Design (v3.7)
 

--- a/engine/src/tangl/mechanics/games/README.md
+++ b/engine/src/tangl/mechanics/games/README.md
@@ -117,9 +117,14 @@ action creation, but conceptually it is a special case of fanout:
 - every such edge points back to the same provider node: the game block itself
 
 In other words, a game block's move set can be understood as a **self-fanout of
-traversable edges** rather than a fundamentally separate mechanism. The current
-PLANNING implementation is still appropriate, but this interpretation is useful
-for future unification with provisioning and frozen-shape graph modes.
+traversable edges** rather than a fundamentally separate mechanism. That is the
+conceptual interpretation only: the implementation remains a local
+planning-time projector **by design**, and `HasGame` moves should not be routed
+through `Resolver.resolve_fanout`. The open-link model
+(`docs/src/design/planning/AFFORDANCE_MODEL.md`) records this mechanism in its
+audit table ("Game self-loop moves") as self-fanout — a provider-fixed offer to
+itself, projected as ordinary self-loop `Action`s and cleared by the game's own
+cleanup discriminator.
 
 It is also one concrete instance of the broader **re-entrant provider** pattern
 used by hubs and repeatable activities: the cursor repeatedly re-enters a

--- a/engine/src/tangl/mechanics/sandbox/README.md
+++ b/engine/src/tangl/mechanics/sandbox/README.md
@@ -4,16 +4,19 @@
 `tangl.mechanics.sandbox` is the incubating family for dynamic scene-location
 hubs.
 
-The package does not introduce a second interaction model. Sandbox locations
-generate ordinary StoryTangl `Action` choices from scoped state such as location
-links, present entities, inventory, world time, and schedules.
+The package does not introduce a second interaction model. Sandbox is a
+**domain client of ordinary Story/VM machinery**: sandbox locations generate
+ordinary StoryTangl `Action` choices from scoped state such as location links,
+present entities, inventory, world time, and schedules.
 
 Sandbox is a specialized instance of a broader StoryTangl pattern: scoped
 containers publish facts, children pull on those facts through dependencies and
 phase handlers, and the runtime renders the result as namespace entries,
-journal fragments, choices, effects, or projection filters. In this package the
-facts are location-centered: exits, assets, fixtures, light, schedules, and
-presence.
+journal fragments, choices, effects, or projection filters. The open-link model
+(`docs/src/design/planning/AFFORDANCE_MODEL.md`) names this pattern the
+**scoped contribution** and names the projector shape **dynamic action
+projection**. In this package the facts are location-centered: exits, assets,
+fixtures, light, schedules, and presence.
 
 Current first-pass surface:
 
@@ -36,9 +39,11 @@ Current first-pass surface:
   consumption mechanics, but not part of sandbox's core identity.
 - `SandboxMob`: a graph-backed actor-like concept with stable location and
   mutable state that can project affordances when present.
-- `SandboxInteraction`: a sponsored local choice that lowers to an ordinary
-  `Action` with target, activation, optional call/return, availability,
-  effects, selected-action journal text, and provenance hints.
+- `SandboxInteraction`: sandbox authoring vocabulary (a "sponsored
+  interaction") for a scoped local choice that lowers to an ordinary `Action`
+  with target, activation, optional call/return, availability, effects,
+  selected-action journal text, and provenance hints. The cross-domain pattern
+  it instantiates is the *scoped contribution*.
 - `SandboxSliceCompiler`: an experimental compact-slice compiler that lowers
   trait-bearing sandbox facts into a runtime `StoryGraph` for pressure tests.
 - `SandboxVisibilityRule` / `SandboxProjectionState`: a small projection filter
@@ -195,8 +200,9 @@ Sponsored interactions are the first shared local-choice surface. A
 optional call/return, availability, effects, selected-action journal text, and
 provenance hints. Present mobs and active locations can sponsor these
 interactions, as can present/carried assets and reachable fixtures. This is a
-sandbox instance of a broader StoryTangl pattern: a concept that is in scope can
-sponsor a choice without owning a separate runtime.
+sandbox instance of a broader StoryTangl pattern — the scoped contribution: a
+concept that is in scope can sponsor a choice without owning a separate
+runtime.
 
 The Adventure import goal is semantic compression, not faithful emulation. A
 compact world schema should declare locations, exits, assets, fixtures, mobs,

--- a/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
+++ b/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
@@ -14,6 +14,13 @@ chapter-like scope of scene-locations that dynamically projects ordinary
 StoryTangl choices from location links, present entities, carried inventory,
 actors, world time, schedules, and local rules.
 
+Stated plainly: **sandbox is a domain client of ordinary Story/VM machinery.**
+In the open-link vocabulary (`docs/src/design/planning/AFFORDANCE_MODEL.md`),
+each sandbox projector is a *dynamic action projection* coordinate in the
+planning matrix, riding the standard pipeline: binding/admission → live
+availability → projection → submission → backend validation → mutation →
+journal output.
+
 The generated choices are normal `Action` edges. They use normal target
 availability, effects, call/return, journal fragments, choice diagnostics,
 ledger history, and replay.
@@ -212,7 +219,10 @@ The important runtime truth is the contribution surface, not the authoring
 category. Entity categories such as location, asset, fixture, actor, companion,
 weather, or debug overlay remain useful authoring vocabulary. At runtime, the
 question is: what does this scoped concept contribute, suppress, or expose for
-the current phase?
+the current phase? The open-link model names this cross-domain pattern the
+**scoped contribution** — a concept visible in the current scope contributes a
+phase-appropriate artifact (action, info affordance, journal fragment,
+modifier, redirect); see `docs/src/design/planning/AFFORDANCE_MODEL.md`.
 
 For now sandbox keeps this as local mechanics code. Promotion candidates, once
 a second non-sandbox consumer appears:
@@ -475,6 +485,13 @@ implementation local and prove that the projection compiles down to ordinary
 StoryTangl actions.
 
 ### Strategy: Sponsored Interactions
+
+Naming note: `SandboxInteraction` — the "sponsored interaction" — is **sandbox
+authoring vocabulary**: authoring sugar that lowers to an ordinary `Action`
+edge. The cross-domain pattern it instantiates is the **scoped contribution**
+(see `docs/src/design/planning/AFFORDANCE_MODEL.md`); the pattern is not owned
+by sandbox, and the term `SandboxInteraction` should not leak into VM/Core or
+other domains.
 
 Build this as a sequence of small slices over the current sandbox work rather
 than by creating a dialogue or encounter subsystem.

--- a/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
+++ b/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
@@ -17,9 +17,10 @@ actors, world time, schedules, and local rules.
 Stated plainly: **sandbox is a domain client of ordinary Story/VM machinery.**
 In the open-link vocabulary (`docs/src/design/planning/AFFORDANCE_MODEL.md`),
 each sandbox projector is a *dynamic action projection* coordinate in the
-planning matrix, riding the standard pipeline: binding/admission → live
-availability → projection → submission → backend validation → mutation →
-journal output.
+planning matrix, riding the standard pipeline: binding/admission → projection →
+live availability → submission → backend validation → mutation → journal output
+(use-time availability is filtered after projection, never folded into
+binding).
 
 The generated choices are normal `Action` edges. They use normal target
 availability, effects, call/return, journal fragments, choice diagnostics,

--- a/engine/src/tangl/vm/VM_DESIGN.md
+++ b/engine/src/tangl/vm/VM_DESIGN.md
@@ -470,6 +470,13 @@ re-executes fragments to reconstruct any point-in-time state.
 The frontier constraint satisfaction system. Provisioning answers: "what entities does
 the cursor need in its scope, and how do we find or create them?"
 
+The conceptual vocabulary — the **open link** as the planning primitive, the
+dependency/affordance duality (same object, opposite fixed endpoints), fanout as a
+cardinality/rule-generation mode, the planning matrix, and the distinction between
+admission (projection-time) and live availability (use-time) — is canonical in
+`docs/src/design/planning/AFFORDANCE_MODEL.md`. This section documents the VM
+implementation surface of that model.
+
 #### Requirement and Dependency
 
 `Requirement` is a `Selector` with provision metadata. Because it inherits Selector, a
@@ -652,10 +659,18 @@ own active entry.
 
 **Dynamic frontier refresh.** Domain packages that project dynamic choices during
 PLANNING must treat those edges as ephemeral affordances. Before rebuilding, a provider
-clears only the previous dynamic edges it generated for that owner node, using tags or
-provenance narrow enough not to delete another provider's work. Re-entering a hub,
-game, or sandbox location therefore recomputes the local frontier from current state
-instead of relying on stale generated paths.
+clears only the previous dynamic edges it generated for that owner node. This is
+**cleanup ownership**, a compound key: scope to the owner node's `edges_out`, then
+match a discriminator tag set. Discriminators across projector families are mutually
+non-subsuming (a subset antichain — families intentionally share tags such as
+`dynamic`), not set-disjoint; the per-family discriminators and the contract are
+documented in the audit table of `docs/src/design/planning/AFFORDANCE_MODEL.md` and
+pinned by invariant tests in `engine/tests/mechanics/test_sandbox_architecture.py`.
+Re-entering a hub, game, or sandbox location therefore recomputes the local frontier
+from current state instead of relying on stale generated paths. The pattern itself —
+phase-local creation of ordinary `Action`s from a scoped source, with explicit
+admission, payload, availability, projection, and cleanup — is named **dynamic action
+projection** in that doc.
 
 
 ---

--- a/engine/src/tangl/vm/provision/SCOPE_MATCHING_DESIGN.md
+++ b/engine/src/tangl/vm/provision/SCOPE_MATCHING_DESIGN.md
@@ -4,6 +4,15 @@
 **Scope:** vm/provision, core/template, story prereq handlers
 **Date:** 2026-03-20
 
+**See also:** `docs/src/design/planning/AFFORDANCE_MODEL.md` — the canonical
+open-link planning model (the open link as planning primitive, the
+dependency/affordance duality, the planning matrix, and the filled audit
+table). This document is the provisioning-side refinement of that model's
+binding step: it specifies how an open link's **target placement context** is
+matched. The request context / target context split below is the concrete form
+of "binding answers whether the relationship can be formed" — live availability
+remains a separate, use-time question.
+
 ---
 
 ## Problem Statement
@@ -486,7 +495,10 @@ otherwise → path.
 
 Affordances are standing offers (persistent available actions, role
 bindings, namespace entries) that are conditionally active based on
-game state. They are **not** a separate resolution system. They
+game state. Canonically, an affordance is the provider-fixed direction
+of the open link (see `docs/src/design/planning/AFFORDANCE_MODEL.md`);
+this section sketches only the deferred resolver integration. They are
+**not** a separate resolution system. They
 integrate into the existing resolver as an early-running provisioner
 that yields offers at cost ≤ 0:
 


### PR DESCRIPTION
## Summary

Item C of the approved v38 annealing synthesis on #268 ("Reconcile vocabulary in the cardinal docs"): cross-link and align terminology with the canonical model doc `docs/src/design/planning/AFFORDANCE_MODEL.md` (v2.2 — open links, planning matrix, filled audit table; PRs #269/#274). Cross-link, do not re-derive: no model content is duplicated or forked.

**Docs only — no code or test changes.**

### Changes

- **`docs/src/design/glossary.md`** — new "Open Links and Projection" section with the canonical pipeline ordering (binding/admission → live availability → projection → submission → backend validation → mutation → journal output) and entries for: open link, dependency, affordance, fanout (cardinality/rule-generation mode, not a third peer), scoped contribution, dynamic action projection, self-fanout, cleanup ownership (compound key: source-node scoping + discriminator tag set; **mutual non-subsumption — a subset antichain — not set disjointness**, pinned by `engine/tests/mechanics/test_sandbox_architecture.py`), interaction request (conceptual name; wire field stays `edge_id`), and projection provenance (additive, non-authoritative lifecycle metadata).
- **`ARCHITECTURE.md`** — provisioning section now points to AFFORDANCE_MODEL.md as the planning/open-link model; the Dependency/Affordance/Fanout bullets are aligned (affordance was previously described as "optional resource attachment" and fanout as "an edge that dynamically generates child edges").
- **`engine/src/tangl/vm/VM_DESIGN.md`** — open-link cross-reference added to the provisioning section; the "dynamic frontier refresh" paragraph restated in cleanup-ownership / dynamic-action-projection vocabulary. The phase-local journal injection language is untouched.
- **`engine/src/tangl/vm/provision/SCOPE_MATCHING_DESIGN.md`** — see-also cross-link positioning this doc as the provisioning-side refinement of the model's binding step (target/request context); one alignment line in the deferred affordance-integration note.
- **Sandbox docs** (`SANDBOX_DESIGN.md`, `README.md`) — state explicitly that sandbox is a **domain client of ordinary Story/VM machinery**; `SandboxInteraction` marked as sandbox authoring vocabulary ("sponsored interaction" / authoring sugar) whose cross-domain pattern is the **scoped contribution**.
- **`engine/src/tangl/mechanics/games/README.md`** — self-fanout kept as the conceptual interpretation of move provisioning; the implementation remains a local projector **by design** (the previous wording implied a future fanout unification; no migration is promised).
- **`docs/src/design/planning/PLANNING_DESIGN.md`** — stale banner hardened: names AFFORDANCE_MODEL.md as the current model and says not to use the v3.7 vocabulary in new docs/code/issues (Reviewer 1 quarantine finding).
- **`docs/src/design/planning/AFFORDANCE_MODEL.md`** — one see-also line linking the glossary section. Filename and the naming-note rename decision untouched.

Widget-contract docs untouched (tracked separately in #235).

### Verification

- `poetry run sphinx-build -W --keep-going -b html docs/src <tmpdir>` — **build succeeded** (strict mode, before and after).
- Glossary implementation references spot-checked against code (`vm.provision` exports, `DirectEdgeRequest(edge_id, payload)`, `project_menu_affordances`, `_project_sandbox_interaction`, `test_sandbox_architecture.py`).

Refs #268, #255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal architectural documentation and planning model terminology for consistency and clarity across design references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->