### PR TITLE
Projection provenance (item D) + compat-seam inventory (item E) — #268

### DIFF
--- a/docs/src/design/planning/AFFORDANCE_MODEL.md
+++ b/docs/src/design/planning/AFFORDANCE_MODEL.md
@@ -589,6 +589,52 @@ engine-owned family), are pinned by an invariant test in
 `engine/tests/mechanics/test_sandbox_architecture.py`; the table rows above are
 the classification it executes.
 
+#### Lifecycle metadata vs presentation hints in `ui_hints` (synthesis item D)
+
+The "Existing tags / hints" column shows the sandbox families carry a rich field
+set inside `ui_hints`. Those fields are not all the same *kind* of thing.
+Classifying them against "who generated this edge / who owns its cleanup?"
+(**lifecycle**) vs "how should a renderer display it?" (**presentation**):
+
+| `ui_hints` field | Emitted by | Classification |
+|---|---|---|
+| `source` (`sandbox_fixture`, `sandbox_link`, …) | base (`_sandbox_contribution_hints`) | **Lifecycle** — names the projecting family; the cleanup-owner answer |
+| `scope` | base | **Lifecycle** — which scope sponsors/owns the edge |
+| `source_label` (`altar`, `guide`, …) | base (optional) | **Lifecycle** — which concept instance generated it (a renderer *may* echo it) |
+| `interaction` / `verb` / `asset` / `key` / `target` / `through` / `mob` / `fixture` / `move` / `word` / `hazard_outcome` / `possession` | per-call extras | **Lifecycle** — identifies the source coordinate this edge was projected from |
+| `contribution` (`movement`, `event`, `resource_allocation`, …) | base | **Conflated** — reads as the projection reason (lifecycle) yet Reviewer 3 marks it advisory display |
+| `source_kind` (`fixture`, `mob`, `scope`, `world_authority`, …) | base (optional) | **Conflated** — advisory display per Reviewer 3, yet also encodes the sponsor's lifecycle kind |
+| `direction` / `raw_direction` | link extras | **Presentation** — IF compass labels; a protected projection difference, display-only |
+
+**The core tension:** the unambiguously-lifecycle fields `source` and `scope`
+ride inside `ui_hints`, whose model docstring (`UIHints`,
+`journal/intent.py`) declares it *"Advisory renderer hints for choices"* — a
+**presentation channel**. Cleanup ownership is lifecycle and should not hide in a
+presentation channel. Menu and game projectors, by contrast, historically
+carried *no* `ui_hints` at all; their only attribution was the discriminator tag
+set (the compound-key cleanup contract above).
+
+**Minimal pass (item D, this iteration):** rather than build the proper
+separation, the menu and game projectors gain the single unambiguously-lifecycle
+token — `source` — in the **same `ui_hints` channel** sandbox already uses, so
+all three families are equally cleanup-explainable
+(`{"source": "menu_fanout"}`, `{"source": "game_self_loop"}`). One token,
+additive, ignorable by existing consumers; tags are untouched, so the
+compound-key contract and its exactly-one-family invariant are unaffected. The
+characterization tests in `test_projection_characterization.py` pin the new
+shape.
+
+**Deferred convergence debt (do *not* build here):** proper separation would
+thread a dedicated lifecycle/provenance channel through `Action` +
+`ChoiceFragment` + the wire DTO, distinct from `UIHints`. That is the
+"general provenance/receipt shape for phase outputs" promotion candidate already
+named in `engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md`
+("General Contribution Pattern"), gated on a second non-sandbox consumer — not
+on this pass. The `source_kind` / `contribution` conflation and the game
+`fanout`-tag drift are likewise *recorded, not fixed* here; each needs its own
+approved migration that updates this table and the matching characterization
+test together.
+
 ---
 
 ## Future Extensions (seams, not commitments)

--- a/docs/src/notes/audits/compat-seams-inventory.md
+++ b/docs/src/notes/audits/compat-seams-inventory.md
@@ -1,0 +1,148 @@
+# Compatibility Seam Inventory (annealing #268, item E)
+
+## Scope
+
+- Objective: catalog the in-repo compatibility seams flagged by the v38
+  annealing synthesis (GitHub issue #268, approved item E), each with an
+  **actionable sunset condition**, so a follow-up cleanup PR can act immediately.
+- Non-goal: **no removals in this pass.** This is a cleanup shopping list, not a
+  deprecation schedule.
+
+## Repo policy (durable, owner-set)
+
+Tests and apps in *this* repo are the **only** legacy consumers: no external
+clients, no version skew, no long-lived saves. So a seam is "sunsettable" the
+moment the named in-repo readers are updated — there is no migration window to
+honor and no external contract to preserve. Each entry below is written as
+"update `<named in-repo readers>` and delete."
+
+---
+
+## Seam 1 — legacy `payload_type` / `input` accepts
+
+**What it bridges.** The pre-typed choice-input shape, where an accept was keyed
+by a bare `input` string plus an optional `payload_type`, instead of the typed
+`accepts.kind` discriminator (`pick` / `text` / `quantity` / `pieces` / `place`
+/ `compose`). It survives only in the web client as `LegacyPayloadAccepts`, a
+member of the `Accepts` union.
+
+**Backend status.** Dead on the backend. The engine `Accepts` union
+(`engine/src/tangl/journal/intent.py`) emits only the six typed kinds; no engine
+or server path produces `payload_type` or an `input`-keyed accept (the
+`payload_kind` / `has_payload_kind` symbols in `core` are unrelated template
+machinery).
+
+**In-repo readers.**
+- `apps/web/src/types/tangl_typedefs.ts` — `LegacyPayloadAccepts` interface
+  (≈ line 420) and its membership in the `Accepts` union (≈ line 449).
+- `apps/web/src/components/story/ChoiceInputView.vue` — reads
+  `accepts.value.input` (≈ line 71) and `accepts.value.payload_type` →
+  `payloadKey` (≈ lines 109–110, 272–307).
+- `apps/web/src/components/story/StoryAction.test.ts` — two cases exercising
+  `payload_type: 'offer_silver'` (≈ lines 197, 263).
+
+**Sunset condition.** Remove `LegacyPayloadAccepts` from the `Accepts` union and
+its interface in `tangl_typedefs.ts`; remove the `input` / `payload_type` /
+`payloadKey` branches in `ChoiceInputView.vue`; delete the two legacy cases in
+`StoryAction.test.ts`. No backend change required (already typed-only).
+
+---
+
+## Seam 2 — `_normalize_choice_labels_in_fragments`
+
+**What it bridges.** Choice fragments that lack an explicit `label`. The REST
+serializer backfills `label` from `source_label`, then `text`, then `content`,
+for both top-level `choice` fragments and `choice`s embedded in `block`
+fragments.
+
+**In-repo readers / mirrors.**
+- `apps/server/src/tangl/rest/routers/story_router.py` — definition
+  (≈ line 136) and its single call site in the `/story` response assembly
+  (≈ line 240).
+- `apps/server/tests/helpers_server/json_fragment_helpers.py` —
+  `extract_choices_from_fragments` carries its **own copy** of the same
+  `source_label`/`text`/`content` → `label` normalization (≈ line 9), so server
+  tests do not actually depend on the router's pass.
+- The web renderer reads `choice.text` for display
+  (`apps/web/src/components/story/StoryAction.vue`), not the normalized `label`.
+
+**Sunset condition.** Confirm the canonical `ChoiceFragment` projection (the
+#271 DTO) always populates `label` at projection time — or that every reader
+falls back on its own (the web client already renders `text`). Then delete
+`_normalize_choice_labels_in_fragments` (def + call at `story_router.py:240`)
+and drop the `_normalize` wrapper inside `extract_choices_from_fragments`.
+
+**#275 note.** PR #275 (typed blocker contract) also touches `story_router.py`
+and `ui_hints` (`cost_previews`). This inventory does not modify the router; if
+#275 lands first, this entry's line numbers shift but the seam is unchanged.
+
+---
+
+## Seam 3 — `edge_id` as the wire field (**keep — do not rename**)
+
+**What it is.** The backend-issued interaction id on every choice; clients
+submit `{edge_id, payload}` to `/story/do`. The synthesis names the *conceptual*
+shape "interaction request" but explicitly **defers any rename** (no concrete
+client/compat need; renaming would churn fixtures for no functional payoff).
+Inventoried here only to record the blast radius for a future rename PR.
+
+**In-repo readers (blast radius if ever renamed).**
+- Web: `apps/web/src/types/tangl_typedefs.ts`,
+  `components/story/StoryFlow.vue`, `StoryAction.vue`, `ChoiceInputView.vue`,
+  and the `StoryFlow.test.ts` / `StoryAction.test.ts` / `StoryBlock.test.ts`
+  fixtures.
+- Engine/service: `engine/src/tangl/service/response.py`,
+  `service/service_manager.py`, `story/system_handlers.py`, `story/analysis.py`.
+
+**Sunset condition.** **None this iteration — keep `edge_id`.** A rename is a
+deferred item (per the synthesis "Deferred findings" table), promoted only by a
+concrete client/compat need, not by doc aesthetics. The "interaction request"
+name stays docs-only vocabulary.
+
+---
+
+## Seam 4 — dynamic-action cleanup tag conventions
+
+**What it is.** The discriminator tag sets that scope each `_clear_dynamic_*`
+helper's GC sweep — the compound-key cleanup contract (`{dynamic, fanout, menu}`,
+`{dynamic, fanout, game}`, `{dynamic, sandbox, <kind>}` ×9, `{dynamic, sandbox,
+incremental}`, world-owned `{dynamic, sandbox, adventure}`). These are **not a
+removable compat seam** — they are the load-bearing cleanup mechanism, pinned by
+the non-subsumption / exactly-one-family invariant (PR #274). Inventoried per the
+synthesis because the *drift* in the convention is sunsettable, the contract is
+not.
+
+**In-repo readers asserting exact tag sets.**
+- `engine/tests/mechanics/test_projection_characterization.py` — per-family
+  exact tag assertions (the executable form of the audit table).
+- `engine/tests/mechanics/test_sandbox_architecture.py` — the non-subsumption /
+  exactly-one-family invariant.
+- `engine/tests/mechanics/test_sandbox.py`,
+  `engine/tests/mechanics/test_sandbox_adventure_slice.py`,
+  `engine/tests/loaders/test_adventure_sandbox_world.py`,
+  `engine/tests/story/test_menu_fanout.py`,
+  `engine/tests/mechanics/games/test_game_handlers.py`,
+  `engine/tests/vm/test_provision_pipeline.py` — golden tag-set behavior.
+
+**Sunset condition.** The *contract* does not sunset. The only sunsettable item
+is the recorded **drift**: game self-loop moves wear `fanout` without touching
+`Resolver.resolve_fanout` (the tag vocabulary lies). Resolving it means an
+intentional, characterized migration that (a) drops `fanout` from
+`_build_game_actions`' tag set and the `_clear_dynamic_game_actions`
+discriminator, and (b) updates the matching `test_projection_characterization.py`
+and `test_game_handlers.py` assertions and the AFFORDANCE_MODEL.md audit table
+together — never as a drive-by. Until then the `fanout` tag is preserved exactly
+(item D added a `source: "game_self_loop"` *hint* alongside it precisely to avoid
+echoing the lie in a second place).
+
+---
+
+## Cross-references
+
+- Approved plan: GitHub issue #268, "Architecture synthesis: v38 Aardvark
+  annealing direction" (item E).
+- Audit table + cleanup-ownership contract:
+  `docs/src/design/planning/AFFORDANCE_MODEL.md` ("The audit table (filled)").
+- Related: PR #274 (cleanup-discriminator invariant), PR #276 (projection
+  characterization tests), PR #277 (doc reconciliation), PR #275 (typed blocker
+  contract, open).

--- a/docs/src/notes/audits/compat-seams-inventory.md
+++ b/docs/src/notes/audits/compat-seams-inventory.md
@@ -67,14 +67,14 @@ fragments.
   (`apps/web/src/components/story/StoryAction.vue`), not the normalized `label`.
 
 **Sunset condition.** Confirm the canonical `ChoiceFragment` projection (the
-#271 DTO) always populates `label` at projection time — or that every reader
+`#271` DTO) always populates `label` at projection time — or that every reader
 falls back on its own (the web client already renders `text`). Then delete
 `_normalize_choice_labels_in_fragments` (def + call at `story_router.py:240`)
 and drop the `_normalize` wrapper inside `extract_choices_from_fragments`.
 
-**#275 note.** PR #275 (typed blocker contract) also touches `story_router.py`
+**`#275` note.** PR #275 (typed blocker contract) also touches `story_router.py`
 and `ui_hints` (`cost_previews`). This inventory does not modify the router; if
-#275 lands first, this entry's line numbers shift but the seam is unchanged.
+`#275` lands first, this entry's line numbers shift but the seam is unchanged.
 
 ---
 

--- a/docs/src/notes/audits/index.rst
+++ b/docs/src/notes/audits/index.rst
@@ -8,3 +8,4 @@ Documentation audits and gap reviews used to drive targeted cleanup work.
 
    core38-doc-audit
    vm38-doc-audit
+   compat-seams-inventory

--- a/engine/src/tangl/mechanics/games/handlers.py
+++ b/engine/src/tangl/mechanics/games/handlers.py
@@ -59,6 +59,13 @@ def _build_game_actions(cursor: HasGame) -> list[Any]:
                 payload={"move": move},
                 accepts=cursor.game_handler.get_move_accepts(cursor.game, move),
                 tags={"dynamic", "fanout", "game"},
+                # Minimal cleanup-attribution token (synthesis item D): names the
+                # projecting family in the same channel sandbox already uses, so
+                # game moves are as cleanup-explainable as sandbox interactions.
+                # "game_self_loop" (not "game_fanout") to avoid echoing the
+                # recorded fanout-tag drift; lifecycle/diagnostic only, tags
+                # remain the cleanup authority.
+                ui_hints={"source": "game_self_loop"},
             )
         )
     return actions

--- a/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
+++ b/engine/src/tangl/mechanics/sandbox/SANDBOX_DESIGN.md
@@ -228,7 +228,10 @@ modifier, redirect); see `docs/src/design/planning/AFFORDANCE_MODEL.md`.
 For now sandbox keeps this as local mechanics code. Promotion candidates, once
 a second non-sandbox consumer appears:
 
-- a general provenance/receipt shape for phase outputs;
+- a general provenance/receipt shape for phase outputs — sandbox today rides its
+  provenance in `ui_hints` (a presentation channel); see the lifecycle-vs-
+  presentation classification of those fields under "The audit table (filled)"
+  in `docs/src/design/planning/AFFORDANCE_MODEL.md` (synthesis item D);
 - story-level projection filters over journal and choices;
 - a broader scoped contribution provider that can return actions, journal
   fragments, suppressions, or schedules.

--- a/engine/src/tangl/story/fabula/materializer.py
+++ b/engine/src/tangl/story/fabula/materializer.py
@@ -1111,6 +1111,11 @@ class StoryMaterializer:
                 successor_id=provider.uid,
                 text=MenuBlock.action_text_for(provider),
                 tags={"dynamic", "fanout", "menu"},
+                # Same minimal cleanup-attribution token as the lazy
+                # project_menu_affordances path (synthesis item D), so menu
+                # actions are equally cleanup-explainable whether they were
+                # eager-built (frozen shape) here or planning-projected.
+                ui_hints={"source": "menu_fanout"},
             )
 
     @staticmethod

--- a/engine/src/tangl/story/system_handlers.py
+++ b/engine/src/tangl/story/system_handlers.py
@@ -153,6 +153,11 @@ def project_menu_affordances(*, caller, ctx, **_kw):
             successor_id=provider.uid,
             text=MenuBlock.action_text_for(provider),
             tags={"dynamic", "fanout", "menu"},
+            # Minimal cleanup-attribution token (synthesis item D): names the
+            # projecting family in the same channel sandbox already uses, so
+            # menu actions are as cleanup-explainable as sandbox interactions.
+            # Lifecycle/diagnostic only; tags remain the cleanup authority.
+            ui_hints={"source": "menu_fanout"},
         )
     return None
 

--- a/engine/tests/mechanics/test_projection_characterization.py
+++ b/engine/tests/mechanics/test_projection_characterization.py
@@ -13,10 +13,10 @@ These tests RECORD the current differences between the projector families.
 They must NOT be read as a uniformity contract: where families differ (game
 actions wear the ``fanout`` tag without touching fanout machinery; sandbox
 carries six-plus provenance-ish fields in ``ui_hints`` while menu and game
-carry none; incremental's hand-rolled hints bypass
-``_sandbox_contribution_hints`` and so lack ``scope``), the difference is the
-pinned expectation. A future convergence PR must consciously update both the
-audit table and the matching test here.
+carry only the single ``source`` lifecycle token added by synthesis item D;
+incremental's hand-rolled hints bypass ``_sandbox_contribution_hints`` and so
+lack ``scope``), the difference is the pinned expectation. A future convergence
+PR must consciously update both the audit table and the matching test here.
 
 Cleanup vocabulary: the per-family discriminator tag sets are **mutually
 non-subsuming** (a subset antichain — families intentionally share tags like
@@ -248,9 +248,11 @@ def _enter_menu_hub() -> tuple[Graph, Block]:
 def test_menu_fanout_action_shape() -> None:
     """Audit-table row: "Menu fanout".
 
-    The reference path — the only consumer of real ``Fanout`` machinery — and
-    the provenance-poor one: tags only, no ``ui_hints``, no payload, and a
-    positional (index-derived) label instead of a source-derived one.
+    The reference path — the only consumer of real ``Fanout`` machinery. Since
+    synthesis item D it carries the single ``source`` lifecycle token (the
+    minimal cleanup-attribution added so menu is as explainable as sandbox),
+    but still no other hints, no payload, and a positional (index-derived)
+    label instead of a source-derived one.
     """
     _, hub = _enter_menu_hub()
 
@@ -260,9 +262,10 @@ def test_menu_fanout_action_shape() -> None:
     assert {action.text for action in actions} == {"Listen to Aria", "Brew tea"}
     for action in actions:
         assert action.tags == {"dynamic", "fanout", "menu"}
-        # Recorded difference: no provenance hints at all, unlike sandbox
-        # families which carry six-plus provenance-ish fields in ui_hints.
-        assert action.ui_hints is None
+        # Item D minimal attribution: one lifecycle token, in the same channel
+        # sandbox uses, naming the projecting family — and nothing else. Still
+        # far poorer than sandbox's six-plus provenance-ish fields.
+        assert _hints(action) == {"source": "menu_fanout"}
         assert action.payload is None
         assert action.accepts is None
         assert _availability_exprs(action) == []
@@ -554,7 +557,9 @@ def test_game_self_loop_move_action_shape() -> None:
     touching ``Resolver.resolve_fanout`` — the tag vocabulary lies (see the
     audit table's drift column). Also recorded: the display text lives in
     ``label`` (``text`` stays empty), inverting the sandbox families' machine
-    label + display ``text`` split, and there are no ``ui_hints`` at all.
+    label + display ``text`` split. Since synthesis item D the only ``ui_hints``
+    is the single ``source`` lifecycle token (``game_self_loop``, deliberately
+    not ``game_fanout`` so it does not echo the fanout-tag lie).
     """
     graph, block = _rps_block()
 
@@ -568,7 +573,7 @@ def test_game_self_loop_move_action_shape() -> None:
     for action in actions:
         assert action.text == ""
         assert action.tags == {"dynamic", "fanout", "game"}
-        assert action.ui_hints is None
+        assert _hints(action) == {"source": "game_self_loop"}
         assert action.accepts is None  # RPS declares no client input contract
         assert _availability_exprs(action) == []
         assert _effect_exprs(action) == []

--- a/engine/tests/story/test_menu_fanout.py
+++ b/engine/tests/story/test_menu_fanout.py
@@ -199,6 +199,13 @@ def test_frozen_shape_eager_init_prebuilds_menu_actions() -> None:
         "archive",
         "Secret project",
     }
+    # Eager-built menu actions carry the same item-D cleanup-attribution token
+    # as the lazy projection path, so provenance does not depend on init mode.
+    assert all(
+        (action.ui_hints.model_dump() if action.ui_hints else {}).get("source")
+        == "menu_fanout"
+        for action in actions
+    )
 
 
 def test_frozen_shape_menu_does_not_refresh_during_planning() -> None:


### PR DESCRIPTION
Implements approved items **D** and **E** of the v38 Aardvark annealing synthesis ([#268](https://github.com/derekmerck/storytangl/issues/268), "Architecture synthesis"). Gated on A/B/C, all merged ([#274](https://github.com/derekmerck/storytangl/pull/274) audit table + cleanup invariant, [#276](https://github.com/derekmerck/storytangl/pull/276) characterization tests, [#277](https://github.com/derekmerck/storytangl/pull/277) doc reconciliation). Non-breaking.

## Item D — normalize existing provenance (minimal form)

**Classification note** (`docs/src/design/planning/AFFORDANCE_MODEL.md`, new subsection under "The audit table (filled)"): classifies each sandbox `ui_hints` field as **lifecycle** (`source`, `scope`, `source_label`, coordinate extras), **presentation** (`direction`/`raw_direction` — protected IF labels), or **conflated** (`source_kind`, `contribution`). Names the core tension explicitly — the unambiguously-lifecycle `source`/`scope` ride inside `ui_hints`, a channel whose own model docstring declares it *"Advisory renderer hints for choices"* (presentation). Proper separation (a dedicated lifecycle channel across `Action` + `ChoiceFragment` + wire DTO) is recorded as **deferred convergence debt**, cross-linked to the existing "general provenance/receipt shape" promotion candidate in `SANDBOX_DESIGN.md`. Not built here.

**Minimal attribution token**: menu (`project_menu_affordances`) and game (`_build_game_actions`) projectors now emit the single lifecycle field `source` in the *same* `ui_hints` channel sandbox uses — `{"source": "menu_fanout"}` and `{"source": "game_self_loop"}`. One token, additive, optional, ignorable by existing consumers; **tags are untouched**, so the compound-key cleanup contract and its exactly-one-family invariant ([#274](https://github.com/derekmerck/storytangl/pull/274)) are unaffected. `game_self_loop` (not `game_fanout`) deliberately avoids echoing the recorded game fanout-tag drift.

### ⚠️ Intentional characterization-pin updates (conscious convergence step)

Adding `ui_hints` to menu/game breaks exactly two B golden assertions by design. Both are updated deliberately — **not routed around**:

- `test_menu_fanout_action_shape`: `assert action.ui_hints is None` → `assert _hints(action) == {"source": "menu_fanout"}`
- `test_game_self_loop_move_action_shape`: `assert action.ui_hints is None` → `assert _hints(action) == {"source": "game_self_loop"}`

Docstrings and the module header are updated to record the new pinned shape. All other assertions in that module and the `test_sandbox_architecture.py` invariants pass unchanged.

**Out of scope (recorded, not fixed):** the game `fanout`-tag drift and the adventure two-family cleanup overlap — each needs its own approved follow-up.

## Item E — compatibility seam inventory

`docs/src/notes/audits/compat-seams-inventory.md` (added to the audits toctree): catalogs four in-repo compat seams with **actionable per-seam sunset conditions**, under the owner policy that in-repo tests/apps are the only legacy consumers — a cleanup shopping list, **no removals**:

1. legacy `payload_type` / `input` accepts — web-client only; backend already typed; readers named.
2. `_normalize_choice_labels_in_fragments` — REST label backfill + its server-test mirror.
3. `edge_id` wire field — **keep, no rename**; readers enumerated as blast radius for a future rename.
4. dynamic-action cleanup tag conventions — contract is load-bearing; only the game `fanout`-tag drift is sunsettable, via a characterized migration.

[#275](https://github.com/derekmerck/storytangl/pull/275) (typed blocker contract, open) overlaps on `story_router.py` + `ui_hints` (`cost_previews`); this PR does not modify the router, so if #275 lands first only the inventory's line numbers shift.

## Verification

- `poetry run pytest engine/tests apps/cli/tests apps/server/tests` → **2634 passed, 66 skipped, 10 xfailed**.
- `poetry run sphinx-build -W --keep-going -b html docs/src <tmp>` → **build succeeded**, no warnings.
- Web untouched (only inventoried), so web tests not required.

Refs #268, #255, PRs #274/#276/#277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive documentation of UI hints system and metadata handling
  * Created compatibility seams inventory documenting legacy behavior bridges and sunset conditions

* **New Features**
  * Enhanced menu and game actions with diagnostic attribution metadata for improved traceability

* **Tests**
  * Updated test expectations to align with new action metadata structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->