### PR TITLE
Provider-bound role grants (mu-affordances phase 1)

### DIFF
--- a/docs/src/notes/MU_AFFORDANCES.md
+++ b/docs/src/notes/MU_AFFORDANCES.md
@@ -1,445 +1,389 @@
-# Mu-Affordances and Microconcepts
+# Facets: Mu-Affordances and Mu-Dependencies
 
-**Document Version:** 0.1  
-**Status:** DESIGN NOTE - vocabulary and implementation direction only  
-**Prior art:** issue `#113`, issue `#141`, `scratch/mechanics/badge/badge.py`,
-`engine/src/tangl/prose/mu_block.py`, `engine/src/tangl/prose/dialog.py`  
-**Relevant layers:** `tangl.core`, `tangl.vm.provision`, `tangl.story.concepts`,
-`tangl.story.episode`, `tangl.prose`
+**Document Version:** 0.3
+**Status:** DESIGN NOTE - vocabulary and implementation direction
+**Prior art:** issue `#113`, issue `#141`, `engine/src/tangl/story/concepts/role.py`
+(phase-1 grants), `engine/src/tangl/mechanics/sandbox/visibility.py` (restrictions),
+`engine/src/tangl/prose/mu_block.py`, `scratch/mechanics/badge/badge.py`
+**Relevant layers:** `tangl.core`, `tangl.vm`, `tangl.story.concepts`,
+`tangl.mechanics.sandbox`, `tangl.prose`, `tangl.journal`
 
 ---
 
 ## Problem Statement
 
-StoryTangl already has several objects that are clearly meaningful and structured,
-but do not want full graph identity:
+StoryTangl has a recurring need: a concept that is *active in the current scope*
+wants to influence a downstream task — prose, choices, navigation, a stat
+challenge — **without** being an independent graph node and without the
+downstream task knowing the concept exists.
 
-- dialog sub-blocks that carry speaker/style metadata before rendering
-- badge-like grants that should follow an assigned provider while a link exists
-- temporary titles, uniforms, avatars, and similar role-linked decorations
-- small provider-side annotations created by planning or provisioning
+Examples that look unrelated but are the same shape:
 
-These objects are "less identified than an Entity" but more meaningful than
-plain dict payloads.
+- a role grants the bound actor a `title` and a short name for prose
+- a held sword grants `+1` on combat stat challenges to its holder
+- a lantern grants `light`; its absence restricts movement to "it's too dark"
+- Stormbringer, once drawn, whispers into the journal **and** suppresses the
+  "put it away" choice until it has been used
+- a Disco-Elysium-style *voice* occasionally contributes a line or suppresses a
+  choice according to its influence and relevance
 
-They need to be:
+These all want to: be authored on a carrier concept, ride the currently active
+binding/scope, be evaluated against current state, be projected into the right
+pipeline, and disappear cleanly when no longer relevant — **as derived state,
+never as mutated provider state.**
 
-- authored or generated in a managed way
-- passed through behaviors and handlers
-- filtered or ordered deterministically
-- projected into namespace, render output, or effective affordances
-- discarded cleanly when their context no longer applies
-
-This note refers to that family as **microconcepts**, and to the
-provider-binding subset as **mu-affordances**.
-
----
-
-## Core Insight
-
-A microconcept is not a small Entity. It is a **context-bound concept carrier**
-with no standalone graph identity.
-
-An Entity has stable identity because it must be registrable, matchable, and
-addressable outside the immediate operation that is using it.
-
-A microconcept is different:
-
-- it is meaningful only relative to a caller, source edge, provider, or render pass
-- it may have provenance such as `source_id` or `subject_id`
-- it does not belong in the graph registry as an independent peer
-- it can still carry labels, tags, locals, media hints, and ordering metadata
-
-In other words, it has **context identity**, not **graph identity**.
-
-This is the common thread between:
-
-- `MuBlock` in discourse parsing
-- old dynamic badges
-- role-linked derived grants from issue `#141`
-- future provider overlays created by dependencies, affordances, or fanout
+This note calls that unit a **Facet**.
 
 ---
 
-## Why "Fragment" Is Not the Right Word
+## Core Insight: the Facet
 
-"Fragment" already has a strong meaning in StoryTangl: rendered or journal-ready
-output records such as content fragments, dialog fragments, media fragments, and
-control fragments.
+A **Facet** is an *offered, concept-bound micro-entity with no graph identity*.
+It is published into the scoped namespace once, and a downstream task **adopts**
+it if the task wants it — given the facet's activation condition, the current
+caller, and current state.
 
-That meaning is useful and should stay stable.
+It has **context identity**, not **graph identity**:
 
-Microconcepts come **before** fragment output, or may never become fragments at
-all. They can be used to:
+- it is meaningful only relative to a carrier, subject, caller, or pipeline pass
+- it may carry provenance (`source_id`, `subject_id`)
+- it does **not** belong in the graph registry as an independent peer
+- it can still carry conditions, payload, tags, and ordering metadata
 
-- enrich a namespace
-- decorate a provider view
-- attach effective tags or media
-- drive dynamic affordance projection
-- parse authored content into more structured intermediate units
+This is the common thread between dynamic badges (`#113`), role-linked grants
+(`#141`), sandbox visibility rules, and `MuBlock` discourse parsing.
 
-So:
+### Publish once, pull to consume
 
-- **Fragment** should remain "rendered output artifact"
-- **Microconcept** should mean "context-bound entity-like concept carrier"
-- **MuBlock** is a render-focused microconcept subtype
-- **MuAffordance** is a provider-binding microconcept subtype
+A facet is *published* exactly once (the only "push" — collection into scope).
+After that it is a passive entry on a discovery bus; tasks that care scan for it
+and dereference. The role never knows the prose engine exists; the sword never
+knows the combat resolver exists. The namespace entry is the rendezvous point,
+and neither end is coupled to the other.
 
-"Component" is possible vocabulary, but it is already overloaded elsewhere in
-engine design. "Microconcept" is the clearer story-facing umbrella.
+This is the same move the engine already makes with `on_gather_ns` +
+`wants_caller_kind`, **flipped from type-driven to data-driven dispatch**: today
+a handler self-selects on the *carrier's class*; a facet carries its relevance as
+*data* (`when`, `applies_to`), so the consumer selects on the *facet's*
+self-description. That is why a facet must be a self-describing value object, not
+an opaque dict — relevance has to be decidable from the facet alone.
+
+The facet is a **handle, not the payload**. It carries references (carrier,
+subject); a consumer dereferences for deep detail (the subject's full media
+library, the modifier's rules). Scope never bloats even when the source detail is
+large.
+
+---
+
+## The Affordance / Dependency Symmetry
+
+A facet has a **polarity**:
+
+- A **mu-affordance** is a facet that *offers a grant* — additive. "Here is
+  more." (title, light, `+1`, a whispered line, an extra choice.)
+- A **mu-dependency** is a facet that *imposes a restriction* — it injects a
+  requirement/condition onto the consumer's task. "You may not, unless…"
+  (darkness suppresses movement; Stormbringer suppresses `peaceful` choices;
+  `require-light` choices are gated until a `light` grant is active.)
+
+This is the **same shape with opposite polarity** — the micro-layer mirror of the
+graph-level duality where an `Affordance` *offers* a provider and a `Dependency`
+*requires* one (same edge shape, opposite fixed endpoint). A restriction is
+simply a dependency the consumer didn't author for itself, contributed from an
+indirect source.
+
+> Naming consequence: "mu-affordance" names only the grant pole. The umbrella is
+> the **Facet**; the two poles are mu-affordance (grant) and mu-dependency
+> (restriction). This note keeps its filename for continuity but is about both.
+
+### The non-dual escape hatch: Transform
+
+A third operation does **not** fit the duality and should not be forced into it:
+a **structural transform** of an assembled contribution bag — e.g. a dialog
+enrichment that splits journal fragment 1 into 1 + 4 and inserts 2, 3 between
+them. That is a positional, non-commutative rewrite, not a value with a fold.
+It rides the *same carrier and activation skeleton* as a facet, but its payload
+is an operation, not a declarative grant/restriction. Keep it rare and explicit;
+do not pretend it is "grant `title: boss`."
+
+---
+
+## Anatomy of a Facet
+
+```text
+Facet  — microconcept value object, no graph identity, carried by a concept
+  channel    : which pipeline may adopt it — ns | prose | choices | navigation | challenge …
+  effect     : affordance (grant) | dependency (restriction)   [ transform = escape hatch ]
+  when       : Predicate over the gathered ns  (activation; selectors + Expr, no hard links)
+  applies_to : selector for the caller / subject / target it acts on
+  payload    : grant data, or restriction (suppress + optional replacement)
+  influence  : weight for precedence / stacking
+```
+
+- `when` reuses the existing core `Predicate` (`tangl.core.runtime_op`), already
+  used by `SandboxVisibilityRule.when`.
+- A concept carries `facets: list[Facet]`.
+- A **generic per-channel adapter** collects in-scope facets and a task *adopts*
+  one when `when` holds ∧ its `channel` matches the pipeline ∧ `applies_to`
+  matches the caller. There is **one adapter per channel**, not per-concept code —
+  that is what keeps a multi-pipeline concept (Stormbringer) encapsulated in one
+  authored entity instead of scattered across the graph.
+
+Phase-1 `RoleGrant` is the degenerate case:
+`RoleGrant ≡ Facet(channel=ns, effect=affordance)`.
+
+### Combine semantics are per-consumer
+
+The adapter collects and filters; **the consumer chooses the fold**. Do not
+hardcode one rule:
+
+- a *name / title* grant may **override** (a role sets your one title) or
+  **decorate** (a drawn sword appends "…and His Hungry Blade" as an ordered
+  suffix) — same channel, opposite fold, which is exactly why the fold is the
+  consumer's call, not the facet's
+- a *+1 combat* grant **stacks** additively (two buffs = +2)
+- *tags* **union**
+- a *restriction* **gates / replaces**, and should **tombstone** rather than
+  delete — record which facet suppressed what (and any replacement), so the
+  operation is auditable, replay-stable, and reversible when its `when` lapses
+
+`SandboxProjectionState` already is a tombstone: it records `active_rules` plus a
+replacement `journal_text` instead of mutating the bag.
+
+---
+
+## Conditioning Vocabulary and Pre-Flight Coverage
+
+Facets condition on — and target — **tags and published properties**, never hard
+links. The vocabulary is the author's: `commerce`, `sheathe`, `peaceful`,
+`require_light`, `is_friendly`, and so on are world-level conventions, not engine
+types. A choice the NPC author tagged `commerce` is what lets a *different* concept
+in your inventory (Stormbringer) suppress it; the coupling is by shared tag, not by
+reference.
+
+Core's job is only to **gesture at the shape**: ship a minimal default inventory of
+published node properties so authors have a starter kit and a worked pattern — e.g.
+sandbox nodes publish `is_dark`, `is_lit`, `is_friendly` into ns, adoptable
+directly as `if here.is_dark(): grues.approach()`. Authors extend the vocabulary
+freely; the engine does not police it.
+
+It can, however, **check coverage**. Because targeting is by tag, a `when` /
+`applies_to` that references a tag nothing ever *produces or presents* is a dead
+condition — a logic flaw or a redundancy. A **pre-flight coverage check** can flag
+"this restriction conditions on `require_light`, but no concept in this world grants
+`light`," exactly as the compiler already flags dangling actor/location references
+(`_collect_provider_ref_issues`, `ISSUE_DANGLING_*`). This is a **world /
+compile-time concern, not a core one**: core ships the starter vocabulary and the
+diagnostic hook; the `WorldCompiler` owns the actual coverage check and any deeper
+solvability analysis.
+
+---
+
+## Reference Implementations
+
+The two poles already exist in the codebase; the work is to name the shared
+shape and lift them onto it.
+
+### Affordance pole — phase-1 role grants (built, issue `#141`)
+
+`RoleGrant` (`engine/src/tangl/story/concepts/role.py`) is an authored grant
+carried on a `Role` binding. While the provider is resolved, `contribute_roles`
+projects it as a derived `ns`-channel overlay: `{label}_{key}` scalars,
+`{label}_tags`, a per-binding `role_grants` accessor, and merged
+`grants`/`grant_tags` views. Precedence: nearer-scope binding overrides/clears;
+across labels the merged map resolves a shared key by `priority`. Authorable via
+the role `grants:` key.
+
+### Dependency pole — sandbox visibility (built)
+
+`SandboxVisibilityRule` (`engine/src/tangl/mechanics/sandbox/visibility.py`) is a
+restriction facet in all but name: a `when` list of predicates over ns, a set of
+suppressions, a replacement `journal_text`, OR-folded into a
+`SandboxProjectionState` that records provenance. It already chose the right
+modelling: **light is the positive grant** (`LightSourceFacet`,
+`sandbox_has_lit_light_source()` in ns); **darkness is the default restriction
+that fires when no light grant is active** — not a negative grant. Today its
+suppression target is three fixed categories; the generalization is to make the
+target a **selector** (`choices tagged peaceful`) instead.
+
+### Both poles on one concept — the Stormbringer loop (worked example)
+
+A single inventory concept carries a bundle of facets plus a little state, and the
+whole episodic puzzle *emerges* from their interaction — with no imperative script
+wired into the scenes where the beats happen to occur:
+
+```text
+Stormbringer  (state: drawn, fed)
+  Facet(navigation, affordance, when="drawn",             payload=light)         # a magic sword glows
+  Facet(prose,      affordance, when="drawn",             payload=whisper_line)  # it murmurs
+  Facet(ns,         affordance, when="drawn",             payload=name_suffix:" and His Hungry Blade", fold=decorate)
+  Facet(choices,    affordance, when="drawn and not fed", payload=add:cut_self)  # offers a bloodletting
+  Facet(choices,    dependency, when="drawn and not fed", applies_to=tag:commerce, suppress)
+  Facet(choices,    dependency, when="drawn and not fed", applies_to=tag:sheathe,  suppress)
+  # actions feed it:  attack/kill -> fed=true   |   cut_self -> fed=true (costs hp)
+```
+
+Run the lamp dry (`ChargeFacet -> 0`; its `light` affordance withdraws, so the
+darkness dependency suppresses movement) and you are *forced* to draw the sword
+for its `light`. At the merchant, the `not fed` hunger gate splits into the Elric
+tragedy:
+
+- **kill the merchant** — feeds the sword on the NPC, stay drawn, walk on (no oil,
+  a corpse); or
+- **cut yourself** — feed it at your own cost, which lifts the gate so you may
+  sheathe, trade, buy oil, relight the lamp, and proceed unbloodied.
+
+Both resolve the same `when="not fed"` gate; the **consequences live on the
+actions, not the facets**. There is always an out (so no hard lock — the general
+hazard is *coverage*, below). And the payoff is **portability**: none of this is
+wired into "the cave scene" or "the battlefield scene." The behavior travels with
+the concept — drop Stormbringer into a labyrinth or a nighttime battlefield and
+the same few functional descriptions reproduce the entire loop. A scattered
+imperative if/else across every phase where a beat *might* fire collapses into a
+handful of declarative facets that go where the concept goes.
+
+The smallest facet in the bundle is the oldest: `name_suffix` is **phase-1's title
+grant**, now bound to the *holder* and gated on `drawn` — *Bill the Adventurer*
+becomes *Bill the Adventurer and His Hungry Blade* while the blade is out and
+reverts the instant it goes away. Same mechanism as `grant title: boss`, but with a
+**decorate** fold instead of override; were you also the boss it would compose to an
+ordered *Boss Bill … and His Hungry Blade*. One worked demo now exercises every
+channel and both poles, and reuses the first thing built.
+
+A Disco-style **voice** is the same skeleton, with `influence` graduating from a
+tie-breaker into a **passive-check weight**: activation generalizes from "binding
+present" to **bound ∧ relevant (`when`) ∧ influence-check-passes**.
+"Always-available" voices are just high-scope bindings, the trick `Player` uses.
 
 ---
 
 ## Existing Prior Art
 
-### 1. MuBlock in discourse parsing
-
-`MuBlock` in `engine/src/tangl/prose/mu_block.py` already expresses the
-basic pattern well:
-
-- smaller than a block
-- not persisted in the graph
-- carries just enough metadata to behave meaningfully
-- promoted into a real output artifact through `to_fragment()`
-
-`DialogMuBlock` in `engine/src/tangl/prose/dialog.py` shows the same pattern
-applied to speaker attribution and dialog styling.
-
-This is the clearest proof that StoryTangl already benefits from managed
-non-entity intermediates.
-
-### 2. Dynamic badges
-
-The old badge system in `scratch/mechanics/badge/badge.py` is the "ur
-mu-affordance" design.
-
-Its enduring ideas are:
-
-- singleton-authored definitions
-- dynamic attach / detach semantics
-- topological dependency ordering
-- hide / supersede relationships
-- projection into both condition context and render output
-
-Its weak point was not the concept. The weak point was the old plumbing:
-
-- explicit mutation of node associations
-- global recomputation scans
-- tag-like state being pushed into nodes instead of derived from current context
-
-### 3. Role-linked grants
-
-Issue `#141` captures the concrete modern use case:
-
-- a role edge resolves to some provider
-- while that edge exists, the provider should gain contextual properties
-- when the provider changes, the contextual properties should move with it
-- nothing should rely on brittle link / unlink scripts staying in sync
-
-That is exactly what a mu-affordance is:
-
-- declared on a carrier edge
-- bound to the currently assigned provider
-- projected as derived state
-- discarded when the assignment changes
-
----
-
-## Definition
-
-### Microconcept
-
-A **microconcept** is a serializable or constructible value object that:
-
-- is carried by or derived from a parent entity, edge, template, or render pass
-- has no standalone registry identity
-- is only meaningful in a specific bound context
-- may be promoted into another runtime artifact such as a namespace view,
-  effective tag set, affordance decoration, or fragment
-
-### Bound Microconcept
-
-A **bound microconcept** is a runtime binding of a microconcept to a specific
-context, such as:
-
-- source node
-- carrier edge
-- resolved provider
-- current caller
-- render source id
-
-This is the object that actual handlers consume.
-
-### Mu-Affordance
-
-A **mu-affordance** is a bound microconcept that decorates or exposes a provider
-through a relationship.
-
-Examples:
-
-- `boss.title == "boss"` while a role edge is active
-- a provider temporarily gains a `uniform` media item through assignment
-- a selected provider gains extra tags or labels while filling a task
-- a fanout-created affordance carries extra provider-facing menu metadata
-
-### MuBlock
-
-A **MuBlock** is a microconcept that specializes in render-oriented content
-structure and usually promotes into fragments.
-
----
-
-## Proposed Shape
-
-The clean shape is two-tiered:
-
-### 1. Authored spec
-
-A small declarative object stored on some carrier:
-
-- node
-- edge
-- template payload
-- content parser output
-
-Possible fields:
-
-- `label`
-- `kind`
-- `priority`
-- `conditions`
-- `locals`
-- `tags`
-- `media`
-- `hides`
-- `source_ref` or other authored selectors
-
-This spec has no graph UID of its own.
-
-### 2. Runtime binding
-
-A lightweight bound view with context attached:
-
-- `carrier`
-- `subject`
-- `caller`
-- `source_id`
-- merged or effective `locals`
-- effective `tags`
-- projected media or narrative annotations
-
-Handlers then consume this binding without pretending it is a graph peer.
-
----
-
-## Relationship to Existing Engine Layers
-
-### Core / VM
-
-The VM does not need a brand new universal "micro task" system to support the
-useful parts of this idea.
-
-The immediate path is to reuse existing handler surfaces:
-
-- `on_gather_ns` for contextual property exposure
-- planning / provisioning for dynamic provider-side affordances
-- journal or content gather handlers for render projection
-
-This is enough to support the first meaningful applications.
-
-### Story
-
-Story layer code is where microconcepts become narratively legible:
-
-- roles grant titles and avatars
-- affordances expose badge-like temporary status
-- anonymous blocks or discovered providers may contribute contextual metadata
-- block content can parse into dialog or card-like micro-blocks before render
-
-### Discourse
-
-Discourse parsing already has the clearest example of microconcept promotion:
-
-`MuBlock -> Fragment`
-
-That same promotion shape can later support:
-
-- `MuAffordance -> BoundProviderView`
-- `MuAffordance -> EffectiveTagOverlay`
-- `MuAffordance -> Media projection`
-
----
-
-## Preferred Implementation Strategy
-
-### Phase 1: provider-bound grants
-
-Start with the narrowest and most valuable slice from issue `#141`.
-
-- Add edge-carried grant specs on story relationships such as `Role`
-- Bind those grants to the currently resolved provider
-- Expose them through namespace gathering as a contextual provider view
-- Keep the grants derived, not persisted as mutable provider state
-
-This solves the motivating examples:
-
-- title
-- rank
-- badge
-- avatar
-- uniform
-
-### Phase 2: effective overlay helpers
-
-Add a small set of helpers for consuming bound microconcepts:
-
-- effective locals
-- effective tags
-- effective media
-- precedence / supersession ordering
-
-This is the modern replacement for old dynamic badge mutation.
-
-### Phase 3: relation to fanout
-
-Allow planning-time created affordances to carry microconcept-like metadata that
-binds to the selected provider.
-
-This matters for:
-
-- menu hubs
-- sandbox hubs
-- gathered provider choices
-- future actor / location roster views
-
-### Phase 4: evaluate common base with MuBlock
-
-Only after the first two slices are working should StoryTangl decide whether
-`MuBlock` and provider-side microconcepts want a shared base implementation or
-just shared vocabulary.
-
-The concept is shared already. The code does not need to be prematurely unified.
-
----
-
-## What Should Not Be in Scope Yet
-
-Issue `#113` bundled several larger ideas together. They should remain separate
-from the first mu-affordance implementation:
-
-- a universal heavy-task / light-task dispatch split
-- a complete replacement of existing VM phase wiring
-- global achievements or reactive rule engines
-- generic enter / exit micro-dependency scripting
-- persistent snapshotting of derived microconcept state
-
-Those may later use the same vocabulary, but they are not required to realize
-the main value here.
+### MuBlock (discourse parsing)
+
+`MuBlock` (`engine/src/tangl/prose/mu_block.py`) is a render-oriented
+microconcept: smaller than a block, never in the graph, promoted to a fragment
+via `to_fragment()`. It is the clearest proof StoryTangl already benefits from
+managed non-entity intermediates, and a candidate to share a base with facets
+later (Phase 4).
+
+### Dynamic badges (`#113`)
+
+The old badge system (`scratch/mechanics/badge/badge.py`) is the "ur facet": it
+already had *both poles* (grant tags / hide-supersede), topological ordering, and
+projection into both condition context and render output. Its weakness was
+plumbing, not concept — explicit node mutation and global rescans instead of
+derived projection.
 
 ---
 
 ## Design Rules
 
-### 1. Derived beats stored
-
-If a property can be computed from current topology and current context, prefer
-derived projection over mutating stored state.
-
-### 2. Promote only when necessary
-
-If something needs durable identity, inventory presence, or independent mutable
-state, it should become a real Entity or Token. Otherwise it should remain a
-microconcept.
-
-### 3. Context is part of the contract
-
-Microconcepts are not free-floating. The binding context is what makes them
-meaningful.
-
-### 4. Fragment remains output vocabulary
-
-Do not overload "fragment" for provider overlays or relationship-bound grants.
-
-### 5. Story semantics live above the generic layer
-
-The generic layer should know about binding and projection. Story layer code
-should know about titles, avatars, uniforms, badge text, and dialog speakers.
+1. **Derived beats stored.** If a property can be computed from current topology
+   and context, project it; never mutate provider/holder state.
+2. **Prefer a positive affordance + gate over a negative dependency.** Model the
+   capability (`light`) and let the restriction be "default when the capability is
+   absent." Reserve active restrictions for genuinely subtractive intent with no
+   positive form (Stormbringer's "peaceful unavailable until it swings").
+3. **Share discovery, not the fold.** One per-channel adapter does collection +
+   `when`/`applies_to` filtering; only the *fold* is bespoke. Otherwise the
+   duplication you avoided reappears at the consumption layer.
+4. **Tombstone restrictions.** Suppress with provenance + optional replacement;
+   do not destructively delete from the bag.
+5. **`when` must be replay-deterministic.** Any activation that reads rolly /
+   influence state must resolve identically on every replay of the same trace, or
+   it breaks fabula-invariance and replay-as-reskin.
+6. **Context is part of the contract.** Facets are meaningful only relative to
+   their binding/caller; that is what distinguishes them from free-floating data.
+7. **Promote only when necessary.** Durable identity, inventory presence, or
+   independent mutable state → a real Entity/Token. Otherwise stay a facet.
+8. **Story semantics live above the generic layer.** The core layer knows
+   channels, polarity, activation, folding; story code knows titles, uniforms,
+   badge text, whispers, and "too dark to see."
 
 ---
 
-## Example Story Use Cases
+## Naming Reconciliation
 
-### Role-linked title
+The sandbox already spends **"Facet"** on *typed capability components*
+(`LightSourceFacet.illuminates()`, `ChargeFacet.consume()`) — behavioral policy
+objects, not grant/restriction entries. These are a different layer. Preferred
+resolution: the core micro-affordance entry takes the word **Facet**; capability
+objects *emit* facets (a lit `LightSourceFacet` emits the `light` grant). Rename
+the sandbox capability classes (`…Capability` / `…Policy`) **when the sandbox
+migrates onto the core model**, not before — but choose the distinction
+deliberately rather than colliding.
 
-```yaml
-roles:
-  - label: boss
-    selector:
-      has_kind: Actor
-    grants:
-      title: "boss"
-      tags: ["management"]
-```
+---
 
-While the role is bound, the namespace can expose:
+## Phased Strategy
 
-- `boss`
-- `boss_title`
-- `boss.tags`
+### Phase 1 — affordance grants on bindings (DONE, `#141`)
 
-without mutating the underlying actor permanently.
+`RoleGrant` + `ns`-channel projection from active role bindings. The degenerate
+facet; the first conformance consumer.
 
-### Role-linked avatar or uniform
+### Phase 2 — promote `Facet` to a shared primitive
 
-```yaml
-roles:
-  - label: foreman
-    selector:
-      has_kind: Actor
-    grants:
-      media:
-        - name: "foreman_uniform.svg"
-          media_role: "avatar_im"
-```
+Introduce the `Facet` value object (core-neutral data + `Predicate`) and refactor
+phase-1 role grants to be its first `effect=affordance, channel=ns` consumer. No
+new behavior; the rail under what already works.
 
-The assigned provider temporarily gains visual presentation metadata through the
-role relationship.
+### Phase 3 — the dependency pole as a shared restriction channel
 
-### Dialog parsing
+Generalize `SandboxVisibilityRule` into `effect=dependency` facets whose
+`applies_to` is a selector over choices/affordances, consumed by the planning /
+navigation pipeline. Settle restriction **conflict resolution** here (selector
+vetoes don't OR like booleans).
 
-Authored block text can parse into `DialogMuBlock` items which later render into
-attributed journal fragments, carrying speaker and discourse metadata without
-turning each utterance into a graph node.
+### Phase 4 — more channels and influence
+
+`prose`/`journal` grants; influence-weighted voice activation (passive checks,
+deterministic); the Transform escape hatch for journal-compose restructuring;
+evaluate a shared base with `MuBlock`.
+
+### Out of scope (stays separate, may share vocabulary later)
+
+A universal heavy/light task dispatch split; replacing existing VM phase wiring;
+global reactive rule engines; persistent snapshotting of derived facet state.
+
+---
+
+## Load-Bearing Decisions (settle before core code)
+
+- **`effect` / `channel` enums.** Is `transform` a third `effect`, or its own
+  carried-operation type? (Leaning: its own type — it is not a fold.)
+- **Restriction conflict resolution.** Two restrictions on one choice — veto
+  wins? priority? The sandbox OR's booleans; selector-targeted vetoes need a
+  defined policy.
+- **Replay determinism** of influence/rolly `when` predicates.
+- **`applies_to` selector shape** — what a facet is allowed to target.
+- **Placement.** `Facet` value object in `tangl.core`; channel adapters where each
+  pipeline lives (VM / story / journal). Do not pull pipeline knowledge into core.
+- **Coverage / solvability is world-level, not core.** The pre-flight check that
+  every conditioned tag is presentable somewhere (see *Conditioning Vocabulary*)
+  lives in `WorldCompiler` diagnostics, beside the dangling-ref checks. Core ships
+  only the starter vocabulary and the hook — not the analysis.
 
 ---
 
 ## Open Questions
 
-- Should the generic implementation call these `MicroconceptSpec` /
-  `BoundMicroconcept`, or use a more VM-neutral name like `AttachmentSpec` /
-  `BoundAttachment`?
-- Should bound provider views be proxy objects, plain mappings, or lightweight
-  wrappers with explicit accessors?
-- How should multiple active mu-affordances resolve conflicts for the same key:
-  priority, scope, order of attachment, or explicit policy?
-- Should effective tags become selector-visible everywhere, or only through
-  specific helper paths?
-- How much shared code should `MuBlock` and provider-bound microconcepts
-  actually have, versus just sharing terminology?
+- Should bound subject views be proxy objects, plain mappings, or lightweight
+  accessors? (Phase 1 chose plain mappings.)
+- Per-subject vs scope-wide merge of grants. Phase 1 merges scope-wide as a
+  convenience; the principled primitive is per-subject (the holder accumulates),
+  which the combat/voice cases will force.
+- How much code should `MuBlock` and facets actually share, versus terminology?
 
 ---
 
-## Proposed Near-Term Outcome
+## Near-Term Outcome
 
-The near-term goal is not a giant "micro-behavior" subsystem.
-
-The near-term goal is a clean way to represent **managed entity-like things with
-less identity than Entities**, so StoryTangl can:
-
-- bind temporary properties to providers through relationships
-- carry small conceptual units through the VM without full graph registration
-- parse authored content into structured intermediate units
-- keep rendered fragments as the final output vocabulary
-
-That would consolidate the useful core of issues `#113` and `#141` while
-aligning with the old badge work and the already-working `MuBlock` pattern.
+A single way to represent **managed, entity-like things with less identity than
+Entities** — concept-bound, condition-gated, channel-routed, polarity-aware
+(grant or restriction), folded with provenance — so StoryTangl can bind temporary
+properties and constraints to providers/holders through relationships, carry them
+through the VM without graph registration, and keep rendered fragments as the
+final output vocabulary. Phase 1 is the worked example; the Facet is the
+generalization.

--- a/engine/src/tangl/ir/story_ir/actor_script_models.py
+++ b/engine/src/tangl/ir/story_ir/actor_script_models.py
@@ -63,6 +63,15 @@ class RoleScript(BaseScriptItem):
         description="Provisioning policy such as ``EXISTING`` or ``CREATE``.",
     )
 
+    grants: Optional[dict[str, Any]] = Field(
+        None,
+        description=(
+            "Provider-bound grants (mu-affordance, phase 1): scalar overlays plus "
+            "reserved ``tags``/``priority`` keys, projected onto the bound provider "
+            "while the role binding is active. See RoleGrant."
+        ),
+    )
+
     assets: list[AssetsScript] = None     # assets associated with the role, titles, gold badge for sherif
 
     @model_validator(mode="after")

--- a/engine/src/tangl/story/__init__.py
+++ b/engine/src/tangl/story/__init__.py
@@ -59,6 +59,7 @@ from .concepts import (
     Location,
     Player,
     Role,
+    RoleGrant,
     Setting,
     get_narrator_key,
 )
@@ -148,6 +149,7 @@ __all__ = [
     "ResolutionError",
     "ResolutionFailureReason",
     "Role",
+    "RoleGrant",
     "Scene",
     "Setting",
     "StoryCompiler",

--- a/engine/src/tangl/story/concepts/__init__.py
+++ b/engine/src/tangl/story/concepts/__init__.py
@@ -26,7 +26,7 @@ from .asset import AssetType, AssetWallet, CountableAsset, HasAssets
 from .location import Location
 from .narrator_knowledge import EntityKnowledge, HasNarratorKnowledge, get_narrator_key
 from .player import Player
-from .role import Role
+from .role import Role, RoleGrant
 from .setting import Setting
 
 __all__ = [
@@ -40,6 +40,7 @@ __all__ = [
     "Location",
     "Player",
     "Role",
+    "RoleGrant",
     "Setting",
     "get_narrator_key",
 ]

--- a/engine/src/tangl/story/concepts/role.py
+++ b/engine/src/tangl/story/concepts/role.py
@@ -3,12 +3,95 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
+from pydantic import Field, model_validator
+
 from tangl.core import Selector
+from tangl.core.bases import BaseModelPlus
+from tangl.type_hints import Tag
 from tangl.vm import Dependency
 
 from ..dispatch import on_gather_ns
 from .actor import Actor
 from .narrator_knowledge import HasNarratorKnowledge
+
+
+# Authoring keys that carry structured grant metadata rather than scalar locals.
+_GRANT_RESERVED_KEYS = ("locals", "tags", "priority")
+
+
+class RoleGrant(BaseModelPlus):
+    """RoleGrant(locals: dict[str, Any] = {}, tags: set[Tag] = set(), priority: int = 0)
+
+    Provider-bound grant carried on a role binding (mu-affordance, phase 1).
+
+    Why
+    ----
+    A role binding should be able to decorate whoever currently fills it with
+    lightweight, relationship-scoped overlays -- a title, a rank, a badge text,
+    or derived tags -- without writing that state back onto the provider. The
+    active binding is the source of truth: the overlay is *derived* at namespace
+    gather time and disappears automatically when the binding is swapped or
+    cleared. This is the narrow first slice of the broader microconcept design.
+
+    Key Features
+    ------------
+    * ``locals`` carry scalar overlays (e.g. ``title``, ``rank``) projected
+      under the role label as ``{label}_{key}``.
+    * ``tags`` carry derived tags projected as ``{label}_tags`` and unioned into
+      the merged ``grant_tags`` scope view.
+    * ``priority`` orders precedence when multiple active bindings grant the same
+      key into the merged ``grants`` scope view: higher priority wins; ties break
+      by scope nearness (handled by gather order) then authored label.
+
+    Authoring
+    ---------
+    Accepts a flat authored mapping where ``tags`` and ``priority`` are reserved
+    and every other key folds into ``locals``::
+
+        grants:
+          title: "boss"
+          tags: ["management"]
+
+    is equivalent to ``RoleGrant(locals={"title": "boss"}, tags={"management"})``.
+
+    See also
+    --------
+    ``docs/src/notes/MU_AFFORDANCES.md``
+        Governing design note (microconcepts / mu-affordances).
+    :class:`Role`
+        Relationship carrier that materializes these grants onto its provider.
+    """
+
+    locals: dict[str, Any] = Field(default_factory=dict)
+    tags: set[Tag] = Field(default_factory=set)
+    priority: int = 0
+
+    @model_validator(mode="before")
+    @classmethod
+    def _fold_flat_authoring(cls, data: Any) -> Any:
+        """Fold flat authored grant mappings into the structured shape.
+
+        Top-level keys other than ``locals``/``tags``/``priority`` are treated as
+        scalar locals so authors can write the ergonomic ``{title: "boss"}`` form
+        alongside the explicit ``{locals: {...}}`` form.
+        """
+        if not isinstance(data, Mapping):
+            return data
+        extra = {key: value for key, value in data.items() if key not in _GRANT_RESERVED_KEYS}
+        if not extra:
+            return data
+        folded: dict[str, Any] = {
+            key: value for key, value in data.items() if key in _GRANT_RESERVED_KEYS
+        }
+        merged_locals = dict(folded.get("locals") or {})
+        merged_locals.update(extra)
+        folded["locals"] = merged_locals
+        return folded
+
+    @property
+    def is_empty(self) -> bool:
+        """Return ``True`` when the grant projects nothing."""
+        return not self.locals and not self.tags
 
 
 class Role(HasNarratorKnowledge, Dependency[Actor]):
@@ -31,6 +114,8 @@ class Role(HasNarratorKnowledge, Dependency[Actor]):
     * Publishes additive aliases such as ``guide_role`` and ``role_edges`` so
       templates and filters can address role-level epistemic state separately
       from provider-level knowledge.
+    * Carries an optional :class:`RoleGrant` whose scalar/tag overlays are
+      projected onto the currently bound provider while the binding is active.
     * Contributes a merged ``roles`` mapping during namespace gathering.
 
     API
@@ -42,9 +127,13 @@ class Role(HasNarratorKnowledge, Dependency[Actor]):
     --------
     :class:`Actor`
         Default provider type bound by role dependencies.
+    :class:`RoleGrant`
+        Provider-bound overlay declared on the role binding.
     :class:`~tangl.vm.provision.requirement.Dependency`
         Base provisioning edge contract used by story roles.
     """
+
+    grants: RoleGrant | None = None
 
     @staticmethod
     def _invoke_provider_ns(provider: Any) -> dict[str, Any]:
@@ -64,7 +153,12 @@ class Role(HasNarratorKnowledge, Dependency[Actor]):
         return {key: item for key, item in payload.items() if item is not provider}
 
     def provide_role_symbols(self) -> dict[str, Any]:
-        """Publish role/provider symbols for gather-time namespace assembly."""
+        """Publish role/provider symbols for gather-time namespace assembly.
+
+        Grant overlays are projected separately by :func:`contribute_roles` from
+        the scope-resolved grant set, so that a nearer binding's grant (or its
+        absence) wins for a given label.
+        """
         provider = self.provider
         label = self.get_label()
         if provider is None or not label:
@@ -83,7 +177,7 @@ def _role_sort_key(role: Role) -> tuple[str, str]:
 
 @on_gather_ns
 def contribute_roles(*, caller, ctx, **_kw):
-    """Inject role providers and role metadata into assembled scoped namespaces."""
+    """Inject role providers, role metadata, and provider-bound grants into scope."""
     if not hasattr(caller, "edges_out"):
         return None
 
@@ -92,6 +186,10 @@ def contribute_roles(*, caller, ctx, **_kw):
     contributions: dict[str, Any] = {}
     roles: dict[str, Any] = {}
     role_edges: dict[str, Role] = {}
+    # Per-label grants resolved with nearer-scope-overrides semantics: outer
+    # scopes are visited first, so a nearer binding's grant (or its absence)
+    # wins for a given label.
+    role_grants: dict[str, RoleGrant] = {}
     for scope in reversed(scope_nodes):
         scope_roles = sorted(scope.edges_out(Selector(has_kind=Role)), key=_role_sort_key)
         for role in scope_roles:
@@ -105,10 +203,47 @@ def contribute_roles(*, caller, ctx, **_kw):
             if label:
                 contributions[f"{label}_role"] = role
                 role_edges[label] = role
+                grant = role.grants
+                if provider is not None and grant is not None and not grant.is_empty:
+                    role_grants[label] = grant
+                else:
+                    role_grants.pop(label, None)
 
     if roles:
         contributions["roles"] = roles
     if role_edges:
         contributions["role_edges"] = role_edges
+
+    # Project the scope-resolved grants. Label-scoped keys (``{label}_{key}`` and
+    # ``{label}_tags``) are written after the provider symbols above, so a grant
+    # intentionally overrides a same-named provider value. The merged scope views
+    # resolve different labels granting the same key by priority (higher wins;
+    # ties keep the first label in sorted order); tags simply union.
+    #
+    # NOTE (phase-1 convenience): ``grants``/``grant_tags`` merge scope-wide. The
+    # generalized Facet model favors a per-subject merge instead -- see
+    # docs/src/notes/MU_AFFORDANCES.md (Open Questions). Treat these flat views as
+    # provisional, not the final contract, when promoting Facet to core.
+    merged_grants: dict[str, Any] = {}
+    grant_priority: dict[str, int] = {}
+    grant_tags: set[Tag] = set()
+    for label in sorted(role_grants):
+        grant = role_grants[label]
+        for key, value in grant.locals.items():
+            contributions[f"{label}_{key}"] = value
+            if key not in merged_grants or grant.priority > grant_priority[key]:
+                merged_grants[key] = value
+                grant_priority[key] = grant.priority
+        if grant.tags:
+            tags = set(grant.tags)
+            contributions[f"{label}_tags"] = tags
+            grant_tags |= tags
+
+    if role_grants:
+        contributions["role_grants"] = dict(role_grants)
+    if merged_grants:
+        contributions["grants"] = merged_grants
+    if grant_tags:
+        contributions["grant_tags"] = grant_tags
 
     return contributions or None

--- a/engine/src/tangl/story/concepts/role.py
+++ b/engine/src/tangl/story/concepts/role.py
@@ -203,11 +203,18 @@ def contribute_roles(*, caller, ctx, **_kw):
             if label:
                 contributions[f"{label}_role"] = role
                 role_edges[label] = role
-                grant = role.grants
-                if provider is not None and grant is not None and not grant.is_empty:
-                    role_grants[label] = grant
-                else:
-                    role_grants.pop(label, None)
+                # Only a *bound* role owns its label's grant, mirroring how an
+                # unbound nearer role does not shadow the parent's provider symbol
+                # (``provide_role_symbols`` returns nothing when unbound). A nearer
+                # bound role with no grant clears the parent's; an unbound nearer
+                # role is an empty slot — the parent's provider and grant show
+                # through unchanged.
+                if provider is not None:
+                    grant = role.grants
+                    if grant is not None and not grant.is_empty:
+                        role_grants[label] = grant
+                    else:
+                        role_grants.pop(label, None)
 
     if roles:
         contributions["roles"] = roles

--- a/engine/src/tangl/story/fabula/materializer.py
+++ b/engine/src/tangl/story/fabula/materializer.py
@@ -955,12 +955,16 @@ class StoryMaterializer:
                 requirement_kwargs["is_qualified"] = self._is_qualified_path(identifier)
 
             requirement = Requirement(**requirement_kwargs)
-            dep = dependency_kind(
-                registry=state.graph,
-                label=label,
-                predecessor_id=source.uid,
-                requirement=requirement,
-            )
+            dep_kwargs: dict[str, Any] = {
+                "registry": state.graph,
+                "label": label,
+                "predecessor_id": source.uid,
+                "requirement": requirement,
+            }
+            grants = spec.get("grants")
+            if grants is not None and "grants" in getattr(dependency_kind, "model_fields", {}):
+                dep_kwargs["grants"] = grants
+            dep = dependency_kind(**dep_kwargs)
 
             if identifier:
                 candidate = self._find_runtime_entity(

--- a/engine/src/tangl/story/fabula/materializer.py
+++ b/engine/src/tangl/story/fabula/materializer.py
@@ -962,7 +962,12 @@ class StoryMaterializer:
                 "requirement": requirement,
             }
             grants = spec.get("grants")
-            if grants is not None and "grants" in getattr(dependency_kind, "model_fields", {}):
+            if grants is not None:
+                if "grants" not in dependency_kind.model_fields:
+                    raise ValueError(
+                        f"{dependency_kind.__name__} dependency {label!r} does not "
+                        f"support grants"
+                    )
                 dep_kwargs["grants"] = grants
             dep = dependency_kind(**dep_kwargs)
 

--- a/engine/tests/story/test_role_grants.py
+++ b/engine/tests/story/test_role_grants.py
@@ -153,8 +153,7 @@ def test_grant_follows_swapped_provider() -> None:
     assert ns_b["boss"] is actor_b
     assert ns_b["boss_title"] == "boss"
     # Nothing was stamped onto the provider itself.
-    assert "title" not in actor_a.tags
-    assert not getattr(actor_a, "locals", {})
+    assert "title" not in actor_a.get_ns()
 
 
 def test_grant_disappears_when_binding_cleared() -> None:
@@ -264,6 +263,29 @@ def test_nearer_scope_role_without_grant_clears_parent_grant() -> None:
     assert "boss_title" not in ns
     assert "role_grants" not in ns
     assert "grants" not in ns
+
+
+def test_nearer_scope_unbound_role_inherits_parent_provider_and_grant() -> None:
+    # A nearer role that is *unbound* is an empty slot, not an override: the
+    # parent's bound provider and its grant show through, mirroring provider-symbol
+    # inheritance. (Contrast the bound case above, where the nearer binding does
+    # override and clear.)
+    graph, scene, block = _build_scene_with_block()
+    scene_actor = Actor(label="scene_boss", name="Scene Boss")
+    graph.add(scene_actor)
+
+    scene_role = _role("boss", scene, grants={"title": "scene-boss"})
+    block_role = _role("boss", block)  # nearer, unbound slot
+    graph.add(scene_role)
+    graph.add(block_role)
+    scene_role.set_provider(scene_actor)
+
+    ns = _gather(graph, block)
+
+    assert ns["boss"] is scene_actor
+    assert ns["boss_title"] == "scene-boss"
+    assert ns["role_grants"]["boss"].locals == {"title": "scene-boss"}
+    assert ns["grants"]["title"] == "scene-boss"
 
 
 # ---------------------------------------------------------------------------

--- a/engine/tests/story/test_role_grants.py
+++ b/engine/tests/story/test_role_grants.py
@@ -1,0 +1,321 @@
+"""Contract tests for provider-bound role grants (mu-affordances, phase 1).
+
+Covers grant materialization on an active binding, scope visibility, automatic
+removal/swap when the binding changes, and deterministic multi-binding
+precedence. See ``docs/src/notes/MU_AFFORDANCES.md`` and issue #141.
+"""
+
+from __future__ import annotations
+
+from tangl.story import InitMode, World
+from tangl.story.concepts import Actor, Role, RoleGrant
+from tangl.story.episode import Block, Scene
+from tangl.story.story_graph import StoryGraph
+from tangl.vm import Requirement
+from tangl.vm.runtime.frame import PhaseCtx
+
+
+def _build_scene_with_block() -> tuple[StoryGraph, Scene, Block]:
+    graph = StoryGraph(label="grant_story")
+    scene = Scene(label="scene")
+    block = Block(label="block")
+    graph.add(scene)
+    graph.add(block)
+    scene.add_child(block)
+    return graph, scene, block
+
+
+def _gather(graph: StoryGraph, block: Block) -> dict:
+    """Gather a fresh scoped namespace (a new ctx avoids per-ctx ns caching)."""
+    return PhaseCtx(graph=graph, cursor_id=block.uid).get_ns(block)
+
+
+def _role(label: str, predecessor: object, **kwargs) -> Role:
+    return Role(
+        label=label,
+        predecessor_id=predecessor.uid,
+        requirement=Requirement(has_kind=Actor, hard_requirement=False),
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# RoleGrant authoring shape
+# ---------------------------------------------------------------------------
+
+
+def test_role_grant_folds_flat_authoring_into_locals_and_tags() -> None:
+    grant = RoleGrant.model_validate({"title": "boss", "rank": 3, "tags": ["mgmt"], "priority": 2})
+
+    assert grant.locals == {"title": "boss", "rank": 3}
+    assert grant.tags == {"mgmt"}
+    assert grant.priority == 2
+    assert not grant.is_empty
+
+
+def test_role_grant_accepts_structured_authoring() -> None:
+    grant = RoleGrant.model_validate({"locals": {"title": "boss"}, "tags": ["a", "b"]})
+
+    assert grant.locals == {"title": "boss"}
+    assert grant.tags == {"a", "b"}
+    assert RoleGrant().is_empty
+
+
+# ---------------------------------------------------------------------------
+# Materialization on an active binding
+# ---------------------------------------------------------------------------
+
+
+def test_grant_projects_onto_bound_provider() -> None:
+    graph, scene, block = _build_scene_with_block()
+    actor = Actor(label="joe", name="Joe")
+    graph.add(actor)
+    role = _role("boss", scene, grants={"title": "boss", "tags": ["management"]})
+    graph.add(role)
+    role.set_provider(actor)
+
+    ns = _gather(graph, block)
+
+    # Label-scoped projection rides alongside the existing provider symbols.
+    assert ns["boss"] is actor
+    assert ns["boss_title"] == "boss"
+    assert ns["boss_tags"] == {"management"}
+    # Canonical per-binding accessor and merged scope views.
+    assert ns["role_grants"]["boss"].locals == {"title": "boss"}
+    assert ns["grants"] == {"title": "boss"}
+    assert ns["grant_tags"] == {"management"}
+
+
+def test_grant_overrides_same_named_provider_symbol() -> None:
+    graph, scene, block = _build_scene_with_block()
+    actor = Actor(label="joe", name="Joe")
+    graph.add(actor)
+    role = _role("boss", scene, grants={"name": "The Boss"})
+    graph.add(role)
+    role.set_provider(actor)
+
+    ns = _gather(graph, block)
+
+    # Grant is layered after provider.get_ns(), so it wins for a shared key.
+    assert ns["boss_name"] == "The Boss"
+
+
+def test_unbound_role_contributes_no_grant() -> None:
+    graph, scene, block = _build_scene_with_block()
+    role = _role("boss", scene, grants={"title": "boss"})
+    graph.add(role)  # never bound
+
+    ns = _gather(graph, block)
+
+    assert "boss_title" not in ns
+    assert "grants" not in ns
+    assert "role_grants" not in ns
+
+
+def test_role_without_grants_projects_nothing_extra() -> None:
+    graph, scene, block = _build_scene_with_block()
+    actor = Actor(label="joe", name="Joe")
+    graph.add(actor)
+    role = _role("boss", scene)
+    graph.add(role)
+    role.set_provider(actor)
+
+    ns = _gather(graph, block)
+
+    assert ns["boss"] is actor
+    assert "boss_title" not in ns
+    assert "grants" not in ns
+    assert "grant_tags" not in ns
+
+
+# ---------------------------------------------------------------------------
+# Rebinding / unbinding update the derived grants automatically
+# ---------------------------------------------------------------------------
+
+
+def test_grant_follows_swapped_provider() -> None:
+    graph, scene, block = _build_scene_with_block()
+    actor_a = Actor(label="amy", name="Amy")
+    actor_b = Actor(label="ben", name="Ben")
+    graph.add(actor_a)
+    graph.add(actor_b)
+    role = _role("boss", scene, grants={"title": "boss"})
+    graph.add(role)
+
+    role.set_provider(actor_a)
+    ns_a = _gather(graph, block)
+    assert ns_a["boss"] is actor_a
+    assert ns_a["boss_title"] == "boss"
+
+    role.set_provider(actor_b)
+    ns_b = _gather(graph, block)
+    # The overlay moves with the binding: it now decorates Ben, not Amy.
+    assert ns_b["boss"] is actor_b
+    assert ns_b["boss_title"] == "boss"
+    # Nothing was stamped onto the provider itself.
+    assert "title" not in actor_a.tags
+    assert not getattr(actor_a, "locals", {})
+
+
+def test_grant_disappears_when_binding_cleared() -> None:
+    graph, scene, block = _build_scene_with_block()
+    actor = Actor(label="joe", name="Joe")
+    graph.add(actor)
+    role = _role("boss", scene, grants={"title": "boss", "tags": ["mgmt"]})
+    graph.add(role)
+
+    role.set_provider(actor)
+    assert _gather(graph, block)["boss_title"] == "boss"
+
+    role.set_provider(None)
+    ns = _gather(graph, block)
+    assert "boss_title" not in ns
+    assert "boss_tags" not in ns
+    assert "grants" not in ns
+    assert "grant_tags" not in ns
+
+
+# ---------------------------------------------------------------------------
+# Multi-binding precedence
+# ---------------------------------------------------------------------------
+
+
+def test_merged_grants_resolve_same_key_by_priority() -> None:
+    graph, scene, block = _build_scene_with_block()
+    captain = Actor(label="cap", name="Cap")
+    deputy = Actor(label="dep", name="Dep")
+    graph.add(captain)
+    graph.add(deputy)
+
+    role_high = _role("captain", scene, grants={"clearance": "high", "priority": 10})
+    role_low = _role("deputy", scene, grants={"clearance": "low", "priority": 1})
+    graph.add(role_high)
+    graph.add(role_low)
+    role_high.set_provider(captain)
+    role_low.set_provider(deputy)
+
+    ns = _gather(graph, block)
+
+    # Same merged key -> higher priority wins; label-scoped keys stay distinct.
+    assert ns["grants"]["clearance"] == "high"
+    assert ns["captain_clearance"] == "high"
+    assert ns["deputy_clearance"] == "low"
+
+
+def test_merged_grant_tags_union_across_bindings() -> None:
+    graph, scene, block = _build_scene_with_block()
+    a = Actor(label="a", name="A")
+    b = Actor(label="b", name="B")
+    graph.add(a)
+    graph.add(b)
+
+    role_a = _role("alpha", scene, grants={"tags": ["x"]})
+    role_b = _role("beta", scene, grants={"tags": ["y"]})
+    graph.add(role_a)
+    graph.add(role_b)
+    role_a.set_provider(a)
+    role_b.set_provider(b)
+
+    ns = _gather(graph, block)
+
+    assert ns["grant_tags"] == {"x", "y"}
+
+
+def test_nearer_scope_grant_overrides_parent_scope() -> None:
+    graph, scene, block = _build_scene_with_block()
+    scene_actor = Actor(label="scene_boss", name="Scene Boss")
+    block_actor = Actor(label="block_boss", name="Block Boss")
+    graph.add(scene_actor)
+    graph.add(block_actor)
+
+    scene_role = _role("boss", scene, grants={"title": "scene-boss"})
+    block_role = _role("boss", block, grants={"title": "block-boss"})
+    graph.add(scene_role)
+    graph.add(block_role)
+    scene_role.set_provider(scene_actor)
+    block_role.set_provider(block_actor)
+
+    ns = _gather(graph, block)
+
+    # Nearer (block) binding wins for the shared label.
+    assert ns["boss"] is block_actor
+    assert ns["boss_title"] == "block-boss"
+    assert ns["role_grants"]["boss"].locals == {"title": "block-boss"}
+    assert ns["grants"]["title"] == "block-boss"
+
+
+def test_nearer_scope_role_without_grant_clears_parent_grant() -> None:
+    graph, scene, block = _build_scene_with_block()
+    scene_actor = Actor(label="scene_boss", name="Scene Boss")
+    block_actor = Actor(label="block_boss", name="Block Boss")
+    graph.add(scene_actor)
+    graph.add(block_actor)
+
+    scene_role = _role("boss", scene, grants={"title": "scene-boss"})
+    block_role = _role("boss", block)  # nearer binding, no grant
+    graph.add(scene_role)
+    graph.add(block_role)
+    scene_role.set_provider(scene_actor)
+    block_role.set_provider(block_actor)
+
+    ns = _gather(graph, block)
+
+    assert ns["boss"] is block_actor
+    assert "boss_title" not in ns
+    assert "role_grants" not in ns
+    assert "grants" not in ns
+
+
+# ---------------------------------------------------------------------------
+# Authoring round-trip through compile + materialize
+# ---------------------------------------------------------------------------
+
+
+def _grant_script() -> dict:
+    return {
+        "label": "grant_demo",
+        "metadata": {"title": "Grant Demo", "start_at": "intro.start"},
+        "actors": {
+            "guard": {"name": "Joe", "kind": "tangl.story.concepts.actor.actor.Actor"},
+        },
+        "scenes": {
+            "intro": {
+                "blocks": {
+                    "start": {
+                        "content": "Start",
+                        "roles": [
+                            {
+                                "label": "host",
+                                "actor_ref": "guard",
+                                "grants": {"title": "boss", "tags": ["management"]},
+                            }
+                        ],
+                    },
+                },
+            }
+        },
+    }
+
+
+def test_authored_grants_materialize_onto_role_binding() -> None:
+    world = World.from_script_data(script_data=_grant_script())
+    result = world.create_story("grant_run", init_mode=InitMode.EAGER)
+    graph = result.graph
+
+    from tangl.core import Selector
+
+    role = next(iter(Selector(has_kind=Role).filter(graph.values())))
+    assert role.grants is not None
+    assert role.grants.locals == {"title": "boss"}
+    assert role.grants.tags == {"management"}
+    assert role.satisfied
+
+    block = next(
+        node
+        for node in Selector(has_kind=Block).filter(graph.values())
+        if node.get_label().endswith("start")
+    )
+    ns = PhaseCtx(graph=graph, cursor_id=block.uid).get_ns(block)
+    assert ns["host_title"] == "boss"
+    assert ns["host_tags"] == {"management"}
+    assert ns["grants"] == {"title": "boss"}


### PR DESCRIPTION
## Summary

Implements **mu-affordances phase 1** (#141): provider-bound grants that ride an active `Role` binding. When a role's provider is resolved, the role's authored `RoleGrant` (title / rank / badge scalars + derived tags) is projected as a **derived** namespace overlay — never stamped onto the provider, and automatically updated when the binding is swapped or cleared.

This is the **first conformance consumer** of the broader **Facet** model: `RoleGrant ≡ Facet(channel=ns, effect=affordance)`. The design work it triggered is captured in the spec re-expansion that rides along (`docs/src/notes/MU_AFFORDANCES.md`, v0.3).

## What's in it

- `RoleGrant` value object (`locals` / `tags` / `priority`) with flat authoring fold; `Role.grants` field.
- `contribute_roles` projects, while the provider is bound: `{label}_{key}` scalars, `{label}_tags`, a per-binding `role_grants` accessor, and merged `grants` / `grant_tags` scope views.
- Deterministic precedence: nearer-scope binding overrides/clears; merged keys resolve by `priority`; tags union.
- YAML authoring via the role `grants:` key (RoleScript → materializer, guarded so only grant-capable carriers receive it).
- Spec re-expansion to the unified **Facet** model: affordance/dependency polarity (the micro mirror of the graph Affordance/Dependency duality), channels, per-consumer folds, the Stormbringer end-to-end worked example, a world-level pre-flight coverage check, and load-bearing decisions parked for the Phase-2 core promotion.

## #141 "Done when" — all met

- [x] A role/relationship carrier can declare provider-bound grants
- [x] The bound provider exposes the effective derived values without manual mutation bookkeeping
- [x] Rebinding or unlinking updates the effective grants automatically
- [x] Tests cover add, swap, remove, and multi-binding precedence

## Tests

`engine/tests/story/test_role_grants.py` — authoring shape, materialize / swap / remove, multi-binding precedence, scope override + clear, and a compile→materialize authoring round-trip. Full `engine/tests` suite green (2584 passed).

## Notes for review

- One deliberate semantic to watch: the merged `grants` / `grant_tags` views merge **scope-wide**; the generalized Facet model favors a **per-subject** merge. Kept (it is #141's stated precedence deliverable) and signposted in code + spec as provisional, not the final contract.
- No behavior change outside the new grant path; phase-1 is a clean degenerate of the Facet model, so it rolls into the unified plan without rework.

Refs #141, #280, #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Role grants now support provider-bound overlays with configurable tags, priority levels, and local variables.

* **Documentation**
  * Updated Facet model documentation reflecting revised architecture, semantics, and implementation strategy.

* **Tests**
  * Added comprehensive test suite covering role grants parsing, materialization, override behavior, and scope precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->