### PR TITLE
Add component facet assembly slices

### DIFF
--- a/engine/src/tangl/mechanics/assembly/__init__.py
+++ b/engine/src/tangl/mechanics/assembly/__init__.py
@@ -4,9 +4,13 @@ Composable loadout containers built on :class:`tangl.core.Selector`.
 
 from .base import HasResourceCost, HasSlottedContainer, SlottedContainer
 from .budget import BudgetTracker, ResourceBudget
+from .component import Component, ComponentFacet, ConnectorPolarity
 from .slot import Slot, SlotGroup
 
 __all__ = [
+    "Component",
+    "ComponentFacet",
+    "ConnectorPolarity",
     "HasResourceCost",
     "HasSlottedContainer",
     "SlottedContainer",

--- a/engine/src/tangl/mechanics/assembly/base.py
+++ b/engine/src/tangl/mechanics/assembly/base.py
@@ -106,7 +106,7 @@ class SlottedContainer(BaseModel, Generic[CT]):
     def fold_giver_payloads(
         self: "SlottedContainer[FacetComponentT]",
         channel: str,
-    ) -> list[Any]:
+    ) -> list[object | None]:
         """Return payloads from active ``giver`` facets on one channel."""
 
         return [
@@ -117,18 +117,32 @@ class SlottedContainer(BaseModel, Generic[CT]):
     def materialize_defaults(self) -> list[CT]:
         """Opt-in population of enabled empty slots that declare defaults."""
 
+        pending = [
+            slot_name
+            for slot_name, slot in self.slots.items()
+            if slot.default_factory is not None and not self.assignments.get(slot_name)
+        ]
         materialized: list[CT] = []
-        for slot_name, slot in self.slots.items():
-            if self.assignments.get(slot_name):
-                continue
-            if slot.default_factory is None:
-                continue
-            if not self.is_slot_enabled(slot_name):
-                continue
+        while pending:
+            progressed = False
+            for slot_name in list(pending):
+                slot = self.slots[slot_name]
+                if self.assignments.get(slot_name) or not self.is_slot_enabled(slot_name):
+                    pending.remove(slot_name)
+                    continue
+                if any(
+                    not self.assignments.get(prerequisite)
+                    for prerequisite in slot.prerequisite_slots
+                ):
+                    continue
 
-            component = cast(CT, slot.default_factory())
-            self.assign(slot_name, component)
-            materialized.append(component)
+                component = cast(CT, slot.default_factory())
+                self.assign(slot_name, component)
+                materialized.append(component)
+                pending.remove(slot_name)
+                progressed = True
+            if not progressed:
+                break
         return materialized
 
     def get_aggregate(self, name: str, default: float = 0.0) -> float:

--- a/engine/src/tangl/mechanics/assembly/base.py
+++ b/engine/src/tangl/mechanics/assembly/base.py
@@ -3,16 +3,18 @@ from __future__ import annotations
 from collections import defaultdict
 from enum import Enum
 from numbers import Real
-from typing import Any, ClassVar, Generic, Optional, Protocol, TypeVar
+from typing import Any, ClassVar, Generic, Optional, Protocol, TypeVar, cast
 
 from pydantic import BaseModel, Field, model_validator
 
-from tangl.core import Entity
+from tangl.core import Entity, Selector
 from tangl.type_hints import Tag
 from .budget import BudgetTracker
+from .component import Component, ComponentFacet
 from .slot import Slot, SlotGroup
 
 CT = TypeVar("CT", bound=Entity)
+FacetComponentT = TypeVar("FacetComponentT", bound=Component)
 
 
 class HasResourceCost(Protocol):
@@ -53,7 +55,7 @@ class SlottedContainer(BaseModel, Generic[CT]):
     def assign(self, slot_name: str, component: CT) -> None:
         can_assign, reason = self.can_assign(slot_name, component)
         if not can_assign:
-            raise ValueError(f"Cannot assign {getattr(component, 'label', component)!r} to {slot_name}: {reason}")
+            raise ValueError(f"Cannot assign {component.label!r} to {slot_name}: {reason}")
 
         self.assignments[slot_name].append(component)
 
@@ -77,6 +79,57 @@ class SlottedContainer(BaseModel, Generic[CT]):
         for components in self.assignments.values():
             result.extend(components)
         return result
+
+    def component_facets(
+        self: "SlottedContainer[FacetComponentT]",
+        *,
+        channel: str | None = None,
+        facet_type: str | None = None,
+    ) -> list[ComponentFacet]:
+        """Discover matching facets from currently assigned components."""
+
+        facets: list[ComponentFacet] = []
+        slot_names = list(self.slots)
+        slot_names.extend(name for name in self.assignments if name not in self.slots)
+        for slot_name in slot_names:
+            components = self.assignments.get(slot_name, [])
+            for component in components:
+                facets.extend(
+                    component.component_facets(
+                        channel=channel,
+                        facet_type=facet_type,
+                        subject_id=slot_name,
+                    )
+                )
+        return facets
+
+    def fold_giver_payloads(
+        self: "SlottedContainer[FacetComponentT]",
+        channel: str,
+    ) -> list[Any]:
+        """Return payloads from active ``giver`` facets on one channel."""
+
+        return [
+            facet.payload
+            for facet in self.component_facets(channel=channel, facet_type="giver")
+        ]
+
+    def materialize_defaults(self) -> list[CT]:
+        """Opt-in population of enabled empty slots that declare defaults."""
+
+        materialized: list[CT] = []
+        for slot_name, slot in self.slots.items():
+            if self.assignments.get(slot_name):
+                continue
+            if slot.default_factory is None:
+                continue
+            if not self.is_slot_enabled(slot_name):
+                continue
+
+            component = cast(CT, slot.default_factory())
+            self.assign(slot_name, component)
+            materialized.append(component)
+        return materialized
 
     def get_aggregate(self, name: str, default: float = 0.0) -> float:
         """Sum one direct numeric attribute across assigned components.
@@ -154,9 +207,20 @@ class SlottedContainer(BaseModel, Generic[CT]):
             return False, f"No such slot: {slot_name}"
 
         slot = self.slots[slot_name]
+        if not self.is_slot_enabled(slot_name):
+            return False, f"Slot disabled: {slot_name}"
+
         selects, reason = slot.selects_for(component)
         if not selects:
             return False, reason
+
+        missing_prerequisites = [
+            prerequisite
+            for prerequisite in slot.prerequisite_slots
+            if not self.assignments.get(prerequisite)
+        ]
+        if missing_prerequisites:
+            return False, f"Missing prerequisite slots: {', '.join(missing_prerequisites)}"
 
         current_count = len(self.assignments.get(slot_name, []))
         if current_count >= slot.max_count:
@@ -170,12 +234,32 @@ class SlottedContainer(BaseModel, Generic[CT]):
 
         return True, ""
 
+    def is_slot_enabled(self, slot_name: str) -> bool:
+        if slot_name not in self.slots:
+            raise KeyError(f"No such slot: {slot_name}")
+
+        slot = self.slots[slot_name]
+        if not slot.enablement_criteria:
+            return True
+        if self.owner is None:
+            return False
+        return Selector(**slot.enablement_criteria).matches(self.owner)
+
     def validate(self) -> list[str]:
         errors: list[str] = []
 
         for slot_name, slot in self.slots.items():
-            if slot.required and not self.assignments.get(slot_name):
+            enabled = self.is_slot_enabled(slot_name)
+            if not enabled and self.assignments.get(slot_name):
+                errors.append(f"Disabled slot occupied: {slot_name}")
+            if enabled and slot.required and not self.assignments.get(slot_name):
                 errors.append(f"Required slot empty: {slot_name}")
+            if enabled and self.assignments.get(slot_name):
+                for prerequisite in slot.prerequisite_slots:
+                    if not self.assignments.get(prerequisite):
+                        errors.append(
+                            f"Slot '{slot_name}' missing prerequisite slot: {prerequisite}"
+                        )
 
         for group in self.slot_groups:
             total = sum(len(self.assignments.get(name, [])) for name in group.slot_names)

--- a/engine/src/tangl/mechanics/assembly/component.py
+++ b/engine/src/tangl/mechanics/assembly/component.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -14,7 +14,7 @@ class ComponentFacet(BaseModel):
 
     channel: str
     facet_type: str
-    payload: Any = None
+    payload: object | None = None
     source_id: str | None = None
     subject_id: str | None = None
 

--- a/engine/src/tangl/mechanics/assembly/component.py
+++ b/engine/src/tangl/mechanics/assembly/component.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from tangl.core import Entity
+
+ConnectorPolarity = Literal["plug", "socket"]
+
+
+class ComponentFacet(BaseModel):
+    """Lightweight context-bound contribution carried by an assembly component."""
+
+    channel: str
+    facet_type: str
+    payload: Any = None
+    source_id: str | None = None
+    subject_id: str | None = None
+
+    def matches(self, channel: str | None = None, facet_type: str | None = None) -> bool:
+        """Return whether this facet matches the requested coordinate."""
+
+        if channel is not None and self.channel != channel:
+            return False
+        if facet_type is not None and self.facet_type != facet_type:
+            return False
+        return True
+
+    def with_provenance(
+        self,
+        *,
+        source_id: str | None = None,
+        subject_id: str | None = None,
+    ) -> "ComponentFacet":
+        """Return a derived copy with missing provenance filled in."""
+
+        return self.model_copy(
+            update={
+                "source_id": self.source_id or source_id,
+                "subject_id": self.subject_id or subject_id,
+            }
+        )
+
+
+class Component(Entity):
+    """Assembly component that carries facets and optional connector metadata."""
+
+    facets: list[ComponentFacet] = Field(default_factory=list)
+    connector_shape: str | None = None
+    connector_polarity: ConnectorPolarity | None = None
+
+    def component_facets(
+        self,
+        *,
+        channel: str | None = None,
+        facet_type: str | None = None,
+        subject_id: str | None = None,
+    ) -> list[ComponentFacet]:
+        """Return matching facets with derived source/subject provenance."""
+
+        source_id = str(self.uid)
+        return [
+            facet.with_provenance(source_id=source_id, subject_id=subject_id)
+            for facet in self.facets
+            if facet.matches(channel=channel, facet_type=facet_type)
+        ]

--- a/engine/src/tangl/mechanics/assembly/slot.py
+++ b/engine/src/tangl/mechanics/assembly/slot.py
@@ -6,6 +6,8 @@ from pydantic import BaseModel, Field
 
 from tangl.core import Entity, Selector
 
+from .component import Component, ConnectorPolarity
+
 
 class Slot(BaseModel):
     """Slot(name: str, selection_criteria: dict[str, Any], max_count: int = 1, required: bool = False)
@@ -32,6 +34,11 @@ class Slot(BaseModel):
     selection_criteria: dict[str, Any] = Field(default_factory=dict)
     max_count: int = 1
     required: bool = False
+    connector_shape: str | None = None
+    connector_polarity: ConnectorPolarity | None = None
+    prerequisite_slots: list[str] = Field(default_factory=list)
+    enablement_criteria: dict[str, Any] = Field(default_factory=dict)
+    default_factory: Callable[[], Entity] | None = Field(default=None, exclude=True)
 
     def selects_for(self, component: Entity) -> tuple[bool, str]:
         """Return whether ``component`` satisfies the slot's criteria.
@@ -48,13 +55,36 @@ class Slot(BaseModel):
             a human-readable explanation.
         """
 
-        try:
-            selector = Selector(**self.selection_criteria)
-            if selector.matches(component):
-                return True, ""
+        selector = Selector(**self.selection_criteria)
+        if not selector.matches(component):
             return False, f"Component doesn't match criteria: {self.selection_criteria}"
-        except Exception as exc:  # pragma: no cover - defensive logging
-            return False, f"Error matching: {exc}"
+
+        return self._selects_connector_for(component)
+
+    def _selects_connector_for(self, component: Entity) -> tuple[bool, str]:
+        if self.connector_shape is None and self.connector_polarity is None:
+            return True, ""
+
+        if not isinstance(component, Component):
+            return False, "Component has no assembly connector"
+
+        if self.connector_shape is not None and component.connector_shape != self.connector_shape:
+            return (
+                False,
+                f"Connector shape mismatch: {component.connector_shape} != {self.connector_shape}",
+            )
+
+        if self.connector_polarity is not None:
+            if component.connector_polarity is None:
+                return False, "Component has no connector polarity"
+
+            if component.connector_polarity == self.connector_polarity:
+                return (
+                    False,
+                    f"Connector polarity mismatch: both are {self.connector_polarity}",
+                )
+
+        return True, ""
 
     @classmethod
     def for_type(

--- a/engine/src/tangl/mechanics/presence/ornaments/ornaments.py
+++ b/engine/src/tangl/mechanics/presence/ornaments/ornaments.py
@@ -11,7 +11,8 @@ to each actor's body.
 
 from __future__ import annotations
 from collections import defaultdict
-from typing import Any
+
+from collections.abc import Sequence
 
 from pydantic import Field
 
@@ -21,6 +22,8 @@ from tangl.core import Entity, Node
 from tangl.lang.helpers import oxford_join
 from tangl.lang.body_parts import BodyPart, BodyRegion
 from .enums import OrnamentType
+
+CoveredRegion = BodyRegion | BodyPart | str
 
 
 class Ornament(Entity):
@@ -91,9 +94,12 @@ class Ornamentation(Node):
 
     collection: list[Ornament] = Field(default_factory=list)
 
-    def by_part_type(self, covered_regions: list[Any] = None) -> dict[tuple[OrnamentType, BodyPart], list[Ornament]]:
+    @staticmethod
+    def _covered_mask(
+        covered_regions: Sequence[CoveredRegion] | None = None,
+        covered_mask: BodyPart = BodyPart.NONE,
+    ) -> BodyPart:
         covered_regions = covered_regions or []
-        covered_mask = BodyPart.NONE
         for region in covered_regions:
             if isinstance(region, BodyRegion):
                 covered_mask |= region.to_part_mask()
@@ -107,7 +113,15 @@ class Ornamentation(Node):
                 resolved_part = BodyPart._missing_(region)
                 if isinstance(resolved_part, BodyPart):
                     covered_mask |= resolved_part
+        return covered_mask
 
+    def by_part_type(
+        self,
+        covered_regions: Sequence[CoveredRegion] | None = None,
+        *,
+        covered_mask: BodyPart = BodyPart.NONE,
+    ) -> dict[tuple[OrnamentType, BodyPart], list[Ornament]]:
+        covered_mask = self._covered_mask(covered_regions or [], covered_mask)
         res = defaultdict(list)
         for ornament in self.collection:
             if covered_mask and bool(ornament.body_part & covered_mask):
@@ -126,10 +140,15 @@ class Ornamentation(Node):
     # def __bool__(self):
     #     return len(self.ornaments) > 0
 
-    def describe_items(self, *, possessive: str = "their") -> list[str]:
+    def describe_items(
+        self,
+        *,
+        possessive: str = "their",
+        covered_regions: Sequence[CoveredRegion] | None = None,
+        covered_mask: BodyPart = BodyPart.NONE,
+    ) -> list[str]:
         """Return concise ornament phrases suitable for appearance summaries."""
-        covered_regions: list[Any] = []
-        grouped = self.by_part_type(covered_regions)
+        grouped = self.by_part_type(covered_regions, covered_mask=covered_mask)
 
         items: list[str] = []
         for (ornament_type, body_part), ornaments in sorted(
@@ -146,13 +165,34 @@ class Ornamentation(Node):
             )
         return items
 
-    def describe_summary(self, *, possessive: str = "their") -> str:
+    def describe_summary(
+        self,
+        *,
+        possessive: str = "their",
+        covered_regions: Sequence[CoveredRegion] | None = None,
+        covered_mask: BodyPart = BodyPart.NONE,
+    ) -> str:
         """Return a compact joined ornament summary without sentence framing."""
-        return oxford_join(self.describe_items(possessive=possessive))
+        return oxford_join(
+            self.describe_items(
+                possessive=possessive,
+                covered_regions=covered_regions,
+                covered_mask=covered_mask,
+            )
+        )
 
     # @on_render.register()
-    def describe(self) -> dict[str, str]:
-        summary = self.describe_summary(possessive="their")
+    def describe(
+        self,
+        *,
+        covered_regions: Sequence[CoveredRegion] | None = None,
+        covered_mask: BodyPart = BodyPart.NONE,
+    ) -> dict[str, str]:
+        summary = self.describe_summary(
+            possessive="their",
+            covered_regions=covered_regions,
+            covered_mask=covered_mask,
+        )
         if not summary:
             return {"ornaments": ""}
         return {"ornaments": f"They have {summary}."}

--- a/engine/src/tangl/mechanics/presence/outfit.py
+++ b/engine/src/tangl/mechanics/presence/outfit.py
@@ -33,8 +33,8 @@ class OutfitManager(SlottedContainer[Wearable]):
             name=f"{region.name.lower()}_{layer.value}",
             selection_criteria={
                 "predicate": (
-                    lambda wearable, r=region, l=layer.value: (
-                        r in wearable.covers and wearable.layer.value <= l
+                    lambda wearable, r=region, layer_value=layer.value: (
+                        r in wearable.covers and wearable.layer.value <= layer_value
                     )
                 )
             },
@@ -79,6 +79,8 @@ class OutfitManager(SlottedContainer[Wearable]):
         for component in self.components():
             if component.state != WearableState.ON:
                 continue
+            if component.layer < WearableLayer.INNER:
+                continue
             for region in component.covers:
                 mask |= region.to_part_mask()
         return mask
@@ -88,6 +90,8 @@ class OutfitManager(SlottedContainer[Wearable]):
         regions: set[BodyRegion] = set()
         for component in self.components():
             if component.state != WearableState.ON:
+                continue
+            if component.layer < WearableLayer.INNER:
                 continue
             regions.update(component.covers)
         return sorted(regions, key=lambda region: region.name)
@@ -108,7 +112,7 @@ class OutfitManager(SlottedContainer[Wearable]):
             for idx, item in enumerate(items_here[:-1]):
                 if item.state == WearableState.OPEN:
                     covering_item = items_here[idx + 1]
-                    if covering_item.state == WearableState.CLOSED:
+                    if covering_item.state == WearableState.ON:
                         errors.append(
                             f"{item.label} is open but covered by closed {covering_item.label}"
                         )

--- a/engine/src/tangl/mechanics/presence/outfit.py
+++ b/engine/src/tangl/mechanics/presence/outfit.py
@@ -64,9 +64,9 @@ class OutfitManager(SlottedContainer[Wearable]):
     def describe_items(self) -> list[str]:
         """Return concise wearable labels suitable for prose or prompt adapters."""
         return [
-            component.render_desc()
+            desc
             for component in self.components()
-            if component.render_desc()
+            if (desc := component.render_desc())
         ]
 
     def describe(self) -> str:
@@ -79,7 +79,7 @@ class OutfitManager(SlottedContainer[Wearable]):
         for component in self.components():
             if component.state != WearableState.ON:
                 continue
-            for region in sorted(component.covers, key=lambda region: region.name):
+            for region in component.covers:
                 mask |= region.to_part_mask()
         return mask
 

--- a/engine/src/tangl/mechanics/presence/outfit.py
+++ b/engine/src/tangl/mechanics/presence/outfit.py
@@ -10,10 +10,10 @@ facets such as `look`. It belongs in the `presence` family rather than behind an
 from __future__ import annotations
 
 from tangl.lang.helpers import oxford_join
-from tangl.lang.body_parts import BodyRegion
+from tangl.lang.body_parts import BodyPart, BodyRegion
 from tangl.mechanics.assembly import Slot, SlottedContainer
 from tangl.mechanics.presence.wearable import Wearable
-from tangl.mechanics.presence.wearable.enums import WearableLayer
+from tangl.mechanics.presence.wearable.enums import WearableLayer, WearableState
 
 
 class OutfitManager(SlottedContainer[Wearable]):
@@ -33,7 +33,9 @@ class OutfitManager(SlottedContainer[Wearable]):
             name=f"{region.name.lower()}_{layer.value}",
             selection_criteria={
                 "predicate": (
-                    lambda wearable, r=region, l=layer.value: r in wearable.covers and wearable.layer.value <= l
+                    lambda wearable, r=region, l=layer.value: (
+                        r in wearable.covers and wearable.layer.value <= l
+                    )
                 )
             },
             max_count=3,
@@ -61,11 +63,34 @@ class OutfitManager(SlottedContainer[Wearable]):
 
     def describe_items(self) -> list[str]:
         """Return concise wearable labels suitable for prose or prompt adapters."""
-        return [component.render_desc() for component in self.components() if component.render_desc()]
+        return [
+            component.render_desc()
+            for component in self.components()
+            if component.render_desc()
+        ]
 
     def describe(self) -> str:
         """Return a compact phrase describing the current outfit."""
         return oxford_join(self.describe_items())
+
+    def covered_mask(self) -> BodyPart:
+        """Return the fine body-part mask covered by currently worn components."""
+        mask = BodyPart.NONE
+        for component in self.components():
+            if component.state != WearableState.ON:
+                continue
+            for region in sorted(component.covers, key=lambda region: region.name):
+                mask |= region.to_part_mask()
+        return mask
+
+    def covered_regions(self) -> list[BodyRegion]:
+        """Return coarse regions overlapped by currently worn components."""
+        regions: set[BodyRegion] = set()
+        for component in self.components():
+            if component.state != WearableState.ON:
+                continue
+            regions.update(component.covers)
+        return sorted(regions, key=lambda region: region.name)
 
     def _validate_custom(self) -> list[str]:
         errors: list[str] = []
@@ -75,13 +100,15 @@ class OutfitManager(SlottedContainer[Wearable]):
             errors.append(f"Need 3+ uniform pieces (have {uniform_count})")
 
         for region in BodyRegion:
-            items_here = [component for component in self.components() if region in component.covers]
+            items_here = [
+                component for component in self.components() if region in component.covers
+            ]
             items_here.sort(key=lambda wearable: wearable.layer.value)
 
             for idx, item in enumerate(items_here[:-1]):
-                if getattr(item, "state", None) and item.state.name == "OPEN":
+                if item.state == WearableState.OPEN:
                     covering_item = items_here[idx + 1]
-                    if getattr(covering_item, "state", None) and covering_item.state.name == "CLOSED":
+                    if covering_item.state == WearableState.CLOSED:
                         errors.append(
                             f"{item.label} is open but covered by closed {covering_item.label}"
                         )

--- a/engine/tests/mechanics/presence/test_ornament.py
+++ b/engine/tests/mechanics/presence/test_ornament.py
@@ -1,13 +1,21 @@
+from collections.abc import Iterator
+
 import pytest
 
 from tangl.lang.body_parts import BodyPart, BodyRegion
 from tangl.mechanics.presence.ornaments import Ornamentation, Ornament, OrnamentType
 from tangl.mechanics.presence.outfit import OutfitManager
-from tangl.mechanics.presence.wearable import Wearable, WearableLayer, WearableType
+from tangl.mechanics.presence.wearable import (
+    Wearable,
+    WearableLayer,
+    WearableState,
+    WearableType,
+)
 
 
 @pytest.fixture(autouse=True)
-def reset_wearable_types():
+def reset_wearable_types() -> Iterator[None]:
+    """Reset wearable singleton fixtures around each test."""
     WearableType.clear_instances()
     yield
     WearableType.clear_instances()
@@ -131,3 +139,42 @@ def test_outfit_coverage_hides_arm_tattoo_but_not_face_mark() -> None:
 
     assert "crescent" in summary
     assert "dragon" not in summary
+
+
+def test_body_layer_wearables_do_not_hide_ornaments() -> None:
+    marking_type = WearableType(
+        label="ornament_body_marking",
+        noun="body marking",
+        covers={BodyRegion.TOP},
+        layer=WearableLayer.BODY,
+    )
+    outfit = OutfitManager()
+    outfit.assign("top_20", Wearable(token_from=marking_type.label))
+
+    assert outfit.covered_mask() == BodyPart.NONE
+    assert outfit.covered_regions() == []
+
+
+def test_open_inner_wearable_under_worn_outer_layer_is_invalid() -> None:
+    shirt_type = WearableType(
+        label="ornament_open_shirt",
+        noun="shirt",
+        covers={BodyRegion.TOP},
+        layer=WearableLayer.INNER,
+    )
+    coat_type = WearableType(
+        label="ornament_closed_coat",
+        noun="coat",
+        covers={BodyRegion.TOP},
+        layer=WearableLayer.OUTER,
+    )
+    outfit = OutfitManager()
+    outfit.assign(
+        "top_40",
+        Wearable(token_from=shirt_type.label, state=WearableState.OPEN),
+    )
+    outfit.assign("top_60", Wearable(token_from=coat_type.label))
+
+    assert outfit.validate() == [
+        "ornament_open_shirt is open but covered by closed ornament_closed_coat"
+    ]

--- a/engine/tests/mechanics/presence/test_ornament.py
+++ b/engine/tests/mechanics/presence/test_ornament.py
@@ -1,8 +1,17 @@
+import pytest
 
 from tangl.lang.body_parts import BodyPart, BodyRegion
 from tangl.mechanics.presence.ornaments import Ornamentation, Ornament, OrnamentType
+from tangl.mechanics.presence.outfit import OutfitManager
+from tangl.mechanics.presence.wearable import Wearable, WearableLayer, WearableType
 
-import pytest
+
+@pytest.fixture(autouse=True)
+def reset_wearable_types():
+    WearableType.clear_instances()
+    yield
+    WearableType.clear_instances()
+
 
 def test_ornaments():
 
@@ -71,8 +80,54 @@ def test_ornament_descriptions_are_neutral_and_filter_covered_regions():
     assert orn.describe()["ornaments"].startswith("They have ")
 
 
-@pytest.mark.xfail(reason="Need to write", raises=NotImplementedError)
-def test_ornament_details():
-    # todo: - visibility by outfit coverage
-    #       - desc by part vs. by type
-    raise NotImplementedError
+def test_covered_mask_hides_arm_tattoo_but_not_face_mark() -> None:
+    face_scar = Ornament(
+        body_part=BodyPart.FACE,
+        ornament_type=OrnamentType.SCAR,
+        text="a grim scar",
+    )
+    arm_tattoo = Ornament(
+        body_part=BodyPart.RIGHT_ARM,
+        ornament_type=OrnamentType.TATTOO,
+        text="a dragon",
+    )
+    ornaments = Ornamentation(collection=[face_scar, arm_tattoo])
+
+    summary = ornaments.describe_summary(covered_mask=BodyPart.TOP)
+
+    assert "scars" in summary
+    assert "dragon" not in summary
+
+
+def test_outfit_coverage_hides_arm_tattoo_but_not_face_mark() -> None:
+    shirt_type = WearableType(
+        label="ornament_test_shirt",
+        noun="shirt",
+        covers={BodyRegion.TOP},
+        layer=WearableLayer.OUTER,
+    )
+    outfit = OutfitManager()
+    outfit.assign("top_60", Wearable(token_from=shirt_type.label))
+
+    ornaments = Ornamentation(
+        collection=[
+            Ornament(
+                body_part=BodyPart.FACE,
+                ornament_type=OrnamentType.MARKER,
+                text="a blue crescent",
+            ),
+            Ornament(
+                body_part=BodyPart.RIGHT_ARM,
+                ornament_type=OrnamentType.TATTOO,
+                text="a dragon",
+            ),
+        ]
+    )
+
+    assert outfit.covered_mask() == BodyPart.TOP
+    assert outfit.covered_regions() == [BodyRegion.TOP]
+
+    summary = ornaments.describe_summary(covered_mask=outfit.covered_mask())
+
+    assert "crescent" in summary
+    assert "dragon" not in summary

--- a/engine/tests/mechanics/test_assembly.py
+++ b/engine/tests/mechanics/test_assembly.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import ClassVar
+from typing import ClassVar, Literal
 
 import pytest
 from pydantic import Field
@@ -10,6 +10,7 @@ from tangl.core import Entity
 from tangl.mechanics.assembly import (
     Component,
     ComponentFacet,
+    ConnectorPolarity,
     HasSlottedContainer,
     Slot,
     SlotGroup,
@@ -112,6 +113,22 @@ class DefaultLoadoutContainer(SlottedContainer[TestComponent]):
     }
 
 
+class OutOfOrderDefaultLoadoutContainer(SlottedContainer[TestComponent]):
+    slots: ClassVar[dict[str, Slot]] = {
+        "powerplant": Slot.for_tags(
+            "powerplant",
+            tags={"powerplant"},
+            prerequisite_slots=["chassis"],
+            default_factory=lambda: TestComponent(label="starter-motor", tags={"powerplant"}),
+        ),
+        "chassis": Slot.for_tags(
+            "chassis",
+            tags={"chassis"},
+            default_factory=lambda: TestComponent(label="starter-frame", tags={"chassis"}),
+        ),
+    }
+
+
 class ShapeComponent(Component):
     weight_cost: float = 0.0
 
@@ -206,8 +223,8 @@ def component_beta() -> TestComponent:
 def shape_plug(
     shape: str,
     *,
-    polarity: str = "plug",
-    challenge_op: str | None = None,
+    polarity: ConnectorPolarity = "plug",
+    challenge_op: Literal["add", "multiply", "subtract"] | None = None,
     challenge_value: float | None = None,
     weight_cost: float = 0.0,
 ) -> ShapeComponent:
@@ -481,6 +498,19 @@ def test_materialize_defaults_skips_disabled_slots_and_keeps_existing_assignment
     assert container.get_slot("chassis") == [custom_frame]
     assert container.get_slot("powerplant")[0].label == "starter-motor"
     assert container.get_slot("turret") == []
+
+
+def test_materialize_defaults_handles_out_of_order_prerequisite_defaults() -> None:
+    container = OutOfOrderDefaultLoadoutContainer()
+
+    materialized = container.materialize_defaults()
+
+    assert [component.label for component in materialized] == [
+        "starter-frame",
+        "starter-motor",
+    ]
+    assert container.get_slot("chassis")[0].label == "starter-frame"
+    assert container.get_slot("powerplant")[0].label == "starter-motor"
 
 
 def test_shape_board_star_plug_seats_in_star_socket() -> None:

--- a/engine/tests/mechanics/test_assembly.py
+++ b/engine/tests/mechanics/test_assembly.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import ClassVar
 
 import pytest
 from pydantic import Field
 
 from tangl.core import Entity
-from tangl.mechanics.assembly import HasSlottedContainer, Slot, SlotGroup, SlottedContainer
+from tangl.mechanics.assembly import (
+    Component,
+    ComponentFacet,
+    HasSlottedContainer,
+    Slot,
+    SlotGroup,
+    SlottedContainer,
+)
 
 
 class LoadoutTag(Enum):
@@ -30,12 +38,14 @@ class TestComponent(Entity):
 
 
 class TestContainer(SlottedContainer[TestComponent]):
-    slots = {
+    slots: ClassVar[dict[str, Slot]] = {
         "alpha": Slot.for_type("alpha", TestComponent, tags={"alpha"}, required=True),
         "beta": Slot.for_tags("beta", tags={"beta"}, max_count=2),
     }
-    slot_groups = [SlotGroup(name="group", slot_names=["alpha", "beta"], min_total=1, max_total=3)]
-    tracked_resources = ["power"]
+    slot_groups: ClassVar[list[SlotGroup]] = [
+        SlotGroup(name="group", slot_names=["alpha", "beta"], min_total=1, max_total=3)
+    ]
+    tracked_resources: ClassVar[list[str]] = ["power"]
 
     def _validate_custom(self) -> list[str]:
         errors = super()._validate_custom()
@@ -49,6 +59,140 @@ class TestHost(HasSlottedContainer, Entity):
     max_power: float = 2.0
 
 
+class PrerequisiteContainer(SlottedContainer[TestComponent]):
+    slots: ClassVar[dict[str, Slot]] = {
+        "chassis": Slot.for_tags("chassis", tags={"chassis"}),
+        "powerplant": Slot.for_tags(
+            "powerplant",
+            tags={"powerplant"},
+            prerequisite_slots=["chassis"],
+        ),
+        "turret": Slot.for_tags(
+            "turret",
+            tags={"turret"},
+            prerequisite_slots=["powerplant"],
+        ),
+    }
+
+
+class ConditionalHost(Entity):
+    frame_size: str = "small"
+
+
+class ConditionalContainer(SlottedContainer[TestComponent]):
+    slots: ClassVar[dict[str, Slot]] = {
+        "turret": Slot.for_tags(
+            "turret",
+            tags={"turret"},
+            required=True,
+            enablement_criteria={"frame_size": "large"},
+        )
+    }
+
+
+class DefaultLoadoutContainer(SlottedContainer[TestComponent]):
+    slots: ClassVar[dict[str, Slot]] = {
+        "chassis": Slot.for_tags(
+            "chassis",
+            tags={"chassis"},
+            default_factory=lambda: TestComponent(label="starter-frame", tags={"chassis"}),
+        ),
+        "powerplant": Slot.for_tags(
+            "powerplant",
+            tags={"powerplant"},
+            prerequisite_slots=["chassis"],
+            default_factory=lambda: TestComponent(label="starter-motor", tags={"powerplant"}),
+        ),
+        "turret": Slot.for_tags(
+            "turret",
+            tags={"turret"},
+            enablement_criteria={"frame_size": "large"},
+            default_factory=lambda: TestComponent(label="starter-turret", tags={"turret"}),
+        ),
+    }
+
+
+class ShapeComponent(Component):
+    weight_cost: float = 0.0
+
+    def get_cost(self, resource: str) -> float:
+        if resource == "weight":
+            return self.weight_cost
+        return 0.0
+
+
+class ShapeBoard(SlottedContainer[ShapeComponent]):
+    slots: ClassVar[dict[str, Slot]] = {
+        "star": Slot(
+            name="star",
+            connector_shape="star",
+            connector_polarity="socket",
+        ),
+        "circle": Slot(
+            name="circle",
+            connector_shape="circle",
+            connector_polarity="socket",
+        ),
+        "square": Slot(
+            name="square",
+            connector_shape="square",
+            connector_polarity="socket",
+        ),
+    }
+    empty_slot_text: ClassVar[dict[str, str]] = {
+        "star": "an empty star-shaped slot",
+        "circle": "an empty circular slot",
+        "square": "an empty square slot",
+    }
+
+    def describe(self) -> str:
+        filled_slots = {
+            facet.subject_id: str(facet.payload)
+            for facet in self.component_facets(channel="prose", facet_type="giver")
+        }
+        parts = [
+            filled_slots.get(slot_name, empty_text)
+            for slot_name, empty_text in self.empty_slot_text.items()
+        ]
+        return f"A board with {parts[0]}, {parts[1]}, and {parts[2]}."
+
+    def challenge_value(self, initial: float = 0.0) -> float:
+        result = initial
+        for facet in self.component_facets(channel="challenge", facet_type="changer"):
+            payload = facet.payload
+            if not isinstance(payload, dict):
+                raise TypeError("Shape-board challenge facets require dict payloads")
+
+            op = payload["op"]
+            value = payload["value"]
+            if op == "add":
+                result += value
+            elif op == "multiply":
+                result *= value
+            elif op == "subtract":
+                result -= value
+            else:
+                raise ValueError(f"Unsupported shape-board challenge op: {op}")
+        return result
+
+    def hits_target(self, target: float, *, initial: float = 0.0) -> bool:
+        return self.challenge_value(initial=initial) == target
+
+
+class WeightedShapeBoard(ShapeBoard):
+    tracked_resources: ClassVar[list[str]] = ["weight"]
+
+
+EMPTY_BOARD_DESCRIPTION = (
+    "A board with an empty star-shaped slot, an empty circular slot, "
+    "and an empty square slot."
+)
+FILLED_STAR_BOARD_DESCRIPTION = (
+    "A board with a filled star-shaped slot, an empty circular slot, "
+    "and an empty square slot."
+)
+
+
 @pytest.fixture
 def component_alpha() -> TestComponent:
     return TestComponent(label="alpha", tags={"alpha"}, power_cost=1.0)
@@ -57,6 +201,39 @@ def component_alpha() -> TestComponent:
 @pytest.fixture
 def component_beta() -> TestComponent:
     return TestComponent(label="beta", tags={"beta"}, power_cost=0.5)
+
+
+def shape_plug(
+    shape: str,
+    *,
+    polarity: str = "plug",
+    challenge_op: str | None = None,
+    challenge_value: float | None = None,
+    weight_cost: float = 0.0,
+) -> ShapeComponent:
+    facets = [
+        ComponentFacet(
+            channel="prose",
+            facet_type="giver",
+            payload=f"a filled {shape}-shaped slot",
+        )
+    ]
+    if challenge_op is not None and challenge_value is not None:
+        facets.append(
+            ComponentFacet(
+                channel="challenge",
+                facet_type="changer",
+                payload={"op": challenge_op, "value": challenge_value},
+            )
+        )
+
+    return ShapeComponent(
+        label=f"{shape}-{polarity}",
+        connector_shape=shape,
+        connector_polarity=polarity,
+        facets=facets,
+        weight_cost=weight_cost,
+    )
 
 
 def test_slot_matching(component_alpha: TestComponent, component_beta: TestComponent) -> None:
@@ -199,3 +376,176 @@ def test_get_aggregate_raises_for_non_numeric_present_values() -> None:
 
     with pytest.raises(TypeError, match="expected numeric values"):
         container.get_aggregate("status_text")
+
+
+def test_slot_prerequisite_rejects_missing_direct_dependency() -> None:
+    container = PrerequisiteContainer()
+
+    with pytest.raises(ValueError, match="Missing prerequisite slots: chassis"):
+        container.assign(
+            "powerplant",
+            TestComponent(label="motor", tags={"powerplant"}),
+        )
+
+    container.assign("chassis", TestComponent(label="frame", tags={"chassis"}))
+    container.assign("powerplant", TestComponent(label="motor", tags={"powerplant"}))
+
+    assert container.validate() == []
+
+
+def test_slot_prerequisites_support_chained_dependencies() -> None:
+    container = PrerequisiteContainer()
+
+    with pytest.raises(ValueError, match="Missing prerequisite slots: powerplant"):
+        container.assign("turret", TestComponent(label="turret", tags={"turret"}))
+
+    container.assign("chassis", TestComponent(label="frame", tags={"chassis"}))
+    container.assign("powerplant", TestComponent(label="motor", tags={"powerplant"}))
+    container.assign("turret", TestComponent(label="turret", tags={"turret"}))
+
+    assert container.validate() == []
+
+
+def test_slot_prerequisite_validation_reports_broken_existing_loadout() -> None:
+    container = PrerequisiteContainer()
+    chassis = TestComponent(label="frame", tags={"chassis"})
+    container.assign("chassis", chassis)
+    container.assign("powerplant", TestComponent(label="motor", tags={"powerplant"}))
+    container.assign("turret", TestComponent(label="turret", tags={"turret"}))
+
+    container.unassign("chassis", chassis)
+
+    assert container.validate() == [
+        "Slot 'powerplant' missing prerequisite slot: chassis",
+    ]
+
+
+def test_slot_enablement_rejects_disabled_slot_without_required_empty_error() -> None:
+    host = ConditionalHost(label="compact", frame_size="small")
+    container = ConditionalContainer(owner=host)
+
+    assert not container.is_slot_enabled("turret")
+    assert container.validate() == []
+
+    with pytest.raises(ValueError, match="Slot disabled: turret"):
+        container.assign("turret", TestComponent(label="turret", tags={"turret"}))
+
+
+def test_slot_enablement_allows_required_slot_when_owner_matches() -> None:
+    host = ConditionalHost(label="large", frame_size="large")
+    container = ConditionalContainer(owner=host)
+
+    assert container.is_slot_enabled("turret")
+    assert container.validate() == ["Required slot empty: turret"]
+
+    container.assign("turret", TestComponent(label="turret", tags={"turret"}))
+
+    assert container.validate() == []
+
+
+def test_slot_enablement_reports_occupied_slot_after_owner_state_changes() -> None:
+    host = ConditionalHost(label="large", frame_size="large")
+    container = ConditionalContainer(owner=host)
+    container.assign("turret", TestComponent(label="turret", tags={"turret"}))
+
+    host.frame_size = "small"
+
+    assert container.validate() == ["Disabled slot occupied: turret"]
+
+
+def test_materialize_defaults_populates_enabled_empty_slots_in_order() -> None:
+    host = ConditionalHost(label="large", frame_size="large")
+    container = DefaultLoadoutContainer(owner=host)
+
+    materialized = container.materialize_defaults()
+
+    assert [component.label for component in materialized] == [
+        "starter-frame",
+        "starter-motor",
+        "starter-turret",
+    ]
+    assert container.get_slot("chassis")[0].label == "starter-frame"
+    assert container.get_slot("powerplant")[0].label == "starter-motor"
+    assert container.get_slot("turret")[0].label == "starter-turret"
+
+
+def test_materialize_defaults_skips_disabled_slots_and_keeps_existing_assignments() -> None:
+    host = ConditionalHost(label="compact", frame_size="small")
+    container = DefaultLoadoutContainer(owner=host)
+    custom_frame = TestComponent(label="custom-frame", tags={"chassis"})
+    container.assign("chassis", custom_frame)
+
+    materialized = container.materialize_defaults()
+
+    assert [component.label for component in materialized] == ["starter-motor"]
+    assert container.get_slot("chassis") == [custom_frame]
+    assert container.get_slot("powerplant")[0].label == "starter-motor"
+    assert container.get_slot("turret") == []
+
+
+def test_shape_board_star_plug_seats_in_star_socket() -> None:
+    board = ShapeBoard()
+    board.assign("star", shape_plug("star"))
+
+    assert board.get_slot("star")[0].label == "star-plug"
+
+    with pytest.raises(ValueError, match="Slot full"):
+        board.assign("star", shape_plug("star"))
+
+
+def test_shape_board_rejects_star_plug_in_circle_socket() -> None:
+    board = ShapeBoard()
+
+    with pytest.raises(ValueError, match="Connector shape mismatch"):
+        board.assign("circle", shape_plug("star"))
+
+
+def test_shape_board_rejects_two_sockets() -> None:
+    board = ShapeBoard()
+
+    with pytest.raises(ValueError, match="Connector polarity mismatch"):
+        board.assign("star", shape_plug("star", polarity="socket"))
+
+
+def test_shape_board_description_changes_after_assign_unassign() -> None:
+    board = ShapeBoard()
+    star_plug = shape_plug("star")
+
+    assert board.describe() == EMPTY_BOARD_DESCRIPTION
+
+    board.assign("star", star_plug)
+
+    assert board.describe() == FILLED_STAR_BOARD_DESCRIPTION
+    assert board.fold_giver_payloads("prose") == ["a filled star-shaped slot"]
+
+    board.unassign("star", star_plug)
+
+    assert board.describe() == EMPTY_BOARD_DESCRIPTION
+
+
+def test_shape_board_changer_facets_fold_into_target_check() -> None:
+    board = ShapeBoard()
+    board.assign("star", shape_plug("star", challenge_op="add", challenge_value=3))
+    board.assign("circle", shape_plug("circle", challenge_op="multiply", challenge_value=2))
+    board.assign("square", shape_plug("square", challenge_op="subtract", challenge_value=1))
+
+    assert board.challenge_value(initial=4) == 13
+    assert board.hits_target(13, initial=4)
+    assert not board.hits_target(12, initial=4)
+
+
+def test_shape_board_discrete_slot_and_continuous_weight_budget_gate_assignment() -> None:
+    board = WeightedShapeBoard()
+
+    assert board.budgets is not None
+    board.budgets.add_budget("weight", 2.0)
+    board.assign("star", shape_plug("star", weight_cost=1.25))
+
+    with pytest.raises(ValueError, match="Slot full"):
+        board.assign("star", shape_plug("star"))
+
+    board.assign("circle", shape_plug("circle", weight_cost=0.5))
+    assert board.budgets.budgets["weight"].consumed == 1.75
+
+    with pytest.raises(ValueError, match="Insufficient weight"):
+        board.assign("square", shape_plug("square", weight_cost=0.5))


### PR DESCRIPTION
## Summary

Implements the first component/facet follow-through from #280/#131:

- adds assembly-local `Component` / `ComponentFacet` carriers with stable provenance;
- extends `Slot` with connector shape/polarity, prerequisite slots, owner-based enablement, and opt-in default factories;
- adds `SlottedContainer` helpers for facet discovery, giver payload folds, slot enablement, and explicit default materialization;
- proves the shape-board stages in tests: connector admission, derived prose donation, challenge changer fold, budgets, prerequisites, enablement, and defaults;
- lands the #283 presence first-slice: outfit coverage masks can hide covered ornaments while leaving visible marks.

## Notes

This intentionally keeps the generalized layer small. The shape-board owns its challenge fold; the assembly layer only supplies the common discovery/admission/defaulting primitives. `EntityTemplate` authoring and full association lifecycle hooks are still deferred until a real authored/default or multi-connector consumer forces them.

Tracker comments posted:

- #131 status update: implementation slices for #194/#195/#196 drafted locally.
- #283 status update: coverage first-slice drafted locally.

## Verification

- `poetry run pytest engine/tests/mechanics/test_assembly.py`
- `poetry run pytest engine/tests/mechanics`
- `poetry run pytest engine/tests`

Full suite result: 2601 passed, 65 skipped, 9 xfailed.

Refs #280, #131, #194, #195, #196, #283.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Component assembly system now supports facets with connector polarity types (plug/socket)
- Slots support prerequisites and conditional enablement based on configuration state
- Ornament visibility can be filtered based on body coverage from worn clothing
- Outfit tracking computes covered body regions and parts

## Improvements
- Enhanced validation checks for slot prerequisites and occupancy rules
- Default slot materialization for automatic population of empty slots
- Ornament descriptions respect coverage masks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->