### PR TITLE
Add ledger journal slice accessors

### DIFF
--- a/engine/src/tangl/journal/fragments.py
+++ b/engine/src/tangl/journal/fragments.py
@@ -77,6 +77,20 @@ class GroupFragment(BaseFragment, extra="allow"):
         ]
 
 
+class JournalMarkerFragment(BaseFragment, extra="allow"):
+    """Point marker used to compute journal slices at read time.
+
+    Markers are stored in the same stream as presentation fragments so replay,
+    persistence, and provenance stay unified. They mark a start point; spans are
+    computed by :class:`tangl.vm.runtime.ledger.Ledger`.
+    """
+
+    fragment_type: Literal["marker"] = "marker"
+    marker_type: str
+    marker_name: str | None = None
+    path: str | None = None
+
+
 class PieceFragment(BaseFragment, extra="allow"):
     """Identified game piece: a tracked object the player can reference, place
     into a zone, or pick as a choice payload (candidate, document, token, asset).
@@ -234,6 +248,7 @@ _FRAGMENT_DTO_TYPES: dict[str, type[BaseFragment]] = {
     "dialog": DialogFragment,
     "group": GroupFragment,
     "kv": KvFragment,
+    "marker": JournalMarkerFragment,
     "media": MediaFragment,
     "piece": PieceFragment,
     "update": ControlFragment,
@@ -306,6 +321,7 @@ __all__ = [
     "ControlFragmentType",
     "DialogFragment",
     "GroupFragment",
+    "JournalMarkerFragment",
     "KvFragment",
     "KvRow",
     "MediaFragment",

--- a/engine/src/tangl/service/service_manager.py
+++ b/engine/src/tangl/service/service_manager.py
@@ -504,7 +504,6 @@ class ServiceManager:
             else:
                 edge_id = request.edge_id
 
-            before_step = session.ledger.step
             try:
                 session.ledger.resolve_choice(edge_id, choice_payload=request.payload)
             except ValueError as exc:
@@ -525,7 +524,7 @@ class ServiceManager:
                         )
                     ],
                 )
-            fragments = list(session.ledger.get_journal(since_step=max(before_step + 1, 0)))
+            fragments = list(session.ledger.get_current_update())
             return self._build_runtime_envelope(session.ledger, fragments=fragments)
 
     @service_method(

--- a/engine/src/tangl/vm/VM_DESIGN.md
+++ b/engine/src/tangl/vm/VM_DESIGN.md
@@ -464,6 +464,17 @@ construct Frames directly.
 `OrderedRegistry` across all frames. Replay slices this registry by step range and
 re-executes fragments to reconstruct any point-in-time state.
 
+**Journal retrieval is one bounded slice primitive.** `Ledger.get_slice()` returns
+fragments in the half-open step span `[since_step, until_step)`, with optional
+`Selector` filtering; `get_journal()` is compatibility sugar over that primitive.
+Higher-level reads compute bounds and then call the same primitive: `get_current_update()`
+uses the most recent resolution watermark, bookmarks resolve to a marker step, and
+section-style reads run from one marker to the next compatible marker or the current
+step. Section/book/scene names are data, not VM enums. A container may opt into automatic
+section markers by setting `locals["section_type"]` plus optional `section_name` and
+`section_path`; the ledger writes those markers as ordinary stream fragments when the
+container-entry hop commits. Markers are points, spans are computed views.
+
 
 ### Provisioning (`provision/`)
 

--- a/engine/src/tangl/vm/runtime/ledger.py
+++ b/engine/src/tangl/vm/runtime/ledger.py
@@ -105,6 +105,7 @@ class Ledger(Entity):
     call_stack_ids: list[UUID] = Field(default_factory=list)
     last_redirect: dict | None = None
     redirect_trace: list[dict] = Field(default_factory=list)
+    current_update_start_step: int = 0
 
     def _call_stack(self) -> list[TraversableEdge]:
         """Resolve call stack UIDs to edge objects (introspection only)."""
@@ -185,6 +186,7 @@ class Ledger(Entity):
         self.call_stack_ids = []
         self.last_redirect = None
         self.redirect_trace = []
+        self.current_update_start_step = 0
         self.causality_mode = CausalityMode.CLEAN
         self.causality_break_reason = None
         self.causality_break_step_id = None
@@ -310,6 +312,10 @@ class Ledger(Entity):
             self.output_stream.append(delta)
             delta_id = delta.uid
 
+        marker = self._section_marker_for_trace(trace)
+        if marker is not None:
+            self.output_stream.append(marker)
+
         self.output_stream.append(
             StepRecord(
                 step=trace.step,
@@ -322,6 +328,26 @@ class Ledger(Entity):
                 call_stack_ids=list(trace.call_stack_ids),
                 algorithm_id=self.replay_algorithm_id,
             )
+        )
+
+    def _section_marker_for_trace(self, trace: StepTrace) -> BaseFragment | None:
+        """Return an auto section marker for committed container-entry hops."""
+        cursor = self.graph.get(trace.cursor_id)
+        if not isinstance(cursor, TraversableNode) or not cursor.is_container:
+            return None
+        section_type = cursor.locals.get("section_type")
+        if not section_type:
+            return None
+        marker_name = cursor.locals.get("section_name") or cursor.label or str(cursor.uid)
+        path = cursor.locals.get("section_path") or marker_name
+        return BaseFragment(
+            fragment_type="marker",
+            content=marker_name,
+            marker_type=str(section_type),
+            marker_name=str(marker_name),
+            path=str(path),
+            source_id=cursor.uid,
+            step=trace.step,
         )
 
     @staticmethod
@@ -425,12 +451,14 @@ class Ledger(Entity):
 
     def resolve_choice(self, edge_id: UUID, *, choice_payload: Any = None) -> None:
         """Resolve a player choice and sync frame results into ledger state."""
+        update_start_step = max(self.cursor_steps + 1, 0)
         edge = self._require_choice_edge(edge_id)
         self._provision_selected_destination(edge)
 
         frame = self.get_frame()
         self._run_frame_choice(frame=frame, edge=edge, choice_payload=choice_payload)
         self._commit_frame_choice(frame=frame)
+        self.current_update_start_step = update_start_step
 
     @staticmethod
     def _coerce_fragment_record(record: Any) -> BaseFragment | None:
@@ -446,28 +474,199 @@ class Ledger(Entity):
             "fragment_type": str(fragment_type),
             "step": step,
         }
-        for key in ("content", "text", "source_id", "edge_id", "available", "unavailable_reason"):
+        for key in (
+            "content",
+            "text",
+            "source_id",
+            "edge_id",
+            "available",
+            "unavailable_reason",
+            "marker_type",
+            "marker_name",
+            "path",
+        ):
             if hasattr(record, key):
                 payload[key] = getattr(record, key)
         return BaseFragment(**payload)
 
-    def get_journal(self, *, since_step: int = 0, limit: int = 0) -> list[BaseFragment]:
-        """Return output fragments in chronological order, optionally filtered."""
+    @staticmethod
+    def _fragment_step(fragment: BaseFragment) -> int:
+        raw_step = getattr(fragment, "step", -1)
+        return -1 if raw_step is None else int(raw_step)
+
+    @staticmethod
+    def _is_marker(fragment: BaseFragment, marker_type: str | None = None) -> bool:
+        if str(fragment.fragment_type) != "marker":
+            return False
+        if marker_type is None:
+            return True
+        return getattr(fragment, "marker_type", None) == marker_type
+
+    def get_slice(
+        self,
+        *,
+        since_step: int = 0,
+        until_step: int | None = None,
+        selector: Selector | None = None,
+        limit: int = 0,
+    ) -> list[BaseFragment]:
+        """Return output fragments in the half-open step span ``[since, until)``."""
         fragments: list[BaseFragment] = []
 
         for record in self.output_stream.values():
             fragment = self._coerce_fragment_record(record)
             if fragment is None:
                 continue
-            raw_step = getattr(fragment, "step", -1)
-            step = -1 if raw_step is None else int(raw_step)
-            if step >= since_step or step < 0:
-                fragments.append(fragment)
+            step = self._fragment_step(fragment)
+            if step >= 0:
+                if step < since_step:
+                    continue
+                if until_step is not None and step >= until_step:
+                    continue
+            if selector is not None and not selector.matches(fragment):
+                continue
+            fragments.append(fragment)
 
         if limit > 0 and len(fragments) > limit:
             fragments = fragments[-limit:]
 
         return fragments
+
+    def get_journal(
+        self,
+        *,
+        since_step: int = 0,
+        until_step: int | None = None,
+        selector: Selector | None = None,
+        limit: int = 0,
+    ) -> list[BaseFragment]:
+        """Return journal fragments; compatibility wrapper for :meth:`get_slice`."""
+        return self.get_slice(
+            since_step=since_step,
+            until_step=until_step,
+            selector=selector,
+            limit=limit,
+        )
+
+    def get_current_update(
+        self,
+        *,
+        selector: Selector | None = None,
+        limit: int = 0,
+    ) -> list[BaseFragment]:
+        """Return fragments produced by the most recent successful choice resolution."""
+        return self.get_slice(
+            since_step=self.current_update_start_step,
+            until_step=max(self.cursor_steps + 1, 0),
+            selector=selector,
+            limit=limit,
+        )
+
+    def markers(
+        self,
+        *,
+        marker_type: str | None = None,
+        marker_name: str | None = None,
+    ) -> list[BaseFragment]:
+        """Return stream marker fragments in chronological order."""
+        result = [
+            fragment
+            for fragment in self.get_slice()
+            if self._is_marker(fragment, marker_type=marker_type)
+        ]
+        if marker_name is not None:
+            result = [
+                fragment
+                for fragment in result
+                if getattr(fragment, "marker_name", None) == marker_name
+            ]
+        return result
+
+    def set_bookmark(
+        self,
+        name: str,
+        *,
+        step: int | None = None,
+        overwrite: bool = False,
+    ) -> BaseFragment:
+        """Append a named bookmark marker at ``step`` or the current ledger step."""
+        if not overwrite and self.find_marker(name, marker_type="bookmark") is not None:
+            raise KeyError(f"Bookmark already exists: {name}")
+        marker = BaseFragment(
+            fragment_type="marker",
+            content=name,
+            marker_type="bookmark",
+            marker_name=name,
+            step=max(self.cursor_steps, 0) if step is None else step,
+        )
+        self.output_stream.append(marker)
+        return marker
+
+    def find_marker(
+        self,
+        name_or_index: str | int = "latest",
+        *,
+        marker_type: str = "bookmark",
+    ) -> BaseFragment | None:
+        """Find a marker by name, index, or ``latest`` within one marker type."""
+        markers = self.markers(marker_type=marker_type)
+        if not markers:
+            return None
+        if isinstance(name_or_index, int):
+            try:
+                return markers[name_or_index]
+            except IndexError:
+                return None
+        if name_or_index == "latest":
+            return markers[-1]
+        return next(
+            (
+                marker
+                for marker in reversed(markers)
+                if getattr(marker, "marker_name", None) == name_or_index
+            ),
+            None,
+        )
+
+    def _next_marker_step(
+        self,
+        *,
+        start_step: int,
+        marker_types: list[str],
+    ) -> int:
+        candidates = [
+            self._fragment_step(marker)
+            for marker_type in marker_types
+            for marker in self.markers(marker_type=marker_type)
+            if self._fragment_step(marker) > start_step
+        ]
+        if candidates:
+            return min(candidates)
+        return max(self.cursor_steps + 1, 0)
+
+    def get_marked_slice(
+        self,
+        name_or_index: str | int = "latest",
+        *,
+        marker_type: str = "bookmark",
+        stop_marker_types: list[str] | None = None,
+        selector: Selector | None = None,
+        limit: int = 0,
+    ) -> list[BaseFragment]:
+        """Return a slice from one marker to the next logical marker/current step."""
+        marker = self.find_marker(name_or_index, marker_type=marker_type)
+        if marker is None:
+            raise KeyError(f"Marker {name_or_index!r}@{marker_type} not found")
+        start_step = self._fragment_step(marker)
+        return self.get_slice(
+            since_step=start_step,
+            until_step=self._next_marker_step(
+                start_step=start_step,
+                marker_types=stop_marker_types or [marker_type],
+            ),
+            selector=selector,
+            limit=limit,
+        )
 
     def unstructure(self) -> UnstructuredData:
         """Serialize ledger state to plain data for persistence."""
@@ -479,6 +678,7 @@ class Ledger(Entity):
             "cursor_steps": self.cursor_steps,
             "choice_steps": self.choice_steps,
             "reentrant_steps": self.reentrant_steps,
+            "current_update_start_step": self.current_update_start_step,
             "call_stack_ids": list(self.call_stack_ids),
             "last_redirect": self.last_redirect,
             "redirect_trace": self.redirect_trace,
@@ -526,6 +726,7 @@ class Ledger(Entity):
             cursor_steps=data.get("cursor_steps", -1),
             choice_steps=data.get("choice_steps", -1),
             reentrant_steps=data.get("reentrant_steps", -1),
+            current_update_start_step=data.get("current_update_start_step", 0),
             call_stack_ids=[_coerce_uuid(uid) for uid in data.get("call_stack_ids", [])],
             last_redirect=data.get("last_redirect"),
             redirect_trace=list(data.get("redirect_trace", [])),

--- a/engine/src/tangl/vm/runtime/ledger.py
+++ b/engine/src/tangl/vm/runtime/ledger.py
@@ -645,23 +645,6 @@ class Ledger(Entity):
             None,
         )
 
-    def _next_marker_step(
-        self,
-        *,
-        start_step: int,
-        marker_types: list[str],
-    ) -> int:
-        marker_type_set = set(marker_types)
-        candidates = [
-            self._fragment_step(marker)
-            for marker in self.markers()
-            if getattr(marker, "marker_type", None) in marker_type_set
-            and self._fragment_step(marker) > start_step
-        ]
-        if candidates:
-            return min(candidates)
-        return max(self.cursor_steps + 1, 0)
-
     def get_marked_slice(
         self,
         name_or_index: str | int = "latest",
@@ -675,16 +658,39 @@ class Ledger(Entity):
         marker = self.find_marker(name_or_index, marker_type=marker_type)
         if marker is None:
             raise KeyError(f"Marker {name_or_index!r}@{marker_type} not found")
-        start_step = self._fragment_step(marker)
-        return self.get_slice(
-            since_step=start_step,
-            until_step=self._next_marker_step(
-                start_step=start_step,
-                marker_types=stop_marker_types or [marker_type],
+        marker_type_set = set(stop_marker_types or [marker_type])
+        stream = [
+            (index, fragment)
+            for index, record in enumerate(self.output_stream.values())
+            if (fragment := self._coerce_fragment_record(record)) is not None
+        ]
+        start_index = next(index for index, fragment in stream if fragment.uid == marker.uid)
+        stop_index = next(
+            (
+                index
+                for index, fragment in stream
+                if index > start_index
+                and self._is_marker(fragment)
+                and getattr(fragment, "marker_type", None) in marker_type_set
             ),
-            selector=selector,
-            limit=limit,
+            len(stream),
         )
+        until_step = max(self.cursor_steps + 1, 0)
+        fragments: list[BaseFragment] = []
+        for index, fragment in stream:
+            if index < start_index or index >= stop_index:
+                continue
+            step = self._fragment_step(fragment)
+            if step < 0 or step >= until_step:
+                continue
+            if selector is not None and not selector.matches(fragment):
+                continue
+            fragments.append(fragment)
+
+        if limit > 0 and len(fragments) > limit:
+            fragments = fragments[-limit:]
+
+        return fragments
 
     def unstructure(self) -> UnstructuredData:
         """Serialize ledger state to plain data for persistence."""

--- a/engine/src/tangl/vm/runtime/ledger.py
+++ b/engine/src/tangl/vm/runtime/ledger.py
@@ -558,12 +558,26 @@ class Ledger(Entity):
         limit: int = 0,
     ) -> list[BaseFragment]:
         """Return fragments produced by the most recent successful choice resolution."""
-        return self.get_slice(
+        fragments = self.get_slice(
             since_step=self.current_update_start_step,
             until_step=max(self.cursor_steps + 1, 0),
             selector=selector,
-            limit=limit,
         )
+        fragment_ids = {fragment.uid for fragment in fragments}
+        live_fragments = [
+            fragment
+            for fragment in self.get_slice(
+                since_step=self.current_update_start_step,
+                selector=selector,
+            )
+            if self._fragment_step(fragment) < 0 and fragment.uid not in fragment_ids
+        ]
+        fragments.extend(live_fragments)
+
+        if limit > 0 and len(fragments) > limit:
+            fragments = fragments[-limit:]
+
+        return fragments
 
     def markers(
         self,

--- a/engine/src/tangl/vm/runtime/ledger.py
+++ b/engine/src/tangl/vm/runtime/ledger.py
@@ -518,7 +518,10 @@ class Ledger(Entity):
             if fragment is None:
                 continue
             step = self._fragment_step(fragment)
-            if step >= 0:
+            if step < 0:
+                if until_step is not None and until_step > 0:
+                    continue
+            else:
                 if step < since_step:
                     continue
                 if until_step is not None and step >= until_step:
@@ -634,11 +637,12 @@ class Ledger(Entity):
         start_step: int,
         marker_types: list[str],
     ) -> int:
+        marker_type_set = set(marker_types)
         candidates = [
             self._fragment_step(marker)
-            for marker_type in marker_types
-            for marker in self.markers(marker_type=marker_type)
-            if self._fragment_step(marker) > start_step
+            for marker in self.markers()
+            if getattr(marker, "marker_type", None) in marker_type_set
+            and self._fragment_step(marker) > start_step
         ]
         if candidates:
             return min(candidates)

--- a/engine/tests/vm/test_ledger.py
+++ b/engine/tests/vm/test_ledger.py
@@ -598,6 +598,26 @@ class TestLedgerJournal:
             selector=presentation,
         ) == [f1, f2]
 
+    def test_marker_slice_starts_at_marker_position_within_same_step(self) -> None:
+        ledger, _ = _make_ledger("a", "b")
+        before = ContentFragment(content="before bookmark", step=2)
+        after = ContentFragment(content="after bookmark", step=2)
+        next_section = JournalMarkerFragment(
+            marker_type="bookmark",
+            marker_name="next",
+            step=2,
+        )
+        excluded = ContentFragment(content="after next bookmark", step=2)
+        ledger.cursor_steps = 2
+        ledger.output_stream.append(before)
+        marker = ledger.set_bookmark("here")
+        ledger.output_stream.extend([after, next_section, excluded])
+
+        presentation = Selector(predicate=lambda fragment: fragment.fragment_type != "marker")
+
+        assert marker.step == before.step == after.step
+        assert ledger.get_marked_slice("here", selector=presentation) == [after]
+
     def test_set_bookmark_appends_named_marker(self) -> None:
         ledger, _ = _make_ledger("a", "b")
 

--- a/engine/tests/vm/test_ledger.py
+++ b/engine/tests/vm/test_ledger.py
@@ -547,6 +547,16 @@ class TestLedgerJournal:
             f2,
         ]
 
+    def test_get_slice_excludes_unstamped_fragments_from_bounded_ranges(self) -> None:
+        ledger, _ = _make_ledger("a", "b")
+        unstamped = ContentFragment(content="legacy")
+        current = ContentFragment(content="current", step=2)
+        ledger.output_stream.extend([unstamped, current])
+
+        assert ledger.get_slice() == [unstamped, current]
+        assert ledger.get_slice(since_step=0, until_step=0) == [unstamped]
+        assert ledger.get_slice(since_step=2, until_step=3) == [current]
+
     def test_get_current_update_uses_resolution_watermark(self) -> None:
         ledger, _ = _make_ledger("a", "b")
         f1 = ContentFragment(content="previous", step=1)

--- a/engine/tests/vm/test_ledger.py
+++ b/engine/tests/vm/test_ledger.py
@@ -562,12 +562,13 @@ class TestLedgerJournal:
         f1 = ContentFragment(content="previous", step=1)
         f2 = ContentFragment(content="current one", step=2)
         f3 = ChoiceFragment(edge_id=uuid4(), text="current two", step=3)
+        live_choice = ChoiceFragment(edge_id=uuid4(), text="live affordance")
         f4 = ContentFragment(content="future", step=4)
-        ledger.output_stream.extend([f1, f2, f3, f4])
+        ledger.output_stream.extend([f1, f2, f3, live_choice, f4])
         ledger.current_update_start_step = 2
         ledger.cursor_steps = 3
 
-        assert ledger.get_current_update() == [f2, f3]
+        assert ledger.get_current_update() == [f2, f3, live_choice]
 
     def test_marker_slice_runs_from_marker_to_next_logical_marker(self) -> None:
         ledger, _ = _make_ledger("a", "b")

--- a/engine/tests/vm/test_ledger.py
+++ b/engine/tests/vm/test_ledger.py
@@ -19,7 +19,7 @@ from uuid import uuid4
 import pytest
 
 from tangl.core import EntityTemplate, Graph, Selector, Snapshot, TemplateRegistry
-from tangl.journal.fragments import ChoiceFragment, ContentFragment
+from tangl.journal.fragments import ChoiceFragment, ContentFragment, JournalMarkerFragment
 from tangl.journal.media import MediaFragment as JournalMediaFragment
 from tangl.media.media_data_type import MediaDataType
 from tangl.vm import TraversableGraphFactory
@@ -314,6 +314,14 @@ class TestLedgerResolveChoice:
         ledger.resolve_choice(edge.uid)
         assert ledger.choice_steps == initial_choice + 1
 
+    def test_resolve_records_current_update_start_step(self) -> None:
+        ledger, [a, _b] = _make_ledger("a", "b")
+        edge = list(a.edges_out())[0]
+
+        ledger.resolve_choice(edge.uid)
+
+        assert ledger.current_update_start_step == 1
+
     def test_resolve_choice_forwards_choice_payload_to_frame(self, monkeypatch) -> None:
         ledger, [a, b] = _make_ledger("a", "b")
         edge = list(a.edges_out())[0]
@@ -413,6 +421,39 @@ class TestLedgerResolveChoice:
 
         assert ledger.cursor_history == [root.uid, container.uid, entry.uid]
 
+    def test_section_marked_container_entry_appends_marker_fragment(self) -> None:
+        g = Graph()
+        root = _node(g, label="root")
+        scene = _node(
+            g,
+            label="scene",
+            locals={
+                "section_type": "scene",
+                "section_name": "opening",
+                "section_path": "book_1.scene_1",
+            },
+        )
+        entry = _node(g, label="entry")
+        scene.add_child(entry)
+        scene.source_id = entry.uid
+        _edge(g, predecessor_id=root.uid, successor_id=scene.uid)
+
+        import tangl.vm.system_handlers as sh
+        on_prereqs(sh.descend_into_container)
+
+        ledger = Ledger(graph=g, cursor_id=root.uid)
+        edge = list(root.edges_out())[0]
+        ledger.resolve_choice(edge.uid)
+
+        marker = ledger.find_marker("opening", marker_type="scene")
+        assert marker is not None
+        assert marker.content == "opening"
+        assert marker.path == "book_1.scene_1"
+        assert marker.source_id == scene.uid
+        assert ledger.get_marked_slice("opening", marker_type="scene") == [
+            marker,
+        ]
+
     def test_reentrant_steps_increments_on_self_loop_hops(self) -> None:
         ledger, [a, _b] = _make_ledger("a", "b")
 
@@ -490,6 +531,73 @@ class TestLedgerJournal:
 
         assert ledger.get_journal(since_step=2) == [f2, f3]
         assert ledger.get_journal(limit=2) == [f2, f3]
+
+    def test_get_slice_applies_half_open_step_bounds_and_selector(self) -> None:
+        ledger, _ = _make_ledger("a", "b")
+        f1 = ContentFragment(content="one", step=1)
+        f2 = ContentFragment(content="two", step=2)
+        f3 = ChoiceFragment(edge_id=uuid4(), text="three", step=3)
+        ledger.output_stream.extend([f1, f2, f3])
+
+        content_only = Selector(predicate=lambda fragment: fragment.fragment_type == "content")
+
+        assert ledger.get_slice(since_step=1, until_step=3, selector=content_only) == [f1, f2]
+        assert ledger.get_journal(since_step=1, until_step=3, selector=content_only) == [
+            f1,
+            f2,
+        ]
+
+    def test_get_current_update_uses_resolution_watermark(self) -> None:
+        ledger, _ = _make_ledger("a", "b")
+        f1 = ContentFragment(content="previous", step=1)
+        f2 = ContentFragment(content="current one", step=2)
+        f3 = ChoiceFragment(edge_id=uuid4(), text="current two", step=3)
+        f4 = ContentFragment(content="future", step=4)
+        ledger.output_stream.extend([f1, f2, f3, f4])
+        ledger.current_update_start_step = 2
+        ledger.cursor_steps = 3
+
+        assert ledger.get_current_update() == [f2, f3]
+
+    def test_marker_slice_runs_from_marker_to_next_logical_marker(self) -> None:
+        ledger, _ = _make_ledger("a", "b")
+        scene_start = JournalMarkerFragment(
+            marker_type="scene",
+            marker_name="scene_1",
+            step=1,
+        )
+        f1 = ContentFragment(content="scene prose", step=1)
+        f2 = ContentFragment(content="scene choice", step=2)
+        next_book = JournalMarkerFragment(
+            marker_type="book",
+            marker_name="book_2",
+            step=3,
+        )
+        f3 = ContentFragment(content="next book", step=3)
+        ledger.output_stream.extend([scene_start, f1, f2, next_book, f3])
+        ledger.cursor_steps = 3
+
+        presentation = Selector(predicate=lambda fragment: fragment.fragment_type != "marker")
+
+        assert ledger.find_marker("scene_1", marker_type="scene") is scene_start
+        assert ledger.get_marked_slice(
+            "scene_1",
+            marker_type="scene",
+            stop_marker_types=["scene", "book"],
+            selector=presentation,
+        ) == [f1, f2]
+
+    def test_set_bookmark_appends_named_marker(self) -> None:
+        ledger, _ = _make_ledger("a", "b")
+
+        bookmark = ledger.set_bookmark("intro", step=2)
+
+        assert bookmark.fragment_type == "marker"
+        assert bookmark.marker_type == "bookmark"
+        assert bookmark.marker_name == "intro"
+        assert ledger.find_marker("intro") is bookmark
+        with pytest.raises(KeyError, match="Bookmark already exists"):
+            ledger.set_bookmark("intro")
 
     def test_get_journal_preserves_base_media_fragments(self) -> None:
         ledger, _ = _make_ledger("a", "b")


### PR DESCRIPTION
## Summary

Implements the first #191 journal retrieval slice:

- adds `Ledger.get_slice()` as the bounded `[since_step, until_step)` primitive, with selector and limit support
- keeps `get_journal()` as compatibility sugar over `get_slice()`
- adds current-update retrieval via a ledger-owned resolution watermark
- adds stream marker fragments plus bookmark / marked-slice helpers
- auto-emits section markers for committed container-entry hops when the container opts in with `locals["section_type"]`
- documents the slice/marker contract in `VM_DESIGN.md`

Markers are stored as ordinary journal fragments, but VM code only treats them structurally through `BaseFragment` fields, so the runtime layer does not import concrete journal DTO classes.

## Validation

- `poetry run pytest engine/tests/vm/test_ledger.py engine/tests/service/test_service_manager.py engine/tests/journal/test_fragment_dto.py`
- `poetry run pytest engine/tests/vm engine/tests/service`
- `poetry run pytest engine/tests`
- `/Users/derek/.local/bin/coderabbit review --agent --base-commit e0bc5b1ef9b27bf0a8998c88309f89a858f320f8 -c AGENTS.md` -> 0 issues after fixing its two initial minor test-style notes

Refs #191.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added marker fragments (including section markers) to support marker-based journal slicing and bookmarks.
  * Introduced a unified fragment-slicing API with half-open `[since_step, until_step)` bounds, optional selector filtering, and limit controls.
  * Expanded journal read helpers with current-update “watermark” behavior and marker-to-next-marker slice retrieval.
* **Documentation**
  * Updated VM Ledger design to document the new bounded slice contract and marker production/read semantics.
* **Bug Fixes**
  * Corrected choice-resolution journal bounds so the current update starts from the latest resolution point.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->