### PR TITLE
Implement owner-bound component managers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,27 @@ full type map and rationale.**
 - **One template → entity path.** `EntityTemplate.materialize()` is the core
   shape-instantiation path. Higher layers may add policy or post-
   materialization behavior, but they should not bypass the template system.
+- **One constructor-form persistence path.** Graph/runtime objects round-trip
+  through `unstructure()` / `structure()`. `EntityTemplate.materialize()` and
+  service DTO projection may wrap that path for their own workflows, but raw
+  `model_dump()` / `model_validate()` is not a persistence contract and is not
+  proof that graph-owned state survives. Any type that points at another entity
+  must persist an explicit reference form (usually ids) and restore live
+  pointers through the owning registry/graph.
+- **Embedded constructor-form fields must opt in explicitly.** Field
+  `include=True` only says "persist this field even if it was mutated in
+  place." A separate marker such as `unstructurable=True` should mean "this field
+  contains constructor-form-capable value objects; recursively call
+  `unstructure()` / `structure()` here." Do not infer recursive graph embedding
+  from `Entity`-like types by default: full graph items should usually be
+  referenced by id, while embedded managers/value objects opt into
+  constructor-form recursion. This generalizes the existing one-off pattern in
+  `Registry.members` and `EntityTemplate.payload`: fields excluded from raw
+  Pydantic dumping but deliberately walked through constructor form.
+  It must stay much smaller than the legacy automorphic structuring experiments
+  under `scratch/legacy/core/core-23/structuring/`: no data-driven self-casting,
+  no opportunistic template/default lookup, no child-field inference from
+  property names, and no broad "make the object shape itself" pipeline.
 - **Import direction is a strict DAG.** `core ← vm ← story ← service`.
   No cycles, no upward imports, no conditional cross-layer imports.
 - **Every entity in the runtime graph is an Entity subclass.** If something
@@ -249,6 +270,9 @@ StoryTangl uses Git LFS for `.png` and `.jpg` files.
 ## Miscellaneous
 - No try/except around imports. Declare dependencies in `pyproject.toml`.
 - `Path` objects over raw strings for filesystem paths.
-- Use `model_dump`/`model_validate`, not manual dict munging.
+- Use `model_dump`/`model_validate` only for local Pydantic snapshots, DTOs, or
+  schema-bound data. For persistence, graph round-trips, materialization inputs,
+  and anything with entity references, use the blessed `unstructure()` /
+  `structure()` path instead of overriding or relying on `model_dump()`.
 - If updating an implementation detailed in a `_DESIGN.md` doc, update the
   doc's status section so it does not go stale.

--- a/docs/src/contrib/coding_style.md
+++ b/docs/src/contrib/coding_style.md
@@ -41,6 +41,26 @@ presentation (renderers, web/UI)
 ## 4) Data model & serialization
 - Pydantic v2 models for entities and records.
 - `Entity.structure(data)` is the factory; `unstructure()` emits a minimal, portable dict (class tag + uid).
+- `model_dump()` is not the persistence contract. Use it for DTOs, schemas, and
+  local Pydantic views; do not use it as proof that runtime graph state
+  round-trips.
+- Treat field inclusion and recursive structuring as orthogonal. A field marker
+  like `include=True` controls whether a mutated/default field is emitted; a
+  marker like `unstructurable=True` should control whether nested values are
+  recursively converted through `unstructure()` / `structure()`.
+- This is the generic form of existing explicit paths such as
+  `Registry.members` and `EntityTemplate.payload`: raw Pydantic dumping skips
+  the field, and constructor-form logic walks the contained values.
+- Anything that stores or derives pointers to other entities must unstructure
+  those links explicitly, usually as ids, and restore live objects through the
+  owning registry/graph during `structure()`.
+- Do not auto-embed arbitrary `Entity`-typed fields. If a nested value is a
+  real graph member, persist a reference. If it is an owner-bound manager or
+  value object, mark the field for constructor-form recursion.
+- Keep recursive constructor-form handling narrow. The legacy automorphic
+  experiments in `scratch/legacy/core/core-23/structuring/` are explicit
+  non-goals: no self-casting, no self-templating, no misnamed-child inference,
+  and no broad object-self-shaping pipeline.
 - No implicit IO in models; persistence belongs to ledger/service.
 
 ## 4a) Type purity on attributes
@@ -110,6 +130,10 @@ presentation (renderers, web/UI)
 
 ## 13) Tests (contracts > mechanics)
 - Round-trip `structure/unstructure` for composites.
+- For any manager/component/sub-entity-like object that holds graph references,
+  test a populated sample graph through `Graph.unstructure()` /
+  `Graph.structure()`, then assert restored ids, membership, and dereferenced
+  objects. A passing `model_dump()` / `model_validate()` test is not sufficient.
 - Phase reducers return the documented shape.
 - Provisioning policies enforce required fields.
 - Event canonicalization removes redundant updates; replay reproduces state.

--- a/engine/src/tangl/core/bases.py
+++ b/engine/src/tangl/core/bases.py
@@ -349,7 +349,10 @@ class Unstructurable(BaseModelPlus):
             for option in args:
                 if option is type(None):
                     continue
-                return cls._structure_unstructurable_value(value, option, _ctx=_ctx)
+                try:
+                    return cls._structure_unstructurable_value(value, option, _ctx=_ctx)
+                except (TypeError, ValueError):
+                    continue
             return value
 
         if origin in (dict,):

--- a/engine/src/tangl/core/bases.py
+++ b/engine/src/tangl/core/bases.py
@@ -96,13 +96,26 @@ from __future__ import annotations
 from abc import abstractmethod
 from copy import deepcopy
 from functools import total_ordering
-from inspect import isclass
+from inspect import isclass, signature
 import logging
 import time
-from typing import Any, Callable, ClassVar, Optional, Self, Type
+from types import UnionType
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Optional,
+    Self,
+    Type,
+    Union,
+    get_args,
+    get_origin,
+)
 from uuid import UUID, uuid4
 
 from pydantic import Field, field_validator
+from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
 from shortuuid import ShortUUID
 
 from tangl.type_hints import Identifier, Label, StringMap, Tag, UnstructuredData, Hash
@@ -246,6 +259,10 @@ class Unstructurable(BaseModelPlus):
       objects (including live Type references).
     - Wire-safe flattening (JSON/YAML safe primitives) is handled by the persistence
       service layer.
+    - Pydantic ``model_dump()`` is not a substitute for this constructor form.
+      It does not know StoryTangl's graph-reference conventions and can silently
+      deep-dump live entity pointers or omit mutated default managers. Runtime
+      graph state must prove itself through ``unstructure()`` / ``structure()``.
     - `evolve()` preserves ``uid`` by default; pass ``uid=uuid4()`` for a new identity.
     - `evolve()` uses ``deepcopy`` internally; for entities with large mutable state,
       consider field-level cloning if performance becomes a hotspot.
@@ -257,6 +274,19 @@ class Unstructurable(BaseModelPlus):
       was only mutated in place and never reassigned (so ``exclude_unset``
       cannot drop them). Still-default/empty values remain elided, so this does
       not chum snapshots with nulls or defaults.
+    - Recursive constructor-form handling is a separate concern from inclusion.
+      The field marker ``json_schema_extra={"unstructurable": True}`` means
+      "walk this embedded value through its own
+      ``unstructure()`` / ``structure()`` hooks." Full graph entities should not
+      be recursively embedded by default; they should be referenced by id unless
+      a field deliberately opts into embedded constructor-form semantics.
+      This generalizes explicit constructor-form handling for fields like
+      ``EntityTemplate.payload``; ``Registry.members`` keeps its bespoke path so
+      ``Registry.add()`` can preserve ownership-binding guardrails.
+      It should not revive the old automorphic structuring experiments from
+      ``scratch/legacy/core/core-23/structuring/``: no self-casting from data,
+      self-templating, property-name child inference, or object-self-shaping
+      pipeline belongs in the core constructor-form path.
     - Set ``guard_unstructure = True`` for classes that should refuse constructor-form
       export because they carry non-serializable behavior.
 
@@ -279,14 +309,137 @@ class Unstructurable(BaseModelPlus):
     """
 
     @classmethod
-    def structure(cls, data: UnstructuredData) -> Self:
+    def structure(cls, data: UnstructuredData, _ctx: Any = None) -> Self:
         data = dict(data)
         cls_ = data.pop('kind', cls)
         if not isclass(cls_):
             raise TypeError(f"Expected {cls_} to be a class")
+        if hasattr(cls_, "_match_fields"):
+            for name in cls_._match_fields(unstructurable=True):
+                if name not in data:
+                    continue
+                field_info = cls_.model_fields[name]
+                data[name] = cls._structure_unstructurable_value(
+                    data[name],
+                    field_info.annotation,
+                    _ctx=_ctx,
+                )
         return cls_(**data)
 
     guard_unstructure: ClassVar[bool] = False
+
+    @classmethod
+    def _structure_unstructurable_value(
+        cls,
+        value: Any,
+        annotation: Any = Any,
+        *,
+        _ctx: Any = None,
+    ) -> Any:
+        """Structure a marked embedded value using annotation or explicit ``kind``."""
+        if value is None:
+            return None
+
+        origin = get_origin(annotation)
+        args = get_args(annotation)
+
+        if origin in (Union, UnionType):
+            if value is None:
+                return None
+            for option in args:
+                if option is type(None):
+                    continue
+                return cls._structure_unstructurable_value(value, option, _ctx=_ctx)
+            return value
+
+        if origin in (dict,):
+            value_type = args[1] if len(args) == 2 else Any
+            return {
+                key: cls._structure_unstructurable_value(item, value_type, _ctx=_ctx)
+                for key, item in value.items()
+            }
+
+        if origin in (list, set, frozenset):
+            value_type = args[0] if args else Any
+            structured = [
+                cls._structure_unstructurable_value(item, value_type, _ctx=_ctx)
+                for item in value
+            ]
+            return origin(structured)
+
+        if origin is tuple:
+            if len(args) == 2 and args[1] is Ellipsis:
+                return tuple(
+                    cls._structure_unstructurable_value(item, args[0], _ctx=_ctx)
+                    for item in value
+                )
+            return tuple(
+                cls._structure_unstructurable_value(
+                    item,
+                    args[index] if index < len(args) else Any,
+                    _ctx=_ctx,
+                )
+                for index, item in enumerate(value)
+            )
+
+        if isinstance(value, dict):
+            cls_hint = value.get("kind", annotation)
+            if isclass(cls_hint) and hasattr(cls_hint, "structure"):
+                if "_ctx" in signature(cls_hint.structure).parameters:
+                    return cls_hint.structure(value, _ctx=_ctx)
+                return cls_hint.structure(value)
+            if isclass(annotation):
+                return annotation(**value)
+
+        return value
+
+    @classmethod
+    def _unstructure_unstructurable_value(cls, value: Any) -> Any:
+        """Unstructure a marked embedded value without falling back to model_dump."""
+        unstructure = getattr(value, "unstructure", None)
+        if callable(unstructure):
+            return unstructure()
+        if isinstance(value, dict):
+            return {
+                key: cls._unstructure_unstructurable_value(item)
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return [cls._unstructure_unstructurable_value(item) for item in value]
+        if isinstance(value, tuple):
+            return tuple(cls._unstructure_unstructurable_value(item) for item in value)
+        if isinstance(value, set):
+            return [cls._unstructure_unstructurable_value(item) for item in value]
+        if isinstance(value, frozenset):
+            return [cls._unstructure_unstructurable_value(item) for item in value]
+        return value
+
+    @staticmethod
+    def _field_default(field_info: FieldInfo) -> Any:
+        if field_info.default_factory is not None:
+            return field_info.default_factory()
+        return field_info.default
+
+    def _should_unstructure_field(
+        self,
+        name: str,
+        field_info: FieldInfo,
+        value: Any,
+    ) -> bool:
+        if field_info.is_required():
+            return True
+        if name in self.model_fields_set:
+            return True
+        extra = field_info.json_schema_extra or {}
+        if extra.get("include") is not True:
+            return False
+
+        default = self._field_default(field_info)
+        if default is PydanticUndefined:
+            return True
+        return self._unstructure_unstructurable_value(value) != (
+            self._unstructure_unstructurable_value(default)
+        )
 
     def unstructure(self) -> UnstructuredData:
         """Return constructor-form data.
@@ -303,12 +456,17 @@ class Unstructurable(BaseModelPlus):
             )
 
         exclude_fields = set(self._match_fields(exclude=True))
+        unstructurable_fields = set(self._match_fields(unstructurable=True))
         data = self.model_dump(
-            exclude=exclude_fields,
+            exclude=exclude_fields | unstructurable_fields,
             exclude_unset=True,
             exclude_defaults=True,
         )
-        include_fields = set(self._match_fields(include=True)) - exclude_fields
+        include_fields = (
+            set(self._match_fields(include=True))
+            - exclude_fields
+            - unstructurable_fields
+        )
         if include_fields:
             # Persist non-default values of opted-in fields even when they were
             # only mutated in place (exclude_unset would otherwise drop them);
@@ -317,6 +475,11 @@ class Unstructurable(BaseModelPlus):
             data.update(
                 self.model_dump(include=include_fields, exclude_defaults=True)
             )
+        for name in unstructurable_fields:
+            field_info = type(self).model_fields[name]
+            value = getattr(self, name)
+            if self._should_unstructure_field(name, field_info, value):
+                data[name] = self._unstructure_unstructurable_value(value)
         if 'uid' not in data and hasattr(self, 'uid'):
             data['uid'] = getattr(self, 'uid')
         data['kind'] = self.__class__

--- a/engine/src/tangl/core/bases.py
+++ b/engine/src/tangl/core/bases.py
@@ -312,8 +312,8 @@ class Unstructurable(BaseModelPlus):
     def structure(cls, data: UnstructuredData, _ctx: Any = None) -> Self:
         data = dict(data)
         cls_ = data.pop('kind', cls)
-        if not isclass(cls_):
-            raise TypeError(f"Expected {cls_} to be a class")
+        if not isclass(cls_) or not issubclass(cls_, cls):
+            raise TypeError(f"Expected a subclass of {cls.__name__}, got {cls_!r}")
         if hasattr(cls_, "_match_fields"):
             for name in cls_._match_fields(unstructurable=True):
                 if name not in data:

--- a/engine/src/tangl/core/entity.py
+++ b/engine/src/tangl/core/entity.py
@@ -95,4 +95,4 @@ class Entity(Unstructurable, HasIdentity, HasNamespace):
             from .dispatch import do_create
 
             data = do_create(data=data, ctx=_ctx)
-        return super().structure(data)
+        return super().structure(data, _ctx=_ctx)

--- a/engine/src/tangl/core/template.py
+++ b/engine/src/tangl/core/template.py
@@ -178,8 +178,12 @@ class EntityTemplate(RegistryAware, Record, Generic[ET]):
     # template to be used within a scope, or once per scope.  That should be captured in
     # metadata.
 
-    payload: ET = Field(..., exclude=True)
-    # Excluded from pydantic model_dump; unstructure/structure handles payload explicitly.
+    payload: ET = Field(
+        ...,
+        exclude=True,
+        json_schema_extra={"unstructurable": True},
+    )
+    # Excluded from pydantic model_dump; generic unstructurable recursion handles payload.
     admission_scope: str | None = None
     # Optional target-context scope gate for provisioning admission.
 
@@ -258,22 +262,6 @@ class EntityTemplate(RegistryAware, Record, Generic[ET]):
         else:
             updates.pop('uid', None)  # exact copy, discard any override uid
         return self.payload.evolve(**updates)
-
-    def unstructure(self) -> UnstructuredData:
-        """Serialize template record data plus explicitly serialized payload."""
-        data = super().unstructure()
-        # TODO: could use field annotation introspection to discover members and
-        #       payload include nested entities and automatically structure/unstructure
-        #       them recursively
-        data['payload'] = self.payload.unstructure()
-        return data
-
-    @classmethod
-    def structure(cls, data: UnstructuredData, _ctx=None) -> Self:
-        """Structure template record data plus structured payload."""
-        data = dict(data)
-        data['payload'] = Entity.structure(data['payload'], _ctx=_ctx)
-        return super().structure(data)
 
     def decompile(self, generify = True) -> UnstructuredData:
         """Return author-facing payload script data.

--- a/engine/src/tangl/mechanics/assembly/COMPONENT_DESIGN.md
+++ b/engine/src/tangl/mechanics/assembly/COMPONENT_DESIGN.md
@@ -7,7 +7,7 @@
 :related: presence, credentials, sandbox
 ```
 
-**Document Version:** 0.9
+**Document Version:** 1.0
 **Status:** DESIGN — the bridge spec that routes the assembly/component work
 *through* the facet generalization (`MU_AFFORDANCES.md` v0.3) instead of beside it.
 *v0.2: facet discriminator split into `channel` (relevance) + `facet_type`
@@ -20,6 +20,39 @@ order via a produces/consumes DAG (topo-sort), sharing its acyclicity check with
 **Prior art:** `concepts/role.py` `RoleGrant` (#141, the degenerate affordance facet),
 `mechanics/sandbox/visibility.py` `SandboxVisibilityRule` (the degenerate restriction),
 `mechanics/assembly/base.py` `SlottedContainer`.
+
+---
+
+## Implementation Status: Owner-Bound Managers
+
+The assembly layer now has two storage identities that share the same slot,
+validation, budget, and facet-discovery APIs:
+
+- `SlottedContainer[CT]` is the direct in-memory instrument used by demos, tests, and
+  non-graph consumers. It stores component objects in its slots.
+- `ComponentManager[CT]` is the owner-bound graph-aware specialization. It is embedded
+  on a full graph member, persists with that owner, stores slot membership as component
+  UUIDs, and dereferences those UUIDs through the owner's registry. Its `owner` pointer
+  and transient construction cache are not constructor-form data.
+
+This is the intended middle between "full graph member" and "plain Pydantic blob":
+components remain full graph members when they need graph identity; embedded managers
+serialize by value but hold graph members by reference.
+
+`OutfitManager` is the first concrete manager on this path. A `HasOutfit` actor now
+round-trips through `Graph.unstructure()` / `Graph.structure()` with outfit assignments
+preserved as restored wearable graph members, not inline duplicates.
+
+The neutral vehicle example is the second proof consumer. `Vehicle` embeds a
+`VehicleLoadout`, while chassis, powerplant, suspension, and tire parts are
+`VehicleComponent` graph tokens over `VehicleComponentType` singleton definitions.
+The example exercises named single-occupancy slots, replacement-on-assign, required
+slot validation, total price/weight validation, and a simple weight-to-powerplant
+constraint without importing CarWars-specific semantics into the generic layer.
+
+Follow-up retrofit targets remain open: credential packets, domain vehicle managers
+such as CarWars adapters, robot assemblies, and any world-specific full-graph outfit
+manager such as a future `SharedOutfit` / `FashionShowActor` demo.
 
 ---
 

--- a/engine/src/tangl/mechanics/assembly/__init__.py
+++ b/engine/src/tangl/mechanics/assembly/__init__.py
@@ -2,7 +2,7 @@
 Composable loadout containers built on :class:`tangl.core.Selector`.
 """
 
-from .base import HasResourceCost, HasSlottedContainer, SlottedContainer
+from .base import ComponentManager, HasResourceCost, HasSlottedContainer, SlottedContainer
 from .budget import BudgetTracker, ResourceBudget
 from .component import Component, ComponentFacet, ConnectorPolarity
 from .slot import Slot, SlotGroup
@@ -10,6 +10,7 @@ from .slot import Slot, SlotGroup
 __all__ = [
     "Component",
     "ComponentFacet",
+    "ComponentManager",
     "ConnectorPolarity",
     "HasResourceCost",
     "HasSlottedContainer",

--- a/engine/src/tangl/mechanics/assembly/base.py
+++ b/engine/src/tangl/mechanics/assembly/base.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 from collections import defaultdict
 from enum import Enum
+from inspect import isclass
 from numbers import Real
 from typing import Any, ClassVar, Generic, Optional, Protocol, TypeVar, cast
+from uuid import UUID
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, PrivateAttr, model_validator
 
 from tangl.core import Entity, Selector
-from tangl.type_hints import Tag
+from tangl.type_hints import Tag, UnstructuredData
 from .budget import BudgetTracker
 from .component import Component, ComponentFacet
 from .slot import Slot, SlotGroup
@@ -40,6 +42,27 @@ class SlottedContainer(BaseModel, Generic[CT]):
     budgets: Optional[BudgetTracker] = None
     owner: Any = Field(default=None, exclude=True)
 
+    def _slot_names(self) -> list[str]:
+        return list(self.assignments)
+
+    def _slot_components(self, slot_name: str) -> list[CT]:
+        return self.assignments.get(slot_name, [])
+
+    def _has_slot_components(self, slot_name: str) -> bool:
+        return bool(self._slot_components(slot_name))
+
+    def _slot_count(self, slot_name: str) -> int:
+        return len(self._slot_components(slot_name))
+
+    def _add_to_slot(self, slot_name: str, component: CT) -> None:
+        self.assignments[slot_name].append(component)
+
+    def _remove_from_slot(self, slot_name: str, component: CT) -> bool:
+        if component not in self.assignments.get(slot_name, []):
+            return False
+        self.assignments[slot_name].remove(component)
+        return True
+
     @model_validator(mode="after")
     def _initialize_budgets(self) -> "SlottedContainer[CT]":
         if self.tracked_resources and not self.budgets:
@@ -57,27 +80,23 @@ class SlottedContainer(BaseModel, Generic[CT]):
         if not can_assign:
             raise ValueError(f"Cannot assign {component.label!r} to {slot_name}: {reason}")
 
-        self.assignments[slot_name].append(component)
+        self._add_to_slot(slot_name, component)
 
         if self.budgets:
             self.budgets.recalculate(self.all_components())
 
     def unassign(self, slot_name: str, component: CT) -> None:
-        if slot_name not in self.assignments:
-            return
-
-        if component in self.assignments[slot_name]:
-            self.assignments[slot_name].remove(component)
+        if self._remove_from_slot(slot_name, component):
             if self.budgets:
                 self.budgets.recalculate(self.all_components())
 
     def get_slot(self, slot_name: str) -> list[CT]:
-        return self.assignments.get(slot_name, [])
+        return self._slot_components(slot_name)
 
     def all_components(self) -> list[CT]:
         result: list[CT] = []
-        for components in self.assignments.values():
-            result.extend(components)
+        for slot_name in self._slot_names():
+            result.extend(self._slot_components(slot_name))
         return result
 
     def component_facets(
@@ -90,9 +109,9 @@ class SlottedContainer(BaseModel, Generic[CT]):
 
         facets: list[ComponentFacet] = []
         slot_names = list(self.slots)
-        slot_names.extend(name for name in self.assignments if name not in self.slots)
+        slot_names.extend(name for name in self._slot_names() if name not in self.slots)
         for slot_name in slot_names:
-            components = self.assignments.get(slot_name, [])
+            components = self._slot_components(slot_name)
             for component in components:
                 facets.extend(
                     component.component_facets(
@@ -120,18 +139,18 @@ class SlottedContainer(BaseModel, Generic[CT]):
         pending = [
             slot_name
             for slot_name, slot in self.slots.items()
-            if slot.default_factory is not None and not self.assignments.get(slot_name)
+            if slot.default_factory is not None and not self._has_slot_components(slot_name)
         ]
         materialized: list[CT] = []
         while pending:
             progressed = False
             for slot_name in list(pending):
                 slot = self.slots[slot_name]
-                if self.assignments.get(slot_name) or not self.is_slot_enabled(slot_name):
+                if self._has_slot_components(slot_name) or not self.is_slot_enabled(slot_name):
                     pending.remove(slot_name)
                     continue
                 if any(
-                    not self.assignments.get(prerequisite)
+                    not self._has_slot_components(prerequisite)
                     for prerequisite in slot.prerequisite_slots
                 ):
                     continue
@@ -231,12 +250,12 @@ class SlottedContainer(BaseModel, Generic[CT]):
         missing_prerequisites = [
             prerequisite
             for prerequisite in slot.prerequisite_slots
-            if not self.assignments.get(prerequisite)
+            if not self._has_slot_components(prerequisite)
         ]
         if missing_prerequisites:
             return False, f"Missing prerequisite slots: {', '.join(missing_prerequisites)}"
 
-        current_count = len(self.assignments.get(slot_name, []))
+        current_count = self._slot_count(slot_name)
         if current_count >= slot.max_count:
             return False, f"Slot full ({current_count}/{slot.max_count})"
 
@@ -264,19 +283,19 @@ class SlottedContainer(BaseModel, Generic[CT]):
 
         for slot_name, slot in self.slots.items():
             enabled = self.is_slot_enabled(slot_name)
-            if not enabled and self.assignments.get(slot_name):
+            if not enabled and self._has_slot_components(slot_name):
                 errors.append(f"Disabled slot occupied: {slot_name}")
-            if enabled and slot.required and not self.assignments.get(slot_name):
+            if enabled and slot.required and not self._has_slot_components(slot_name):
                 errors.append(f"Required slot empty: {slot_name}")
-            if enabled and self.assignments.get(slot_name):
+            if enabled and self._has_slot_components(slot_name):
                 for prerequisite in slot.prerequisite_slots:
-                    if not self.assignments.get(prerequisite):
+                    if not self._has_slot_components(prerequisite):
                         errors.append(
                             f"Slot '{slot_name}' missing prerequisite slot: {prerequisite}"
                         )
 
         for group in self.slot_groups:
-            total = sum(len(self.assignments.get(name, [])) for name in group.slot_names)
+            total = sum(self._slot_count(name) for name in group.slot_names)
             if group.min_total is not None and total < group.min_total:
                 errors.append(f"Group '{group.name}': {total} < {group.min_total} (min)")
             if group.max_total is not None and total > group.max_total:
@@ -294,6 +313,87 @@ class SlottedContainer(BaseModel, Generic[CT]):
     @property
     def is_valid(self) -> bool:
         return len(self.validate()) == 0
+
+
+class ComponentManager(SlottedContainer[CT]):
+    """Owner-bound slotted manager that persists graph-member assignments by UUID."""
+
+    assignment_ids: dict[str, list[UUID]] = Field(default_factory=dict)
+    _component_cache: dict[UUID, CT] = PrivateAttr(default_factory=dict)
+
+    def bind_owner(self, owner: Any) -> "ComponentManager[CT]":
+        self.owner = owner
+        return self
+
+    def _slot_names(self) -> list[str]:
+        return list(self.assignment_ids)
+
+    def _owner_registry(self):
+        if self.owner is None:
+            return None
+        return getattr(self.owner, "registry", None)
+
+    def _resolve_component(self, component_id: UUID) -> CT:
+        registry = self._owner_registry()
+        if registry is not None:
+            component = registry.get(component_id)
+            if component is not None:
+                return cast(CT, component)
+        if component_id in self._component_cache:
+            return self._component_cache[component_id]
+        raise KeyError(f"Component {component_id} is not available through the owner registry")
+
+    def _slot_components(self, slot_name: str) -> list[CT]:
+        return [
+            self._resolve_component(component_id)
+            for component_id in self.assignment_ids.get(slot_name, [])
+        ]
+
+    def _has_slot_components(self, slot_name: str) -> bool:
+        return bool(self.assignment_ids.get(slot_name))
+
+    def _slot_count(self, slot_name: str) -> int:
+        return len(self.assignment_ids.get(slot_name, []))
+
+    def _validate_component_registry(self, component: CT) -> None:
+        registry = self._owner_registry()
+        if registry is None:
+            return
+        if getattr(component, "registry", None) is not registry:
+            raise ValueError("Assigned component must belong to the owner's registry")
+        if registry.get(component.uid) is not component:
+            raise ValueError("Assigned component must be registered before assignment")
+
+    def _add_to_slot(self, slot_name: str, component: CT) -> None:
+        self._validate_component_registry(component)
+        self.assignment_ids.setdefault(slot_name, []).append(component.uid)
+        self._component_cache[component.uid] = component
+
+    def _remove_from_slot(self, slot_name: str, component: CT) -> bool:
+        component_ids = self.assignment_ids.get(slot_name)
+        if not component_ids or component.uid not in component_ids:
+            return False
+        component_ids.remove(component.uid)
+        if not component_ids:
+            self.assignment_ids.pop(slot_name, None)
+        return True
+
+    def unstructure(self) -> UnstructuredData:
+        data: UnstructuredData = {"kind": self.__class__}
+        if self.assignment_ids:
+            data["assignment_ids"] = self.assignment_ids
+        if self.budgets is not None:
+            data["budgets"] = self.budgets.model_dump(exclude_defaults=True)
+        return data
+
+    @classmethod
+    def structure(cls, data: UnstructuredData, _ctx: Any = None) -> "ComponentManager[CT]":
+        _ = _ctx
+        payload = dict(data)
+        cls_ = payload.pop("kind", cls)
+        if not isclass(cls_):
+            raise TypeError(f"Expected {cls_} to be a class")
+        return cls_(**payload)
 
 
 class HasSlottedContainer:

--- a/engine/src/tangl/mechanics/assembly/base.py
+++ b/engine/src/tangl/mechanics/assembly/base.py
@@ -403,8 +403,8 @@ class ComponentManager(SlottedContainer[CT]):
         _ = _ctx
         payload = dict(data)
         cls_ = payload.pop("kind", cls)
-        if not isclass(cls_):
-            raise TypeError(f"Expected {cls_} to be a class")
+        if not isclass(cls_) or not issubclass(cls_, cls):
+            raise TypeError(f"Expected a subclass of {cls.__name__}, got {cls_!r}")
         return cls_(**payload)
 
 

--- a/engine/src/tangl/mechanics/assembly/base.py
+++ b/engine/src/tangl/mechanics/assembly/base.py
@@ -359,10 +359,20 @@ class ComponentManager(SlottedContainer[CT]):
         registry = self._owner_registry()
         if registry is None:
             return
-        if getattr(component, "registry", None) is not registry:
+        component_registry = getattr(component, "registry", None)
+        registered_component = registry.get(component.uid)
+        if component_registry is None:
+            if registered_component is not None and registered_component is not component:
+                raise ValueError("Assigned component UID is already registered to another item")
+            registry.add(component)
+            return
+        if component_registry is not registry:
             raise ValueError("Assigned component must belong to the owner's registry")
-        if registry.get(component.uid) is not component:
-            raise ValueError("Assigned component must be registered before assignment")
+        if registered_component is None:
+            registry.add(component)
+            return
+        if registered_component is not component:
+            raise ValueError("Assigned component UID is already registered to another item")
 
     def _add_to_slot(self, slot_name: str, component: CT) -> None:
         self._validate_component_registry(component)
@@ -376,6 +386,8 @@ class ComponentManager(SlottedContainer[CT]):
         component_ids.remove(component.uid)
         if not component_ids:
             self.assignment_ids.pop(slot_name, None)
+        if not any(component.uid in ids for ids in self.assignment_ids.values()):
+            self._component_cache.pop(component.uid, None)
         return True
 
     def unstructure(self) -> UnstructuredData:

--- a/engine/src/tangl/mechanics/assembly/examples/vehicle.py
+++ b/engine/src/tangl/mechanics/assembly/examples/vehicle.py
@@ -178,6 +178,8 @@ class VehicleLoadout(ComponentManager[VehicleComponent]):
         except Exception:
             for old_component in replaced:
                 self._add_to_slot(slot_name, old_component)
+            if self.budgets:
+                self.budgets.recalculate(self.all_components())
             raise
 
     def total_weight(self) -> float:

--- a/engine/src/tangl/mechanics/assembly/examples/vehicle.py
+++ b/engine/src/tangl/mechanics/assembly/examples/vehicle.py
@@ -1,78 +1,328 @@
 from __future__ import annotations
 
+from enum import Enum
 from typing import ClassVar
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
-from tangl.core import Node
-from tangl.mechanics.assembly import HasResourceCost, HasSlottedContainer, Slot, SlottedContainer
+from tangl.core import Node, Singleton, Token, contribute_ns
+from tangl.lang.helpers import oxford_join
+from tangl.mechanics.assembly import ComponentManager, Slot
 
 
-class VehicleComponent(Node, HasResourceCost):
-    """Base class for vehicle parts used in :class:`VehicleLoadout`."""
+class VehiclePartType(Enum):
+    """Named vehicle loadout slots for the neutral vehicle example."""
 
-    power_cost: float = 0.0
+    CHASSIS = "chassis"
+    POWERPLANT = "powerplant"
+    SUSPENSION = "suspension"
+    TIRES = "tires"
+
+
+class VehicleComponentType(Singleton):
+    """Vehicle component definition used by graph-local vehicle part tokens."""
+
+    part_type: VehiclePartType
     weight_cost: float = 0.0
+    price_cost: float = 0.0
+    power_draw: float = 0.0
+    power_output: float = 0.0
+    max_weight: float | None = None
+
+    damage: int = Field(0, json_schema_extra={"instance_var": True})
 
     def get_cost(self, resource: str) -> float:
+        if resource == "price":
+            return self.price_cost
+        if resource == "power":
+            return self.power_draw
         return getattr(self, f"{resource}_cost", 0.0)
 
 
-class VehicleLoadout(SlottedContainer[VehicleComponent]):
-    """Slot definitions and validation for a vehicle configuration."""
+class VehicleComponentToken(Token):
+    """Vehicle part token whose label-like display is the referenced part type."""
+
+    def get_label(self) -> str:
+        return self.token_from or self.label
+
+
+VehicleComponent = VehicleComponentToken._create_wrapper_cls(
+    VehicleComponentType,
+    "VehicleComponent",
+)
+
+
+def _part(part_type: VehiclePartType):
+    return lambda component: getattr(component, "part_type", None) is part_type
+
+
+def _part_name(component: VehicleComponent) -> str:
+    return (component.token_from or component.label).replace("_", " ")
+
+
+def _install_component_types() -> None:
+    if VehicleComponentType.has_instance("mini_chassis"):
+        return
+    VehicleComponentType(
+        label="mini_chassis",
+        part_type=VehiclePartType.CHASSIS,
+        weight_cost=500,
+        price_cost=500,
+        max_weight=900,
+    )
+    VehicleComponentType(
+        label="mid_chassis",
+        part_type=VehiclePartType.CHASSIS,
+        weight_cost=800,
+        price_cost=1000,
+        max_weight=1400,
+    )
+    VehicleComponentType(
+        label="truck_chassis",
+        part_type=VehiclePartType.CHASSIS,
+        weight_cost=1400,
+        price_cost=1600,
+        max_weight=2500,
+    )
+    VehicleComponentType(
+        label="cheap_powerplant",
+        part_type=VehiclePartType.POWERPLANT,
+        weight_cost=200,
+        price_cost=400,
+        power_output=45,
+    )
+    VehicleComponentType(
+        label="big_powerplant",
+        part_type=VehiclePartType.POWERPLANT,
+        weight_cost=450,
+        price_cost=1200,
+        power_output=120,
+    )
+    VehicleComponentType(
+        label="cheap_tires",
+        part_type=VehiclePartType.TIRES,
+        weight_cost=80,
+        price_cost=100,
+    )
+    VehicleComponentType(
+        label="slicks",
+        part_type=VehiclePartType.TIRES,
+        weight_cost=90,
+        price_cost=350,
+    )
+    VehicleComponentType(
+        label="all_terrain",
+        part_type=VehiclePartType.TIRES,
+        weight_cost=150,
+        price_cost=450,
+    )
+    VehicleComponentType(
+        label="cheap_suspension",
+        part_type=VehiclePartType.SUSPENSION,
+        weight_cost=100,
+        price_cost=200,
+    )
+    VehicleComponentType(
+        label="off_road_suspension",
+        part_type=VehiclePartType.SUSPENSION,
+        weight_cost=220,
+        price_cost=600,
+    )
+    VehicleComponentType(
+        label="racing_suspension",
+        part_type=VehiclePartType.SUSPENSION,
+        weight_cost=180,
+        price_cost=700,
+    )
+
+
+_install_component_types()
+
+
+class VehicleLoadout(ComponentManager[VehicleComponent]):
+    """Owner-bound single-slot manager for a neutral vehicle configuration."""
 
     slots: ClassVar[dict[str, Slot]] = {
-        "chassis": Slot.for_tags("chassis", tags={"chassis"}, required=True),
-        "powerplant": Slot.for_tags("powerplant", tags={"powerplant"}, required=True),
-        "weapon_front": Slot.for_tags("weapon_front", tags={"weapon"}, max_count=2),
-        "weapon_rear": Slot.for_tags("weapon_rear", tags={"weapon"}, max_count=2),
-        "weapon_turret": Slot(
-            name="weapon_turret",
-            selection_criteria={
-                "has_tags": {"weapon"},
-                "predicate": lambda weapon: not weapon.has_tags({"melee"}),
-            },
-            max_count=1,
+        "chassis": Slot.for_predicate(
+            "chassis",
+            _part(VehiclePartType.CHASSIS),
+            required=True,
         ),
-        "gadget": Slot.for_tags("gadget", tags={"gadget"}, max_count=5),
+        "powerplant": Slot.for_predicate(
+            "powerplant",
+            _part(VehiclePartType.POWERPLANT),
+            required=True,
+        ),
+        "suspension": Slot.for_predicate(
+            "suspension",
+            _part(VehiclePartType.SUSPENSION),
+            required=True,
+        ),
+        "tires": Slot.for_predicate(
+            "tires",
+            _part(VehiclePartType.TIRES),
+            required=True,
+        ),
     }
 
-    tracked_resources: ClassVar[list[str]] = ["power", "weight"]
+    def assign(self, slot_name: str, component: VehicleComponent) -> None:
+        slot = self.slots[slot_name]
+        replaced = []
+        if slot.max_count == 1 and self._has_slot_components(slot_name):
+            replaced = list(self.get_slot(slot_name))
+            for old_component in replaced:
+                self._remove_from_slot(slot_name, old_component)
+
+        try:
+            super().assign(slot_name, component)
+        except Exception:
+            for old_component in replaced:
+                self._add_to_slot(slot_name, old_component)
+            raise
+
+    def total_weight(self) -> float:
+        return self.get_aggregate_cost("weight")
+
+    def total_price(self) -> float:
+        return self.get_aggregate_cost("price")
+
+    def _single(self, slot_name: str) -> VehicleComponent | None:
+        components = self.get_slot(slot_name)
+        return components[0] if components else None
+
+    def describe_items(self) -> list[str]:
+        """Return concise slot/component labels for prose or prompt adapters."""
+        items: list[str] = []
+        for slot_name in self.slots:
+            component = self._single(slot_name)
+            if component is not None:
+                items.append(f"{slot_name}: {_part_name(component)}")
+        return items
+
+    def describe_warnings(self) -> list[str]:
+        """Return concise loadout warning phrases derived from validation errors."""
+        warnings: list[str] = []
+        for error in self.validate():
+            if error.startswith("Required slot empty: "):
+                slot_name = error.removeprefix("Required slot empty: ")
+                warnings.append(f"missing {slot_name}")
+            elif error.startswith("Powerplant output too low: "):
+                warnings.append("powerplant output is too low")
+            elif error.startswith("Weight exceeds chassis capacity: "):
+                warnings.append("weight exceeds chassis capacity")
+            elif error.startswith("Price exceeds budget: "):
+                warnings.append("price exceeds budget")
+            else:
+                warnings.append(error[:1].lower() + error[1:])
+        return warnings
+
+    def describe(self) -> str:
+        """Return a compact procedural description of the vehicle loadout."""
+        chassis = self._single("chassis")
+        powerplant = self._single("powerplant")
+        suspension = self._single("suspension")
+        tires = self._single("tires")
+
+        if not any((chassis, powerplant, suspension, tires)):
+            description = "an unconfigured vehicle"
+            warnings = self.describe_warnings()
+            if warnings:
+                return f"{description}. Warning: {oxford_join(warnings)}."
+            return description
+
+        parts: list[str] = []
+        if chassis is not None:
+            parts.append(f"built on a {_part_name(chassis)}")
+        if powerplant is not None:
+            parts.append(f"powered by a {_part_name(powerplant)}")
+        if suspension is not None:
+            parts.append(f"riding on {_part_name(suspension)}")
+        if tires is not None:
+            parts.append(f"with {_part_name(tires)}")
+
+        summary = oxford_join(parts)
+        description = f"a vehicle {summary}"
+        warnings = self.describe_warnings()
+        if warnings:
+            return f"{description}. Warning: {oxford_join(warnings)}."
+        return description
 
     def _validate_custom(self) -> list[str]:
         errors: list[str] = []
 
-        chassis_list = self.get_slot("chassis")
-        if chassis_list and self.budgets:
-            chassis = chassis_list[0]
-            max_weight = getattr(chassis, "max_weight", None)
-            weight_budget = self.budgets.budgets.get("weight") if self.budgets else None
-            if max_weight is not None and weight_budget and weight_budget.consumed > max_weight:
+        chassis = self._single("chassis")
+        powerplant = self._single("powerplant")
+        total_weight = self.total_weight()
+        total_price = self.total_price()
+
+        if chassis is not None and chassis.max_weight is not None:
+            if total_weight > chassis.max_weight:
                 errors.append(
-                    f"Weight exceeds chassis capacity: {weight_budget.consumed:.1f} > {max_weight}"
+                    f"Weight exceeds chassis capacity: {total_weight:.1f} > {chassis.max_weight:.1f}"
                 )
 
-        powerplant_list = self.get_slot("powerplant")
-        if powerplant_list and self.budgets:
-            powerplant = powerplant_list[0]
-            max_power = getattr(powerplant, "max_power_output", None)
-            power_budget = self.budgets.budgets.get("power") if self.budgets else None
-            if max_power is not None and power_budget and power_budget.consumed > max_power:
+        if powerplant is not None:
+            owner = self.owner
+            heavy_threshold = getattr(owner, "heavy_weight_threshold", 1200.0)
+            required_power = (
+                getattr(owner, "heavy_power_required", 90.0)
+                if total_weight > heavy_threshold
+                else getattr(owner, "light_power_required", 40.0)
+            )
+            if powerplant.power_output < required_power:
                 errors.append(
-                    f"Power exceeds powerplant capacity: {power_budget.consumed:.1f} > {max_power}"
+                    "Powerplant output too low: "
+                    f"{powerplant.power_output:.1f} < {required_power:.1f}"
                 )
+
+        owner = self.owner
+        max_price = getattr(owner, "max_price", None)
+        if max_price is not None and total_price > max_price:
+            errors.append(f"Price exceeds budget: {total_price:.1f} > {max_price:.1f}")
 
         return errors
 
 
-class Vehicle(HasSlottedContainer, Node):
-    """Vehicle entity with an attached :class:`VehicleLoadout`."""
+class Vehicle(Node):
+    """Vehicle graph member with an embedded owner-bound loadout manager."""
 
-    _container_class: ClassVar[type[SlottedContainer]] = VehicleLoadout
+    max_price: float = 5000.0
+    heavy_weight_threshold: float = 1200.0
+    light_power_required: float = 40.0
+    heavy_power_required: float = 90.0
+    loadout: VehicleLoadout = Field(
+        default_factory=VehicleLoadout,
+        json_schema_extra={"include": True, "unstructurable": True},
+    )
 
-    max_power: float = Field(100.0, description="Power budget available to the loadout.")
-    max_weight: float = Field(1000.0, description="Weight budget available to the loadout.")
+    @model_validator(mode="after")
+    def _bind_loadout_owner(self) -> "Vehicle":
+        self.loadout.bind_owner(self)
+        return self
 
     @property
     def vehicle_loadout(self) -> VehicleLoadout:
-        return self.loadout  # type: ignore[return-value]
+        return self.loadout
+
+    def describe_vehicle(self) -> str:
+        """Return a compact procedural description of this vehicle."""
+        return self.loadout.describe()
+
+    @contribute_ns
+    def provide_vehicle_symbols(self) -> dict[str, object]:
+        """Publish vehicle loadout symbols into the entity-local namespace."""
+        return {
+            "vehicle_loadout": self.loadout,
+            "vehicle_description": self.describe_vehicle(),
+            "vehicle_component_tokens": self.loadout.describe_items(),
+        }
+
+
+__all__ = [
+    "Vehicle",
+    "VehicleComponent",
+    "VehicleComponentToken",
+    "VehicleComponentType",
+    "VehicleLoadout",
+    "VehiclePartType",
+]

--- a/engine/src/tangl/mechanics/assembly/examples/vehicle.py
+++ b/engine/src/tangl/mechanics/assembly/examples/vehicle.py
@@ -265,11 +265,11 @@ class VehicleLoadout(ComponentManager[VehicleComponent]):
 
         if powerplant is not None:
             owner = self.owner
-            heavy_threshold = getattr(owner, "heavy_weight_threshold", 1200.0)
+            heavy_threshold = owner.heavy_weight_threshold
             required_power = (
-                getattr(owner, "heavy_power_required", 90.0)
+                owner.heavy_power_required
                 if total_weight > heavy_threshold
-                else getattr(owner, "light_power_required", 40.0)
+                else owner.light_power_required
             )
             if powerplant.power_output < required_power:
                 errors.append(
@@ -278,7 +278,7 @@ class VehicleLoadout(ComponentManager[VehicleComponent]):
                 )
 
         owner = self.owner
-        max_price = getattr(owner, "max_price", None)
+        max_price = owner.max_price
         if max_price is not None and total_price > max_price:
             errors.append(f"Price exceeds budget: {total_price:.1f} > {max_price:.1f}")
 

--- a/engine/src/tangl/mechanics/presence/PRESENCE_ASSEMBLY_DESIGN.md
+++ b/engine/src/tangl/mechanics/presence/PRESENCE_ASSEMBLY_DESIGN.md
@@ -7,17 +7,31 @@
 :related: media, open_link, credentials, token
 ```
 
-**Status:** DESIGN — assessment, not an implementation plan. The question is how to
-avoid a family of parallel systems that all look like "components attached to a
-body/vehicle/entity, with slots, visibility, constraints, and projections."
+**Status:** DESIGN + FIRST IMPLEMENTATION SLICE. The question is how to avoid a family
+of parallel systems that all look like "components attached to a body/vehicle/entity,
+with slots, visibility, constraints, and projections."
 
 > Issue tracking: see the "Presence / body-attachment unification" issue and the
 > assembly-core issues (#131 umbrella → #194/#195/#196). This doc holds the *what
 > and why*; the issues hold the *where-next*.
 
+## Implementation status
+
+`OutfitManager` now uses the assembly-layer `ComponentManager` path: it is still
+embedded on `HasOutfit`, but its assigned wearables are graph members stored by UUID
+and dereferenced through the owning actor's registry. `HasOutfit.outfit` opts into
+constructor-form persistence with `json_schema_extra={"include": True,
+"unstructurable": True}`, so mutated outfit state survives graph round-trips without
+making the outfit manager a graph item.
+
+This resolves the first serialization identity bug for outfits. The body-attachment
+generalization below remains the design target for ornaments, injuries, cybernetics,
+robot parts, vehicles, and credential packets.
+
 ## Current shape
 
-- `OutfitManager` is already a real `SlottedContainer[Wearable]`.
+- `OutfitManager` is a real `ComponentManager[Wearable]` using the shared
+  `SlottedContainer` slot, validation, budget, and facet APIs.
 - `WearableType` is an `AssetType`; `Wearable` is a token wrapper over that type.
 - `Ornamentation` is still a plain `Node` with `collection: list[Ornament]`.
 - `Ornament` is an `Entity` with `body_part: BodyPart`, `ornament_type: OrnamentType`, `text: str`.

--- a/engine/src/tangl/mechanics/presence/look/look.py
+++ b/engine/src/tangl/mechanics/presence/look/look.py
@@ -363,12 +363,14 @@ class HasSimpleLook(Entity):
 class HasOutfit(Entity):
     """Direct facet exposing outfit state and outfit-driven adapters."""
 
-    outfit: OutfitManager = Field(default_factory=OutfitManager)
+    outfit: OutfitManager = Field(
+        default_factory=OutfitManager,
+        json_schema_extra={"include": True, "unstructurable": True},
+    )
 
     @model_validator(mode="after")
     def _bind_outfit_owner(self) -> "HasOutfit":
-        if self.outfit.owner is None:
-            self.outfit.owner = self
+        self.outfit.bind_owner(self)
         return self
 
     def describe_outfit(self) -> str:

--- a/engine/src/tangl/mechanics/presence/outfit.py
+++ b/engine/src/tangl/mechanics/presence/outfit.py
@@ -11,12 +11,12 @@ from __future__ import annotations
 
 from tangl.lang.helpers import oxford_join
 from tangl.lang.body_parts import BodyPart, BodyRegion
-from tangl.mechanics.assembly import Slot, SlottedContainer
+from tangl.mechanics.assembly import ComponentManager, Slot
 from tangl.mechanics.presence.wearable import Wearable
 from tangl.mechanics.presence.wearable.enums import WearableLayer, WearableState
 
 
-class OutfitManager(SlottedContainer[Wearable]):
+class OutfitManager(ComponentManager[Wearable]):
     """Manage wearable items across body regions and clothing layers.
 
     Key Features

--- a/engine/tests/AGENTS.md
+++ b/engine/tests/AGENTS.md
@@ -34,6 +34,26 @@ Each test module should comprehensively cover its concept:
 - ✅ **Serialization** - Roundtrip testing (unstructure/structure, pickle)
 - ✅ **Integration** - How the concept interacts with related concepts
 
+For graph/runtime data, serialization tests mean constructor-form
+`unstructure()` / `structure()` round-trips, not `model_dump()` snapshots.
+`model_dump()` can prove a DTO or local Pydantic view, but it does not prove
+that entity references, embedded managers, graph membership, or mutated default
+fields survive persistence. Any new manager/component/sub-entity-like type that
+stores or resolves other entities must include a sample graph round-trip with
+populated data and assert that the restored graph has the same ids, membership,
+and dereferenced objects without inline duplicates.
+
+When a field is explicitly marked for embedded constructor-form recursion
+(for example `json_schema_extra={"unstructurable": True}`), tests should prove
+both sides of the marker:
+
+- the parent includes the field when mutated in place, when also marked
+  `include=True`;
+- the nested object is recursively unstructured/structured through its own
+  constructor-form hooks;
+- graph members inside that nested object are still references, not inline
+  duplicate entities.
+
 ### 3. Conciseness and Parsimony
 
 - **Eliminate duplication** - No `test_foo`, `test_foo2`, `test_foo3`
@@ -399,6 +419,24 @@ def test_entity_unstructure_structure_roundtrip(self):
     restored = Entity.structure(data)
     assert isinstance(restored, Person)
     assert restored == original
+```
+
+For relationship-bearing types, build the whole owner graph:
+
+```python
+def test_owner_manager_roundtrips_referenced_members():
+    graph = Graph()
+    owner = graph.add_node(kind=OwnerWithManager, label="owner")
+    component = graph.add_node(kind=ManagedComponent, label="component")
+    owner.manager.assign("slot", component)
+
+    restored = Graph.structure(graph.unstructure())
+    restored_owner = restored.find_node(Selector(label="owner"))
+    restored_component = restored.find_node(Selector(label="component"))
+
+    assert restored_owner.manager.get_slot("slot") == [restored_component]
+    assert restored_owner.manager.get_slot("slot")[0].uid == component.uid
+    assert len([item for item in restored.members.values() if item.uid == component.uid]) == 1
 ```
 
 ### Testing Collections

--- a/engine/tests/core/bases/test_bases.py
+++ b/engine/tests/core/bases/test_bases.py
@@ -194,6 +194,100 @@ class TestUnstructurable:
         right = Demo(value=2)
         assert left.value_hash() != right.value_hash()
 
+    def test_marked_scalar_field_round_trips_with_kind(self) -> None:
+        class Embedded(Unstructurable):
+            value: int
+
+        class SpecialEmbedded(Embedded):
+            name: str
+
+        class Holder(Unstructurable):
+            child: Embedded = Field(json_schema_extra={"unstructurable": True})
+
+        holder = Holder(child=SpecialEmbedded(value=3, name="kept"))
+        data = holder.unstructure()
+        restored = Holder.structure(data)
+
+        assert data["child"]["kind"] is SpecialEmbedded
+        assert isinstance(restored.child, SpecialEmbedded)
+        assert restored.child.name == "kept"
+
+    def test_marked_collection_fields_round_trip_with_kind(self) -> None:
+        class Embedded(Unstructurable):
+            model_config = ConfigDict(frozen=True)
+
+            value: int
+
+        class SpecialEmbedded(Embedded):
+            label: str
+
+        class Holder(Unstructurable):
+            items: list[Embedded] = Field(
+                default_factory=list,
+                json_schema_extra={"include": True, "unstructurable": True},
+            )
+            unique_items: set[Embedded] = Field(
+                default_factory=set,
+                json_schema_extra={"include": True, "unstructurable": True},
+            )
+            by_key: dict[str, Embedded] = Field(
+                default_factory=dict,
+                json_schema_extra={"include": True, "unstructurable": True},
+            )
+
+        first = Embedded(value=1)
+        second = SpecialEmbedded(value=2, label="two")
+        holder = Holder()
+        holder.items.append(second)
+        holder.unique_items.add(first)
+        holder.by_key["second"] = second
+
+        data = holder.unstructure()
+        restored = Holder.structure(data)
+
+        assert isinstance(restored.items[0], SpecialEmbedded)
+        assert restored.items[0].label == "two"
+        assert restored.unique_items == {first}
+        assert isinstance(restored.by_key["second"], SpecialEmbedded)
+
+    def test_unstructurable_marker_is_independent_from_include(self) -> None:
+        class Embedded(Unstructurable):
+            value: int = 0
+
+        class Holder(Unstructurable):
+            recursive: Embedded = Field(
+                default_factory=Embedded,
+                json_schema_extra={"include": True, "unstructurable": True},
+            )
+            ordinary: Embedded = Field(
+                default_factory=Embedded,
+                json_schema_extra={"include": True},
+            )
+
+        holder = Holder()
+        holder.recursive.value = 1
+        holder.ordinary.value = 1
+
+        data = holder.unstructure()
+
+        assert data["recursive"]["kind"] is Embedded
+        assert data["ordinary"] == {"value": 1}
+
+    def test_unstructurable_marker_does_not_emit_mutated_default_without_include(self) -> None:
+        class Embedded(Unstructurable):
+            value: int = 0
+
+        class Holder(Unstructurable):
+            recursive: Embedded = Field(
+                default_factory=Embedded,
+                json_schema_extra={"unstructurable": True},
+            )
+
+        holder = Holder()
+        holder.recursive.value = 1
+
+        assert "recursive" not in holder.unstructure()
+
 
 class TestHasContent:
     """Content-hash trait tests."""

--- a/engine/tests/core/bases/test_bases.py
+++ b/engine/tests/core/bases/test_bases.py
@@ -212,6 +212,16 @@ class TestUnstructurable:
         assert isinstance(restored.child, SpecialEmbedded)
         assert restored.child.name == "kept"
 
+    def test_structure_rejects_kind_outside_declared_hierarchy(self) -> None:
+        class Embedded(Unstructurable):
+            value: int
+
+        class Other(Unstructurable):
+            value: int
+
+        with pytest.raises(TypeError, match="Expected a subclass"):
+            Embedded.structure({"kind": Other, "value": 1})
+
     def test_marked_collection_fields_round_trip_with_kind(self) -> None:
         class Embedded(Unstructurable):
             model_config = ConfigDict(frozen=True)

--- a/engine/tests/core/bases/test_bases.py
+++ b/engine/tests/core/bases/test_bases.py
@@ -250,6 +250,21 @@ class TestUnstructurable:
         assert restored.unique_items == {first}
         assert isinstance(restored.by_key["second"], SpecialEmbedded)
 
+    def test_marked_union_field_tries_later_options_without_kind(self) -> None:
+        class Left(Unstructurable):
+            value: int
+
+        class Right(Unstructurable):
+            name: str
+
+        class Holder(Unstructurable):
+            child: Left | Right = Field(json_schema_extra={"unstructurable": True})
+
+        restored = Holder.structure({"kind": Holder, "child": {"name": "kept"}})
+
+        assert isinstance(restored.child, Right)
+        assert restored.child.name == "kept"
+
     def test_unstructurable_marker_is_independent_from_include(self) -> None:
         class Embedded(Unstructurable):
             value: int = 0

--- a/engine/tests/core/template/test_template.py
+++ b/engine/tests/core/template/test_template.py
@@ -7,6 +7,7 @@ from typing import Iterator
 import pytest
 from pydantic import ValidationError
 
+from tangl.core.dispatch import on_create
 from tangl.core.entity import Entity
 from tangl.core.selector import Selector
 from tangl.core.template import (
@@ -193,6 +194,13 @@ class TestEntityTemplateCompileDecompileSerialization:
     def test_compile_from_dict(self) -> None:
         templ = EntityTemplate.compile({"label": "scene-a", "kind": Scene})
         assert isinstance(templ.payload, Scene)
+
+    def test_compile_forwards_ctx_to_payload_create_hooks(self, null_ctx) -> None:
+        on_create(func=lambda *, data, **_: {"label": "mutated"})
+
+        templ = EntityTemplate.compile({"label": "scene-a", "kind": Scene}, _ctx=null_ctx)
+
+        assert templ.payload.label == "mutated"
 
     def test_decompile_strips_uid_and_seq(self) -> None:
         templ = EntityTemplate(payload=Scene(label="scene-a"))

--- a/engine/tests/mechanics/presence/test_look.py
+++ b/engine/tests/mechanics/presence/test_look.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import pytest
 
+from tangl.core import Graph, Selector
 from tangl.lang.body_parts import BodyPart, BodyRegion
 from tangl.mechanics.presence.look import (
     BodyPhenotype,
@@ -135,6 +136,57 @@ class TestDirectPresenceFacets:
         assert payload.description == "a dragon tattoo on their left arm"
         assert payload.items == ["a dragon tattoo on their left arm"]
         assert payload.media_role == "avatar_im"
+
+
+class TestOutfitSerialization:
+    """Graph-backed outfit manager persistence contract."""
+
+    def test_graph_roundtrip_preserves_outfit_assignments_by_graph_id(self) -> None:
+        shirt_type = WearableType(
+            label="roundtrip_shirt",
+            noun="shirt",
+            covers={BodyRegion.TOP},
+            layer=WearableLayer.OUTER,
+        )
+        coat_type = WearableType(
+            label="roundtrip_coat",
+            noun="coat",
+            covers={BodyRegion.TOP},
+            layer=WearableLayer.OVER,
+        )
+        graph = Graph()
+        actor = graph.add_node(kind=DemoOutfitActor, label="guide")
+        shirt = graph.add_node(
+            kind=Wearable,
+            label="guide-shirt",
+            token_from=shirt_type.label,
+        )
+        coat = graph.add_node(
+            kind=Wearable,
+            label="guide-coat",
+            token_from=coat_type.label,
+        )
+
+        actor.outfit.assign("top_60", shirt)
+        actor.outfit.assign("top_80", coat)
+
+        actor_data = actor.unstructure()
+        graph_data = graph.unstructure()
+        restored = Graph.structure(graph_data)
+        restored_actor = restored.find_one(Selector(label="guide"))
+        restored_shirt = restored.find_one(Selector(label="guide-shirt"))
+        restored_coat = restored.find_one(Selector(label="guide-coat"))
+
+        assert actor_data["outfit"]["assignment_ids"] == {
+            "top_60": [shirt.uid],
+            "top_80": [coat.uid],
+        }
+        assert restored_actor.outfit.owner is restored_actor
+        assert restored_actor.outfit.get_slot("top_60") == [restored_shirt]
+        assert restored_actor.outfit.get_slot("top_80") == [restored_coat]
+        assert restored_actor.outfit.describe_items() == ["shirt", "coat"]
+        assert sum(1 for item in restored.members.values() if item.uid == shirt.uid) == 1
+        assert sum(1 for item in restored.members.values() if item.uid == coat.uid) == 1
 
 
 class TestLookDescription:

--- a/engine/tests/mechanics/test_assembly.py
+++ b/engine/tests/mechanics/test_assembly.py
@@ -327,6 +327,11 @@ def test_component_manager_unassigns_transient_cache_entry() -> None:
     assert component.uid not in manager._component_cache
 
 
+def test_component_manager_structure_rejects_unrelated_kind() -> None:
+    with pytest.raises(TypeError, match="Expected a subclass"):
+        TestComponentManager.structure({"kind": TestComponent})
+
+
 def test_custom_validation(component_alpha: TestComponent) -> None:
     container = TestContainer(owner=TestHost(label="owner"))
     forbidden = TestComponent(label="forbidden", tags={"alpha"})

--- a/engine/tests/mechanics/test_assembly.py
+++ b/engine/tests/mechanics/test_assembly.py
@@ -6,10 +6,11 @@ from typing import ClassVar, Literal
 import pytest
 from pydantic import Field
 
-from tangl.core import Entity
+from tangl.core import Entity, Graph, Node
 from tangl.mechanics.assembly import (
     Component,
     ComponentFacet,
+    ComponentManager,
     ConnectorPolarity,
     HasSlottedContainer,
     Slot,
@@ -53,6 +54,12 @@ class TestContainer(SlottedContainer[TestComponent]):
         if any(component.label == "forbidden" for component in self.all_components()):
             errors.append("Forbidden component present")
         return errors
+
+
+class TestComponentManager(ComponentManager[TestComponent]):
+    slots: ClassVar[dict[str, Slot]] = {
+        "alpha": Slot.for_type("alpha", TestComponent, max_count=2),
+    }
 
 
 class TestHost(HasSlottedContainer, Entity):
@@ -293,6 +300,31 @@ def test_budget_check(component_alpha: TestComponent) -> None:
     container.assign("alpha", component_alpha)
     with pytest.raises(ValueError):
         container.assign("beta", TestComponent(label="power_hungry", tags={"beta"}, power_cost=2.0))
+
+
+def test_component_manager_registers_fresh_component_with_owner_registry() -> None:
+    graph = Graph()
+    owner = Node(label="owner")
+    graph.add(owner)
+    manager = TestComponentManager(owner=owner)
+    component = TestComponent(label="part")
+
+    manager.assign("alpha", component)
+
+    assert graph.get(component.uid) is component
+    assert manager.assignment_ids == {"alpha": [component.uid]}
+    assert manager.get_slot("alpha") == [component]
+
+
+def test_component_manager_unassigns_transient_cache_entry() -> None:
+    manager = TestComponentManager()
+    component = TestComponent(label="part")
+
+    manager.assign("alpha", component)
+    manager.unassign("alpha", component)
+
+    assert manager.assignment_ids == {}
+    assert component.uid not in manager._component_cache
 
 
 def test_custom_validation(component_alpha: TestComponent) -> None:

--- a/engine/tests/mechanics/test_vehicle_example.py
+++ b/engine/tests/mechanics/test_vehicle_example.py
@@ -1,0 +1,173 @@
+"""Vehicle example tests for owner-bound loadout managers."""
+
+from __future__ import annotations
+
+from tangl.core import Graph, Selector
+from tangl.mechanics.assembly.examples.vehicle import (
+    Vehicle,
+    VehicleComponent,
+    VehicleLoadout,
+)
+
+
+def part(label: str) -> VehicleComponent:
+    return VehicleComponent(token_from=label, label=label)
+
+
+def install_baseline(loadout: VehicleLoadout) -> None:
+    loadout.assign("chassis", part("mini_chassis"))
+    loadout.assign("powerplant", part("cheap_powerplant"))
+    loadout.assign("suspension", part("cheap_suspension"))
+    loadout.assign("tires", part("cheap_tires"))
+
+
+def test_vehicle_component_label_uses_reference_label() -> None:
+    component = VehicleComponent(token_from="cheap_tires", label="local-token")
+
+    assert component.get_label() == "cheap_tires"
+
+
+def test_vehicle_loadout_requires_named_slots() -> None:
+    vehicle = Vehicle(label="test-car")
+
+    assert vehicle.loadout.validate() == [
+        "Required slot empty: chassis",
+        "Required slot empty: powerplant",
+        "Required slot empty: suspension",
+        "Required slot empty: tires",
+    ]
+
+    install_baseline(vehicle.loadout)
+
+    assert vehicle.loadout.validate() == []
+
+
+def test_vehicle_description_warns_for_missing_required_parts() -> None:
+    vehicle = Vehicle(label="test-car")
+    loadout = vehicle.loadout
+
+    loadout.assign("chassis", part("mini_chassis"))
+    loadout.assign("powerplant", part("cheap_powerplant"))
+    loadout.assign("suspension", part("cheap_suspension"))
+
+    assert vehicle.describe_vehicle() == (
+        "a vehicle built on a mini chassis, powered by a cheap powerplant, "
+        "and riding on cheap suspension. Warning: missing tires."
+    )
+
+
+def test_vehicle_loadout_replaces_single_slot_occupant() -> None:
+    vehicle = Vehicle(label="test-car")
+    loadout = vehicle.loadout
+
+    loadout.assign("tires", part("cheap_tires"))
+    cheap_tires = loadout.get_slot("tires")[0]
+
+    loadout.assign("tires", part("slicks"))
+    installed_tires = loadout.get_slot("tires")
+
+    assert len(installed_tires) == 1
+    assert installed_tires[0].token_from == "slicks"
+    assert cheap_tires.uid not in loadout.assignment_ids["tires"]
+
+
+def test_heavy_vehicle_requires_big_powerplant() -> None:
+    vehicle = Vehicle(label="hauler")
+    loadout = vehicle.loadout
+
+    loadout.assign("chassis", part("truck_chassis"))
+    loadout.assign("powerplant", part("cheap_powerplant"))
+    loadout.assign("suspension", part("off_road_suspension"))
+    loadout.assign("tires", part("all_terrain"))
+
+    assert "Powerplant output too low: 45.0 < 90.0" in loadout.validate()
+    assert vehicle.describe_vehicle() == (
+        "a vehicle built on a truck chassis, powered by a cheap powerplant, "
+        "riding on off road suspension, and with all terrain. "
+        "Warning: powerplant output is too low."
+    )
+
+    loadout.assign("powerplant", part("big_powerplant"))
+
+    assert loadout.validate() == []
+
+
+def test_vehicle_price_budget_validation() -> None:
+    vehicle = Vehicle(label="too-fancy", max_price=3000)
+    loadout = vehicle.loadout
+
+    loadout.assign("chassis", part("truck_chassis"))
+    loadout.assign("powerplant", part("big_powerplant"))
+    loadout.assign("suspension", part("racing_suspension"))
+    loadout.assign("tires", part("slicks"))
+
+    assert "Price exceeds budget: 3850.0 > 3000.0" in loadout.validate()
+
+
+def test_vehicle_loadout_describes_installed_components() -> None:
+    vehicle = Vehicle(label="demo")
+    install_baseline(vehicle.loadout)
+
+    namespace = vehicle.get_ns()
+
+    assert vehicle.describe_vehicle() == (
+        "a vehicle built on a mini chassis, powered by a cheap powerplant, "
+        "riding on cheap suspension, and with cheap tires"
+    )
+    assert namespace["vehicle_description"] == vehicle.describe_vehicle()
+    assert namespace["vehicle_component_tokens"] == [
+        "chassis: mini chassis",
+        "powerplant: cheap powerplant",
+        "suspension: cheap suspension",
+        "tires: cheap tires",
+    ]
+
+
+def test_vehicle_graph_roundtrip_preserves_loadout_assignments_by_graph_id() -> None:
+    graph = Graph()
+    vehicle = graph.add_node(kind=Vehicle, label="demo-car")
+    chassis = graph.add_node(
+        kind=VehicleComponent,
+        label="demo-chassis",
+        token_from="mid_chassis",
+    )
+    powerplant = graph.add_node(
+        kind=VehicleComponent,
+        label="demo-powerplant",
+        token_from="cheap_powerplant",
+    )
+    suspension = graph.add_node(
+        kind=VehicleComponent,
+        label="demo-suspension",
+        token_from="cheap_suspension",
+    )
+    tires = graph.add_node(
+        kind=VehicleComponent,
+        label="demo-tires",
+        token_from="cheap_tires",
+    )
+
+    vehicle.loadout.assign("chassis", chassis)
+    vehicle.loadout.assign("powerplant", powerplant)
+    vehicle.loadout.assign("suspension", suspension)
+    vehicle.loadout.assign("tires", tires)
+
+    vehicle_data = vehicle.unstructure()
+    restored = Graph.structure(graph.unstructure())
+    restored_vehicle = restored.find_one(Selector(label="demo-car"))
+    restored_tires = restored.find_one(Selector(label="demo-tires"))
+
+    assert vehicle_data["loadout"]["assignment_ids"] == {
+        "chassis": [chassis.uid],
+        "powerplant": [powerplant.uid],
+        "suspension": [suspension.uid],
+        "tires": [tires.uid],
+    }
+    assert restored_vehicle.loadout.owner is restored_vehicle
+    assert restored_vehicle.loadout.get_slot("tires") == [restored_tires]
+    assert restored_vehicle.loadout.validate() == []
+    assert restored_vehicle.describe_vehicle() == (
+        "a vehicle built on a mid chassis, powered by a cheap powerplant, "
+        "riding on cheap suspension, and with cheap tires"
+    )
+    assert sum(1 for item in restored.members.values() if item.uid == tires.uid) == 1


### PR DESCRIPTION
## Summary

- Adds explicit `unstructurable` field recursion for constructor-form persistence, keeping it separate from `include=True`.
- Adds an owner-bound `ComponentManager` that persists graph-member component assignments by id and dereferences them through the owner graph.
- Migrates outfits onto the owner-bound manager path and adds a vehicle loadout proof with slots, replacement semantics, budgets, validation, procedural description, and graph round-trip coverage.
- Updates contributor/design docs to spell out the blessed serialization path and follow-up component-manager targets.

## Verification

- CodeRabbit local review: `/Users/derek/.local/bin/coderabbit review --agent --base-commit fe8c96d29af0e63bc0edc7e58c2d9608478c1a3f -c AGENTS.md`
  - Raised 3 minor issues; fixed the live `VehicleComponentToken.get_label()` and vehicle test docstring notes; the missing future import note was already stale.
- `poetry run pytest engine/tests/core/bases/test_bases.py engine/tests/core/entity/test_entity.py engine/tests/core/template/test_template.py engine/tests/core/registry/test_registry.py engine/tests/mechanics/test_assembly.py engine/tests/mechanics/presence`
- `poetry run pytest engine/tests/mechanics/test_vehicle_example.py`
- `poetry run pytest engine/tests/mechanics`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `ComponentManager` for persistent, graph-backed component slot assignments with registry resolution.
  * Rebuilt the vehicle loadout system around explicit part categories (chassis, powerplant, suspension, tires) with updated tokenized components and rollback-safe slot replacement.

* **Improvements**
  * Improved graph round-trips to preserve outfit/loadout slot assignments and prevent duplicated inlined entities.
  * Strengthened constructor-form serialization for embedded types and recursive references.

* **Documentation / Tests**
  * Updated serialization guidance and added contract tests for constructor-form `unstructure()`/`structure()` behavior and graph persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->