### PR TITLE
Add connector association proof

### DIFF
--- a/engine/src/tangl/mechanics/assembly/COMPONENT_DESIGN.md
+++ b/engine/src/tangl/mechanics/assembly/COMPONENT_DESIGN.md
@@ -50,9 +50,34 @@ The example exercises named single-occupancy slots, replacement-on-assign, requi
 slot validation, total price/weight validation, and a simple weight-to-powerplant
 constraint without importing CarWars-specific semantics into the generic layer.
 
+Connector association is the third proof consumer and the first bilateral one.
+`Connector` specializes `Component` with shape/polarity endpoint metadata, while
+`ConnectionGroupManager` stores assigned connectors and committed pairings by UUID.
+Its `can_connect()` / `can_disconnect()` methods are pure checks; `connect()` /
+`disconnect()` are committed id-backed relationship mutations. Group matching is
+deliberately deterministic first-fit for now, enough to show simple plug/socket
+pairs and PC-like cable bundles without promoting a general transaction engine yet.
+
 Follow-up retrofit targets remain open: credential packets, domain vehicle managers
 such as CarWars adapters, robot assemblies, and any world-specific full-graph outfit
 manager such as a future `SharedOutfit` / `FashionShowActor` demo.
+
+---
+
+## Association v0 Vocabulary
+
+Assembly now treats membership and connection as small association specializations:
+
+- `can_associate` / `can_disassociate` are pure availability checks. They must be safe
+  to call repeatedly during planning, projection, and UI discovery.
+- `associate` / `disassociate` are committed relationship mutations. In this package
+  today those are exposed as domain verbs: assign/unassign and connect/disconnect.
+- `on_associate` / `on_disassociate` are reserved future update-phase hooks for
+  bookkeeping, world reactions, and journal fragments after a mutation has committed.
+
+This is intentionally smaller than the legacy `Associating` handler pipeline. It keeps
+the vocabulary aligned with future roles, credentials, shops, and trades without adding
+a broad transaction framework before connectors and compliance prove the shared shape.
 
 ---
 

--- a/engine/src/tangl/mechanics/assembly/README.md
+++ b/engine/src/tangl/mechanics/assembly/README.md
@@ -9,9 +9,11 @@ Key pieces:
 - `Slot` / `SlotGroup`: selection criteria and aggregate constraints.
 - `SlottedContainer`: generic container that enforces slot rules and optional resource budgets.
 - `HasSlottedContainer`: mixin for embedding a container on an entity (facet-style).
+- `ComponentManager`: owner-bound manager that persists graph-member assignments by id.
+- `Connector` / `ConnectionGroupManager`: endpoint components and id-backed pairings.
 - `BudgetTracker`: helper for tracking resource usage (power, weight, etc.).
 
-See `examples/vehicle.py` for usage patterns.
+See `examples/vehicle.py` and `examples/connectors.py` for usage patterns.
 
 Aggregate helpers operate over the container's current `all_components()`
 result exactly as-is.
@@ -25,3 +27,8 @@ capabilities = vehicle.vehicle_loadout.get_aggregate_tags("capabilities")
 `OutfitManager` has been promoted out of `assembly.examples` into
 `tangl.mechanics.presence.outfit` because active presence mechanics depend on it
 as a real family surface rather than a demo.
+
+Connector association is the first bilateral proof: `can_connect()` and
+`can_disconnect()` are pure checks, while `connect()` and `disconnect()` commit
+id-backed relationship state. Author-facing `on_associate` hooks are reserved
+for a later update-phase layer.

--- a/engine/src/tangl/mechanics/assembly/__init__.py
+++ b/engine/src/tangl/mechanics/assembly/__init__.py
@@ -4,13 +4,16 @@ Composable loadout containers built on :class:`tangl.core.Selector`.
 
 from .base import ComponentManager, HasResourceCost, HasSlottedContainer, SlottedContainer
 from .budget import BudgetTracker, ResourceBudget
-from .component import Component, ComponentFacet, ConnectorPolarity
+from .component import Component, ComponentFacet, Connector, ConnectorPolarity
+from .connection import ConnectionGroupManager
 from .slot import Slot, SlotGroup
 
 __all__ = [
     "Component",
     "ComponentFacet",
     "ComponentManager",
+    "ConnectionGroupManager",
+    "Connector",
     "ConnectorPolarity",
     "HasResourceCost",
     "HasSlottedContainer",

--- a/engine/src/tangl/mechanics/assembly/component.py
+++ b/engine/src/tangl/mechanics/assembly/component.py
@@ -44,11 +44,9 @@ class ComponentFacet(BaseModel):
 
 
 class Component(Entity):
-    """Assembly component that carries facets and optional connector metadata."""
+    """Assembly component that carries facets."""
 
     facets: list[ComponentFacet] = Field(default_factory=list)
-    connector_shape: str | None = None
-    connector_polarity: ConnectorPolarity | None = None
 
     def component_facets(
         self,
@@ -65,3 +63,10 @@ class Component(Entity):
             for facet in self.facets
             if facet.matches(channel=channel, facet_type=facet_type)
         ]
+
+
+class Connector(Component):
+    """Assembly component endpoint that can associate with a compatible endpoint."""
+
+    connector_shape: str
+    connector_polarity: ConnectorPolarity

--- a/engine/src/tangl/mechanics/assembly/connection.py
+++ b/engine/src/tangl/mechanics/assembly/connection.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import Field
+
+from tangl.type_hints import UnstructuredData
+
+from .base import ComponentManager
+from .component import Connector
+
+
+class ConnectionGroupManager(ComponentManager[Connector]):
+    """Owner-bound manager for connector endpoints and their pairwise associations."""
+
+    connection_ids: dict[UUID, UUID] = Field(default_factory=dict)
+    required_connection_slots: set[str] = Field(default_factory=set)
+
+    def _connectors_in_order(self) -> list[Connector]:
+        connectors: list[Connector] = []
+        slot_names = list(self.slots)
+        slot_names.extend(name for name in self._slot_names() if name not in self.slots)
+        for slot_name in slot_names:
+            connectors.extend(self.get_slot(slot_name))
+        return connectors
+
+    def _required_slot_names(self) -> list[str]:
+        if self.required_connection_slots:
+            return [
+                name
+                for name in self.slots
+                if name in self.required_connection_slots
+            ]
+        return [name for name, slot in self.slots.items() if slot.required]
+
+    def required_connectors(self) -> list[Connector]:
+        connectors: list[Connector] = []
+        for slot_name in self._required_slot_names():
+            connectors.extend(self.get_slot(slot_name))
+        return connectors
+
+    def is_connected(self, connector: Connector) -> bool:
+        return connector.uid in self.connection_ids
+
+    def connected_to(self, connector: Connector) -> Connector | None:
+        peer_id = self.connection_ids.get(connector.uid)
+        if peer_id is None:
+            return None
+        return self._resolve_component(peer_id)
+
+    def unassign(self, slot_name: str, component: Connector) -> None:
+        if self.is_connected(component):
+            raise ValueError(f"Cannot unassign connected connector {component.label!r}")
+        super().unassign(slot_name, component)
+
+    @staticmethod
+    def _compatible(first: Connector, second: Connector) -> bool:
+        return (
+            first.uid != second.uid
+            and first.connector_shape == second.connector_shape
+            and first.connector_polarity != second.connector_polarity
+        )
+
+    def can_connect(
+        self,
+        first: Connector,
+        second: Connector,
+        *,
+        other_manager: "ConnectionGroupManager | None" = None,
+    ) -> bool:
+        second_manager = other_manager or self
+        return (
+            self._compatible(first, second)
+            and not self.is_connected(first)
+            and not second_manager.is_connected(second)
+        )
+
+    def connect(
+        self,
+        first: Connector,
+        second: Connector,
+        *,
+        other_manager: "ConnectionGroupManager | None" = None,
+    ) -> None:
+        second_manager = other_manager or self
+        if not self.can_connect(first, second, other_manager=other_manager):
+            raise ValueError(f"Cannot connect {first.label!r} to {second.label!r}")
+
+        self._validate_component_registry(first)
+        second_manager._validate_component_registry(second)
+        self._component_cache[first.uid] = first
+        self._component_cache[second.uid] = second
+        second_manager._component_cache[second.uid] = second
+        second_manager._component_cache[first.uid] = first
+
+        self.connection_ids[first.uid] = second.uid
+        second_manager.connection_ids[second.uid] = first.uid
+
+    def can_disconnect(
+        self,
+        first: Connector,
+        second: Connector,
+        *,
+        other_manager: "ConnectionGroupManager | None" = None,
+    ) -> bool:
+        second_manager = other_manager or self
+        return (
+            self.connection_ids.get(first.uid) == second.uid
+            and second_manager.connection_ids.get(second.uid) == first.uid
+        )
+
+    def disconnect(
+        self,
+        first: Connector,
+        second: Connector,
+        *,
+        other_manager: "ConnectionGroupManager | None" = None,
+    ) -> None:
+        second_manager = other_manager or self
+        if not self.can_disconnect(first, second, other_manager=other_manager):
+            raise ValueError(f"Cannot disconnect {first.label!r} from {second.label!r}")
+        self.connection_ids.pop(first.uid, None)
+        second_manager.connection_ids.pop(second.uid, None)
+
+    def _find_group_pairings(
+        self,
+        other_manager: "ConnectionGroupManager",
+    ) -> list[tuple[Connector, Connector]]:
+        pairings: list[tuple[Connector, Connector]] = []
+        used_remote: set[UUID] = set()
+        for connector in self.required_connectors():
+            if self.is_connected(connector):
+                continue
+            match = next(
+                (
+                    candidate
+                    for candidate in other_manager._connectors_in_order()
+                    if candidate.uid not in used_remote
+                    and self.can_connect(
+                        connector,
+                        candidate,
+                        other_manager=other_manager,
+                    )
+                ),
+                None,
+            )
+            if match is None:
+                return []
+            pairings.append((connector, match))
+            used_remote.add(match.uid)
+        return pairings
+
+    def can_connect_group(self, other_manager: "ConnectionGroupManager") -> bool:
+        unconnected_required = [
+            connector
+            for connector in self.required_connectors()
+            if not self.is_connected(connector)
+        ]
+        if not unconnected_required:
+            return True
+        return len(self._find_group_pairings(other_manager)) == len(unconnected_required)
+
+    def connect_group(
+        self,
+        other_manager: "ConnectionGroupManager",
+    ) -> list[tuple[Connector, Connector]]:
+        pairings = self._find_group_pairings(other_manager)
+        unconnected_required = [
+            connector
+            for connector in self.required_connectors()
+            if not self.is_connected(connector)
+        ]
+        if len(pairings) != len(unconnected_required):
+            raise ValueError("Connection group cannot satisfy all required connectors")
+        for first, second in pairings:
+            self.connect(first, second, other_manager=other_manager)
+        return pairings
+
+    @property
+    def is_complete(self) -> bool:
+        return all(self.is_connected(connector) for connector in self.required_connectors())
+
+    def unstructure(self) -> UnstructuredData:
+        data = super().unstructure()
+        if self.connection_ids:
+            data["connection_ids"] = self.connection_ids
+        if self.required_connection_slots:
+            data["required_connection_slots"] = sorted(self.required_connection_slots)
+        return data

--- a/engine/src/tangl/mechanics/assembly/connection.py
+++ b/engine/src/tangl/mechanics/assembly/connection.py
@@ -39,6 +39,16 @@ class ConnectionGroupManager(ComponentManager[Connector]):
             connectors.extend(self.get_slot(slot_name))
         return connectors
 
+    def _has_required_slot_assignments(self) -> bool:
+        return all(
+            self._has_slot_components(slot_name)
+            for slot_name in self._required_slot_names()
+        )
+
+    def _drop_unassigned_cache(self, connector_id: UUID) -> None:
+        if not any(connector_id in ids for ids in self.assignment_ids.values()):
+            self._component_cache.pop(connector_id, None)
+
     def is_connected(self, connector: Connector) -> bool:
         return connector.uid in self.connection_ids
 
@@ -121,11 +131,15 @@ class ConnectionGroupManager(ComponentManager[Connector]):
             raise ValueError(f"Cannot disconnect {first.label!r} from {second.label!r}")
         self.connection_ids.pop(first.uid, None)
         second_manager.connection_ids.pop(second.uid, None)
+        self._drop_unassigned_cache(second.uid)
+        second_manager._drop_unassigned_cache(first.uid)
 
     def _find_group_pairings(
         self,
         other_manager: "ConnectionGroupManager",
     ) -> list[tuple[Connector, Connector]]:
+        if not self._has_required_slot_assignments():
+            return []
         pairings: list[tuple[Connector, Connector]] = []
         used_remote: set[UUID] = set()
         for connector in self.required_connectors():
@@ -151,6 +165,8 @@ class ConnectionGroupManager(ComponentManager[Connector]):
         return pairings
 
     def can_connect_group(self, other_manager: "ConnectionGroupManager") -> bool:
+        if not self._has_required_slot_assignments():
+            return False
         unconnected_required = [
             connector
             for connector in self.required_connectors()
@@ -164,6 +180,8 @@ class ConnectionGroupManager(ComponentManager[Connector]):
         self,
         other_manager: "ConnectionGroupManager",
     ) -> list[tuple[Connector, Connector]]:
+        if not self._has_required_slot_assignments():
+            raise ValueError("Connection group cannot satisfy all required connectors")
         pairings = self._find_group_pairings(other_manager)
         unconnected_required = [
             connector
@@ -178,6 +196,8 @@ class ConnectionGroupManager(ComponentManager[Connector]):
 
     @property
     def is_complete(self) -> bool:
+        if not self._has_required_slot_assignments():
+            return False
         return all(self.is_connected(connector) for connector in self.required_connectors())
 
     def unstructure(self) -> UnstructuredData:

--- a/engine/src/tangl/mechanics/assembly/examples/connectors.py
+++ b/engine/src/tangl/mechanics/assembly/examples/connectors.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from typing import ClassVar
+
+from pydantic import Field, model_validator
+
+from tangl.core import Node
+from tangl.mechanics.assembly import ConnectionGroupManager, Connector, ConnectorPolarity, Slot
+
+
+class DeviceConnectionGroup(ConnectionGroupManager):
+    """Named connector group used by the neutral connection examples."""
+
+    slots: ClassVar[dict[str, Slot]] = {
+        "power": Slot.for_type("power", Connector, max_count=1),
+        "video": Slot.for_type("video", Connector, max_count=1),
+        "usb": Slot.for_type("usb", Connector, max_count=1),
+        "end_a": Slot.for_type("end_a", Connector, max_count=1),
+        "end_b": Slot.for_type("end_b", Connector, max_count=1),
+        "port": Slot.for_type("port", Connector, max_count=1),
+    }
+
+
+class ConnectedDevice(Node):
+    """Graph member with an embedded connector group manager."""
+
+    connections: DeviceConnectionGroup = Field(
+        default_factory=DeviceConnectionGroup,
+        json_schema_extra={"include": True, "unstructurable": True},
+    )
+
+    @model_validator(mode="after")
+    def _bind_connection_owner(self) -> "ConnectedDevice":
+        self.connections.bind_owner(self)
+        return self
+
+    def add_connector(self, slot_name: str, connector: Connector) -> Connector:
+        self.connections.assign(slot_name, connector)
+        return connector
+
+
+def connector(label: str, shape: str, polarity: ConnectorPolarity) -> Connector:
+    """Create one connector endpoint for examples and tests."""
+
+    return Connector(
+        label=label,
+        connector_shape=shape,
+        connector_polarity=polarity,
+    )
+
+
+def build_pc() -> ConnectedDevice:
+    """Return a PC-like device that requires power, video, and USB connections."""
+
+    device = ConnectedDevice(
+        label="pc",
+        connections=DeviceConnectionGroup(
+            required_connection_slots={"power", "video", "usb"},
+        ),
+    )
+    device.add_connector("power", connector("pc-power-socket", "power", "socket"))
+    device.add_connector("video", connector("pc-video-socket", "video", "socket"))
+    device.add_connector("usb", connector("pc-usb-socket", "usb", "socket"))
+    return device
+
+
+def build_pc_cable_bundle() -> ConnectedDevice:
+    """Return a cable bundle with plugs matching the PC example."""
+
+    device = ConnectedDevice(label="pc-cable-bundle")
+    device.add_connector("power", connector("cable-power-plug", "power", "plug"))
+    device.add_connector("video", connector("cable-video-plug", "video", "plug"))
+    device.add_connector("usb", connector("cable-usb-plug", "usb", "plug"))
+    return device
+
+
+def build_monitor() -> ConnectedDevice:
+    """Return a monitor-like peripheral requiring power and video."""
+
+    device = ConnectedDevice(
+        label="monitor",
+        connections=DeviceConnectionGroup(required_connection_slots={"power", "video"}),
+    )
+    device.add_connector("power", connector("monitor-power-socket", "power", "socket"))
+    device.add_connector("video", connector("monitor-video-socket", "video", "socket"))
+    return device
+
+
+def build_monitor_cable_bundle() -> ConnectedDevice:
+    """Return a cable bundle with plugs matching the monitor example."""
+
+    device = ConnectedDevice(label="monitor-cable-bundle")
+    device.add_connector("power", connector("monitor-cable-power-plug", "power", "plug"))
+    device.add_connector("video", connector("monitor-cable-video-plug", "video", "plug"))
+    return device
+
+
+__all__ = [
+    "ConnectedDevice",
+    "DeviceConnectionGroup",
+    "build_monitor",
+    "build_monitor_cable_bundle",
+    "build_pc",
+    "build_pc_cable_bundle",
+    "connector",
+]

--- a/engine/src/tangl/mechanics/assembly/slot.py
+++ b/engine/src/tangl/mechanics/assembly/slot.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 
 from tangl.core import Entity, Selector
 
-from .component import Component, ConnectorPolarity
+from .component import Connector, ConnectorPolarity
 
 
 class Slot(BaseModel):
@@ -65,7 +65,7 @@ class Slot(BaseModel):
         if self.connector_shape is None and self.connector_polarity is None:
             return True, ""
 
-        if not isinstance(component, Component):
+        if not isinstance(component, Connector):
             return False, "Component has no assembly connector"
 
         if self.connector_shape is not None and component.connector_shape != self.connector_shape:

--- a/engine/tests/mechanics/test_assembly.py
+++ b/engine/tests/mechanics/test_assembly.py
@@ -11,6 +11,7 @@ from tangl.mechanics.assembly import (
     Component,
     ComponentFacet,
     ComponentManager,
+    Connector,
     ConnectorPolarity,
     HasSlottedContainer,
     Slot,
@@ -136,7 +137,7 @@ class OutOfOrderDefaultLoadoutContainer(SlottedContainer[TestComponent]):
     }
 
 
-class ShapeComponent(Component):
+class ShapeComponent(Connector):
     weight_cost: float = 0.0
 
     def get_cost(self, resource: str) -> float:

--- a/engine/tests/mechanics/test_connector_association.py
+++ b/engine/tests/mechanics/test_connector_association.py
@@ -1,0 +1,170 @@
+"""Tests for connector association managers."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import pytest
+
+from tangl.core import Graph, Selector
+from tangl.mechanics.assembly import ConnectionGroupManager, Connector, ConnectorPolarity, Slot
+from tangl.mechanics.assembly.examples.connectors import (
+    ConnectedDevice,
+    DeviceConnectionGroup,
+    build_pc,
+    build_pc_cable_bundle,
+    connector,
+)
+
+
+class ConnectionGroup(ConnectionGroupManager):
+    slots: ClassVar[dict[str, Slot]] = {
+        "a": Slot.for_type("a", Connector, max_count=1),
+        "b": Slot.for_type("b", Connector, max_count=1),
+    }
+
+
+def endpoint(label: str, shape: str, polarity: ConnectorPolarity) -> Connector:
+    return Connector(
+        label=label,
+        connector_shape=shape,
+        connector_polarity=polarity,
+    )
+
+
+def test_connector_group_connects_matching_shape_and_opposite_polarity() -> None:
+    group = ConnectionGroup()
+    plug = endpoint("power-plug", "power", "plug")
+    socket = endpoint("power-socket", "power", "socket")
+
+    group.assign("a", plug)
+    group.assign("b", socket)
+
+    assert group.can_connect(plug, socket)
+
+    group.connect(plug, socket)
+
+    assert group.connected_to(plug) is socket
+    assert group.connected_to(socket) is plug
+    assert group.can_disconnect(plug, socket)
+
+    group.disconnect(plug, socket)
+
+    assert not group.is_connected(plug)
+    assert not group.is_connected(socket)
+
+
+def test_connector_group_rejects_incompatible_or_busy_endpoints() -> None:
+    group = ConnectionGroup()
+    plug = endpoint("power-plug", "power", "plug")
+    second_plug = endpoint("second-power-plug", "power", "plug")
+    video_socket = endpoint("video-socket", "video", "socket")
+    power_socket = endpoint("power-socket", "power", "socket")
+
+    assert not group.can_connect(plug, second_plug)
+    assert not group.can_connect(plug, video_socket)
+
+    group.connect(plug, power_socket)
+
+    assert not group.can_connect(plug, video_socket)
+    assert not group.can_connect(second_plug, power_socket)
+    assert not group.can_disconnect(second_plug, power_socket)
+
+    with pytest.raises(ValueError):
+        group.connect(second_plug, power_socket)
+
+    with pytest.raises(ValueError):
+        group.disconnect(second_plug, power_socket)
+
+
+def test_connector_group_requires_disconnect_before_unassign() -> None:
+    group = ConnectionGroup()
+    plug = endpoint("power-plug", "power", "plug")
+    socket = endpoint("power-socket", "power", "socket")
+
+    group.assign("a", plug)
+    group.assign("b", socket)
+    group.connect(plug, socket)
+
+    with pytest.raises(ValueError):
+        group.unassign("a", plug)
+
+    group.disconnect(plug, socket)
+    group.unassign("a", plug)
+
+    assert group.get_slot("a") == []
+
+
+def test_connector_group_registers_assigned_connectors_with_owner_graph() -> None:
+    graph = Graph()
+    owner = graph.add_node(kind=ConnectedDevice, label="hub")
+    plug = Connector(label="usb-plug", connector_shape="usb", connector_polarity="plug")
+
+    owner.connections.assign("usb", plug)
+
+    assert graph.get(plug.uid) is plug
+    assert owner.connections.get_slot("usb") == [plug]
+
+
+def test_connector_group_roundtrip_preserves_pair_ids() -> None:
+    graph = Graph()
+    pc = graph.add_node(
+        kind=ConnectedDevice,
+        label="pc",
+        connections=DeviceConnectionGroup(required_connection_slots={"power"}),
+    )
+    cable = graph.add_node(kind=ConnectedDevice, label="cable")
+    pc_power = graph.add_node(
+        kind=Connector,
+        label="pc-power-socket",
+        connector_shape="power",
+        connector_polarity="socket",
+    )
+    cable_power = graph.add_node(
+        kind=Connector,
+        label="cable-power-plug",
+        connector_shape="power",
+        connector_polarity="plug",
+    )
+
+    pc.add_connector("power", pc_power)
+    cable.add_connector("power", cable_power)
+    pc.connections.connect(pc_power, cable_power, other_manager=cable.connections)
+
+    restored = Graph.structure(graph.unstructure())
+    restored_pc = restored.find_one(Selector(label="pc"))
+    restored_cable = restored.find_one(Selector(label="cable"))
+    restored_pc_power = restored.find_one(Selector(label="pc-power-socket"))
+    restored_cable_power = restored.find_one(Selector(label="cable-power-plug"))
+
+    assert restored_pc.connections.owner is restored_pc
+    assert restored_cable.connections.owner is restored_cable
+    assert restored_pc.connections.connection_ids == {pc_power.uid: cable_power.uid}
+    assert restored_cable.connections.connection_ids == {cable_power.uid: pc_power.uid}
+    assert restored_pc.connections.connected_to(restored_pc_power) is restored_cable_power
+    assert restored_cable.connections.connected_to(restored_cable_power) is restored_pc_power
+    assert restored_pc.connections.is_complete
+
+
+def test_pc_like_connection_group_completes_against_matching_cable_bundle() -> None:
+    pc = build_pc()
+    cable_bundle = build_pc_cable_bundle()
+
+    assert not pc.connections.is_complete
+    assert pc.connections.can_connect_group(cable_bundle.connections)
+
+    pairings = pc.connections.connect_group(cable_bundle.connections)
+
+    assert [left.connector_shape for left, _right in pairings] == ["power", "video", "usb"]
+    assert pc.connections.is_complete
+
+
+def test_pc_like_connection_group_rejects_incomplete_cable_bundle() -> None:
+    pc = build_pc()
+    cable_bundle = ConnectedDevice(label="incomplete-cable-bundle")
+    cable_bundle.add_connector("power", connector("cable-power-plug", "power", "plug"))
+
+    assert not pc.connections.can_connect_group(cable_bundle.connections)
+
+    with pytest.raises(ValueError):
+        pc.connections.connect_group(cable_bundle.connections)

--- a/engine/tests/mechanics/test_connector_association.py
+++ b/engine/tests/mechanics/test_connector_association.py
@@ -146,6 +146,25 @@ def test_connector_group_roundtrip_preserves_pair_ids() -> None:
     assert restored_pc.connections.is_complete
 
 
+def test_disconnect_drops_remote_cache_entries() -> None:
+    pc = ConnectedDevice(label="pc")
+    cable = ConnectedDevice(label="cable")
+    pc_power = pc.add_connector("power", endpoint("pc-power-socket", "power", "socket"))
+    cable_power = cable.add_connector("power", endpoint("cable-power-plug", "power", "plug"))
+
+    pc.connections.connect(pc_power, cable_power, other_manager=cable.connections)
+
+    assert cable_power.uid in pc.connections._component_cache
+    assert pc_power.uid in cable.connections._component_cache
+
+    pc.connections.disconnect(pc_power, cable_power, other_manager=cable.connections)
+
+    assert pc_power.uid in pc.connections._component_cache
+    assert cable_power.uid not in pc.connections._component_cache
+    assert cable_power.uid in cable.connections._component_cache
+    assert pc_power.uid not in cable.connections._component_cache
+
+
 def test_pc_like_connection_group_completes_against_matching_cable_bundle() -> None:
     pc = build_pc()
     cable_bundle = build_pc_cable_bundle()
@@ -164,6 +183,20 @@ def test_pc_like_connection_group_rejects_incomplete_cable_bundle() -> None:
     cable_bundle = ConnectedDevice(label="incomplete-cable-bundle")
     cable_bundle.add_connector("power", connector("cable-power-plug", "power", "plug"))
 
+    assert not pc.connections.can_connect_group(cable_bundle.connections)
+
+    with pytest.raises(ValueError):
+        pc.connections.connect_group(cable_bundle.connections)
+
+
+def test_required_connection_slots_must_have_connectors() -> None:
+    pc = ConnectedDevice(
+        label="pc",
+        connections=DeviceConnectionGroup(required_connection_slots={"power"}),
+    )
+    cable_bundle = build_pc_cable_bundle()
+
+    assert not pc.connections.is_complete
     assert not pc.connections.can_connect_group(cable_bundle.connections)
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary

- Adds `Connector` as the specialized component endpoint that owns shape/polarity metadata.
- Adds `ConnectionGroupManager` for pure connector compatibility checks plus committed id-backed connect/disconnect state.
- Moves the shape-board fixture to connector-based slots and adds a neutral PC-like connector/cable example.
- Documents association-v0 vocabulary: pure can-associate checks, committed association mutations, and future on-associate hooks.

## Verification

- Local CodeRabbit review: `/Users/derek/.local/bin/coderabbit review --agent --base-commit fa5585ef40c783591ac2a7d971812512d560fe3f -c AGENTS.md`
  - Produced one valid pytest helper naming issue before stalling; fixed and retested.
- `poetry run pytest engine/tests/mechanics/test_assembly.py engine/tests/mechanics/test_connector_association.py engine/tests/mechanics/test_vehicle_example.py engine/tests/mechanics/presence`
- `poetry run pytest engine/tests/mechanics`
- `git diff --check`

## Notes

This is stacked on #291 and should be retargeted to `main` after #291 merges.
