### PR TITLE
Document transaction offer vocabulary

### DIFF
--- a/engine/src/tangl/mechanics/README.md
+++ b/engine/src/tangl/mechanics/README.md
@@ -26,6 +26,10 @@ Within each family, the preferred design lens is:
 - **Writeback**: explicit consequence application
 - **Facade**: thin `HasX` author-facing mixins or helpers
 
+See `TRANSACTION_OFFER_DESIGN.md` for the cross-family vocabulary that unifies
+provisioning offers, association checks, asset transfers, shops, services, and
+writeback receipts.
+
 ## Review Lens
 
 When reviewing or reviving a mechanic family, describe it with these four questions:

--- a/engine/src/tangl/mechanics/TRANSACTION_OFFER_DESIGN.md
+++ b/engine/src/tangl/mechanics/TRANSACTION_OFFER_DESIGN.md
@@ -1,0 +1,271 @@
+# Transaction Offers and Commitments
+
+```{storytangl-topic}
+:topics: association, transaction, provision
+:facets: design, vocabulary
+:relation: unifies
+:related: assembly, assets, provisioning, credentials
+```
+
+**Status:** DESIGN NOTE — vocabulary alignment for future implementation, not a
+landed transaction engine.
+**Scope:** the common offer/accept/writeback shape shared by provisioning,
+association, shops, trades, services, component install flows, and future
+credential/chopshop compliance.
+**Prior art:** VM `Requirement` / `ProvisionOffer`, story asset
+`AssetTransactionManager`, assembly `ComponentManager` and connector association,
+legacy `scratch/legacy/core/core-30/graph_handlers/associating.py`, and the
+CarWars garage/shop proof.
+
+---
+
+## The Unifying Claim
+
+Provisioning and transactions are the same family of operation:
+
+```text
+request/spec + current context
+  -> validated offers
+  -> accept an offer or batch
+  -> apply commitments
+  -> record durable state and receipt metadata
+```
+
+Provisioning is the phase-local version: a requirement needs a provider, handlers
+return offers, the resolver accepts one, and the requirement is bound to the
+provider. A shop/trade/service is the durable update-phase version: a move
+payload asks for an exchange or association, handlers return validated offers, an
+accepted offer commits wallet debits, token creation/movement, slot assignments,
+stat mutations, or other writeback.
+
+The useful abstraction is not "shop." It is a validated promise to perform one
+or more commitments.
+
+---
+
+## Vocabulary
+
+### Spec
+
+A **spec** is plain request data. It says what is being asked for, without
+callbacks and without hidden mutation.
+
+Examples:
+
+- a VM `Requirement`;
+- "buy these catalog items";
+- "install this component in this slot";
+- "pay 10 gp for 10 hp of healing";
+- "confiscate this credential token";
+- "connect this plug to that socket."
+
+Specs may be serialized or logged when useful. They are not themselves proof that
+the operation is currently legal.
+
+### Offer
+
+An **offer** is an ephemeral, validated promise produced from a spec and current
+context. It may carry callbacks, bound objects, priorities, policies, previews,
+and commit functions. Because of those callbacks and object references, offers
+are not durable persistence objects.
+
+Existing `ProvisionOffer` already follows this rule: it is a ranked candidate
+with a callback and `guard_unstructure = True`. A transaction offer should follow
+the same durable/ephemeral split.
+
+### Commitment
+
+A **commitment** is one source/target/effect leg inside an offer. Its core shape
+is bilateral:
+
+```text
+source can provide/send/debit X
+target can receive/accept/credit X
+```
+
+For a trade, both directions are checked:
+
+```text
+A can send X
+B can receive X
+B can send Y
+A can receive Y
+```
+
+`X` and `Y` are not necessarily tokens. They may be fungible wallet counts, stat
+deltas, service capacity, catalog materialization, time, ownership changes, slot
+associations, connector pairings, or graph links.
+
+### Accept
+
+**Accepting** an offer rechecks preflight, then applies all commitments as one
+logical writeback. If any commitment fails, no durable partial mutation should
+survive. A first implementation may use simple reverse-order rollback; later
+graph/runtime integration may provide a richer transaction journal.
+
+### Receipt
+
+A **receipt** is plain result data. It records what happened, what was paid,
+what was created or moved, what service was performed, and what changed. Receipts
+are suitable for round notes, replay diagnostics, journal fragments, or audit
+metadata. Receipts do not carry callbacks.
+
+---
+
+## Provisioning In This Vocabulary
+
+| Current Provisioning Term | Unified Vocabulary |
+| --- | --- |
+| `Requirement` | spec: a request for a provider matching selector/policy |
+| `ProvisionOffer` | offer: a ranked promise to satisfy the requirement |
+| `EXISTING` | commitment provides an already-present entity |
+| `CREATE` | commitment materializes from a template/catalog recipe |
+| `TOKEN` | commitment provides a graph-local token over a singleton/catalog entry |
+| `UPDATE` | commitment applies a delta to an existing provider |
+| `CLONE` | commitment copies an existing provider and applies a delta |
+| offer callback | accept/provide callback |
+| `provider_id` | accepted binding |
+| resolution metadata | receipt/audit of selected policy, step, cursor, reason |
+
+This does not require rewriting provisioning. It gives us common language for
+why provisioning callbacks are ephemeral, why requirements and resolution
+metadata are durable, and why catalog-backed shops look more like provisioners
+than like static inventories.
+
+---
+
+## Association In This Vocabulary
+
+The legacy `Associating` handler had the right symmetry:
+
+```text
+can_associate_with(A, B)
+  = all A.on_can_associate(B)
+  + all B.on_can_associate(A)
+
+associate_with(A, B)
+  = recheck
+  -> A.on_associate(B)
+  -> B.on_associate(A)
+  -> mutate relationship
+```
+
+The new vocabulary preserves that idea without requiring every participant to be
+an `Associating` node. The symmetry moves into the commitment layer:
+
+- `can_*` checks are pure and may run many times during planning and UI
+  projection.
+- source and target both validate capacity, consent, legality, or policy.
+- commit happens only after every commitment passes.
+- post-commit hooks/receipts happen after durable mutation.
+
+Component assignment, connector pairing, asset transfer, shop purchase, healing,
+credential confiscation, and service use are all association-shaped when viewed
+as commitments.
+
+---
+
+## Parameter-Bound Moves
+
+The normal UI rule still stands: do not offer invalid choices. Transaction
+offers cover the narrower case where the move envelope is valid but the submitted
+payload may not be.
+
+Example:
+
+```text
+available move: buy things
+payload: {items: [foo, bar, baz]}
+```
+
+The move kind is valid because the current shop can transact. The payload may be
+invalid because `foo` is not available, the player cannot afford the aggregate
+cost, the target holder cannot receive one of the items, or a chosen install slot
+cannot accept a component. The handler should bind the payload into a concrete
+spec, ask for a validated offer, and reject before writeback if no offer can be
+accepted.
+
+This is the same server-side authority rule used by typed widget accepts: UI
+constraints help, but update logic validates the submitted payload.
+
+---
+
+## Source Modes
+
+Sellers and service providers do not always hold the exact thing the player will
+receive.
+
+### Held Token
+
+The provider owns a discrete token. Accepting the offer moves that token.
+
+### Catalog Provision
+
+The provider owns a catalog/provisioner and can create a token on demand.
+Accepting the offer materializes a fresh token, possibly decrementing stock,
+daily capacity, or another provider ledger.
+
+### Fungible Or Service Capacity
+
+No token moves. Accepting the offer mutates ledgers or state:
+
+```text
+buyer.cash -= 10
+healer.healing_capacity -= 10
+buyer.hp += 10
+```
+
+The same bilateral checks apply: the buyer can pay, the seller can receive
+payment, the healer can provide the service, and the patient can receive the
+state change under current rules.
+
+---
+
+## First Implementation Slice
+
+The first implementation should be deliberately smaller than a general shop
+engine.
+
+Recommended proof:
+
+1. Add a small transaction-offer helper with plain result/receipt types and an
+   ordered commitment protocol.
+2. Implement only the commitment legs forced by a neutral demo:
+   - wallet debit;
+   - optional wallet credit;
+   - existing token move or simple catalog token creation;
+   - component assignment to an owner-bound manager;
+   - replacement return;
+   - reverse-order rollback.
+3. Add a neutral shop/garage example over the existing vehicle component manager.
+4. Test valid purchase/install, aggregate insufficient funds, incompatible slot,
+   provider missing capacity, and mid-commit rollback.
+5. Keep transaction offers ephemeral; persist only resulting state and receipts.
+
+Out of scope for the first slice:
+
+- generic global trade arbitration;
+- author-facing `on_associate` dispatch hooks;
+- graph relationship-backed ownership migration;
+- multi-turn pending offers;
+- a full shop game UI;
+- all possible commitment leg types.
+
+---
+
+## Why This Helps
+
+The same vocabulary covers:
+
+- VM provisioning offers;
+- asset transactions and future holding relations;
+- assembly slot assignment and connector association;
+- CarWars garage/shop install and repair flows;
+- credentials confiscation, return, planting, or bribery;
+- robot/chopshop parts plus permits/compliance;
+- pure service transactions such as healing for money or time.
+
+That common shape should make future issue grooming simpler: when a feature asks
+"can X move from here to there?", "can this service be provided?", or "can this
+association commit?", it should be framed as a spec producing validated offers,
+whose accepted commitments mutate durable state and emit a receipt.

--- a/engine/src/tangl/mechanics/TRANSACTION_OFFER_DESIGN.md
+++ b/engine/src/tangl/mechanics/TRANSACTION_OFFER_DESIGN.md
@@ -2,8 +2,8 @@
 
 ```{storytangl-topic}
 :topics: association, transaction, provision
-:facets: design, vocabulary
-:relation: unifies
+:facets: design, notes
+:relation: defines
 :related: assembly, assets, provisioning, credentials
 ```
 

--- a/engine/src/tangl/mechanics/assembly/COMPONENT_DESIGN.md
+++ b/engine/src/tangl/mechanics/assembly/COMPONENT_DESIGN.md
@@ -78,6 +78,8 @@ Assembly now treats membership and connection as small association specializatio
 This is intentionally smaller than the legacy `Associating` handler pipeline. It keeps
 the vocabulary aligned with future roles, credentials, shops, and trades without adding
 a broad transaction framework before connectors and compliance prove the shared shape.
+The broader offer/commitment vocabulary is captured in
+`../TRANSACTION_OFFER_DESIGN.md`.
 
 ---
 

--- a/engine/src/tangl/story/concepts/asset/ASSET_DESIGN.md
+++ b/engine/src/tangl/story/concepts/asset/ASSET_DESIGN.md
@@ -104,6 +104,11 @@ can:
 A higher-level trade manager can later compare aggregate values and actor
 biases before delegating to the transaction manager.
 
+See `../../../mechanics/TRANSACTION_OFFER_DESIGN.md` for the shared
+spec/offer/commitment/receipt vocabulary that generalizes this manager across
+provisioning, shops, services, assembly assignment, and future relationship
+writeback.
+
 ## Future Core Hooks
 
 Core currently observes link changes with `on_link` and `on_unlink`. Asset


### PR DESCRIPTION
## Summary
- add `TRANSACTION_OFFER_DESIGN.md` as the shared spec/offer/commitment/receipt vocabulary
- map VM provisioning (`Requirement` / `ProvisionOffer` / find/create/update/clone) onto the same shape as transactions
- cross-link the note from mechanics, assembly, and asset transaction docs

## Verification
- `git diff --check`
- docs-only change; no runtime tests run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new design note describing a shared offer/commitment/receipt model across provisioning, transactions, asset transfers, and related workflows.
  * Updated existing design docs with cross-references to the new unified vocabulary so related concepts are easier to discover and follow.
  * Clarified expected transaction behavior, including validation, atomic application, rollback expectations, and durable receipt/audit records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->