### PR TITLE
Add transaction offer helper and neutral garage proof

### DIFF
--- a/engine/src/tangl/mechanics/TRANSACTION_OFFER_DESIGN.md
+++ b/engine/src/tangl/mechanics/TRANSACTION_OFFER_DESIGN.md
@@ -7,8 +7,10 @@
 :related: assembly, assets, provisioning, credentials
 ```
 
-**Status:** DESIGN NOTE — vocabulary alignment for future implementation, not a
-landed transaction engine.
+**Status:** FIRST HELPER LANDED — `tangl.mechanics.transaction` provides an
+ephemeral `TransactionOffer`, ordered rollback-capable commitments, plain
+preflight/receipt data, and a neutral vehicle garage proof. This is still not a
+full shop engine or global transaction arbiter.
 **Scope:** the common offer/accept/writeback shape shared by provisioning,
 association, shops, trades, services, component install flows, and future
 credential/chopshop compliance.
@@ -223,24 +225,37 @@ state change under current rules.
 
 ## First Implementation Slice
 
-The first implementation should be deliberately smaller than a general shop
-engine.
+The first implementation is deliberately smaller than a general shop engine.
 
-Recommended proof:
+Landed proof:
 
-1. Add a small transaction-offer helper with plain result/receipt types and an
-   ordered commitment protocol.
-2. Implement only the commitment legs forced by a neutral demo:
-   - wallet debit;
-   - optional wallet credit;
-   - existing token move or simple catalog token creation;
-   - component assignment to an owner-bound manager;
-   - replacement return;
-   - reverse-order rollback.
-3. Add a neutral shop/garage example over the existing vehicle component manager.
-4. Test valid purchase/install, aggregate insufficient funds, incompatible slot,
-   provider missing capacity, and mid-commit rollback.
-5. Keep transaction offers ephemeral; persist only resulting state and receipts.
+1. `TransactionOffer` stays ephemeral and `guard_unstructure = True`, matching
+   the same callback/live-object boundary as `ProvisionOffer`.
+2. `TransactionCheck` and `TransactionReceipt` are plain data.
+3. `CountableTransferCommitment` proves bilateral wallet debit/credit checks.
+4. `RegistryAddCommitment` proves explicit shape change during accepted
+   writeback: a prepared graph item can enter the registry only when the offer
+   commits.
+5. `ComponentAssignmentCommitment` proves owner-bound component manager
+   assignment, replacement, post-assignment validation, and rollback.
+6. The neutral vehicle garage test buys and installs a component, then proves
+   the resulting graph/loadout state survives `Graph.unstructure()` /
+   `Graph.structure()`.
+7. Rejection before mutation and mid-commit rollback are both covered.
+
+Still recommended for the next consumer-facing slice:
+
+1. Add a neutral shop/garage example module or world-facing fixture over the
+   existing vehicle component manager.
+2. Add commitment legs only when a real consumer forces them:
+   - discrete token move between holders;
+   - catalog-backed token creation with stock/capacity;
+   - replacement return to inventory;
+   - service/stat mutation;
+   - graph link/unlink.
+3. Test aggregate insufficient funds, unavailable catalog/provider capacity,
+   incompatible install targets, and multi-offer/batch selection.
+4. Keep transaction offers ephemeral; persist only resulting state and receipts.
 
 Out of scope for the first slice:
 

--- a/engine/src/tangl/mechanics/TRANSACTION_OFFER_DESIGN.md
+++ b/engine/src/tangl/mechanics/TRANSACTION_OFFER_DESIGN.md
@@ -223,6 +223,80 @@ state change under current rules.
 
 ---
 
+## Binding A Mechanic
+
+A transaction-aware mechanic should stay a thin adapter around its own domain
+rules. The recommended shape is:
+
+```text
+typed move payload
+  -> domain spec
+  -> one or more validated offers
+  -> accept selected offer during update
+  -> receipt feeds round notes / fragments / audit metadata
+```
+
+Keep the binding point obvious:
+
+1. Resolve submitted widget/payload ids into live domain objects.
+2. Validate the move envelope and construct a plain spec.
+3. Build a `TransactionOffer` from ordered commitments.
+4. Call `offer.can_accept()` while still in validation/preflight.
+5. Call `offer.accept()` only in the committed update path.
+6. Use the returned `TransactionReceipt` for notes and projection hints.
+
+Core commitments cover common legs:
+
+- `CountableTransferCommitment` for fungible wallet/resource transfer;
+- `RegistryAddCommitment` for explicit graph/token materialization;
+- `ComponentAssignmentCommitment` for owner-bound assembly slots;
+- `CallbackCommitment` for domain-local state changes that do not deserve a
+  core vocabulary yet.
+
+`CallbackCommitment` is the escape hatch for a world or mechanic package to bind
+local state without hiding it outside the transaction contract. Use it for small,
+named, rollback-capable legs such as:
+
+- remove a selected part from a shop inventory;
+- return a replaced component to an inventory;
+- mark a service provider's daily capacity as used;
+- mutate local repair/reload/recharge state;
+- add mechanic-specific receipt detail for UI fragments.
+
+Do not use a callback commitment as a pile of unstructured work. If the same
+callback shape appears in a second mechanic, promote it into a named commitment.
+
+### CarWars Garage / Salvage Mapping
+
+The current CarWars vehicle bay hand-rolls a useful target pattern:
+
+```text
+install(piece_id, target_slot)
+  -> resolve inventory piece
+  -> resolve loadout slot
+  -> debit cash/time, or zero cash for salvage
+  -> remove piece from inventory
+  -> assign component to vehicle loadout
+  -> return replaced component to inventory
+  -> update fragments from receipt and loadout state
+```
+
+That should bind to transactions as:
+
+- `CountableTransferCommitment(player, garage, "cash", price)` when price is
+  nonzero;
+- another countable commitment or a local wallet leg for elapsed time;
+- `CallbackCommitment("remove from inventory", ...)` for the selected part;
+- `ComponentAssignmentCommitment(vehicle.loadout, slot, part, allow_replace=True)`;
+- `CallbackCommitment("return replaced part", ...)` when a domain wants the
+  replaced component in inventory rather than simply unassigned.
+
+Garage, shop, and salvage should differ mainly in policy functions that compute
+price, time, inventory source, and presentation labels. The transaction shape is
+the same.
+
+---
+
 ## First Implementation Slice
 
 The first implementation is deliberately smaller than a general shop engine.
@@ -238,10 +312,13 @@ Landed proof:
    commits.
 5. `ComponentAssignmentCommitment` proves owner-bound component manager
    assignment, replacement, post-assignment validation, and rollback.
-6. The neutral vehicle garage test buys and installs a component, then proves
+6. `CallbackCommitment` marks the domain-local plug-in spot for inventory,
+   service, and presentation-specific state that still needs transaction
+   preflight/rollback.
+7. The neutral vehicle garage test buys and installs a component, then proves
    the resulting graph/loadout state survives `Graph.unstructure()` /
    `Graph.structure()`.
-7. Rejection before mutation and mid-commit rollback are both covered.
+8. Rejection before mutation and mid-commit rollback are both covered.
 
 Still recommended for the next consumer-facing slice:
 
@@ -250,7 +327,6 @@ Still recommended for the next consumer-facing slice:
 2. Add commitment legs only when a real consumer forces them:
    - discrete token move between holders;
    - catalog-backed token creation with stock/capacity;
-   - replacement return to inventory;
    - service/stat mutation;
    - graph link/unlink.
 3. Test aggregate insufficient funds, unavailable catalog/provider capacity,

--- a/engine/src/tangl/mechanics/transaction.py
+++ b/engine/src/tangl/mechanics/transaction.py
@@ -65,6 +65,44 @@ class TransactionHandler(Protocol[SpecT]):
 
 
 @dataclass
+class CallbackCommitment:
+    """Domain-local commitment backed by explicit preflight, apply, and undo callbacks."""
+
+    label: str
+    apply: Callable[[], object | None]
+    can_apply: Callable[[], TransactionCheck | bool] | None = None
+    undo: Callable[[], None] | None = None
+    _committed: bool = False
+
+    def can_commit(self) -> TransactionCheck:
+        if self.can_apply is None:
+            return TransactionCheck.accept()
+        result = self.can_apply()
+        if isinstance(result, bool):
+            return (
+                TransactionCheck.accept()
+                if result
+                else TransactionCheck.reject("rejected")
+            )
+        return result
+
+    def commit(self) -> object | None:
+        check = self.can_commit()
+        if not check.accepted:
+            raise ValueError(check.reason or f"{self.label} rejected")
+        detail = self.apply()
+        self._committed = True
+        return detail
+
+    def rollback(self) -> None:
+        if not self._committed:
+            return
+        if self.undo is not None:
+            self.undo()
+        self._committed = False
+
+
+@dataclass
 class TransactionOffer:
     """Ephemeral, preflighted promise to apply ordered commitments.
 
@@ -376,6 +414,7 @@ class ComponentAssignmentCommitment:
 
 
 __all__ = [
+    "CallbackCommitment",
     "ComponentAssignmentCommitment",
     "CountableHolder",
     "CountableTransferCommitment",

--- a/engine/src/tangl/mechanics/transaction.py
+++ b/engine/src/tangl/mechanics/transaction.py
@@ -35,6 +35,10 @@ class TransactionReceipt(BaseModelPlus):
     details: list[object] = Field(default_factory=list)
 
 
+class TransactionRollbackError(RuntimeError):
+    """Raised when rollback fails while recovering from a commit error."""
+
+
 class TransactionCommitment(Protocol):
     """One ordered, rollback-capable writeback leg inside a transaction offer."""
 
@@ -94,9 +98,22 @@ class TransactionOffer:
                 detail = commitment.commit()
                 if detail is not None:
                     details.append(detail)
-        except Exception:
+        except Exception as exc:
+            rollback_errors: list[tuple[str, Exception]] = []
             for commitment in reversed(applied):
-                commitment.rollback()
+                try:
+                    commitment.rollback()
+                except Exception as rollback_error:
+                    rollback_errors.append((commitment.label, rollback_error))
+            if rollback_errors:
+                labels = ", ".join(label for label, _ in rollback_errors)
+                error = TransactionRollbackError(
+                    f"transaction rollback failed for: {labels}"
+                )
+                error.add_note(f"original commit error: {exc!r}")
+                for label, rollback_error in rollback_errors:
+                    error.add_note(f"{label}: {rollback_error!r}")
+                raise error from exc
             raise
 
         return TransactionReceipt(
@@ -159,8 +176,14 @@ class CountableTransferCommitment:
         self.giver.spend_countable(self.asset_label, self.amount)
         try:
             self.receiver.gain_countable(self.asset_label, self.amount)
-        except Exception:
-            self.giver.gain_countable(self.asset_label, self.amount)
+        except Exception as exc:
+            try:
+                self.giver.gain_countable(self.asset_label, self.amount)
+            except Exception as rollback_error:
+                error = TransactionRollbackError("countable transfer rollback failed")
+                error.add_note(f"original receive error: {exc!r}")
+                error.add_note(f"refund error: {rollback_error!r}")
+                raise error from exc
             raise
         self._committed = True
         return {
@@ -227,21 +250,72 @@ class ComponentAssignmentCommitment:
     allow_replace: bool = False
     _previous: list[Entity] = field(default_factory=list)
     _committed: bool = False
+    _registered_by_assignment: Entity | None = field(default=None, repr=False)
+    _resolved: Entity | None = field(default=None, repr=False)
 
     def _component(self) -> Entity:
-        if callable(self.component):
-            return self.component()
-        return self.component
+        if self._resolved is None:
+            self._resolved = (
+                self.component()
+                if callable(self.component)
+                else self.component
+            )
+        return self._resolved
+
+    def _can_replace(self, component: Entity) -> TransactionCheck:
+        if not self.allow_replace:
+            return TransactionCheck.reject("replacement disabled")
+        if self.slot_name not in self.manager.slots:
+            return TransactionCheck.reject(f"No such slot: {self.slot_name}")
+
+        slot = self.manager.slots[self.slot_name]
+        replaced = self.manager.get_slot(self.slot_name)
+        if slot.max_count != 1 or not replaced:
+            return TransactionCheck.reject("replacement requires one occupied single slot")
+        if not self.manager.is_slot_enabled(self.slot_name):
+            return TransactionCheck.reject(f"Slot disabled: {self.slot_name}")
+
+        selects, reason = slot.selects_for(component)
+        if not selects:
+            return TransactionCheck.reject(reason)
+
+        missing_prerequisites = [
+            prerequisite
+            for prerequisite in slot.prerequisite_slots
+            if not self.manager._has_slot_components(prerequisite)
+        ]
+        if missing_prerequisites:
+            return TransactionCheck.reject(
+                f"Missing prerequisite slots: {', '.join(missing_prerequisites)}"
+            )
+
+        if self.manager.budgets and hasattr(component, "get_cost"):
+            current = [
+                item
+                for item in self.manager.all_components()
+                if item not in replaced
+            ]
+            current.append(component)
+            for name, budget in self.manager.budgets.budgets.items():
+                total = 0.0
+                for item in current:
+                    if hasattr(item, "get_cost"):
+                        total += float(getattr(item, "get_cost")(name))
+                if total > budget.capacity:
+                    return TransactionCheck.reject(
+                        f"Insufficient {name}: need {total}, have {budget.capacity}"
+                    )
+
+        return TransactionCheck.accept()
 
     def can_commit(self) -> TransactionCheck:
         component = self._component()
         can_assign, reason = self.manager.can_assign(self.slot_name, component)
         if can_assign:
             return TransactionCheck.accept()
-        if self.allow_replace and reason.startswith("Slot full"):
-            slot = self.manager.slots.get(self.slot_name)
-            if slot is not None and slot.max_count == 1 and self.manager.get_slot(self.slot_name):
-                return TransactionCheck.accept()
+        replace_check = self._can_replace(component)
+        if replace_check.accepted:
+            return replace_check
         return TransactionCheck.reject(reason)
 
     def commit(self) -> Mapping[str, object]:
@@ -251,8 +325,27 @@ class ComponentAssignmentCommitment:
 
         component = self._component()
         self._previous = list(self.manager.get_slot(self.slot_name))
-        self.manager.assign(self.slot_name, component)
+        component_registry = getattr(component, "registry", None)
+        slot = self.manager.slots[self.slot_name]
+        replacing = self.allow_replace and slot.max_count == 1 and bool(self._previous)
+        if replacing:
+            for item in self._previous:
+                self.manager.unassign(self.slot_name, item)
+        try:
+            self.manager.assign(self.slot_name, component)
+        except Exception:
+            if replacing:
+                for item in self._previous:
+                    self.manager.assign(self.slot_name, item)
+            raise
         self._committed = True
+        owner_registry = self.manager._owner_registry()
+        if (
+            component_registry is None
+            and owner_registry is not None
+            and owner_registry.get(component.uid) is component
+        ):
+            self._registered_by_assignment = component
 
         if self.validate_after:
             errors = self.manager.validate()
@@ -274,6 +367,10 @@ class ComponentAssignmentCommitment:
             self.manager.unassign(self.slot_name, item)
         for item in self._previous:
             self.manager.assign(self.slot_name, item)
+        owner_registry = self.manager._owner_registry()
+        if self._registered_by_assignment is not None and owner_registry is not None:
+            owner_registry.remove(self._registered_by_assignment.uid)
+        self._registered_by_assignment = None
         self._previous = []
         self._committed = False
 
@@ -288,4 +385,5 @@ __all__ = [
     "TransactionHandler",
     "TransactionOffer",
     "TransactionReceipt",
+    "TransactionRollbackError",
 ]

--- a/engine/src/tangl/mechanics/transaction.py
+++ b/engine/src/tangl/mechanics/transaction.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import ClassVar, Protocol, TypeVar
+
+from pydantic import Field
+
+from tangl.core import Entity, Registry
+from tangl.core.bases import BaseModelPlus
+
+from .assembly import ComponentManager
+
+
+class TransactionCheck(BaseModelPlus):
+    """Pure preflight result for one transaction offer or commitment."""
+
+    accepted: bool
+    reason: str | None = None
+
+    @classmethod
+    def accept(cls) -> "TransactionCheck":
+        return cls(accepted=True)
+
+    @classmethod
+    def reject(cls, reason: str) -> "TransactionCheck":
+        return cls(accepted=False, reason=reason)
+
+
+class TransactionReceipt(BaseModelPlus):
+    """Plain result data from accepting an ephemeral transaction offer."""
+
+    offer_label: str | None = None
+    commitment_labels: list[str] = Field(default_factory=list)
+    details: list[object] = Field(default_factory=list)
+
+
+class TransactionCommitment(Protocol):
+    """One ordered, rollback-capable writeback leg inside a transaction offer."""
+
+    label: str
+
+    def can_commit(self) -> TransactionCheck:
+        ...
+
+    def commit(self) -> object | None:
+        ...
+
+    def rollback(self) -> None:
+        ...
+
+
+SpecT = TypeVar("SpecT")
+
+
+class TransactionHandler(Protocol[SpecT]):
+    """Structural protocol for helpers that produce validated transaction offers."""
+
+    def get_transaction_offers(self, spec: SpecT) -> Iterable["TransactionOffer"]:
+        ...
+
+
+@dataclass
+class TransactionOffer:
+    """Ephemeral, preflighted promise to apply ordered commitments.
+
+    Offers deliberately carry live objects and rollback callbacks. They are not
+    persistence records; serialize the originating spec and returned receipt instead.
+    """
+
+    label: str | None = None
+    commitments: list[TransactionCommitment] = field(default_factory=list)
+
+    guard_unstructure: ClassVar[bool] = True
+
+    def can_accept(self) -> TransactionCheck:
+        for commitment in self.commitments:
+            check = commitment.can_commit()
+            if not check.accepted:
+                prefix = f"{commitment.label}: " if commitment.label else ""
+                return TransactionCheck.reject(prefix + (check.reason or "rejected"))
+        return TransactionCheck.accept()
+
+    def accept(self) -> TransactionReceipt:
+        check = self.can_accept()
+        if not check.accepted:
+            raise ValueError(check.reason or "transaction offer rejected")
+
+        applied: list[TransactionCommitment] = []
+        details: list[object] = []
+        try:
+            for commitment in self.commitments:
+                applied.append(commitment)
+                detail = commitment.commit()
+                if detail is not None:
+                    details.append(detail)
+        except Exception:
+            for commitment in reversed(applied):
+                commitment.rollback()
+            raise
+
+        return TransactionReceipt(
+            offer_label=self.label,
+            commitment_labels=[commitment.label for commitment in applied],
+            details=details,
+        )
+
+
+class CountableHolder(Protocol):
+    """Minimal fungible-wallet surface used by countable transfer commitments."""
+
+    def can_give_countable(
+        self,
+        asset_label: str,
+        amount: int,
+        receiver: object | None = None,
+    ) -> bool:
+        ...
+
+    def can_receive_countable(
+        self,
+        asset_label: str,
+        amount: int,
+        giver: object | None = None,
+    ) -> bool:
+        ...
+
+    def spend_countable(self, asset_label: str, amount: int) -> None:
+        ...
+
+    def gain_countable(self, asset_label: str, amount: int) -> None:
+        ...
+
+
+@dataclass
+class CountableTransferCommitment:
+    """Transfer one fungible asset count between two holders."""
+
+    giver: CountableHolder
+    receiver: CountableHolder
+    asset_label: str
+    amount: int
+    label: str = "transfer countable"
+    _committed: bool = False
+
+    def can_commit(self) -> TransactionCheck:
+        if self.amount < 0:
+            return TransactionCheck.reject("amount must be non-negative")
+        if not self.giver.can_give_countable(self.asset_label, self.amount, self.receiver):
+            return TransactionCheck.reject("giver cannot provide countable asset")
+        if not self.receiver.can_receive_countable(self.asset_label, self.amount, self.giver):
+            return TransactionCheck.reject("receiver cannot accept countable asset")
+        return TransactionCheck.accept()
+
+    def commit(self) -> Mapping[str, object]:
+        check = self.can_commit()
+        if not check.accepted:
+            raise ValueError(check.reason or "countable transfer rejected")
+        self.giver.spend_countable(self.asset_label, self.amount)
+        try:
+            self.receiver.gain_countable(self.asset_label, self.amount)
+        except Exception:
+            self.giver.gain_countable(self.asset_label, self.amount)
+            raise
+        self._committed = True
+        return {
+            "kind": "countable_transfer",
+            "asset": self.asset_label,
+            "amount": self.amount,
+        }
+
+    def rollback(self) -> None:
+        if not self._committed:
+            return
+        self.receiver.spend_countable(self.asset_label, self.amount)
+        self.giver.gain_countable(self.asset_label, self.amount)
+        self._committed = False
+
+
+@dataclass
+class RegistryAddCommitment:
+    """Add a newly prepared entity to a registry during offer acceptance."""
+
+    registry: Registry
+    item: Entity
+    label: str = "add registry item"
+    _committed: bool = False
+
+    def can_commit(self) -> TransactionCheck:
+        existing = self.registry.get(self.item.uid)
+        if existing is not None and existing is not self.item:
+            return TransactionCheck.reject("registry already contains item uid")
+        return TransactionCheck.accept()
+
+    def commit(self) -> Mapping[str, object]:
+        check = self.can_commit()
+        if not check.accepted:
+            raise ValueError(check.reason or "registry add rejected")
+        if self.registry.get(self.item.uid) is None:
+            self.registry.add(self.item)
+            self._committed = True
+        return {
+            "kind": "registry_add",
+            "item_id": self.item.uid,
+            "item_label": self.item.get_label(),
+        }
+
+    def rollback(self) -> None:
+        if not self._committed:
+            return
+        self.registry.remove(self.item.uid)
+        self._committed = False
+
+
+ComponentSupplier = Entity | Callable[[], Entity]
+
+
+@dataclass
+class ComponentAssignmentCommitment:
+    """Assign a graph component to an owner-bound component manager slot."""
+
+    manager: ComponentManager
+    slot_name: str
+    component: ComponentSupplier
+    label: str = "assign component"
+    validate_after: bool = False
+    allow_replace: bool = False
+    _previous: list[Entity] = field(default_factory=list)
+    _committed: bool = False
+
+    def _component(self) -> Entity:
+        if callable(self.component):
+            return self.component()
+        return self.component
+
+    def can_commit(self) -> TransactionCheck:
+        component = self._component()
+        can_assign, reason = self.manager.can_assign(self.slot_name, component)
+        if can_assign:
+            return TransactionCheck.accept()
+        if self.allow_replace and reason.startswith("Slot full"):
+            slot = self.manager.slots.get(self.slot_name)
+            if slot is not None and slot.max_count == 1 and self.manager.get_slot(self.slot_name):
+                return TransactionCheck.accept()
+        return TransactionCheck.reject(reason)
+
+    def commit(self) -> Mapping[str, object]:
+        check = self.can_commit()
+        if not check.accepted:
+            raise ValueError(check.reason or "component assignment rejected")
+
+        component = self._component()
+        self._previous = list(self.manager.get_slot(self.slot_name))
+        self.manager.assign(self.slot_name, component)
+        self._committed = True
+
+        if self.validate_after:
+            errors = self.manager.validate()
+            if errors:
+                raise ValueError("; ".join(errors))
+
+        return {
+            "kind": "component_assignment",
+            "slot": self.slot_name,
+            "component_id": component.uid,
+            "component_label": component.get_label(),
+            "replaced_ids": [item.uid for item in self._previous],
+        }
+
+    def rollback(self) -> None:
+        if not self._committed:
+            return
+        for item in list(self.manager.get_slot(self.slot_name)):
+            self.manager.unassign(self.slot_name, item)
+        for item in self._previous:
+            self.manager.assign(self.slot_name, item)
+        self._previous = []
+        self._committed = False
+
+
+__all__ = [
+    "ComponentAssignmentCommitment",
+    "CountableHolder",
+    "CountableTransferCommitment",
+    "RegistryAddCommitment",
+    "TransactionCheck",
+    "TransactionCommitment",
+    "TransactionHandler",
+    "TransactionOffer",
+    "TransactionReceipt",
+]

--- a/engine/tests/mechanics/test_transaction_offer.py
+++ b/engine/tests/mechanics/test_transaction_offer.py
@@ -1,0 +1,183 @@
+"""Transaction offer tests over the neutral vehicle assembly example."""
+
+from __future__ import annotations
+
+import pytest
+
+from tangl.core import Graph, Node, Selector
+from tangl.mechanics.assembly.examples.vehicle import (
+    Vehicle,
+    VehicleComponent,
+    VehicleLoadout,
+)
+from tangl.mechanics.transaction import (
+    ComponentAssignmentCommitment,
+    CountableTransferCommitment,
+    RegistryAddCommitment,
+    TransactionCheck,
+    TransactionOffer,
+)
+from tangl.story.concepts.asset import HasAssets
+
+
+class GarageActor(HasAssets, Node):
+    """Graph actor with a fungible wallet for transaction proof tests."""
+
+
+class FailingCommitment:
+    """Commitment test double that fails after preflight accepts."""
+
+    label = "fail late"
+
+    def can_commit(self) -> TransactionCheck:
+        return TransactionCheck.accept()
+
+    def commit(self) -> None:
+        raise RuntimeError("late failure")
+
+    def rollback(self) -> None:
+        return None
+
+
+def part(label: str) -> VehicleComponent:
+    return VehicleComponent(token_from=label, label=label)
+
+
+def install_baseline(loadout: VehicleLoadout) -> None:
+    loadout.assign("chassis", part("mini_chassis"))
+    loadout.assign("powerplant", part("cheap_powerplant"))
+    loadout.assign("suspension", part("cheap_suspension"))
+    loadout.assign("tires", part("cheap_tires"))
+
+
+def test_transaction_offer_rejects_invalid_payload_before_mutation() -> None:
+    graph = Graph()
+    buyer = graph.add_node(kind=GarageActor, label="buyer")
+    shop = graph.add_node(kind=GarageActor, label="shop")
+    vehicle = graph.add_node(kind=Vehicle, label="car")
+    slicks = part("slicks")
+    buyer.gain_countable("cash", 100)
+
+    offer = TransactionOffer(
+        label="buy impossible powerplant",
+        commitments=[
+            CountableTransferCommitment(buyer, shop, "cash", 350),
+            RegistryAddCommitment(graph, slicks),
+            ComponentAssignmentCommitment(vehicle.loadout, "powerplant", slicks),
+        ],
+    )
+
+    check = offer.can_accept()
+
+    assert not check.accepted
+    assert check.reason == "transfer countable: giver cannot provide countable asset"
+    assert buyer.wallet["cash"] == 100
+    assert shop.wallet["cash"] == 0
+    assert graph.get(slicks.uid) is None
+    assert vehicle.loadout.get_slot("powerplant") == []
+
+    with pytest.raises(ValueError, match="giver cannot provide countable asset"):
+        offer.accept()
+
+
+def test_transaction_offer_rolls_back_applied_commitments_after_late_failure() -> None:
+    graph = Graph()
+    buyer = graph.add_node(kind=GarageActor, label="buyer")
+    shop = graph.add_node(kind=GarageActor, label="shop")
+    tires = part("slicks")
+    buyer.gain_countable("cash", 1000)
+
+    offer = TransactionOffer(
+        label="buy tires then fail",
+        commitments=[
+            CountableTransferCommitment(buyer, shop, "cash", 350),
+            RegistryAddCommitment(graph, tires),
+            FailingCommitment(),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="late failure"):
+        offer.accept()
+
+    assert buyer.wallet["cash"] == 1000
+    assert shop.wallet["cash"] == 0
+    assert graph.get(tires.uid) is None
+
+
+def test_transaction_offer_buys_installs_and_round_trips_vehicle_component() -> None:
+    graph = Graph()
+    buyer = graph.add_node(kind=GarageActor, label="buyer")
+    shop = graph.add_node(kind=GarageActor, label="shop")
+    vehicle = graph.add_node(kind=Vehicle, label="car")
+    tires = part("slicks")
+    buyer.gain_countable("cash", 1000)
+    install_baseline(vehicle.loadout)
+
+    offer = TransactionOffer(
+        label="buy and install slicks",
+        commitments=[
+            CountableTransferCommitment(buyer, shop, "cash", 350),
+            RegistryAddCommitment(graph, tires),
+            ComponentAssignmentCommitment(
+                vehicle.loadout,
+                "tires",
+                tires,
+                validate_after=True,
+                allow_replace=True,
+            ),
+        ],
+    )
+
+    receipt = offer.accept()
+
+    assert buyer.wallet["cash"] == 650
+    assert shop.wallet["cash"] == 350
+    assert graph.get(tires.uid) is tires
+    assert vehicle.loadout.get_slot("tires") == [tires]
+    assert receipt.offer_label == "buy and install slicks"
+    assert receipt.commitment_labels == [
+        "transfer countable",
+        "add registry item",
+        "assign component",
+    ]
+
+    restored = Graph.structure(graph.unstructure())
+    restored_vehicle = restored.find_one(Selector(label="car"))
+    restored_tires = restored.find_one(Selector(label="slicks"))
+
+    assert restored_vehicle.loadout.owner is restored_vehicle
+    assert restored_vehicle.loadout.get_slot("tires") == [restored_tires]
+    assert restored_vehicle.loadout.validate() == []
+
+
+def test_transaction_offer_rolls_back_component_assignment_validation_failure() -> None:
+    graph = Graph()
+    buyer = graph.add_node(kind=GarageActor, label="buyer")
+    shop = graph.add_node(kind=GarageActor, label="shop")
+    vehicle = graph.add_node(kind=Vehicle, label="car", max_price=800)
+    truck_chassis = part("truck_chassis")
+    buyer.gain_countable("cash", 3000)
+    install_baseline(vehicle.loadout)
+
+    offer = TransactionOffer(
+        label="buy too expensive chassis",
+        commitments=[
+            CountableTransferCommitment(buyer, shop, "cash", 1600),
+            RegistryAddCommitment(graph, truck_chassis),
+            ComponentAssignmentCommitment(
+                vehicle.loadout,
+                "chassis",
+                truck_chassis,
+                validate_after=True,
+                allow_replace=True,
+            ),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="Price exceeds budget"):
+        offer.accept()
+
+    assert buyer.wallet["cash"] == 3000
+    assert shop.wallet["cash"] == 0
+    assert graph.get(truck_chassis.uid) is None
+    assert vehicle.loadout.get_slot("chassis")[0].token_from == "mini_chassis"

--- a/engine/tests/mechanics/test_transaction_offer.py
+++ b/engine/tests/mechanics/test_transaction_offer.py
@@ -15,6 +15,7 @@ from tangl.mechanics.assembly.examples.vehicle import (
     VehiclePartType,
 )
 from tangl.mechanics.transaction import (
+    CallbackCommitment,
     ComponentAssignmentCommitment,
     CountableTransferCommitment,
     RegistryAddCommitment,
@@ -208,6 +209,69 @@ def test_component_assignment_allow_replace_works_for_base_manager() -> None:
     offer.accept()
 
     assert loadout.get_slot("tires") == [slicks]
+
+
+def test_callback_commitment_binds_domain_local_inventory_moves() -> None:
+    graph = Graph()
+    vehicle = graph.add_node(kind=Vehicle, label="car")
+    inventory = [part("slicks")]
+    tires = inventory[0]
+
+    def remove_from_inventory() -> dict[str, object]:
+        inventory.remove(tires)
+        return {"kind": "inventory_remove", "item_id": tires.uid}
+
+    offer = TransactionOffer(
+        label="install inventory tires",
+        commitments=[
+            CallbackCommitment(
+                "remove from inventory",
+                apply=remove_from_inventory,
+                can_apply=lambda: tires in inventory,
+                undo=lambda: inventory.append(tires),
+            ),
+            ComponentAssignmentCommitment(vehicle.loadout, "tires", tires),
+        ],
+    )
+
+    receipt = offer.accept()
+
+    assert inventory == []
+    assert vehicle.loadout.get_slot("tires") == [tires]
+    assert receipt.details[0]["kind"] == "inventory_remove"
+
+
+def test_callback_commitment_rolls_back_domain_local_inventory_moves() -> None:
+    graph = Graph()
+    vehicle = graph.add_node(kind=Vehicle, label="car", max_price=50)
+    inventory = [part("truck_chassis")]
+    chassis = inventory[0]
+    install_baseline(vehicle.loadout)
+
+    offer = TransactionOffer(
+        label="failed inventory install",
+        commitments=[
+            CallbackCommitment(
+                "remove from inventory",
+                apply=lambda: inventory.remove(chassis),
+                can_apply=lambda: chassis in inventory,
+                undo=lambda: inventory.append(chassis),
+            ),
+            ComponentAssignmentCommitment(
+                vehicle.loadout,
+                "chassis",
+                chassis,
+                validate_after=True,
+                allow_replace=True,
+            ),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="Price exceeds budget"):
+        offer.accept()
+
+    assert inventory == [chassis]
+    assert vehicle.loadout.get_slot("chassis")[0].token_from == "mini_chassis"
 
 
 def test_transaction_offer_buys_installs_and_round_trips_vehicle_component() -> None:

--- a/engine/tests/mechanics/test_transaction_offer.py
+++ b/engine/tests/mechanics/test_transaction_offer.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
+
 import pytest
 
 from tangl.core import Graph, Node, Selector
+from tangl.mechanics.assembly import ComponentManager, Slot
 from tangl.mechanics.assembly.examples.vehicle import (
     Vehicle,
     VehicleComponent,
     VehicleLoadout,
+    VehiclePartType,
 )
 from tangl.mechanics.transaction import (
     ComponentAssignmentCommitment,
@@ -16,6 +20,7 @@ from tangl.mechanics.transaction import (
     RegistryAddCommitment,
     TransactionCheck,
     TransactionOffer,
+    TransactionRollbackError,
 )
 from tangl.story.concepts.asset import HasAssets
 
@@ -37,6 +42,39 @@ class FailingCommitment:
 
     def rollback(self) -> None:
         return None
+
+
+class TrackingCommitment:
+    """Commitment test double that records rollback attempts."""
+
+    def __init__(self, label: str, *, fail_rollback: bool = False) -> None:
+        self.label = label
+        self.fail_rollback = fail_rollback
+        self.rolled_back = False
+
+    def can_commit(self) -> TransactionCheck:
+        return TransactionCheck.accept()
+
+    def commit(self) -> None:
+        return None
+
+    def rollback(self) -> None:
+        self.rolled_back = True
+        if self.fail_rollback:
+            raise RuntimeError(f"{self.label} rollback failed")
+
+
+class BasicVehicleLoadout(ComponentManager[VehicleComponent]):
+    """Single-slot manager without VehicleLoadout's replacement override."""
+
+    slots: ClassVar[dict[str, Slot]] = {
+        "tires": Slot.for_predicate(
+            "tires",
+            lambda component: (
+                getattr(component, "part_type", None) is VehiclePartType.TIRES
+            ),
+        ),
+    }
 
 
 def part(label: str) -> VehicleComponent:
@@ -104,6 +142,74 @@ def test_transaction_offer_rolls_back_applied_commitments_after_late_failure() -
     assert graph.get(tires.uid) is None
 
 
+def test_transaction_offer_attempts_all_rollbacks_before_reporting_failure() -> None:
+    first = TrackingCommitment("first")
+    second = TrackingCommitment("second", fail_rollback=True)
+    offer = TransactionOffer(
+        label="rollback failure",
+        commitments=[
+            first,
+            second,
+            FailingCommitment(),
+        ],
+    )
+
+    with pytest.raises(TransactionRollbackError, match="second"):
+        offer.accept()
+
+    assert first.rolled_back
+    assert second.rolled_back
+
+
+def test_component_assignment_callable_supplier_resolves_once() -> None:
+    graph = Graph()
+    vehicle = graph.add_node(kind=Vehicle, label="car")
+    created: list[VehicleComponent] = []
+
+    def make_tires() -> VehicleComponent:
+        component = part("slicks")
+        created.append(component)
+        return component
+
+    offer = TransactionOffer(
+        label="install generated tires",
+        commitments=[
+            ComponentAssignmentCommitment(vehicle.loadout, "tires", make_tires),
+        ],
+    )
+
+    assert offer.can_accept().accepted
+    offer.accept()
+
+    assert len(created) == 1
+    assert vehicle.loadout.get_slot("tires") == [created[0]]
+    assert graph.get(created[0].uid) is created[0]
+
+
+def test_component_assignment_allow_replace_works_for_base_manager() -> None:
+    loadout = BasicVehicleLoadout()
+    cheap_tires = part("cheap_tires")
+    slicks = part("slicks")
+    loadout.assign("tires", cheap_tires)
+
+    offer = TransactionOffer(
+        label="replace base-manager tires",
+        commitments=[
+            ComponentAssignmentCommitment(
+                loadout,
+                "tires",
+                slicks,
+                allow_replace=True,
+            ),
+        ],
+    )
+
+    assert offer.can_accept().accepted
+    offer.accept()
+
+    assert loadout.get_slot("tires") == [slicks]
+
+
 def test_transaction_offer_buys_installs_and_round_trips_vehicle_component() -> None:
     graph = Graph()
     buyer = graph.add_node(kind=GarageActor, label="buyer")
@@ -163,7 +269,6 @@ def test_transaction_offer_rolls_back_component_assignment_validation_failure() 
         label="buy too expensive chassis",
         commitments=[
             CountableTransferCommitment(buyer, shop, "cash", 1600),
-            RegistryAddCommitment(graph, truck_chassis),
             ComponentAssignmentCommitment(
                 vehicle.loadout,
                 "chassis",


### PR DESCRIPTION
## Summary
- Land `tangl.mechanics.transaction` with ephemeral `TransactionOffer`, ordered rollback-capable commitments, and plain check/receipt data
- Prove countable transfers, registry adds, and component assignment with rollback and post-commit validation
- Update the design note to mark the first helper slice as landed and outline the next consumer-facing steps

## Testing
- Added unit tests covering invalid preflight rejection, late failure rollback, successful buy-and-install flow, and validation rollback
- Verified the neutral vehicle flow round-trips through `Graph.unstructure()` / `Graph.structure()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transactional preflight, commit, and rollback support for grouped actions.
  * End-user flows now return a receipt with committed steps and result details.
  * Expanded vehicle assembly handling to support safer component assignment and recovery.
* **Bug Fixes**
  * Invalid actions are now rejected before any changes are applied.
  * If a later step fails, earlier changes are automatically rolled back.
  * Component validation failures now leave the target slot unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->