### PR TITLE
Document transaction offer follow-through

### DIFF
--- a/engine/src/tangl/mechanics/README.md
+++ b/engine/src/tangl/mechanics/README.md
@@ -30,6 +30,11 @@ See `TRANSACTION_OFFER_DESIGN.md` for the cross-family vocabulary that unifies
 provisioning offers, association checks, asset transfers, shops, services, and
 writeback receipts.
 
+The first runtime helper for that vocabulary lives in `transaction.py`. It is
+deliberately small: an ephemeral `TransactionOffer` validates, accepts, and
+receipts a list of commitments while domain mechanics keep their own policy and
+author-facing words.
+
 ## Review Lens
 
 When reviewing or reviving a mechanic family, describe it with these four questions:
@@ -55,6 +60,9 @@ are using it systematically.
   story-capable mechanic family.
 - **Assembly**: constrained slot-and-budget optimization kernel used by higher-level
   authored loadouts.
+- **Transaction offers**: cross-family writeback helper for preflighted,
+  multi-leg mutations such as shop purchases, service exchanges, asset movement,
+  and component assignment. It is not a shop engine or inventory model by itself.
 - **Demographics**: profile and naming facet, currently being modernized toward a
   cleaner v38-facing surface.
 - **Presence / Wearable** and **Presence / Ornaments**: reusable presence/runtime

--- a/engine/src/tangl/mechanics/assembly/COMPONENT_DESIGN.md
+++ b/engine/src/tangl/mechanics/assembly/COMPONENT_DESIGN.md
@@ -56,7 +56,14 @@ Connector association is the third proof consumer and the first bilateral one.
 Its `can_connect()` / `can_disconnect()` methods are pure checks; `connect()` /
 `disconnect()` are committed id-backed relationship mutations. Group matching is
 deliberately deterministic first-fit for now, enough to show simple plug/socket
-pairs and PC-like cable bundles without promoting a general transaction engine yet.
+pairs and PC-like cable bundles while keeping connector compatibility local to assembly.
+
+Transaction offers are now the first writeback layer adjacent to these managers.
+`tangl.mechanics.transaction` supplies ephemeral offers, commitments, rollback
+checks, and receipts for cases where association also costs, creates, moves, or
+mutates something else. A vehicle garage proof uses component assignment as one
+commitment inside a multi-leg offer, while the manager still owns slot legality
+and persisted identity.
 
 Follow-up retrofit targets remain open: credential packets, domain vehicle managers
 such as CarWars adapters, robot assemblies, and any world-specific full-graph outfit
@@ -76,10 +83,11 @@ Assembly now treats membership and connection as small association specializatio
   bookkeeping, world reactions, and journal fragments after a mutation has committed.
 
 This is intentionally smaller than the legacy `Associating` handler pipeline. It keeps
-the vocabulary aligned with future roles, credentials, shops, and trades without adding
-a broad transaction framework before connectors and compliance prove the shared shape.
-The broader offer/commitment vocabulary is captured in
-`../TRANSACTION_OFFER_DESIGN.md`.
+the vocabulary aligned with future roles, credentials, shops, and trades while leaving
+multi-party writeback to the broader offer/commitment helper in
+`../TRANSACTION_OFFER_DESIGN.md`. Assembly association answers the local question
+"may this member or endpoint bind here?"; transaction offers answer the update-phase
+question "which checked mutations commit together?"
 
 ---
 

--- a/engine/src/tangl/story/concepts/asset/ASSET_DESIGN.md
+++ b/engine/src/tangl/story/concepts/asset/ASSET_DESIGN.md
@@ -94,8 +94,14 @@ storage itself.
 ## Transaction Model
 
 `AssetTransactionManager` validates a complete transfer before mutating wallets
-or holder asset maps. Once the graph relationship model exists, the same manager
-can:
+or holder asset maps. It remains the story-level convenience for the current
+holder surface. The cross-family `tangl.mechanics.transaction` helper now carries
+the shared spec/offer/commitment/receipt shape for broader shops, services,
+assembly assignment, and mixed writeback.
+
+Once the graph relationship model exists, asset transfers should bind to that
+offer/commitment helper rather than grow a parallel trade framework. The asset
+side can then:
 
 - move discrete asset tokens by updating holding/ownership links;
 - debit and credit `AssetWallet` counts;
@@ -132,9 +138,10 @@ experiments, not a complete inventory system.
   `can_receive_*`) directly. A later relationship framework should generalize
   this into preflight/acceptance rules that assets, connections, attachments,
   and other mutable associations can share.
-- `AssetTransactionManager` does not yet batch mixed discrete and fungible
-  changes atomically. The trade manager should build on a batched transaction
-  plan that validates every leg before mutating anything.
+- `AssetTransactionManager` is not yet adapted to `TransactionOffer` for mixed
+  discrete, fungible, and service operations. The generic helper exists; the
+  remaining work is to express holder-map and future holding-edge changes as
+  commitments that validate every leg before mutating anything.
 - `HasAssets` nominates `inv` and `assets` into local namespaces, but there is
   no story-level `Player`/avatar concept yet. Sandbox currently uses
   `SandboxScope.player_assets` as the explicit player stand-in; promote a real


### PR DESCRIPTION
## Summary

- update mechanics docs to describe `transaction.py` as the landed cross-family offer/commitment helper
- update assembly/component docs to position transaction offers next to owner-bound managers and connector association
- update asset design notes so future holder/trade work points at `TransactionOffer` instead of a hypothetical separate batch plan

## Tracker grooming

- commented on #219 with the transaction-helper status and remaining component-manager targets
- commented on #246 with the credentials/malfeasance binding shape

## Verification

- `git diff --check`
- `poetry run pytest engine/tests/mechanics/test_transaction_offer.py`
- `/Users/derek/.local/bin/coderabbit review --agent --base-commit a9f221f0e42257b828b0b7682a0849c2ae84b763 -c AGENTS.md` raised 0 issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how multi-step transactions are handled across the system, including validation, acceptance, receipts, and rollback checks.
  * Expanded guidance for component and asset workflows to explain when to use the shared transaction-offer flow for multi-leg changes.
  * Updated asset transfer notes to emphasize full validation before changes are applied and to better describe current limitations for mixed operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->