### PR TITLE
Add transaction delta commitments

### DIFF
--- a/engine/src/tangl/mechanics/TRANSACTION_OFFER_DESIGN.md
+++ b/engine/src/tangl/mechanics/TRANSACTION_OFFER_DESIGN.md
@@ -248,6 +248,11 @@ Keep the binding point obvious:
 Core commitments cover common legs:
 
 - `CountableTransferCommitment` for fungible wallet/resource transfer;
+- `ValueDeltaCommitment` for bounded scalar state reached through explicit
+  getter/setter callbacks;
+- `MappingDeltaCommitment` for simple resource pools such as fuel, ammo,
+  repair capacity, service capacity, or HP maps;
+- `StatDeltaCommitment` for progression/stat-like values that expose `fv`;
 - `RegistryAddCommitment` for explicit graph/token materialization;
 - `ComponentAssignmentCommitment` for owner-bound assembly slots;
 - `CallbackCommitment` for domain-local state changes that do not deserve a
@@ -265,6 +270,9 @@ named, rollback-capable legs such as:
 
 Do not use a callback commitment as a pile of unstructured work. If the same
 callback shape appears in a second mechanic, promote it into a named commitment.
+The first promoted examples are the value/mapping/stat delta commitments above:
+they cover repair, refuel, reload, healing, and provider-capacity debits without
+turning services into a separate core mechanic.
 
 ### CarWars Garage / Salvage Mapping
 
@@ -307,18 +315,21 @@ Landed proof:
    the same callback/live-object boundary as `ProvisionOffer`.
 2. `TransactionCheck` and `TransactionReceipt` are plain data.
 3. `CountableTransferCommitment` proves bilateral wallet debit/credit checks.
-4. `RegistryAddCommitment` proves explicit shape change during accepted
+4. `ValueDeltaCommitment`, `MappingDeltaCommitment`, and `StatDeltaCommitment`
+   prove service/fungible/stat mutation legs such as repair, refuel, reload, and
+   healing.
+5. `RegistryAddCommitment` proves explicit shape change during accepted
    writeback: a prepared graph item can enter the registry only when the offer
    commits.
-5. `ComponentAssignmentCommitment` proves owner-bound component manager
+6. `ComponentAssignmentCommitment` proves owner-bound component manager
    assignment, replacement, post-assignment validation, and rollback.
-6. `CallbackCommitment` marks the domain-local plug-in spot for inventory,
+7. `CallbackCommitment` marks the domain-local plug-in spot for inventory,
    service, and presentation-specific state that still needs transaction
    preflight/rollback.
-7. The neutral vehicle garage test buys and installs a component, then proves
+8. The neutral vehicle garage test buys and installs a component, then proves
    the resulting graph/loadout state survives `Graph.unstructure()` /
    `Graph.structure()`.
-8. Rejection before mutation and mid-commit rollback are both covered.
+9. Rejection before mutation and mid-commit rollback are both covered.
 
 Still recommended for the next consumer-facing slice:
 
@@ -327,7 +338,6 @@ Still recommended for the next consumer-facing slice:
 2. Add commitment legs only when a real consumer forces them:
    - discrete token move between holders;
    - catalog-backed token creation with stock/capacity;
-   - service/stat mutation;
    - graph link/unlink.
 3. Test aggregate insufficient funds, unavailable catalog/provider capacity,
    incompatible install targets, and multi-offer/batch selection.

--- a/engine/src/tangl/mechanics/TRANSACTION_OFFER_DESIGN.md
+++ b/engine/src/tangl/mechanics/TRANSACTION_OFFER_DESIGN.md
@@ -245,6 +245,13 @@ Keep the binding point obvious:
 5. Call `offer.accept()` only in the committed update path.
 6. Use the returned `TransactionReceipt` for notes and projection hints.
 
+`TransactionOffer.can_accept()` evaluates built-in value/mapping/stat delta
+commitments cumulatively, so repeated changes to the same resource are checked
+as one planned total before the offer is presented as acceptable. `accept()`
+still rechecks each commitment against live state immediately before mutation;
+that closes the normal time-of-check/time-of-use gap without making offers
+durable locks.
+
 Core commitments cover common legs:
 
 - `CountableTransferCommitment` for fungible wallet/resource transfer;

--- a/engine/src/tangl/mechanics/TRANSACTION_OFFER_DESIGN.md
+++ b/engine/src/tangl/mechanics/TRANSACTION_OFFER_DESIGN.md
@@ -252,6 +252,12 @@ still rechecks each commitment against live state immediately before mutation;
 that closes the normal time-of-check/time-of-use gap without making offers
 durable locks.
 
+Mapping and stat deltas have natural planning keys (`mapping + key`, `stats +
+stat_name`). Generic value deltas use callbacks, so callers must provide
+`planning_key` when an offer contains multiple scalar callback deltas. Without
+that explicit identity, `can_accept()` rejects the ambiguous plan instead of
+guessing which callbacks target the same field.
+
 Core commitments cover common legs:
 
 - `CountableTransferCommitment` for fungible wallet/resource transfer;

--- a/engine/src/tangl/mechanics/transaction.py
+++ b/engine/src/tangl/mechanics/transaction.py
@@ -56,6 +56,7 @@ class TransactionCommitment(Protocol):
 
 SpecT = TypeVar("SpecT")
 Number = int | float
+_PLAN_MISSING = object()
 
 
 class TransactionHandler(Protocol[SpecT]):
@@ -117,8 +118,19 @@ class TransactionOffer:
     guard_unstructure: ClassVar[bool] = True
 
     def can_accept(self) -> TransactionCheck:
+        planned_deltas: dict[object, Number] = {}
         for commitment in self.commitments:
-            check = commitment.can_commit()
+            if isinstance(
+                commitment,
+                (
+                    ValueDeltaCommitment,
+                    MappingDeltaCommitment,
+                    StatDeltaCommitment,
+                ),
+            ):
+                check = commitment.can_commit_with_plan(planned_deltas)
+            else:
+                check = commitment.can_commit()
             if not check.accepted:
                 prefix = f"{commitment.label}: " if commitment.label else ""
                 return TransactionCheck.reject(prefix + (check.reason or "rejected"))
@@ -280,8 +292,14 @@ class ValueDeltaCommitment:
     detail_label: str | None = None
     min_value: Number | None = None
     max_value: Number | None = None
+    planning_key: object | None = None
     _previous: Number = field(default=0, init=False, repr=False)
     _committed: bool = field(default=False, init=False, repr=False)
+
+    def _plan_key(self) -> object:
+        if self.planning_key is not None:
+            return self.planning_key
+        return ("value_delta", id(self.get_value), id(self.set_value))
 
     def can_commit(self) -> TransactionCheck:
         return _check_delta(
@@ -290,6 +308,27 @@ class ValueDeltaCommitment:
             self.min_value,
             self.max_value,
         )
+
+    def can_commit_with_plan(
+        self,
+        planned_deltas: MutableMapping[object, Number],
+    ) -> TransactionCheck:
+        key = self._plan_key()
+        planned_current = planned_deltas.get(key, _PLAN_MISSING)
+        current = (
+            self.get_value()
+            if planned_current is _PLAN_MISSING
+            else planned_current
+        )
+        check = _check_delta(
+            current,
+            self.delta,
+            self.min_value,
+            self.max_value,
+        )
+        if check.accepted:
+            planned_deltas[key] = current + self.delta
+        return check
 
     def commit(self) -> Mapping[str, object]:
         current = self.get_value()
@@ -337,6 +376,9 @@ class MappingDeltaCommitment:
     _had_previous: bool = field(default=False, init=False, repr=False)
     _committed: bool = field(default=False, init=False, repr=False)
 
+    def _plan_key(self) -> object:
+        return ("mapping_delta", id(self.values), self.key)
+
     def can_commit(self) -> TransactionCheck:
         return _check_delta(
             self.values.get(self.key, self.default),
@@ -344,6 +386,27 @@ class MappingDeltaCommitment:
             self.min_value,
             self.max_value,
         )
+
+    def can_commit_with_plan(
+        self,
+        planned_deltas: MutableMapping[object, Number],
+    ) -> TransactionCheck:
+        key = self._plan_key()
+        planned_current = planned_deltas.get(key, _PLAN_MISSING)
+        current = (
+            self.values.get(self.key, self.default)
+            if planned_current is _PLAN_MISSING
+            else planned_current
+        )
+        check = _check_delta(
+            current,
+            self.delta,
+            self.min_value,
+            self.max_value,
+        )
+        if check.accepted:
+            planned_deltas[key] = current + self.delta
+        return check
 
     def commit(self) -> Mapping[str, object]:
         self._had_previous = self.key in self.values
@@ -396,6 +459,9 @@ class StatDeltaCommitment:
     _previous: float = field(default=0.0, init=False, repr=False)
     _committed: bool = field(default=False, init=False, repr=False)
 
+    def _plan_key(self) -> object:
+        return ("stat_delta", id(self.stats), self.stat_name)
+
     def can_commit(self) -> TransactionCheck:
         if self.stat_name not in self.stats:
             return TransactionCheck.reject(f"missing stat: {self.stat_name}")
@@ -405,6 +471,29 @@ class StatDeltaCommitment:
             self.min_value,
             self.max_value,
         )
+
+    def can_commit_with_plan(
+        self,
+        planned_deltas: MutableMapping[object, Number],
+    ) -> TransactionCheck:
+        if self.stat_name not in self.stats:
+            return TransactionCheck.reject(f"missing stat: {self.stat_name}")
+        key = self._plan_key()
+        planned_current = planned_deltas.get(key, _PLAN_MISSING)
+        current = (
+            self.stats[self.stat_name].fv
+            if planned_current is _PLAN_MISSING
+            else planned_current
+        )
+        check = _check_delta(
+            current,
+            self.delta,
+            self.min_value,
+            self.max_value,
+        )
+        if check.accepted:
+            planned_deltas[key] = current + self.delta
+        return check
 
     def commit(self) -> Mapping[str, object]:
         if self.stat_name not in self.stats:

--- a/engine/src/tangl/mechanics/transaction.py
+++ b/engine/src/tangl/mechanics/transaction.py
@@ -119,6 +119,7 @@ class TransactionOffer:
 
     def can_accept(self) -> TransactionCheck:
         planned_deltas: dict[object, Number] = {}
+        unkeyed_value_delta_seen = False
         for commitment in self.commitments:
             if isinstance(
                 commitment,
@@ -128,6 +129,17 @@ class TransactionOffer:
                     StatDeltaCommitment,
                 ),
             ):
+                if (
+                    isinstance(commitment, ValueDeltaCommitment)
+                    and commitment.planning_key is None
+                ):
+                    if unkeyed_value_delta_seen:
+                        prefix = f"{commitment.label}: " if commitment.label else ""
+                        return TransactionCheck.reject(
+                            prefix
+                            + "multiple unkeyed value deltas require planning_key"
+                        )
+                    unkeyed_value_delta_seen = True
                 check = commitment.can_commit_with_plan(planned_deltas)
             else:
                 check = commitment.can_commit()
@@ -299,7 +311,7 @@ class ValueDeltaCommitment:
     def _plan_key(self) -> object:
         if self.planning_key is not None:
             return self.planning_key
-        return ("value_delta", id(self.get_value), id(self.set_value))
+        return ("value_delta", id(self))
 
     def can_commit(self) -> TransactionCheck:
         return _check_delta(

--- a/engine/src/tangl/mechanics/transaction.py
+++ b/engine/src/tangl/mechanics/transaction.py
@@ -263,6 +263,12 @@ def _check_delta(
     return TransactionCheck.accept()
 
 
+def _is_zero(value: Number) -> bool:
+    if isinstance(value, float):
+        return abs(value) < 1e-9
+    return value == 0
+
+
 @dataclass
 class ValueDeltaCommitment:
     """Apply one bounded numeric delta through explicit getter/setter callbacks."""
@@ -272,10 +278,10 @@ class ValueDeltaCommitment:
     delta: Number
     label: str = "mutate value"
     detail_label: str | None = None
-    min_value: Number | None = 0
+    min_value: Number | None = None
     max_value: Number | None = None
-    _previous: Number | None = None
-    _committed: bool = False
+    _previous: Number = field(default=0, init=False, repr=False)
+    _committed: bool = field(default=False, init=False, repr=False)
 
     def can_commit(self) -> TransactionCheck:
         return _check_delta(
@@ -286,10 +292,15 @@ class ValueDeltaCommitment:
         )
 
     def commit(self) -> Mapping[str, object]:
-        check = self.can_commit()
+        current = self.get_value()
+        check = _check_delta(
+            current,
+            self.delta,
+            self.min_value,
+            self.max_value,
+        )
         if not check.accepted:
             raise ValueError(check.reason or "value delta rejected")
-        current = self.get_value()
         next_value = current + self.delta
         self.set_value(next_value)
         self._previous = current
@@ -305,9 +316,8 @@ class ValueDeltaCommitment:
     def rollback(self) -> None:
         if not self._committed:
             return
-        if self._previous is not None:
-            self.set_value(self._previous)
-        self._previous = None
+        self.set_value(self._previous)
+        self._previous = 0
         self._committed = False
 
 
@@ -323,9 +333,9 @@ class MappingDeltaCommitment:
     max_value: Number | None = None
     default: Number = 0
     drop_zero: bool = False
-    _previous: Number | None = None
-    _had_previous: bool = False
-    _committed: bool = False
+    _previous: Number = field(default=0, init=False, repr=False)
+    _had_previous: bool = field(default=False, init=False, repr=False)
+    _committed: bool = field(default=False, init=False, repr=False)
 
     def can_commit(self) -> TransactionCheck:
         return _check_delta(
@@ -336,13 +346,18 @@ class MappingDeltaCommitment:
         )
 
     def commit(self) -> Mapping[str, object]:
-        check = self.can_commit()
-        if not check.accepted:
-            raise ValueError(check.reason or "mapping delta rejected")
         self._had_previous = self.key in self.values
         current = self.values.get(self.key, self.default)
+        check = _check_delta(
+            current,
+            self.delta,
+            self.min_value,
+            self.max_value,
+        )
+        if not check.accepted:
+            raise ValueError(check.reason or "mapping delta rejected")
         next_value = current + self.delta
-        if self.drop_zero and next_value == 0:
+        if self.drop_zero and _is_zero(next_value):
             self.values.pop(self.key, None)
         else:
             self.values[self.key] = next_value
@@ -359,11 +374,11 @@ class MappingDeltaCommitment:
     def rollback(self) -> None:
         if not self._committed:
             return
-        if self._had_previous and self._previous is not None:
+        if self._had_previous:
             self.values[self.key] = self._previous
         else:
             self.values.pop(self.key, None)
-        self._previous = None
+        self._previous = 0
         self._had_previous = False
         self._committed = False
 
@@ -378,8 +393,8 @@ class StatDeltaCommitment:
     label: str = "mutate stat"
     min_value: float | None = None
     max_value: float | None = None
-    _previous: float | None = None
-    _committed: bool = False
+    _previous: float = field(default=0.0, init=False, repr=False)
+    _committed: bool = field(default=False, init=False, repr=False)
 
     def can_commit(self) -> TransactionCheck:
         if self.stat_name not in self.stats:
@@ -392,11 +407,18 @@ class StatDeltaCommitment:
         )
 
     def commit(self) -> Mapping[str, object]:
-        check = self.can_commit()
-        if not check.accepted:
-            raise ValueError(check.reason or "stat delta rejected")
+        if self.stat_name not in self.stats:
+            raise ValueError(f"missing stat: {self.stat_name}")
         stat = self.stats[self.stat_name]
         current = stat.fv
+        check = _check_delta(
+            current,
+            self.delta,
+            self.min_value,
+            self.max_value,
+        )
+        if not check.accepted:
+            raise ValueError(check.reason or "stat delta rejected")
         next_value = current + self.delta
         stat.fv = next_value
         self._previous = current
@@ -412,9 +434,8 @@ class StatDeltaCommitment:
     def rollback(self) -> None:
         if not self._committed:
             return
-        if self._previous is not None:
-            self.stats[self.stat_name].fv = self._previous
-        self._previous = None
+        self.stats[self.stat_name].fv = self._previous
+        self._previous = 0.0
         self._committed = False
 
 

--- a/engine/src/tangl/mechanics/transaction.py
+++ b/engine/src/tangl/mechanics/transaction.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping, MutableMapping
 from dataclasses import dataclass, field
 from typing import ClassVar, Protocol, TypeVar
 
@@ -55,6 +55,7 @@ class TransactionCommitment(Protocol):
 
 
 SpecT = TypeVar("SpecT")
+Number = int | float
 
 
 class TransactionHandler(Protocol[SpecT]):
@@ -187,6 +188,12 @@ class CountableHolder(Protocol):
         ...
 
 
+class StatLike(Protocol):
+    """Minimal stat surface for transaction-backed stat deltas."""
+
+    fv: float
+
+
 @dataclass
 class CountableTransferCommitment:
     """Transfer one fungible asset count between two holders."""
@@ -235,6 +242,179 @@ class CountableTransferCommitment:
             return
         self.receiver.spend_countable(self.asset_label, self.amount)
         self.giver.gain_countable(self.asset_label, self.amount)
+        self._committed = False
+
+
+def _check_delta(
+    current: Number,
+    delta: Number,
+    min_value: Number | None,
+    max_value: Number | None,
+) -> TransactionCheck:
+    next_value = current + delta
+    if min_value is not None and next_value < min_value:
+        return TransactionCheck.reject(
+            f"value below minimum: {next_value} < {min_value}"
+        )
+    if max_value is not None and next_value > max_value:
+        return TransactionCheck.reject(
+            f"value above maximum: {next_value} > {max_value}"
+        )
+    return TransactionCheck.accept()
+
+
+@dataclass
+class ValueDeltaCommitment:
+    """Apply one bounded numeric delta through explicit getter/setter callbacks."""
+
+    get_value: Callable[[], Number]
+    set_value: Callable[[Number], None]
+    delta: Number
+    label: str = "mutate value"
+    detail_label: str | None = None
+    min_value: Number | None = 0
+    max_value: Number | None = None
+    _previous: Number | None = None
+    _committed: bool = False
+
+    def can_commit(self) -> TransactionCheck:
+        return _check_delta(
+            self.get_value(),
+            self.delta,
+            self.min_value,
+            self.max_value,
+        )
+
+    def commit(self) -> Mapping[str, object]:
+        check = self.can_commit()
+        if not check.accepted:
+            raise ValueError(check.reason or "value delta rejected")
+        current = self.get_value()
+        next_value = current + self.delta
+        self.set_value(next_value)
+        self._previous = current
+        self._committed = True
+        return {
+            "kind": "value_delta",
+            "label": self.detail_label or self.label,
+            "delta": self.delta,
+            "previous_value": current,
+            "value": next_value,
+        }
+
+    def rollback(self) -> None:
+        if not self._committed:
+            return
+        if self._previous is not None:
+            self.set_value(self._previous)
+        self._previous = None
+        self._committed = False
+
+
+@dataclass
+class MappingDeltaCommitment:
+    """Apply one bounded numeric delta to a mutable resource mapping."""
+
+    values: MutableMapping[str, Number]
+    key: str
+    delta: Number
+    label: str = "mutate mapping value"
+    min_value: Number | None = 0
+    max_value: Number | None = None
+    default: Number = 0
+    drop_zero: bool = False
+    _previous: Number | None = None
+    _had_previous: bool = False
+    _committed: bool = False
+
+    def can_commit(self) -> TransactionCheck:
+        return _check_delta(
+            self.values.get(self.key, self.default),
+            self.delta,
+            self.min_value,
+            self.max_value,
+        )
+
+    def commit(self) -> Mapping[str, object]:
+        check = self.can_commit()
+        if not check.accepted:
+            raise ValueError(check.reason or "mapping delta rejected")
+        self._had_previous = self.key in self.values
+        current = self.values.get(self.key, self.default)
+        next_value = current + self.delta
+        if self.drop_zero and next_value == 0:
+            self.values.pop(self.key, None)
+        else:
+            self.values[self.key] = next_value
+        self._previous = current
+        self._committed = True
+        return {
+            "kind": "mapping_delta",
+            "key": self.key,
+            "delta": self.delta,
+            "previous_value": current,
+            "value": next_value,
+        }
+
+    def rollback(self) -> None:
+        if not self._committed:
+            return
+        if self._had_previous and self._previous is not None:
+            self.values[self.key] = self._previous
+        else:
+            self.values.pop(self.key, None)
+        self._previous = None
+        self._had_previous = False
+        self._committed = False
+
+
+@dataclass
+class StatDeltaCommitment:
+    """Apply one bounded delta to a stat-like value in a stat mapping."""
+
+    stats: MutableMapping[str, StatLike]
+    stat_name: str
+    delta: float
+    label: str = "mutate stat"
+    min_value: float | None = None
+    max_value: float | None = None
+    _previous: float | None = None
+    _committed: bool = False
+
+    def can_commit(self) -> TransactionCheck:
+        if self.stat_name not in self.stats:
+            return TransactionCheck.reject(f"missing stat: {self.stat_name}")
+        return _check_delta(
+            self.stats[self.stat_name].fv,
+            self.delta,
+            self.min_value,
+            self.max_value,
+        )
+
+    def commit(self) -> Mapping[str, object]:
+        check = self.can_commit()
+        if not check.accepted:
+            raise ValueError(check.reason or "stat delta rejected")
+        stat = self.stats[self.stat_name]
+        current = stat.fv
+        next_value = current + self.delta
+        stat.fv = next_value
+        self._previous = current
+        self._committed = True
+        return {
+            "kind": "stat_delta",
+            "stat": self.stat_name,
+            "delta": self.delta,
+            "previous_value": current,
+            "value": next_value,
+        }
+
+    def rollback(self) -> None:
+        if not self._committed:
+            return
+        if self._previous is not None:
+            self.stats[self.stat_name].fv = self._previous
+        self._previous = None
         self._committed = False
 
 
@@ -418,11 +598,15 @@ __all__ = [
     "ComponentAssignmentCommitment",
     "CountableHolder",
     "CountableTransferCommitment",
+    "MappingDeltaCommitment",
     "RegistryAddCommitment",
+    "StatDeltaCommitment",
+    "StatLike",
     "TransactionCheck",
     "TransactionCommitment",
     "TransactionHandler",
     "TransactionOffer",
     "TransactionReceipt",
     "TransactionRollbackError",
+    "ValueDeltaCommitment",
 ]

--- a/engine/tests/mechanics/test_transaction_offer.py
+++ b/engine/tests/mechanics/test_transaction_offer.py
@@ -414,6 +414,32 @@ def test_value_delta_commitment_rejects_over_repair_before_mutation() -> None:
     assert vehicle.hp == 8
 
 
+def test_value_delta_commitment_rolls_back_repair_service_state() -> None:
+    vehicle = RepairTarget(hp=3, max_hp=10)
+    service = {"repair_capacity": 10}
+
+    offer = TransactionOffer(
+        label="repair then fail",
+        commitments=[
+            MappingDeltaCommitment(service, "repair_capacity", -5),
+            ValueDeltaCommitment(
+                get_value=lambda: vehicle.hp,
+                set_value=lambda value: setattr(vehicle, "hp", int(value)),
+                delta=5,
+                max_value=vehicle.max_hp,
+                detail_label="vehicle.hp",
+            ),
+            FailingCommitment(),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="late failure"):
+        offer.accept()
+
+    assert service["repair_capacity"] == 10
+    assert vehicle.hp == 3
+
+
 def test_mapping_delta_commitment_rolls_back_resource_mutations() -> None:
     station = {"fuel": 20}
     vehicle = {"fuel": 2}
@@ -477,3 +503,49 @@ def test_stat_delta_commitment_mutates_progression_stat() -> None:
     assert clinic["healing_capacity"] == 10
     assert patient["health"].fv == 60.0
     assert receipt.details[1]["kind"] == "stat_delta"
+
+
+def test_stat_delta_commitment_rolls_back_after_late_failure() -> None:
+    patient = {"health": Stat(fv=50.0)}
+    clinic = {"healing_capacity": 20}
+
+    offer = TransactionOffer(
+        label="heal then fail",
+        commitments=[
+            MappingDeltaCommitment(clinic, "healing_capacity", -10),
+            StatDeltaCommitment(
+                patient,
+                "health",
+                10.0,
+                min_value=0.0,
+                max_value=100.0,
+            ),
+            FailingCommitment(),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="late failure"):
+        offer.accept()
+
+    assert clinic["healing_capacity"] == 20
+    assert patient["health"].fv == 50.0
+
+
+def test_stat_delta_commitment_rejects_missing_stat_before_mutation() -> None:
+    patient = {"health": Stat(fv=50.0)}
+    clinic = {"healing_capacity": 20}
+
+    offer = TransactionOffer(
+        label="heal missing stat",
+        commitments=[
+            MappingDeltaCommitment(clinic, "healing_capacity", -10),
+            StatDeltaCommitment(patient, "morale", 10.0),
+        ],
+    )
+
+    check = offer.can_accept()
+
+    assert not check.accepted
+    assert check.reason == "mutate stat: missing stat: morale"
+    assert clinic["healing_capacity"] == 20
+    assert patient["health"].fv == 50.0

--- a/engine/tests/mechanics/test_transaction_offer.py
+++ b/engine/tests/mechanics/test_transaction_offer.py
@@ -14,14 +14,18 @@ from tangl.mechanics.assembly.examples.vehicle import (
     VehicleLoadout,
     VehiclePartType,
 )
+from tangl.mechanics.progression import Stat
 from tangl.mechanics.transaction import (
     CallbackCommitment,
     ComponentAssignmentCommitment,
     CountableTransferCommitment,
+    MappingDeltaCommitment,
     RegistryAddCommitment,
+    StatDeltaCommitment,
     TransactionCheck,
     TransactionOffer,
     TransactionRollbackError,
+    ValueDeltaCommitment,
 )
 from tangl.story.concepts.asset import HasAssets
 
@@ -76,6 +80,12 @@ class BasicVehicleLoadout(ComponentManager[VehicleComponent]):
             ),
         ),
     }
+
+
+class RepairTarget:
+    def __init__(self, hp: int, max_hp: int) -> None:
+        self.hp = hp
+        self.max_hp = max_hp
 
 
 def part(label: str) -> VehicleComponent:
@@ -350,3 +360,120 @@ def test_transaction_offer_rolls_back_component_assignment_validation_failure() 
     assert shop.wallet["cash"] == 0
     assert graph.get(truck_chassis.uid) is None
     assert vehicle.loadout.get_slot("chassis")[0].token_from == "mini_chassis"
+
+
+def test_value_delta_commitment_binds_repair_service_state() -> None:
+    vehicle = RepairTarget(hp=3, max_hp=10)
+    service = {"repair_capacity": 10}
+
+    offer = TransactionOffer(
+        label="repair vehicle",
+        commitments=[
+            MappingDeltaCommitment(service, "repair_capacity", -5),
+            ValueDeltaCommitment(
+                get_value=lambda: vehicle.hp,
+                set_value=lambda value: setattr(vehicle, "hp", int(value)),
+                delta=5,
+                max_value=vehicle.max_hp,
+                detail_label="vehicle.hp",
+            ),
+        ],
+    )
+
+    receipt = offer.accept()
+
+    assert service["repair_capacity"] == 5
+    assert vehicle.hp == 8
+    assert receipt.details[0]["kind"] == "mapping_delta"
+    assert receipt.details[1]["label"] == "vehicle.hp"
+
+
+def test_value_delta_commitment_rejects_over_repair_before_mutation() -> None:
+    vehicle = RepairTarget(hp=8, max_hp=10)
+    service = {"repair_capacity": 10}
+
+    offer = TransactionOffer(
+        label="over repair vehicle",
+        commitments=[
+            MappingDeltaCommitment(service, "repair_capacity", -5),
+            ValueDeltaCommitment(
+                get_value=lambda: vehicle.hp,
+                set_value=lambda value: setattr(vehicle, "hp", int(value)),
+                delta=5,
+                max_value=vehicle.max_hp,
+                detail_label="vehicle.hp",
+            ),
+        ],
+    )
+
+    check = offer.can_accept()
+
+    assert not check.accepted
+    assert check.reason == "mutate value: value above maximum: 13 > 10"
+    assert service["repair_capacity"] == 10
+    assert vehicle.hp == 8
+
+
+def test_mapping_delta_commitment_rolls_back_resource_mutations() -> None:
+    station = {"fuel": 20}
+    vehicle = {"fuel": 2}
+
+    offer = TransactionOffer(
+        label="refuel then fail",
+        commitments=[
+            MappingDeltaCommitment(station, "fuel", -8),
+            MappingDeltaCommitment(vehicle, "fuel", 8, max_value=10),
+            FailingCommitment(),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="late failure"):
+        offer.accept()
+
+    assert station["fuel"] == 20
+    assert vehicle["fuel"] == 2
+
+
+def test_mapping_delta_commitment_can_drop_zero_and_restore_missing_key() -> None:
+    ammo = {"rockets": 2}
+    station: dict[str, int] = {}
+
+    offer = TransactionOffer(
+        label="reload rockets",
+        commitments=[
+            MappingDeltaCommitment(ammo, "rockets", -2, drop_zero=True),
+            MappingDeltaCommitment(station, "spent_rockets", 2),
+            FailingCommitment(),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="late failure"):
+        offer.accept()
+
+    assert ammo == {"rockets": 2}
+    assert station == {}
+
+
+def test_stat_delta_commitment_mutates_progression_stat() -> None:
+    patient = {"health": Stat(fv=50.0)}
+    clinic = {"healing_capacity": 20}
+
+    offer = TransactionOffer(
+        label="heal patient",
+        commitments=[
+            MappingDeltaCommitment(clinic, "healing_capacity", -10),
+            StatDeltaCommitment(
+                patient,
+                "health",
+                10.0,
+                min_value=0.0,
+                max_value=100.0,
+            ),
+        ],
+    )
+
+    receipt = offer.accept()
+
+    assert clinic["healing_capacity"] == 10
+    assert patient["health"].fv == 60.0
+    assert receipt.details[1]["kind"] == "stat_delta"

--- a/engine/tests/mechanics/test_transaction_offer.py
+++ b/engine/tests/mechanics/test_transaction_offer.py
@@ -440,6 +440,42 @@ def test_value_delta_commitment_rolls_back_repair_service_state() -> None:
     assert vehicle.hp == 3
 
 
+def test_value_delta_commitment_preflights_cumulative_same_target_deltas() -> None:
+    vehicle = RepairTarget(hp=7, max_hp=10)
+
+    def get_hp() -> int:
+        return vehicle.hp
+
+    def set_hp(value: int | float) -> None:
+        vehicle.hp = int(value)
+
+    offer = TransactionOffer(
+        label="over repair in pieces",
+        commitments=[
+            ValueDeltaCommitment(
+                get_value=get_hp,
+                set_value=set_hp,
+                delta=2,
+                max_value=vehicle.max_hp,
+                planning_key=("vehicle", id(vehicle), "hp"),
+            ),
+            ValueDeltaCommitment(
+                get_value=get_hp,
+                set_value=set_hp,
+                delta=2,
+                max_value=vehicle.max_hp,
+                planning_key=("vehicle", id(vehicle), "hp"),
+            ),
+        ],
+    )
+
+    check = offer.can_accept()
+
+    assert not check.accepted
+    assert check.reason == "mutate value: value above maximum: 11 > 10"
+    assert vehicle.hp == 7
+
+
 def test_mapping_delta_commitment_rolls_back_resource_mutations() -> None:
     station = {"fuel": 20}
     vehicle = {"fuel": 2}
@@ -458,6 +494,24 @@ def test_mapping_delta_commitment_rolls_back_resource_mutations() -> None:
 
     assert station["fuel"] == 20
     assert vehicle["fuel"] == 2
+
+
+def test_mapping_delta_commitment_preflights_cumulative_same_key_deltas() -> None:
+    service = {"repair_capacity": 5}
+
+    offer = TransactionOffer(
+        label="overspend repair capacity",
+        commitments=[
+            MappingDeltaCommitment(service, "repair_capacity", -4),
+            MappingDeltaCommitment(service, "repair_capacity", -4),
+        ],
+    )
+
+    check = offer.can_accept()
+
+    assert not check.accepted
+    assert check.reason == "mutate mapping value: value below minimum: -3 < 0"
+    assert service["repair_capacity"] == 5
 
 
 def test_mapping_delta_commitment_can_drop_zero_and_restore_missing_key() -> None:
@@ -529,6 +583,34 @@ def test_stat_delta_commitment_rolls_back_after_late_failure() -> None:
 
     assert clinic["healing_capacity"] == 20
     assert patient["health"].fv == 50.0
+
+
+def test_stat_delta_commitment_preflights_cumulative_same_stat_deltas() -> None:
+    patient = {"health": Stat(fv=85.0)}
+
+    offer = TransactionOffer(
+        label="over heal in pieces",
+        commitments=[
+            StatDeltaCommitment(
+                patient,
+                "health",
+                10.0,
+                max_value=100.0,
+            ),
+            StatDeltaCommitment(
+                patient,
+                "health",
+                10.0,
+                max_value=100.0,
+            ),
+        ],
+    )
+
+    check = offer.can_accept()
+
+    assert not check.accepted
+    assert check.reason == "mutate stat: value above maximum: 105.0 > 100.0"
+    assert patient["health"].fv == 85.0
 
 
 def test_stat_delta_commitment_rejects_missing_stat_before_mutation() -> None:

--- a/engine/tests/mechanics/test_transaction_offer.py
+++ b/engine/tests/mechanics/test_transaction_offer.py
@@ -476,6 +476,36 @@ def test_value_delta_commitment_preflights_cumulative_same_target_deltas() -> No
     assert vehicle.hp == 7
 
 
+def test_value_delta_commitment_requires_key_for_multiple_unkeyed_deltas() -> None:
+    vehicle = RepairTarget(hp=7, max_hp=10)
+
+    offer = TransactionOffer(
+        label="ambiguous scalar repair",
+        commitments=[
+            ValueDeltaCommitment(
+                get_value=lambda: vehicle.hp,
+                set_value=lambda value: setattr(vehicle, "hp", int(value)),
+                delta=2,
+                max_value=vehicle.max_hp,
+            ),
+            ValueDeltaCommitment(
+                get_value=lambda: vehicle.hp,
+                set_value=lambda value: setattr(vehicle, "hp", int(value)),
+                delta=2,
+                max_value=vehicle.max_hp,
+            ),
+        ],
+    )
+
+    check = offer.can_accept()
+
+    assert not check.accepted
+    assert check.reason == (
+        "mutate value: multiple unkeyed value deltas require planning_key"
+    )
+    assert vehicle.hp == 7
+
+
 def test_mapping_delta_commitment_rolls_back_resource_mutations() -> None:
     station = {"fuel": 20}
     vehicle = {"fuel": 2}


### PR DESCRIPTION
## Summary

- add rollback-capable `ValueDeltaCommitment`, `MappingDeltaCommitment`, and `StatDeltaCommitment`
- cover repair/refuel/reload/healing-style service state with bounded preflight checks
- document the new service/fungible/stat mutation legs in the transaction-offer design note

## Verification

- `git diff --check`
- `poetry run pytest engine/tests/mechanics/test_transaction_offer.py`
- `poetry run pytest engine/tests/mechanics/test_assembly.py engine/tests/mechanics/test_vehicle_example.py engine/tests/mechanics/test_transaction_offer.py`
- `poetry run pytest engine/tests/mechanics`
- `/Users/derek/.local/bin/coderabbit review --agent --base-commit d65d6b738b6f1e86157866d7e234dad14c62d2ef -c AGENTS.md` raised 0 issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for bounded numeric changes to values, mapped resources, and progression stats.
  * Improved transaction handling for repair, refuel, reload, healing, and similar adjustments.

* **Bug Fixes**
  * Added stronger pre-checks so invalid changes are rejected before anything is modified.
  * Improved rollback behavior to fully restore state after a later step fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->