### PR TITLE
Optimize graph materialization template lookups

### DIFF
--- a/engine/src/tangl/core/factory.py
+++ b/engine/src/tangl/core/factory.py
@@ -61,10 +61,27 @@ class _TemplateIndex:
             matches.append(templ)
 
     def template_hash(self, templ: EntityTemplate) -> Hash:
-        return self.hash_by_uid[templ.uid]
+        templ_hash = self.hash_by_uid.get(templ.uid)
+        if templ_hash is None:
+            templ_hash = templ.content_hash()
+            self.hash_by_uid[templ.uid] = templ_hash
+            self._index_identifier(templ_hash, templ)
+        return templ_hash
 
     def parent_template(self, templ: EntityTemplate) -> TemplateGroup | None:
-        return self.parent_by_child_uid.get(templ.uid)
+        parent = self.parent_by_child_uid.get(templ.uid)
+        if parent is not None:
+            return parent
+
+        registry = templ.registry
+        if registry is None:
+            return None
+        parent = registry.find_one(Selector(has_kind=TemplateGroup, has_member=templ))
+        if not isinstance(parent, TemplateGroup):
+            return None
+        self.parent_by_child_uid[templ.uid] = parent
+        self.template_hash(parent)
+        return parent
 
     def template_depth(self, templ: EntityTemplate) -> int:
         depth = 0
@@ -101,11 +118,13 @@ class _TemplateIndex:
     def remember_materialized(self, templ: EntityTemplate, item: GraphItem) -> None:
         self.materialized_by_hash[self.template_hash(templ)].append(item)
 
-    def parent_graph_item(self, templ: EntityTemplate) -> GraphItem | None:
+    def parent_graph_item(self, templ: EntityTemplate, *, graph: Graph) -> GraphItem | None:
         parent = self.parent_template(templ)
         if parent is None:
             return None
         matches = self.materialized_by_hash.get(self.template_hash(parent), [])
+        if not matches:
+            matches = list(graph.find_all(Selector(templ_hash=self.template_hash(parent))))
         if not matches:
             return None
         return _resolve_single_match(
@@ -329,7 +348,7 @@ class GraphFactory(Singleton):
                 graph.add(group)
                 template_index.remember_materialized(templ, group)
 
-                parent = template_index.parent_graph_item(templ)
+                parent = template_index.parent_graph_item(templ, graph=graph)
                 if parent:
                     _attach_to_parent(parent, group)
 
@@ -339,7 +358,7 @@ class GraphFactory(Singleton):
                 graph.add(node)
                 template_index.remember_materialized(templ, node)
 
-                parent = template_index.parent_graph_item(templ)
+                parent = template_index.parent_graph_item(templ, graph=graph)
                 if parent:
                     _attach_to_parent(parent, node)
 

--- a/engine/src/tangl/core/factory.py
+++ b/engine/src/tangl/core/factory.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Iterable
 from typing import Iterator
+from uuid import UUID
 
 from pydantic import Field
+
+from tangl.type_hints import Hash, Identifier
 
 from .registry import HierarchicalGroup
 from .singleton import Singleton
@@ -35,23 +38,29 @@ class _TemplateIndex:
 
     def __init__(self, templates: Iterable[EntityTemplate]) -> None:
         self.templates = list(templates)
-        self.by_identifier: dict[object, list[EntityTemplate]] = defaultdict(list)
-        self.hash_by_uid: dict[object, bytes] = {}
-        self.parent_by_child_uid: dict[object, TemplateGroup] = {}
-        self.materialized_by_hash: dict[bytes, list[GraphItem]] = defaultdict(list)
+        self.by_identifier: dict[Identifier, list[EntityTemplate]] = defaultdict(list)
+        self.hash_by_uid: dict[UUID, Hash] = {}
+        self.parent_by_child_uid: dict[UUID, TemplateGroup] = {}
+        self.materialized_by_hash: dict[Hash, list[GraphItem]] = defaultdict(list)
 
         for templ in self.templates:
             templ_hash = templ.content_hash()
             self.hash_by_uid[templ.uid] = templ_hash
+            self._index_identifier(templ_hash, templ)
             for identifier in templ.get_identifiers():
-                self.by_identifier[identifier].append(templ)
+                self._index_identifier(identifier, templ)
 
         for templ in self.templates:
             if isinstance(templ, TemplateGroup):
                 for member_id in templ.member_ids:
                     self.parent_by_child_uid.setdefault(member_id, templ)
 
-    def template_hash(self, templ: EntityTemplate) -> bytes:
+    def _index_identifier(self, identifier: Identifier, templ: EntityTemplate) -> None:
+        matches = self.by_identifier[identifier]
+        if templ not in matches:
+            matches.append(templ)
+
+    def template_hash(self, templ: EntityTemplate) -> Hash:
         return self.hash_by_uid[templ.uid]
 
     def parent_template(self, templ: EntityTemplate) -> TemplateGroup | None:
@@ -59,7 +68,7 @@ class _TemplateIndex:
 
     def template_depth(self, templ: EntityTemplate) -> int:
         depth = 0
-        seen: set[object] = set()
+        seen: set[UUID] = set()
         parent = self.parent_template(templ)
         while parent is not None:
             if parent.uid in seen:
@@ -107,7 +116,7 @@ class _TemplateIndex:
     def resolve_template(
         self,
         *,
-        identifier: object,
+        identifier: Identifier,
         kind: type[GraphItem],
         description: str,
     ) -> EntityTemplate:
@@ -237,32 +246,20 @@ class GraphFactory(Singleton):
         self,
         *,
         edge: Edge,
-        templs: TemplateRegistry,
-        graph: Graph,
-        template_index: _TemplateIndex | None = None,
+        template_index: _TemplateIndex,
     ) -> Node:
         predecessor_ref = self._resolve_edge_ref(edge, "predecessor_ref")
-        if template_index is not None:
-            ref_templ = template_index.resolve_template(
-                identifier=predecessor_ref,
-                kind=Node,
-                description=(
-                    f"predecessor template {predecessor_ref!r} "
-                    f"for edge {edge.get_label()!r}"
-                ),
-            )
-            return template_index.resolve_materialized_node(
-                templ=ref_templ,
-                description=f"materialized predecessor for edge {edge.get_label()!r}",
-            )
-
-        ref_templ = _resolve_single_match(
-            list(templs.find_all(Selector(has_kind=Node, has_identifier=predecessor_ref))),
-            f"predecessor template {predecessor_ref!r} for edge {edge.get_label()!r}",
+        ref_templ = template_index.resolve_template(
+            identifier=predecessor_ref,
+            kind=Node,
+            description=(
+                f"predecessor template {predecessor_ref!r} "
+                f"for edge {edge.get_label()!r}"
+            ),
         )
-        return _resolve_single_match(
-            list(graph.find_nodes(Selector(templ_hash=ref_templ.content_hash()))),
-            f"materialized predecessor for edge {edge.get_label()!r}",
+        return template_index.resolve_materialized_node(
+            templ=ref_templ,
+            description=f"materialized predecessor for edge {edge.get_label()!r}",
         )
 
     def _resolve_successor(
@@ -351,8 +348,6 @@ class GraphFactory(Singleton):
                 edge: Edge = templ.materialize()
                 predecessor = self._resolve_predecessor(
                     edge=edge,
-                    templs=templs,
-                    graph=graph,
                     template_index=template_index,
                 )
                 successor = self._resolve_successor(

--- a/engine/src/tangl/core/factory.py
+++ b/engine/src/tangl/core/factory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from collections.abc import Iterable
 from typing import Iterator
 
@@ -14,25 +15,6 @@ from .template import TemplateRegistry, EntityTemplate, TemplateGroup
 from .token import TokenCatalog
 
 
-# pseudo-graph-item helpers for template hierarchy
-def _parent_templ(templ: EntityTemplate) -> TemplateGroup | None:
-    registry = templ.registry
-    if registry is None:
-        return None
-    return registry.find_one(Selector(has_member=templ))
-
-
-def _ancestor_templs(templ: EntityTemplate) -> Iterator[TemplateGroup]:
-    parent = _parent_templ(templ)
-    while parent:
-        yield parent
-        parent = _parent_templ(parent)
-
-
-def _template_depth(templ: EntityTemplate) -> int:
-    return len(list(_ancestor_templs(templ)))
-
-
 def _resolve_single_match[T](matches: list[T], description: str) -> T:
     if not matches:
         raise ValueError(f"{description} did not resolve")
@@ -41,33 +23,117 @@ def _resolve_single_match[T](matches: list[T], description: str) -> T:
     return matches[0]
 
 
-def _get_parent_by_templ(
-    templ_hash: bytes,
-    templs: TemplateRegistry,
-    graph: Graph,
-) -> GraphItem | None:
-    ref_templ = _resolve_single_match(
-        list(templs.find_all(Selector(has_identifier=templ_hash))),
-        f"template {templ_hash!r}",
-    )
-    ref_templ_parent = _parent_templ(ref_templ)
-    if ref_templ_parent is None:
-        return None
-    ref_templ_parent_hash = ref_templ_parent.content_hash()
-    matches = list(graph.find_all(Selector(templ_hash=ref_templ_parent_hash)))
-    if not matches:
-        return None
-    return _resolve_single_match(
-        matches,
-        f"parent graph item for template {ref_templ_parent.get_label()!r}",
-    )
-
-
 def _attach_to_parent(parent: GraphItem, child: GraphItem) -> None:
     if isinstance(parent, (Subgraph, HierarchicalGroup)):
         parent.add_member(child)
         return
     raise TypeError(f"Parent {parent.__class__.__name__} does not support child membership")
+
+
+class _TemplateIndex:
+    """Per-materialization lookup cache for immutable template providers."""
+
+    def __init__(self, templates: Iterable[EntityTemplate]) -> None:
+        self.templates = list(templates)
+        self.by_identifier: dict[object, list[EntityTemplate]] = defaultdict(list)
+        self.hash_by_uid: dict[object, bytes] = {}
+        self.parent_by_child_uid: dict[object, TemplateGroup] = {}
+        self.materialized_by_hash: dict[bytes, list[GraphItem]] = defaultdict(list)
+
+        for templ in self.templates:
+            templ_hash = templ.content_hash()
+            self.hash_by_uid[templ.uid] = templ_hash
+            for identifier in templ.get_identifiers():
+                self.by_identifier[identifier].append(templ)
+
+        for templ in self.templates:
+            if isinstance(templ, TemplateGroup):
+                for member_id in templ.member_ids:
+                    self.parent_by_child_uid.setdefault(member_id, templ)
+
+    def template_hash(self, templ: EntityTemplate) -> bytes:
+        return self.hash_by_uid[templ.uid]
+
+    def parent_template(self, templ: EntityTemplate) -> TemplateGroup | None:
+        return self.parent_by_child_uid.get(templ.uid)
+
+    def template_depth(self, templ: EntityTemplate) -> int:
+        depth = 0
+        seen: set[object] = set()
+        parent = self.parent_template(templ)
+        while parent is not None:
+            if parent.uid in seen:
+                raise ValueError(f"template hierarchy cycle at {parent.get_label()!r}")
+            seen.add(parent.uid)
+            depth += 1
+            parent = self.parent_template(parent)
+        return depth
+
+    def graph_groups(self) -> list[TemplateGroup]:
+        return sorted(
+            (
+                templ
+                for templ in self.templates
+                if isinstance(templ, TemplateGroup) and templ.has_payload_kind(GraphItem)
+            ),
+            key=self.template_depth,
+        )
+
+    def node_templates(self) -> Iterator[EntityTemplate]:
+        return (
+            templ
+            for templ in self.templates
+            if not isinstance(templ, TemplateGroup) and templ.has_kind(Node)
+        )
+
+    def edge_templates(self) -> Iterator[EntityTemplate]:
+        return (templ for templ in self.templates if templ.has_kind(Edge))
+
+    def remember_materialized(self, templ: EntityTemplate, item: GraphItem) -> None:
+        self.materialized_by_hash[self.template_hash(templ)].append(item)
+
+    def parent_graph_item(self, templ: EntityTemplate) -> GraphItem | None:
+        parent = self.parent_template(templ)
+        if parent is None:
+            return None
+        matches = self.materialized_by_hash.get(self.template_hash(parent), [])
+        if not matches:
+            return None
+        return _resolve_single_match(
+            matches,
+            f"parent graph item for template {parent.get_label()!r}",
+        )
+
+    def resolve_template(
+        self,
+        *,
+        identifier: object,
+        kind: type[GraphItem],
+        description: str,
+    ) -> EntityTemplate:
+        return _resolve_single_match(
+            [
+                templ
+                for templ in self.by_identifier.get(identifier, [])
+                if templ.has_kind(kind)
+            ],
+            description,
+        )
+
+    def resolve_materialized_node(
+        self,
+        *,
+        templ: EntityTemplate,
+        description: str,
+    ) -> Node:
+        return _resolve_single_match(
+            [
+                item
+                for item in self.materialized_by_hash[self.template_hash(templ)]
+                if isinstance(item, Node)
+            ],
+            description,
+        )
 
 
 class GraphFactory(Singleton):
@@ -173,8 +239,23 @@ class GraphFactory(Singleton):
         edge: Edge,
         templs: TemplateRegistry,
         graph: Graph,
+        template_index: _TemplateIndex | None = None,
     ) -> Node:
         predecessor_ref = self._resolve_edge_ref(edge, "predecessor_ref")
+        if template_index is not None:
+            ref_templ = template_index.resolve_template(
+                identifier=predecessor_ref,
+                kind=Node,
+                description=(
+                    f"predecessor template {predecessor_ref!r} "
+                    f"for edge {edge.get_label()!r}"
+                ),
+            )
+            return template_index.resolve_materialized_node(
+                templ=ref_templ,
+                description=f"materialized predecessor for edge {edge.get_label()!r}",
+            )
+
         ref_templ = _resolve_single_match(
             list(templs.find_all(Selector(has_kind=Node, has_identifier=predecessor_ref))),
             f"predecessor template {predecessor_ref!r} for edge {edge.get_label()!r}",
@@ -235,41 +316,45 @@ class GraphFactory(Singleton):
             graph = self.graph_type(**kwargs)
         graph.bind_factory(self)
 
-        templ_regs = list(template_groups) if template_groups is not None else self._provide_templates()
+        templ_regs = (
+            list(template_groups)
+            if template_groups is not None
+            else self._provide_templates()
+        )
+        template_indexes = [
+            (templs, _TemplateIndex(templs.find_all()))
+            for templs in templ_regs
+        ]
 
-        for templs in templ_regs:
-            for templ in templs.find_all(
-                Selector(
-                    predicate=lambda templ: isinstance(templ, TemplateGroup)
-                    and templ.has_payload_kind(GraphItem),
-                ),
-                sort_key=_template_depth,
-            ):
+        for _templs, template_index in template_indexes:
+            for templ in template_index.graph_groups():
                 group: GraphItem = templ.materialize()
                 graph.add(group)
+                template_index.remember_materialized(templ, group)
 
-                parent = _get_parent_by_templ(group.templ_hash, templs, graph)
+                parent = template_index.parent_graph_item(templ)
                 if parent:
                     _attach_to_parent(parent, group)
 
-        for templs in templ_regs:
-            for templ in templs.find_all(
-                Selector(
-                    predicate=lambda templ: not isinstance(templ, TemplateGroup),
-                    has_kind=Node,
-                )
-            ):
+        for _templs, template_index in template_indexes:
+            for templ in template_index.node_templates():
                 node: Node = templ.materialize()
                 graph.add(node)
+                template_index.remember_materialized(templ, node)
 
-                parent = _get_parent_by_templ(node.templ_hash, templs, graph)
+                parent = template_index.parent_graph_item(templ)
                 if parent:
                     _attach_to_parent(parent, node)
 
-        for templs in templ_regs:
-            for templ in templs.find_all(Selector(has_kind=Edge)):
+        for templs, template_index in template_indexes:
+            for templ in template_index.edge_templates():
                 edge: Edge = templ.materialize()
-                predecessor = self._resolve_predecessor(edge=edge, templs=templs, graph=graph)
+                predecessor = self._resolve_predecessor(
+                    edge=edge,
+                    templs=templs,
+                    graph=graph,
+                    template_index=template_index,
+                )
                 successor = self._resolve_successor(
                     edge=edge,
                     predecessor=predecessor,

--- a/engine/src/tangl/media/media_resource/media_provisioning.py
+++ b/engine/src/tangl/media/media_resource/media_provisioning.py
@@ -385,7 +385,8 @@ class MediaInventoryProvisioner:
     inventories: list[MediaInventory]
 
     @staticmethod
-    def _graph_local_copy(candidate: MediaRIT, *, _ctx: Any = None) -> MediaRIT:
+    def graph_local_copy(candidate: MediaRIT, *, _ctx: Any = None) -> MediaRIT:
+        """Return ``candidate`` or a graph-local clone suitable for dependency binding."""
         graph = getattr(_ctx, "graph", None)
         if graph is candidate.registry:
             return candidate
@@ -405,6 +406,10 @@ class MediaInventoryProvisioner:
         provider.bind_registry(None)
         return provider
 
+    @staticmethod
+    def _graph_local_copy(candidate: MediaRIT, *, _ctx: Any = None) -> MediaRIT:
+        return MediaInventoryProvisioner.graph_local_copy(candidate, _ctx=_ctx)
+
     def get_dependency_offers(self, requirement: Requirement) -> Iterator[ProvisionOffer]:
         if not self.inventories:
             return
@@ -417,7 +422,7 @@ class MediaInventoryProvisioner:
                 priority=Priority.NORMAL,
                 distance_from_caller=0,
                 candidate=candidate,
-                callback=lambda *_, _candidate=candidate, **kw: self._graph_local_copy(
+                callback=lambda *_, _candidate=candidate, **kw: self.graph_local_copy(
                     _candidate,
                     _ctx=kw.get("_ctx"),
                 ),

--- a/engine/src/tangl/story/fabula/materializer.py
+++ b/engine/src/tangl/story/fabula/materializer.py
@@ -811,7 +811,11 @@ class StoryMaterializer:
         if world is None:
             return
 
-        candidate = world.resources.get_rit(media_id)
+        resources = world.resources
+        if resources is None:
+            return
+
+        candidate = resources.get_rit(media_id)
         if candidate is None:
             return
 

--- a/engine/src/tangl/story/fabula/materializer.py
+++ b/engine/src/tangl/story/fabula/materializer.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from types import SimpleNamespace
 from typing import Any, Mapping
 from uuid import UUID
 
@@ -801,8 +800,8 @@ class StoryMaterializer:
             spec["dependency_id"] = dep.uid
             spec.setdefault("fallback_text", self._coerce_str(spec.get("text")))
 
-    @staticmethod
     def _prelink_named_inventory_media(
+        self,
         *,
         dep: MediaDep,
         media_id: str,
@@ -818,10 +817,11 @@ class StoryMaterializer:
         if not isinstance(candidate, MediaRIT):
             return
 
-        provider = MediaInventoryProvisioner._graph_local_copy(
-            candidate,
-            _ctx=SimpleNamespace(graph=state.graph),
+        ctx = self._make_prelink_ctx(
+            state=state,
+            cursor_id=dep.predecessor_id,
         )
+        provider = MediaInventoryProvisioner._graph_local_copy(candidate, _ctx=ctx)
         if not dep.satisfied_by(provider):
             return
 

--- a/engine/src/tangl/story/fabula/materializer.py
+++ b/engine/src/tangl/story/fabula/materializer.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 from tangl.core import EntityTemplate, GraphFactory, GraphItem, Selector, TemplateRegistry
 from tangl.media.media_creators.media_spec import MediaSpec
-from tangl.media.media_resource import MediaDep, MediaResourceInventoryTag as MediaRIT
+from tangl.media.media_resource import MediaDep
 from tangl.media.media_resource.media_provisioning import MediaInventoryProvisioner
 from tangl.vm.ctx import VmPhaseCtx
 from tangl.vm.runtime.frame import PhaseCtx
@@ -808,26 +808,24 @@ class StoryMaterializer:
         state: _MaterializationState,
     ) -> None:
         world = state.graph.world
-        resources = getattr(world, "resources", None) if world is not None else None
-        get_rit = getattr(resources, "get_rit", None)
-        if not callable(get_rit):
+        if world is None:
             return
 
-        candidate = get_rit(media_id)
-        if not isinstance(candidate, MediaRIT):
+        candidate = world.resources.get_rit(media_id)
+        if candidate is None:
             return
 
         ctx = self._make_prelink_ctx(
             state=state,
             cursor_id=dep.predecessor_id,
         )
-        provider = MediaInventoryProvisioner._graph_local_copy(candidate, _ctx=ctx)
+        provider = MediaInventoryProvisioner.graph_local_copy(candidate, _ctx=ctx)
         if not dep.satisfied_by(provider):
             return
 
         if provider.registry is not state.graph:
             state.graph.add(provider)
-        dep.set_provider(provider)
+        dep.set_provider(provider, _ctx=ctx)
         if dep.requirement.resolution_reason is None:
             dep.requirement.resolution_reason = "direct_media_id"
 

--- a/engine/src/tangl/story/fabula/materializer.py
+++ b/engine/src/tangl/story/fabula/materializer.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from types import SimpleNamespace
 from typing import Any, Mapping
 from uuid import UUID
 
 from tangl.core import EntityTemplate, GraphFactory, GraphItem, Selector, TemplateRegistry
 from tangl.media.media_creators.media_spec import MediaSpec
-from tangl.media.media_resource import MediaDep
+from tangl.media.media_resource import MediaDep, MediaResourceInventoryTag as MediaRIT
+from tangl.media.media_resource.media_provisioning import MediaInventoryProvisioner
 from tangl.vm.ctx import VmPhaseCtx
 from tangl.vm.runtime.frame import PhaseCtx
 from tangl.vm.provision.materialization import resolve_story_materialize_hook
@@ -795,8 +797,39 @@ class StoryMaterializer:
                 scope=self._coerce_str(spec.get("scope")),
                 hard=bool(spec.get("hard", False)),
             )
+            self._prelink_named_inventory_media(dep=dep, media_id=media_id, state=state)
             spec["dependency_id"] = dep.uid
             spec.setdefault("fallback_text", self._coerce_str(spec.get("text")))
+
+    @staticmethod
+    def _prelink_named_inventory_media(
+        *,
+        dep: MediaDep,
+        media_id: str,
+        state: _MaterializationState,
+    ) -> None:
+        world = state.graph.world
+        resources = getattr(world, "resources", None) if world is not None else None
+        get_rit = getattr(resources, "get_rit", None)
+        if not callable(get_rit):
+            return
+
+        candidate = get_rit(media_id)
+        if not isinstance(candidate, MediaRIT):
+            return
+
+        provider = MediaInventoryProvisioner._graph_local_copy(
+            candidate,
+            _ctx=SimpleNamespace(graph=state.graph),
+        )
+        if not dep.satisfied_by(provider):
+            return
+
+        if provider.registry is not state.graph:
+            state.graph.add(provider)
+        dep.set_provider(provider)
+        if dep.requirement.resolution_reason is None:
+            dep.requirement.resolution_reason = "direct_media_id"
 
     def _wire_actions_for_block(
         self,
@@ -999,6 +1032,8 @@ class StoryMaterializer:
         state: _MaterializationState,
     ) -> None:
         for dep in dependencies:
+            if dep.provider is not None and dep.satisfied:
+                continue
             ctx = self._make_prelink_ctx(state=state, cursor_id=dep.predecessor_id)
             resolver = Resolver.from_ctx(ctx)
             was_satisfied = dep.satisfied

--- a/engine/tests/core/factory/test_graph_factory.py
+++ b/engine/tests/core/factory/test_graph_factory.py
@@ -28,6 +28,26 @@ class GraphFactoryTestDouble(GraphFactory):
     """Test-local singleton subclass used to isolate factory instances."""
 
 
+class _TemplateSubset:
+    """Minimal read-only template subset for materialization tests."""
+
+    def __init__(self, registry: TemplateRegistry, selected_labels: set[str]) -> None:
+        self.registry = registry
+        self.selected_labels = selected_labels
+
+    def find_all(self, selector: Selector | None = None, *, sort_key=None):
+        values = [
+            value
+            for value in self.registry.values()
+            if getattr(value, "label", None) in self.selected_labels
+        ]
+        if selector is not None:
+            values = list(selector.filter(values))
+        if sort_key is not None:
+            values = sorted(values, key=sort_key)
+        return values
+
+
 @pytest.fixture(autouse=True)
 def clear_factories() -> None:
     GraphFactoryTestDouble.clear_instances()
@@ -108,6 +128,33 @@ class TestGraphFactoryMaterialize:
 
         assert restored.factory is factory
         assert restored.get_authorities() == [factory.dispatch]
+
+    def test_materialize_child_subset_attaches_to_existing_parent(self) -> None:
+        template_registry = TemplateRegistry(label="seeded_parent_templates")
+        root = _template_group(registry=template_registry, label="root")
+        start = _node_template(registry=template_registry, label="root.start")
+        root.add_child(start)
+
+        factory = GraphFactoryTestDouble(label="seeded_parent_factory", templates=template_registry)
+        graph = factory.materialize_graph(
+            template_groups=[
+                _TemplateSubset(template_registry, selected_labels={"root"}),
+            ]
+        )
+        root_group = graph.find_node(Selector(label="root"))
+
+        factory.materialize_graph(
+            graph=graph,
+            template_groups=[
+                _TemplateSubset(template_registry, selected_labels={"root.start"}),
+            ],
+        )
+        start_node = graph.find_node(Selector(label="start"))
+
+        assert root_group is not None
+        assert start_node is not None
+        assert list(root_group.members()) == [start_node]
+        assert start_node.has_path("root.start")
 
     def test_predecessor_binding_uses_template_provenance(self) -> None:
         template_registry = TemplateRegistry(label="edge_templates")

--- a/engine/tests/story/test_story_init.py
+++ b/engine/tests/story/test_story_init.py
@@ -481,6 +481,9 @@ def test_story_materializer_wires_inventory_media_without_wrapping_direct_media(
 
     assert len(media_deps) == 1
     assert media_deps[0].provider is not None
+    assert media_deps[0].provider.registry is result.graph
+    assert media_deps[0].resolution_reason == "direct_media_id"
+    assert media_deps[0].provider.path == asset
     assert start.media[0].get("dependency_id") == media_deps[0].uid
     assert "dependency_id" not in start.media[1]
     assert "dependency_id" not in start.media[2]

--- a/engine/tests/story/test_story_init.py
+++ b/engine/tests/story/test_story_init.py
@@ -491,6 +491,23 @@ def test_story_materializer_wires_inventory_media_without_wrapping_direct_media(
     assert "dependency_id" not in start.media[2]
 
 
+def test_story_materializer_allows_inventory_media_without_resource_manager() -> None:
+    script = _base_script()
+    script["scenes"]["intro"]["blocks"]["start"]["media"] = [
+        {"name": "missing.svg", "text": "Missing"},
+    ]
+
+    world = World.from_script_data(script_data=script)
+    result = world.create_story("media_story_without_resources", init_mode=InitMode.EAGER)
+
+    start = next(node for node in Selector(has_kind=Block, label="start").filter(result.graph.values()))
+    media_deps = [edge for edge in start.edges_out() if isinstance(edge, MediaDep)]
+
+    assert len(media_deps) == 1
+    assert media_deps[0].provider is None
+    assert start.media[0].get("dependency_id") == media_deps[0].uid
+
+
 def test_service_manager_create_story_with_world_param() -> None:
     world = World.from_script_data(script_data=_base_script())
     manager = build_service_manager(PersistenceManagerFactory.native_in_mem())

--- a/engine/tests/story/test_story_init.py
+++ b/engine/tests/story/test_story_init.py
@@ -483,6 +483,8 @@ def test_story_materializer_wires_inventory_media_without_wrapping_direct_media(
     assert media_deps[0].provider is not None
     assert media_deps[0].provider.registry is result.graph
     assert media_deps[0].resolution_reason == "direct_media_id"
+    assert media_deps[0].requirement.resolved_cursor_id == start.uid
+    assert media_deps[0].requirement.resolved_step == 0
     assert media_deps[0].provider.path == asset
     assert start.media[0].get("dependency_id") == media_deps[0].uid
     assert "dependency_id" not in start.media[1]


### PR DESCRIPTION
## Summary

- add a per-materialization `_TemplateIndex` for immutable template providers
- replace repeated selector scans for template parent lookup and predecessor provenance with indexed lookups
- direct-bind named inventory media during materialization when the world resource manager can resolve the authored media id
- skip eager resolver work for dependencies that already have a concrete provider
- keep the general `Registry` / `Selector` model unchanged and preserve existing missing/ambiguous ref errors

## Validation

- `PYTHONPATH=engine/src ../storytangl-venv/bin/python -m pytest engine/tests/core/factory/test_graph_factory.py engine/tests/vm/test_factory.py engine/tests/story/test_compiler_scope_resolution.py engine/tests/loaders/test_reference_world.py`
- `PYTHONPATH=engine/src ../storytangl-venv/bin/python -m pytest engine/tests/core/factory/test_graph_factory.py engine/tests/vm/test_factory.py engine/tests/story/test_compiler_scope_resolution.py engine/tests/loaders/test_reference_world.py engine/tests/story/test_story_init.py engine/tests/media/test_resource_manager.py engine/tests/media/test_media_provisioning.py`
- CarWars smoke against this branch source:
  `PYTHONPATH=tmp/storytangl/engine/src tmp/storytangl-venv/bin/python -m pytest carwars/tests/test_loader.py::test_cw1_world_compiles_and_materializes carwars/tests/test_phase1_demo.py::test_phase1_report_counts_and_gate`

## CarWars Benchmark

Measured from `/Users/derek/dev/carwars-gamebooks` with `PYTHONPATH=tmp/storytangl/engine/src`.

Before:

- `cw1 create_story`: ~30.967s
- `cw2 create_story`: ~24.666s
- `cw3 create_story`: ~24.887s
- `cw4 create_story`: ~24.803s
- `cw5 create_story`: ~24.719s
- `cw6 create_story`: ~25.439s

After:

- `cw1 create_story`: ~10.149s
- `cw2 create_story`: ~3.975s
- `cw3 create_story`: ~4.441s
- `cw4 create_story`: ~4.125s
- `cw5 create_story`: ~4.435s
- `cw6 create_story`: ~5.119s

After direct named-media prelink:

- `cw1 create_story`: ~1.019s
- `cw2 create_story`: ~0.526s
- `cw3 create_story`: ~0.588s
- `cw4 create_story`: ~0.611s
- `cw5 create_story`: ~0.856s
- `cw6 create_story`: ~0.657s

The remaining all-book cost is now mostly anthology compile (~3s total) rather than per-book materialization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template and graph materialization to resolve template relationships and predecessor links more reliably, including when materializing only a selected subset of templates.
  * Fixed inventory-backed media wiring to avoid redundant dependency resolution and to preserve correct provider details and fallback text.
  * Direct media references now consistently retain the correct local asset path and resolution metadata.

* **Tests**
  * Expanded assertions for direct media wiring behavior.
  * Added coverage for attaching newly materialized child templates into an existing partially materialized graph.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->