### PR TITLE
Add transaction asset commitments

### DIFF
--- a/engine/src/tangl/mechanics/TRANSACTION_OFFER_DESIGN.md
+++ b/engine/src/tangl/mechanics/TRANSACTION_OFFER_DESIGN.md
@@ -269,6 +269,10 @@ Core commitments cover common legs:
 - `MappingDeltaCommitment` for simple resource pools such as fuel, ammo,
   repair capacity, service capacity, or HP maps;
 - `StatDeltaCommitment` for progression/stat-like values that expose `fv`;
+- `AssetMoveCommitment` for moving one existing discrete graph asset/token
+  between holder-like objects;
+- `CatalogAssetCommitment` for creating one catalog-backed graph asset/token
+  during offer acceptance, optionally registering it with a graph/registry;
 - `RegistryAddCommitment` for explicit graph/token materialization;
 - `ComponentAssignmentCommitment` for owner-bound assembly slots;
 - `CallbackCommitment` for domain-local state changes that do not deserve a
@@ -355,26 +359,28 @@ Landed proof:
 4. `ValueDeltaCommitment`, `MappingDeltaCommitment`, and `StatDeltaCommitment`
    prove service/fungible/stat mutation legs such as repair, refuel, reload, and
    healing.
-5. `RegistryAddCommitment` proves explicit shape change during accepted
+5. `AssetMoveCommitment` proves existing discrete graph-token movement between
+   holder-like objects with policy checks and rollback.
+6. `CatalogAssetCommitment` proves catalog-backed token creation during accepted
+   writeback, with optional graph registration and rollback.
+7. `RegistryAddCommitment` proves explicit shape change during accepted
    writeback: a prepared graph item can enter the registry only when the offer
    commits.
-6. `ComponentAssignmentCommitment` proves owner-bound component manager
+8. `ComponentAssignmentCommitment` proves owner-bound component manager
    assignment, replacement, post-assignment validation, and rollback.
-7. `CallbackCommitment` marks the domain-local plug-in spot for inventory,
+9. `CallbackCommitment` marks the domain-local plug-in spot for inventory,
    service, and presentation-specific state that still needs transaction
    preflight/rollback.
-8. The neutral vehicle garage test buys and installs a component, then proves
+10. The neutral vehicle garage test buys and installs a component, then proves
    the resulting graph/loadout state survives `Graph.unstructure()` /
    `Graph.structure()`.
-9. Rejection before mutation and mid-commit rollback are both covered.
+11. Rejection before mutation and mid-commit rollback are both covered.
 
 Still recommended for the next consumer-facing slice:
 
 1. Add a neutral shop/garage example module or world-facing fixture over the
    existing vehicle component manager.
 2. Add commitment legs only when a real consumer forces them:
-   - discrete token move between holders;
-   - catalog-backed token creation with stock/capacity;
    - graph link/unlink.
 3. Test aggregate insufficient funds, unavailable catalog/provider capacity,
    incompatible install targets, and multi-offer/batch selection.

--- a/engine/src/tangl/mechanics/transaction.py
+++ b/engine/src/tangl/mechanics/transaction.py
@@ -6,7 +6,7 @@ from typing import ClassVar, Protocol, TypeVar
 
 from pydantic import Field
 
-from tangl.core import Entity, Registry
+from tangl.core import Entity, Registry, Token
 from tangl.core.bases import BaseModelPlus
 
 from .assembly import ComponentManager
@@ -212,6 +212,36 @@ class CountableHolder(Protocol):
         ...
 
 
+class AssetHolder(Protocol):
+    """Minimal discrete-asset holder surface for move/create commitments."""
+
+    def get_asset(self, label: str) -> Entity | None:
+        ...
+
+    def get_asset_key(self, asset: Entity | str) -> str | None:
+        ...
+
+    def can_give_asset(
+        self,
+        asset: Entity,
+        receiver: object | None = None,
+    ) -> bool:
+        ...
+
+    def can_receive_asset(
+        self,
+        asset: Entity,
+        giver: object | None = None,
+    ) -> bool:
+        ...
+
+    def add_asset(self, asset: Entity, *, label: str | None = None) -> None:
+        ...
+
+    def remove_asset(self, asset: Entity | str) -> Entity:
+        ...
+
+
 class StatLike(Protocol):
     """Minimal stat surface for transaction-backed stat deltas."""
 
@@ -266,6 +296,178 @@ class CountableTransferCommitment:
             return
         self.receiver.spend_countable(self.asset_label, self.amount)
         self.giver.gain_countable(self.asset_label, self.amount)
+        self._committed = False
+
+
+def _asset_holder_key(asset: Entity, label: str | None = None) -> str | None:
+    if label is not None:
+        return label
+    key = asset.get_label()
+    if key:
+        return key
+    if isinstance(asset, Token) and asset.token_from:
+        return asset.token_from
+    return None
+
+
+def _receiver_key_available(
+    receiver: AssetHolder,
+    asset: Entity,
+    label: str | None,
+) -> TransactionCheck:
+    key = _asset_holder_key(asset, label)
+    if key is None:
+        return TransactionCheck.accept()
+    existing = receiver.get_asset(key)
+    if existing is not None and existing is not asset:
+        return TransactionCheck.reject("receiver already holds asset key")
+    return TransactionCheck.accept()
+
+
+AssetRef = Entity | str
+
+
+@dataclass
+class AssetMoveCommitment:
+    """Move one existing discrete graph asset between holder-like objects."""
+
+    giver: AssetHolder
+    receiver: AssetHolder
+    asset: AssetRef
+    label: str = "move asset"
+    receiver_label: str | None = None
+    _moved: Entity | None = field(default=None, init=False, repr=False)
+    _giver_label: str | None = field(default=None, init=False, repr=False)
+    _committed: bool = field(default=False, init=False, repr=False)
+
+    def _asset(self) -> Entity | None:
+        if isinstance(self.asset, str):
+            return self.giver.get_asset(self.asset)
+        return self.asset
+
+    def can_commit(self) -> TransactionCheck:
+        asset = self._asset()
+        if asset is None:
+            return TransactionCheck.reject("giver does not hold asset")
+        if not self.giver.can_give_asset(asset, self.receiver):
+            return TransactionCheck.reject("giver cannot give asset")
+        if not self.receiver.can_receive_asset(asset, self.giver):
+            return TransactionCheck.reject("receiver cannot receive asset")
+        return _receiver_key_available(self.receiver, asset, self.receiver_label)
+
+    def commit(self) -> Mapping[str, object]:
+        check = self.can_commit()
+        if not check.accepted:
+            raise ValueError(check.reason or "asset move rejected")
+        asset = self._asset()
+        if asset is None:
+            raise ValueError("giver does not hold asset")
+        giver_label = self.giver.get_asset_key(self.asset)
+        moved = self.giver.remove_asset(giver_label if giver_label is not None else asset)
+        try:
+            self.receiver.add_asset(moved, label=self.receiver_label)
+        except Exception:
+            self.giver.add_asset(moved, label=giver_label)
+            raise
+        self._moved = moved
+        self._giver_label = giver_label
+        self._committed = True
+        return {
+            "kind": "asset_move",
+            "asset_id": moved.uid,
+            "asset_label": moved.get_label(),
+        }
+
+    def rollback(self) -> None:
+        if not self._committed or self._moved is None:
+            return
+        moved = self.receiver.remove_asset(self._moved)
+        self.giver.add_asset(moved, label=self._giver_label)
+        self._moved = None
+        self._giver_label = None
+        self._committed = False
+
+
+AssetSupplier = Callable[[], Entity]
+
+
+@dataclass
+class CatalogAssetCommitment:
+    """Create one discrete graph asset from a supplier and add it to a holder."""
+
+    receiver: AssetHolder
+    supplier: AssetSupplier
+    registry: Registry | None = None
+    label: str = "create catalog asset"
+    receiver_label: str | None = None
+    preview: Entity | None = None
+    can_create: Callable[[], TransactionCheck | bool] | None = None
+    _created: Entity | None = field(default=None, init=False, repr=False)
+    _registered: bool = field(default=False, init=False, repr=False)
+    _committed: bool = field(default=False, init=False, repr=False)
+
+    def can_commit(self) -> TransactionCheck:
+        if self.can_create is not None:
+            result = self.can_create()
+            if isinstance(result, bool):
+                if not result:
+                    return TransactionCheck.reject("catalog cannot create asset")
+            elif not result.accepted:
+                return result
+        if self.preview is not None:
+            if (
+                self.registry is not None
+                and self.registry.get(self.preview.uid) is not None
+            ):
+                return TransactionCheck.reject("registry already contains item uid")
+            if not self.receiver.can_receive_asset(self.preview, None):
+                return TransactionCheck.reject("receiver cannot receive asset")
+            return _receiver_key_available(
+                self.receiver,
+                self.preview,
+                self.receiver_label,
+            )
+        return TransactionCheck.accept()
+
+    def commit(self) -> Mapping[str, object]:
+        check = self.can_commit()
+        if not check.accepted:
+            raise ValueError(check.reason or "catalog asset creation rejected")
+        item = self.supplier()
+        if self.registry is not None and self.registry.get(item.uid) is not None:
+            raise ValueError("registry already contains item uid")
+        if not self.receiver.can_receive_asset(item, None):
+            raise ValueError("receiver cannot receive asset")
+        key_check = _receiver_key_available(self.receiver, item, self.receiver_label)
+        if not key_check.accepted:
+            raise ValueError(key_check.reason or "receiver cannot receive asset")
+
+        if self.registry is not None:
+            self.registry.add(item)
+            self._registered = True
+        try:
+            self.receiver.add_asset(item, label=self.receiver_label)
+        except Exception:
+            if self._registered and self.registry is not None:
+                self.registry.remove(item.uid)
+                self._registered = False
+            raise
+        self._created = item
+        self._committed = True
+        return {
+            "kind": "catalog_asset",
+            "asset_id": item.uid,
+            "asset_label": item.get_label(),
+        }
+
+    def rollback(self) -> None:
+        if not self._committed or self._created is None:
+            return
+        self.receiver.remove_asset(self._created)
+        if self._registered and self.registry is not None:
+            self.registry.remove(self._created.uid)
+        self._created = None
+        self._registered = False
         self._committed = False
 
 
@@ -716,7 +918,10 @@ class ComponentAssignmentCommitment:
 
 
 __all__ = [
+    "AssetHolder",
+    "AssetMoveCommitment",
     "CallbackCommitment",
+    "CatalogAssetCommitment",
     "ComponentAssignmentCommitment",
     "CountableHolder",
     "CountableTransferCommitment",

--- a/engine/src/tangl/mechanics/transaction.py
+++ b/engine/src/tangl/mechanics/transaction.py
@@ -119,6 +119,7 @@ class TransactionOffer:
 
     def can_accept(self) -> TransactionCheck:
         planned_deltas: dict[object, Number] = {}
+        planned_assets: dict[object, Entity] = {}
         unkeyed_value_delta_seen = False
         for commitment in self.commitments:
             if isinstance(
@@ -141,6 +142,8 @@ class TransactionOffer:
                         )
                     unkeyed_value_delta_seen = True
                 check = commitment.can_commit_with_plan(planned_deltas)
+            elif isinstance(commitment, AssetMoveCommitment):
+                check = commitment.can_commit_with_plan(planned_assets)
             else:
                 check = commitment.can_commit()
             if not check.accepted:
@@ -355,6 +358,37 @@ class AssetMoveCommitment:
             return TransactionCheck.reject("receiver cannot receive asset")
         return _receiver_key_available(self.receiver, asset, self.receiver_label)
 
+    def can_commit_with_plan(
+        self,
+        planned_assets: MutableMapping[object, Entity],
+    ) -> TransactionCheck:
+        check = self.can_commit()
+        if not check.accepted:
+            return check
+        asset = self._asset()
+        if asset is None:
+            return TransactionCheck.reject("giver does not hold asset")
+
+        move_key = ("asset_move", id(self.giver), asset.uid)
+        if move_key in planned_assets:
+            return TransactionCheck.reject("asset already planned for move")
+
+        receiver_key = _asset_holder_key(asset, self.receiver_label)
+        receive_key = (
+            None
+            if receiver_key is None
+            else ("asset_receive", id(self.receiver), receiver_key)
+        )
+        if receive_key is not None:
+            planned_asset = planned_assets.get(receive_key)
+            if planned_asset is not None and planned_asset is not asset:
+                return TransactionCheck.reject("receiver already planned for asset key")
+
+        planned_assets[move_key] = asset
+        if receive_key is not None:
+            planned_assets[receive_key] = asset
+        return TransactionCheck.accept()
+
     def commit(self) -> Mapping[str, object]:
         check = self.can_commit()
         if not check.accepted:
@@ -362,8 +396,8 @@ class AssetMoveCommitment:
         asset = self._asset()
         if asset is None:
             raise ValueError("giver does not hold asset")
-        giver_label = self.giver.get_asset_key(self.asset)
-        moved = self.giver.remove_asset(giver_label if giver_label is not None else asset)
+        giver_label = self.giver.get_asset_key(asset)
+        moved = self.giver.remove_asset(asset)
         try:
             self.receiver.add_asset(moved, label=self.receiver_label)
         except Exception:

--- a/engine/src/tangl/story/concepts/asset/ASSET_DESIGN.md
+++ b/engine/src/tangl/story/concepts/asset/ASSET_DESIGN.md
@@ -97,7 +97,8 @@ storage itself.
 or holder asset maps. It remains the story-level convenience for the current
 holder surface. The cross-family `tangl.mechanics.transaction` helper now carries
 the shared spec/offer/commitment/receipt shape for broader shops, services,
-assembly assignment, and mixed writeback.
+assembly assignment, holder-local asset movement, catalog-backed token creation,
+and mixed writeback.
 
 Once the graph relationship model exists, asset transfers should bind to that
 offer/commitment helper rather than grow a parallel trade framework. The asset
@@ -138,10 +139,10 @@ experiments, not a complete inventory system.
   `can_receive_*`) directly. A later relationship framework should generalize
   this into preflight/acceptance rules that assets, connections, attachments,
   and other mutable associations can share.
-- `AssetTransactionManager` is not yet adapted to `TransactionOffer` for mixed
-  discrete, fungible, and service operations. The generic helper exists; the
-  remaining work is to express holder-map and future holding-edge changes as
-  commitments that validate every leg before mutating anything.
+- Existing holder-map asset moves and catalog-backed token creation can now be
+  expressed with `AssetMoveCommitment` and `CatalogAssetCommitment`. The
+  remaining work is to express future holding-edge changes with equivalent
+  commitments once graph-backed ownership replaces holder-local maps.
 - `HasAssets` nominates `inv` and `assets` into local namespaces, but there is
   no story-level `Player`/avatar concept yet. Sandbox currently uses
   `SandboxScope.player_assets` as the explicit player stand-in; promote a real

--- a/engine/src/tangl/story/concepts/asset/holder.py
+++ b/engine/src/tangl/story/concepts/asset/holder.py
@@ -37,6 +37,16 @@ class HasAssets(HasNamespace):
                 return asset
         return None
 
+    def get_asset_key(self, asset: Token | str) -> str | None:
+        """Return the holder key currently used for an asset."""
+        resolved = self.get_asset(asset) if isinstance(asset, str) else asset
+        if resolved is None:
+            return None
+        for label, item in self.assets.items():
+            if item is resolved:
+                return label
+        return None
+
     def has_asset(self, asset: Token | str) -> bool:
         """Return whether this holder currently has the asset."""
         if isinstance(asset, str):

--- a/engine/tests/mechanics/test_transaction_offer.py
+++ b/engine/tests/mechanics/test_transaction_offer.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from typing import ClassVar
 
 import pytest
+from pydantic import Field
 
-from tangl.core import Graph, Node, Selector
+from tangl.core import Graph, Node, Selector, Token
 from tangl.mechanics.assembly import ComponentManager, Slot
 from tangl.mechanics.assembly.examples.vehicle import (
     Vehicle,
@@ -16,7 +17,9 @@ from tangl.mechanics.assembly.examples.vehicle import (
 )
 from tangl.mechanics.progression import Stat
 from tangl.mechanics.transaction import (
+    AssetMoveCommitment,
     CallbackCommitment,
+    CatalogAssetCommitment,
     ComponentAssignmentCommitment,
     CountableTransferCommitment,
     MappingDeltaCommitment,
@@ -27,11 +30,25 @@ from tangl.mechanics.transaction import (
     TransactionRollbackError,
     ValueDeltaCommitment,
 )
-from tangl.story.concepts.asset import HasAssets
+from tangl.story.concepts.asset import AssetType, HasAssets
 
 
 class GarageActor(HasAssets, Node):
     """Graph actor with a fungible wallet for transaction proof tests."""
+
+
+class ShopItemType(AssetType):
+    """Small tokenizable asset type for transaction proof tests."""
+
+
+class SelectiveGarageActor(GarageActor):
+    """Graph actor that can restrict which discrete assets it receives."""
+
+    accepted_assets: set[str] = Field(default_factory=set)
+
+    def can_receive_asset(self, asset: Token, giver: HasAssets | None = None) -> bool:
+        _ = giver
+        return not self.accepted_assets or asset.token_from in self.accepted_assets
 
 
 class FailingCommitment:
@@ -90,6 +107,18 @@ class RepairTarget:
 
 def part(label: str) -> VehicleComponent:
     return VehicleComponent(token_from=label, label=label)
+
+
+@pytest.fixture(autouse=True)
+def _clear_shop_item_types() -> None:
+    ShopItemType.clear_instances()
+    yield
+    ShopItemType.clear_instances()
+
+
+def shop_token(label: str, *, token_label: str | None = None) -> Token:
+    ShopItemType(label=label)
+    return Token[ShopItemType](token_from=label, label=token_label or label)
 
 
 def install_baseline(loadout: VehicleLoadout) -> None:
@@ -282,6 +311,169 @@ def test_callback_commitment_rolls_back_domain_local_inventory_moves() -> None:
 
     assert inventory == [chassis]
     assert vehicle.loadout.get_slot("chassis")[0].token_from == "mini_chassis"
+
+
+def test_asset_move_commitment_moves_existing_token_between_holders() -> None:
+    graph = Graph()
+    giver = graph.add_node(kind=GarageActor, label="shop")
+    receiver = graph.add_node(
+        kind=SelectiveGarageActor,
+        label="buyer",
+        accepted_assets={"medkit"},
+    )
+    medkit = shop_token("medkit")
+    graph.add(medkit)
+    giver.add_asset(medkit)
+
+    offer = TransactionOffer(
+        label="buy held medkit",
+        commitments=[
+            AssetMoveCommitment(giver, receiver, "medkit"),
+        ],
+    )
+
+    receipt = offer.accept()
+
+    assert not giver.has_asset("medkit")
+    assert receiver.has_asset("medkit")
+    assert receipt.details[0]["kind"] == "asset_move"
+    assert receipt.details[0]["asset_id"] == medkit.uid
+
+
+def test_asset_move_commitment_rejects_receiver_policy_before_mutation() -> None:
+    graph = Graph()
+    giver = graph.add_node(kind=GarageActor, label="shop")
+    receiver = graph.add_node(
+        kind=SelectiveGarageActor,
+        label="buyer",
+        accepted_assets={"permit"},
+    )
+    medkit = shop_token("medkit")
+    giver.add_asset(medkit)
+
+    offer = TransactionOffer(
+        label="buy rejected medkit",
+        commitments=[
+            AssetMoveCommitment(giver, receiver, "medkit"),
+        ],
+    )
+
+    check = offer.can_accept()
+
+    assert not check.accepted
+    assert check.reason == "move asset: receiver cannot receive asset"
+    assert giver.has_asset("medkit")
+    assert not receiver.has_asset("medkit")
+
+
+def test_asset_move_commitment_rolls_back_after_late_failure() -> None:
+    graph = Graph()
+    giver = graph.add_node(kind=GarageActor, label="shop")
+    receiver = graph.add_node(kind=GarageActor, label="buyer")
+    medkit = shop_token("medkit")
+    giver.add_asset(medkit, label="sale-bin")
+
+    offer = TransactionOffer(
+        label="buy then fail",
+        commitments=[
+            AssetMoveCommitment(giver, receiver, "medkit"),
+            FailingCommitment(),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="late failure"):
+        offer.accept()
+
+    assert giver.has_asset("medkit")
+    assert giver.get_asset_key("medkit") == "sale-bin"
+    assert not receiver.has_asset("medkit")
+
+
+def test_catalog_asset_commitment_creates_registers_and_holds_token_on_accept() -> None:
+    graph = Graph()
+    buyer = graph.add_node(kind=GarageActor, label="buyer")
+    created: list[Token] = []
+    ShopItemType(label="medkit")
+
+    def make_medkit() -> Token:
+        token = Token[ShopItemType](token_from="medkit", label="catalog_medkit")
+        created.append(token)
+        return token
+
+    offer = TransactionOffer(
+        label="buy catalog medkit",
+        commitments=[
+            CatalogAssetCommitment(buyer, make_medkit, registry=graph),
+        ],
+    )
+
+    assert offer.can_accept().accepted
+    assert created == []
+    receipt = offer.accept()
+
+    medkit = created[0]
+    assert buyer.has_asset("medkit")
+    assert graph.get(medkit.uid) is medkit
+    assert receipt.details[0]["kind"] == "catalog_asset"
+
+
+def test_catalog_asset_commitment_rejects_unavailable_stock_before_creation() -> None:
+    graph = Graph()
+    buyer = graph.add_node(kind=GarageActor, label="buyer")
+    stock = {"medkit": 0}
+    created: list[Token] = []
+    ShopItemType(label="medkit")
+
+    def make_medkit() -> Token:
+        token = Token[ShopItemType](token_from="medkit", label="catalog_medkit")
+        created.append(token)
+        return token
+
+    offer = TransactionOffer(
+        label="buy unavailable medkit",
+        commitments=[
+            MappingDeltaCommitment(stock, "medkit", -1),
+            CatalogAssetCommitment(buyer, make_medkit, registry=graph),
+        ],
+    )
+
+    check = offer.can_accept()
+
+    assert not check.accepted
+    assert check.reason == "mutate mapping value: value below minimum: -1 < 0"
+    assert created == []
+    assert stock == {"medkit": 0}
+    assert not buyer.has_asset("medkit")
+
+
+def test_catalog_asset_commitment_rolls_back_stock_holder_and_registry() -> None:
+    graph = Graph()
+    buyer = graph.add_node(kind=GarageActor, label="buyer")
+    stock = {"medkit": 1}
+    created: list[Token] = []
+    ShopItemType(label="medkit")
+
+    def make_medkit() -> Token:
+        token = Token[ShopItemType](token_from="medkit", label="catalog_medkit")
+        created.append(token)
+        return token
+
+    offer = TransactionOffer(
+        label="buy catalog medkit then fail",
+        commitments=[
+            MappingDeltaCommitment(stock, "medkit", -1),
+            CatalogAssetCommitment(buyer, make_medkit, registry=graph),
+            FailingCommitment(),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="late failure"):
+        offer.accept()
+
+    medkit = created[0]
+    assert stock == {"medkit": 1}
+    assert not buyer.has_asset("medkit")
+    assert graph.get(medkit.uid) is None
 
 
 def test_transaction_offer_buys_installs_and_round_trips_vehicle_component() -> None:

--- a/engine/tests/mechanics/test_transaction_offer.py
+++ b/engine/tests/mechanics/test_transaction_offer.py
@@ -366,6 +366,59 @@ def test_asset_move_commitment_rejects_receiver_policy_before_mutation() -> None
     assert not receiver.has_asset("medkit")
 
 
+def test_asset_move_commitment_rejects_duplicate_planned_move() -> None:
+    graph = Graph()
+    giver = graph.add_node(kind=GarageActor, label="shop")
+    first_receiver = graph.add_node(kind=GarageActor, label="first buyer")
+    second_receiver = graph.add_node(kind=GarageActor, label="second buyer")
+    medkit = shop_token("medkit")
+    giver.add_asset(medkit)
+
+    offer = TransactionOffer(
+        label="sell one medkit twice",
+        commitments=[
+            AssetMoveCommitment(giver, first_receiver, "medkit"),
+            AssetMoveCommitment(giver, second_receiver, "medkit"),
+        ],
+    )
+
+    check = offer.can_accept()
+
+    assert not check.accepted
+    assert check.reason == "move asset: asset already planned for move"
+    with pytest.raises(ValueError, match="asset already planned for move"):
+        offer.accept()
+    assert giver.has_asset("medkit")
+    assert not first_receiver.has_asset("medkit")
+    assert not second_receiver.has_asset("medkit")
+
+
+def test_asset_move_commitment_rejects_duplicate_planned_receiver_key() -> None:
+    graph = Graph()
+    giver = graph.add_node(kind=GarageActor, label="shop")
+    receiver = graph.add_node(kind=GarageActor, label="buyer")
+    medkit = shop_token("medkit")
+    permit = shop_token("permit")
+    giver.add_asset(medkit)
+    giver.add_asset(permit)
+
+    offer = TransactionOffer(
+        label="sell two items into one slot",
+        commitments=[
+            AssetMoveCommitment(giver, receiver, "medkit", receiver_label="promo"),
+            AssetMoveCommitment(giver, receiver, "permit", receiver_label="promo"),
+        ],
+    )
+
+    check = offer.can_accept()
+
+    assert not check.accepted
+    assert check.reason == "move asset: receiver already planned for asset key"
+    assert giver.has_asset("medkit")
+    assert giver.has_asset("permit")
+    assert not receiver.has_asset("promo")
+
+
 def test_asset_move_commitment_rolls_back_after_late_failure() -> None:
     graph = Graph()
     giver = graph.add_node(kind=GarageActor, label="shop")


### PR DESCRIPTION
## Summary

- add `AssetMoveCommitment` for moving existing discrete graph assets between holder-like objects
- add `CatalogAssetCommitment` for catalog-backed token creation during transaction accept
- expose `HasAssets.get_asset_key()` so rollback restores moved tokens under their original holder key
- document the transaction vocabulary update in mechanics and asset design notes

## Notes

- `ValueDeltaCommitment` remains the preferred path for local scalar costs and service/repair state changes.
- `CountableTransferCommitment` remains for real bilateral fungible holders.
- This slice covers holder-map asset moves and catalog-backed token creation; future holding-edge-backed inventory changes are still out of scope.

## Verification

- `/Users/derek/.local/bin/coderabbit review --agent --base-commit e6f9ebabeabbb7fcba86149f0de9a827bb4f75ca -c AGENTS.md` — 0 issues
- `poetry run pytest engine/tests/mechanics/test_transaction_offer.py engine/tests/story/test_asset_concepts.py` — 42 passed
- `poetry run pytest engine/tests/mechanics` — 814 passed, 5 skipped, 4 xfailed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for moving existing discrete assets between holders.
  * Added support for creating catalog-backed assets during accepted transactions, including optional registration.

* **Bug Fixes**
  * Improved transaction safety with pre-checks that prevent invalid asset moves before any changes are made.
  * Added rollback handling so partial transaction failures restore prior state consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->