### PR TITLE
Add neutral vehicle bay transaction example

### DIFF
--- a/engine/src/tangl/mechanics/TRANSACTION_OFFER_DESIGN.md
+++ b/engine/src/tangl/mechanics/TRANSACTION_OFFER_DESIGN.md
@@ -374,16 +374,20 @@ Landed proof:
 10. The neutral vehicle garage test buys and installs a component, then proves
    the resulting graph/loadout state survives `Graph.unstructure()` /
    `Graph.structure()`.
-11. Rejection before mutation and mid-commit rollback are both covered.
+11. The neutral vehicle bay example (`assembly/examples/vehicle_bay.py`) lifts
+    the CarWars-shaped service/shop pattern into generic helpers: scalar service
+    offers, staged inventory install offers, catalog purchase offers, and a
+    catalog buy+install proof that creates and assigns the same component during
+    accepted writeback.
+12. Rejection before mutation and mid-commit rollback are both covered.
 
-Still recommended for the next consumer-facing slice:
+Still recommended for the next consumer-facing slices:
 
-1. Add a neutral shop/garage example module or world-facing fixture over the
-   existing vehicle component manager.
-2. Add commitment legs only when a real consumer forces them:
+1. Add commitment legs only when a real consumer forces them:
    - graph link/unlink.
-3. Test aggregate insufficient funds, unavailable catalog/provider capacity,
-   incompatible install targets, and multi-offer/batch selection.
+2. Test multi-offer/batch selection over the neutral bay fixture.
+3. Replace holder-local asset maps with graph-backed holding/ownership
+   relations when a relationship-backed inventory slice is prioritized.
 4. Keep transaction offers ephemeral; persist only resulting state and receipts.
 
 Out of scope for the first slice:

--- a/engine/src/tangl/mechanics/assembly/examples/vehicle_bay.py
+++ b/engine/src/tangl/mechanics/assembly/examples/vehicle_bay.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping, MutableMapping
 from dataclasses import dataclass, field
 from typing import ClassVar
+from uuid import UUID
 
 from pydantic import Field
 
@@ -11,8 +12,10 @@ from tangl.core.bases import BaseModelPlus
 from tangl.mechanics.assembly import ComponentManager
 from tangl.mechanics.transaction import (
     AssetMoveCommitment,
+    CallbackCommitment,
     CatalogAssetCommitment,
     ComponentAssignmentCommitment,
+    MappingDeltaCommitment,
     TransactionCheck,
     TransactionOffer,
     ValueDeltaCommitment,
@@ -188,6 +191,7 @@ def build_inventory_install_offer(
     part = bay.inventory.get_asset(component_key)
     if part is None:
         raise ValueError(f"Vehicle inventory item not found: {component_key}")
+    before = _components_by_id(bay.vehicle.loadout.all_components())
     commitments: list[object] = []
     commitments.extend(_cost_commitments(bay, cash_cost=price, time_minutes=install_time))
     commitments.extend(
@@ -208,6 +212,7 @@ def build_inventory_install_offer(
             ),
         ],
     )
+    commitments.append(_return_replaced_components_commitment(bay, before))
     commitments.extend(extra_commitments)
     return TransactionOffer(label=f"install {part.get_label()}", commitments=commitments)
 
@@ -219,30 +224,36 @@ def build_catalog_purchase_offer(
     price: int,
     supplier: Callable[[], VehicleComponent] | None = None,
     registry: Registry | None = None,
-    stock: Mapping[str, int] | None = None,
+    stock: MutableMapping[str, int] | None = None,
+    extra_commitments: Iterable[object] = (),
 ) -> TransactionOffer:
     """Build a transaction that buys one catalog component into inventory."""
 
-    can_create = None
+    commitments: list[object] = []
+    commitments.extend(_cost_commitments(bay, cash_cost=price, time_minutes=0))
     if stock is not None:
-
-        def can_create() -> TransactionCheck:
-            if stock.get(label, 0) <= 0:
-                return TransactionCheck.reject("catalog item unavailable")
-            return TransactionCheck.accept()
+        commitments.append(
+            MappingDeltaCommitment(
+                stock,
+                label,
+                -1,
+                label="decrement catalog stock",
+                min_value=0,
+            ),
+        )
+    commitments.append(
+        CatalogAssetCommitment(
+            bay.inventory,
+            supplier or (lambda: component(label)),
+            registry=registry,
+            receiver_label=label,
+        ),
+    )
+    commitments.extend(extra_commitments)
 
     return TransactionOffer(
         label=f"buy {label}",
-        commitments=[
-            *_cost_commitments(bay, cash_cost=price, time_minutes=0),
-            CatalogAssetCommitment(
-                bay.inventory,
-                supplier or (lambda: component(label)),
-                registry=registry,
-                receiver_label=label,
-                can_create=can_create,
-            ),
-        ],
+        commitments=commitments,
     )
 
 
@@ -257,7 +268,12 @@ class CatalogInstallCommitment:
     label: str = "catalog install"
     allow_replace: bool = True
     validate_after: bool = True
-    _assignment: ComponentAssignmentCommitment | None = field(default=None, init=False)
+    _assignment: ComponentAssignmentCommitment | None = field(
+        default=None,
+        init=False,
+        repr=False,
+        compare=False,
+    )
 
     def can_commit(self) -> TransactionCheck:
         return ComponentAssignmentCommitment(
@@ -307,6 +323,7 @@ def build_catalog_install_offer(
     """Build a transaction that creates a catalog part and installs it directly."""
 
     preview_part = preview or component(label)
+    before = _components_by_id(bay.vehicle.loadout.all_components())
     commitments: list[object] = []
     commitments.extend(_cost_commitments(bay, cash_cost=price, time_minutes=install_time))
     commitments.append(
@@ -318,8 +335,46 @@ def build_catalog_install_offer(
             label="create and assign vehicle part",
         ),
     )
+    commitments.append(_return_replaced_components_commitment(bay, before))
     commitments.extend(extra_commitments)
     return TransactionOffer(label=f"buy and install {label}", commitments=commitments)
+
+
+def _components_by_id(components: Iterable[VehicleComponent]) -> dict[UUID, VehicleComponent]:
+    return {item.uid: item for item in components}
+
+
+def _return_replaced_components_commitment(
+    bay: VehicleBay,
+    before: Mapping[UUID, VehicleComponent],
+) -> CallbackCommitment:
+    returned: list[VehicleComponent] = []
+
+    def apply() -> Mapping[str, object]:
+        after = {item.uid for item in bay.vehicle.loadout.all_components()}
+        returned[:] = sorted(
+            (item for uid, item in before.items() if uid not in after),
+            key=lambda item: item.get_label(),
+        )
+        for item in returned:
+            bay.inventory.add_asset(item)
+        return {
+            "kind": "inventory_return",
+            "component_ids": [item.uid for item in returned],
+            "component_labels": [item.get_label() for item in returned],
+        }
+
+    def undo() -> None:
+        for item in returned:
+            if bay.inventory.has_asset(item):
+                bay.inventory.remove_asset(item)
+        returned.clear()
+
+    return CallbackCommitment(
+        "return replaced parts to inventory",
+        apply=apply,
+        undo=undo,
+    )
 
 
 def _cost_commitments(

--- a/engine/src/tangl/mechanics/assembly/examples/vehicle_bay.py
+++ b/engine/src/tangl/mechanics/assembly/examples/vehicle_bay.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import ClassVar
+
+from pydantic import Field
+
+from tangl.core import Entity, Registry
+from tangl.core.bases import BaseModelPlus
+from tangl.mechanics.assembly import ComponentManager
+from tangl.mechanics.transaction import (
+    AssetMoveCommitment,
+    CatalogAssetCommitment,
+    ComponentAssignmentCommitment,
+    TransactionCheck,
+    TransactionOffer,
+    ValueDeltaCommitment,
+)
+
+from .vehicle import Vehicle, VehicleComponent
+
+SERVICE_TIME_MINUTES = 30
+INSTALL_TIME_MINUTES = 60
+
+
+class VehiclePartInventory(BaseModelPlus):
+    """Holder-map inventory for neutral vehicle component examples."""
+
+    guard_unstructure: ClassVar[bool] = True
+
+    items: dict[str, VehicleComponent] = Field(default_factory=dict)
+
+    def _item_key(self, item: VehicleComponent, label: str | None = None) -> str:
+        key = label or item.get_label() or item.token_from
+        if not key:
+            raise ValueError("Vehicle inventory item requires a label")
+        return key
+
+    def get_asset(self, label: str) -> VehicleComponent | None:
+        if label in self.items:
+            return self.items[label]
+        for item in self.items.values():
+            if label == item.get_label() or label == item.token_from:
+                return item
+        return None
+
+    def get_asset_key(self, asset: Entity | str) -> str | None:
+        resolved = self.get_asset(asset) if isinstance(asset, str) else asset
+        if resolved is None:
+            return None
+        for label, item in self.items.items():
+            if item is resolved:
+                return label
+        return None
+
+    def can_give_asset(
+        self,
+        asset: Entity,
+        receiver: object | None = None,
+    ) -> bool:
+        _ = receiver
+        return isinstance(asset, VehicleComponent) and self.has_asset(asset)
+
+    def can_receive_asset(
+        self,
+        asset: Entity,
+        giver: object | None = None,
+    ) -> bool:
+        _ = giver
+        return isinstance(asset, VehicleComponent)
+
+    def add_asset(self, asset: Entity, *, label: str | None = None) -> None:
+        if not isinstance(asset, VehicleComponent):
+            raise TypeError("Vehicle inventory accepts only VehicleComponent tokens")
+        self.items[self._item_key(asset, label)] = asset
+
+    def remove_asset(self, asset: Entity | str) -> VehicleComponent:
+        if isinstance(asset, str):
+            resolved = self.get_asset(asset)
+            if resolved is None:
+                raise KeyError(asset)
+            asset = resolved
+        for label, item in list(self.items.items()):
+            if item is asset:
+                return self.items.pop(label)
+        key = asset.get_label() or repr(asset)
+        raise KeyError(f"Unknown vehicle inventory item: {key}")
+
+    def has_asset(self, asset: Entity | str) -> bool:
+        if isinstance(asset, str):
+            return self.get_asset(asset) is not None
+        return any(item is asset for item in self.items.values())
+
+    def all_items(self) -> list[VehicleComponent]:
+        return list(self.items.values())
+
+
+class VehicleBay(BaseModelPlus):
+    """Neutral vehicle service/shop state used by transaction examples."""
+
+    guard_unstructure: ClassVar[bool] = True
+
+    vehicle: Vehicle = Field(default_factory=Vehicle)
+    cash: int = 1000
+    time_minutes: int = 0
+    inventory: VehiclePartInventory = Field(default_factory=VehiclePartInventory)
+
+
+def component(label: str) -> VehicleComponent:
+    return VehicleComponent(token_from=label, label=label)
+
+
+def value_field_commitment(
+    obj: object,
+    field_name: str,
+    delta: int,
+    *,
+    label: str,
+    detail_label: str | None = None,
+    min_value: int | None = None,
+    max_value: int | None = None,
+) -> ValueDeltaCommitment:
+    """Build a typed scalar field mutation commitment."""
+
+    def get_value() -> int:
+        return int(getattr(obj, field_name))
+
+    def set_value(value: int | float) -> None:
+        setattr(obj, field_name, int(value))
+
+    return ValueDeltaCommitment(
+        get_value=get_value,
+        set_value=set_value,
+        delta=delta,
+        label=label,
+        detail_label=detail_label or field_name,
+        min_value=min_value,
+        max_value=max_value,
+        planning_key=_value_planning_key(obj, field_name),
+    )
+
+
+def build_service_offer(
+    bay: VehicleBay,
+    *,
+    target: object,
+    field_name: str,
+    delta: int,
+    cash_cost: int = 0,
+    time_minutes: int = SERVICE_TIME_MINUTES,
+    label: str = "service vehicle",
+    value_label: str | None = None,
+    min_value: int | None = 0,
+    max_value: int | None = None,
+    extra_commitments: Iterable[object] = (),
+) -> TransactionOffer:
+    """Build a service transaction over cash, time, and one scalar state field."""
+
+    commitments: list[object] = []
+    commitments.extend(_cost_commitments(bay, cash_cost=cash_cost, time_minutes=time_minutes))
+    commitments.append(
+        value_field_commitment(
+            target,
+            field_name,
+            delta,
+            label=value_label or label,
+            min_value=min_value,
+            max_value=max_value,
+        ),
+    )
+    commitments.extend(extra_commitments)
+    return TransactionOffer(label=label, commitments=commitments)
+
+
+def build_inventory_install_offer(
+    bay: VehicleBay,
+    *,
+    component_key: str,
+    slot_name: str,
+    price: int = 0,
+    install_time: int = INSTALL_TIME_MINUTES,
+    extra_commitments: Iterable[object] = (),
+) -> TransactionOffer:
+    """Build a transaction that installs one already-held inventory component."""
+
+    installed = VehiclePartInventory()
+    part = bay.inventory.get_asset(component_key)
+    if part is None:
+        raise ValueError(f"Vehicle inventory item not found: {component_key}")
+    commitments: list[object] = []
+    commitments.extend(_cost_commitments(bay, cash_cost=price, time_minutes=install_time))
+    commitments.extend(
+        [
+            AssetMoveCommitment(
+                bay.inventory,
+                installed,
+                part,
+                label="remove selected part from inventory",
+            ),
+            ComponentAssignmentCommitment(
+                bay.vehicle.loadout,
+                slot_name,
+                part,
+                label="assign vehicle part",
+                allow_replace=True,
+                validate_after=True,
+            ),
+        ],
+    )
+    commitments.extend(extra_commitments)
+    return TransactionOffer(label=f"install {part.get_label()}", commitments=commitments)
+
+
+def build_catalog_purchase_offer(
+    bay: VehicleBay,
+    *,
+    label: str,
+    price: int,
+    supplier: Callable[[], VehicleComponent] | None = None,
+    registry: Registry | None = None,
+    stock: Mapping[str, int] | None = None,
+) -> TransactionOffer:
+    """Build a transaction that buys one catalog component into inventory."""
+
+    can_create = None
+    if stock is not None:
+
+        def can_create() -> TransactionCheck:
+            if stock.get(label, 0) <= 0:
+                return TransactionCheck.reject("catalog item unavailable")
+            return TransactionCheck.accept()
+
+    return TransactionOffer(
+        label=f"buy {label}",
+        commitments=[
+            *_cost_commitments(bay, cash_cost=price, time_minutes=0),
+            CatalogAssetCommitment(
+                bay.inventory,
+                supplier or (lambda: component(label)),
+                registry=registry,
+                receiver_label=label,
+                can_create=can_create,
+            ),
+        ],
+    )
+
+
+@dataclass
+class CatalogInstallCommitment:
+    """Create a catalog component and install it in one committed writeback."""
+
+    manager: ComponentManager[VehicleComponent]
+    slot_name: str
+    supplier: Callable[[], VehicleComponent]
+    preview: VehicleComponent
+    label: str = "catalog install"
+    allow_replace: bool = True
+    validate_after: bool = True
+    _assignment: ComponentAssignmentCommitment | None = field(default=None, init=False)
+
+    def can_commit(self) -> TransactionCheck:
+        return ComponentAssignmentCommitment(
+            self.manager,
+            self.slot_name,
+            self.preview,
+            label=self.label,
+            allow_replace=self.allow_replace,
+            validate_after=self.validate_after,
+        ).can_commit()
+
+    def commit(self) -> Mapping[str, object]:
+        check = self.can_commit()
+        if not check.accepted:
+            raise ValueError(check.reason or "catalog install rejected")
+        item = self.supplier()
+        assignment = ComponentAssignmentCommitment(
+            self.manager,
+            self.slot_name,
+            item,
+            label=self.label,
+            allow_replace=self.allow_replace,
+            validate_after=self.validate_after,
+        )
+        self._assignment = assignment
+        detail = assignment.commit()
+        return {"kind": "catalog_install", **detail}
+
+    def rollback(self) -> None:
+        if self._assignment is None:
+            return
+        self._assignment.rollback()
+        self._assignment = None
+
+
+def build_catalog_install_offer(
+    bay: VehicleBay,
+    *,
+    label: str,
+    slot_name: str,
+    price: int,
+    install_time: int = INSTALL_TIME_MINUTES,
+    supplier: Callable[[], VehicleComponent] | None = None,
+    preview: VehicleComponent | None = None,
+    extra_commitments: Iterable[object] = (),
+) -> TransactionOffer:
+    """Build a transaction that creates a catalog part and installs it directly."""
+
+    preview_part = preview or component(label)
+    commitments: list[object] = []
+    commitments.extend(_cost_commitments(bay, cash_cost=price, time_minutes=install_time))
+    commitments.append(
+        CatalogInstallCommitment(
+            bay.vehicle.loadout,
+            slot_name,
+            supplier or (lambda: component(label)),
+            preview_part,
+            label="create and assign vehicle part",
+        ),
+    )
+    commitments.extend(extra_commitments)
+    return TransactionOffer(label=f"buy and install {label}", commitments=commitments)
+
+
+def _cost_commitments(
+    bay: VehicleBay,
+    *,
+    cash_cost: int,
+    time_minutes: int,
+) -> list[ValueDeltaCommitment]:
+    commitments: list[ValueDeltaCommitment] = []
+    if cash_cost < 0:
+        raise ValueError("cash cost must be non-negative")
+    if time_minutes < 0:
+        raise ValueError("time cost must be non-negative")
+    if cash_cost:
+        commitments.append(
+            value_field_commitment(
+                bay,
+                "cash",
+                -cash_cost,
+                label="pay cash",
+                detail_label="cash",
+                min_value=0,
+            ),
+        )
+    if time_minutes:
+        commitments.append(
+            value_field_commitment(
+                bay,
+                "time_minutes",
+                time_minutes,
+                label="spend time",
+                detail_label="time_minutes",
+                min_value=0,
+            ),
+        )
+    return commitments
+
+
+def _value_planning_key(obj: object, field_name: str) -> tuple[str, object, str]:
+    uid = getattr(obj, "uid", None)
+    identifier = id(obj) if uid is None else uid
+    return (obj.__class__.__name__, identifier, field_name)
+
+
+__all__ = [
+    "CatalogInstallCommitment",
+    "INSTALL_TIME_MINUTES",
+    "SERVICE_TIME_MINUTES",
+    "VehicleBay",
+    "VehiclePartInventory",
+    "build_catalog_install_offer",
+    "build_catalog_purchase_offer",
+    "build_inventory_install_offer",
+    "build_service_offer",
+    "component",
+    "value_field_commitment",
+]

--- a/engine/src/tangl/mechanics/assembly/examples/vehicle_bay.py
+++ b/engine/src/tangl/mechanics/assembly/examples/vehicle_bay.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable, Mapping, MutableMapping
 from dataclasses import dataclass, field
 from typing import ClassVar
-from uuid import UUID
 
 from pydantic import Field
 
@@ -17,6 +16,7 @@ from tangl.mechanics.transaction import (
     ComponentAssignmentCommitment,
     MappingDeltaCommitment,
     TransactionCheck,
+    TransactionCommitment,
     TransactionOffer,
     ValueDeltaCommitment,
 )
@@ -156,11 +156,11 @@ def build_service_offer(
     value_label: str | None = None,
     min_value: int | None = 0,
     max_value: int | None = None,
-    extra_commitments: Iterable[object] = (),
+    extra_commitments: Iterable[TransactionCommitment] = (),
 ) -> TransactionOffer:
     """Build a service transaction over cash, time, and one scalar state field."""
 
-    commitments: list[object] = []
+    commitments: list[TransactionCommitment] = []
     commitments.extend(_cost_commitments(bay, cash_cost=cash_cost, time_minutes=time_minutes))
     commitments.append(
         value_field_commitment(
@@ -183,7 +183,7 @@ def build_inventory_install_offer(
     slot_name: str,
     price: int = 0,
     install_time: int = INSTALL_TIME_MINUTES,
-    extra_commitments: Iterable[object] = (),
+    extra_commitments: Iterable[TransactionCommitment] = (),
 ) -> TransactionOffer:
     """Build a transaction that installs one already-held inventory component."""
 
@@ -191,9 +191,10 @@ def build_inventory_install_offer(
     part = bay.inventory.get_asset(component_key)
     if part is None:
         raise ValueError(f"Vehicle inventory item not found: {component_key}")
-    before = _components_by_id(bay.vehicle.loadout.all_components())
-    commitments: list[object] = []
+    commitments: list[TransactionCommitment] = []
+    replacement_capture = _replacement_return_commitments(bay, slot_name)
     commitments.extend(_cost_commitments(bay, cash_cost=price, time_minutes=install_time))
+    commitments.append(replacement_capture[0])
     commitments.extend(
         [
             AssetMoveCommitment(
@@ -212,7 +213,7 @@ def build_inventory_install_offer(
             ),
         ],
     )
-    commitments.append(_return_replaced_components_commitment(bay, before))
+    commitments.append(replacement_capture[1])
     commitments.extend(extra_commitments)
     return TransactionOffer(label=f"install {part.get_label()}", commitments=commitments)
 
@@ -225,11 +226,12 @@ def build_catalog_purchase_offer(
     supplier: Callable[[], VehicleComponent] | None = None,
     registry: Registry | None = None,
     stock: MutableMapping[str, int] | None = None,
-    extra_commitments: Iterable[object] = (),
+    extra_commitments: Iterable[TransactionCommitment] = (),
 ) -> TransactionOffer:
     """Build a transaction that buys one catalog component into inventory."""
 
-    commitments: list[object] = []
+    preview = component(label)
+    commitments: list[TransactionCommitment] = []
     commitments.extend(_cost_commitments(bay, cash_cost=price, time_minutes=0))
     if stock is not None:
         commitments.append(
@@ -247,6 +249,7 @@ def build_catalog_purchase_offer(
             supplier or (lambda: component(label)),
             registry=registry,
             receiver_label=label,
+            preview=preview,
         ),
     )
     commitments.extend(extra_commitments)
@@ -275,21 +278,32 @@ class CatalogInstallCommitment:
         compare=False,
     )
 
-    def can_commit(self) -> TransactionCheck:
+    def _assignment_check(self, item: VehicleComponent) -> TransactionCheck:
         return ComponentAssignmentCommitment(
             self.manager,
             self.slot_name,
-            self.preview,
+            item,
             label=self.label,
             allow_replace=self.allow_replace,
             validate_after=self.validate_after,
         ).can_commit()
+
+    def _supplier_matches_preview(self, item: VehicleComponent) -> bool:
+        return item.token_from == self.preview.token_from
+
+    def can_commit(self) -> TransactionCheck:
+        return self._assignment_check(self.preview)
 
     def commit(self) -> Mapping[str, object]:
         check = self.can_commit()
         if not check.accepted:
             raise ValueError(check.reason or "catalog install rejected")
         item = self.supplier()
+        if not self._supplier_matches_preview(item):
+            raise ValueError("catalog supplier did not match preview")
+        item_check = self._assignment_check(item)
+        if not item_check.accepted:
+            raise ValueError(item_check.reason or "catalog install rejected")
         assignment = ComponentAssignmentCommitment(
             self.manager,
             self.slot_name,
@@ -318,14 +332,15 @@ def build_catalog_install_offer(
     install_time: int = INSTALL_TIME_MINUTES,
     supplier: Callable[[], VehicleComponent] | None = None,
     preview: VehicleComponent | None = None,
-    extra_commitments: Iterable[object] = (),
+    extra_commitments: Iterable[TransactionCommitment] = (),
 ) -> TransactionOffer:
     """Build a transaction that creates a catalog part and installs it directly."""
 
     preview_part = preview or component(label)
-    before = _components_by_id(bay.vehicle.loadout.all_components())
-    commitments: list[object] = []
+    commitments: list[TransactionCommitment] = []
+    replacement_capture = _replacement_return_commitments(bay, slot_name)
     commitments.extend(_cost_commitments(bay, cash_cost=price, time_minutes=install_time))
+    commitments.append(replacement_capture[0])
     commitments.append(
         CatalogInstallCommitment(
             bay.vehicle.loadout,
@@ -335,25 +350,25 @@ def build_catalog_install_offer(
             label="create and assign vehicle part",
         ),
     )
-    commitments.append(_return_replaced_components_commitment(bay, before))
+    commitments.append(replacement_capture[1])
     commitments.extend(extra_commitments)
     return TransactionOffer(label=f"buy and install {label}", commitments=commitments)
 
 
-def _components_by_id(components: Iterable[VehicleComponent]) -> dict[UUID, VehicleComponent]:
-    return {item.uid: item for item in components}
-
-
-def _return_replaced_components_commitment(
+def _replacement_return_commitments(
     bay: VehicleBay,
-    before: Mapping[UUID, VehicleComponent],
-) -> CallbackCommitment:
+    slot_name: str,
+) -> tuple[TransactionCommitment, TransactionCommitment]:
+    before: list[VehicleComponent] = []
     returned: list[VehicleComponent] = []
 
+    def capture() -> None:
+        before[:] = list(bay.vehicle.loadout.get_slot(slot_name))
+
     def apply() -> Mapping[str, object]:
-        after = {item.uid for item in bay.vehicle.loadout.all_components()}
+        after = {item.uid for item in bay.vehicle.loadout.get_slot(slot_name)}
         returned[:] = sorted(
-            (item for uid, item in before.items() if uid not in after),
+            (item for item in before if item.uid not in after),
             key=lambda item: item.get_label(),
         )
         for item in returned:
@@ -370,10 +385,17 @@ def _return_replaced_components_commitment(
                 bay.inventory.remove_asset(item)
         returned.clear()
 
-    return CallbackCommitment(
-        "return replaced parts to inventory",
-        apply=apply,
-        undo=undo,
+    return (
+        CallbackCommitment(
+            "capture replaced parts",
+            apply=capture,
+            undo=before.clear,
+        ),
+        CallbackCommitment(
+            "return replaced parts to inventory",
+            apply=apply,
+            undo=undo,
+        ),
     )
 
 
@@ -420,15 +442,15 @@ def _value_planning_key(obj: object, field_name: str) -> tuple[str, object, str]
 
 
 __all__ = [
-    "CatalogInstallCommitment",
-    "INSTALL_TIME_MINUTES",
-    "SERVICE_TIME_MINUTES",
-    "VehicleBay",
-    "VehiclePartInventory",
     "build_catalog_install_offer",
     "build_catalog_purchase_offer",
     "build_inventory_install_offer",
     "build_service_offer",
+    "CatalogInstallCommitment",
     "component",
+    "INSTALL_TIME_MINUTES",
+    "SERVICE_TIME_MINUTES",
     "value_field_commitment",
+    "VehicleBay",
+    "VehiclePartInventory",
 ]

--- a/engine/tests/mechanics/test_vehicle_bay_example.py
+++ b/engine/tests/mechanics/test_vehicle_bay_example.py
@@ -1,0 +1,304 @@
+"""Neutral vehicle bay tests over transaction offer helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from tangl.core import Graph, Selector
+from tangl.mechanics.assembly.examples.vehicle import Vehicle
+from tangl.mechanics.assembly.examples.vehicle_bay import (
+    INSTALL_TIME_MINUTES,
+    CatalogInstallCommitment,
+    VehicleBay,
+    build_catalog_install_offer,
+    build_catalog_purchase_offer,
+    build_inventory_install_offer,
+    build_service_offer,
+    component,
+)
+from tangl.mechanics.transaction import CallbackCommitment
+
+
+def install_baseline(bay: VehicleBay) -> None:
+    bay.vehicle.loadout.assign("chassis", component("mini_chassis"))
+    bay.vehicle.loadout.assign("powerplant", component("cheap_powerplant"))
+    bay.vehicle.loadout.assign("suspension", component("cheap_suspension"))
+    bay.vehicle.loadout.assign("tires", component("cheap_tires"))
+
+
+def test_vehicle_bay_service_offer_spends_cash_time_and_mutates_target() -> None:
+    bay = VehicleBay(cash=500)
+    tire = component("cheap_tires")
+    tire.damage = 3
+
+    offer = build_service_offer(
+        bay,
+        target=tire,
+        field_name="damage",
+        delta=-2,
+        cash_cost=150,
+        time_minutes=30,
+        label="repair component damage",
+    )
+    receipt = offer.accept()
+
+    assert bay.cash == 350
+    assert bay.time_minutes == 30
+    assert tire.damage == 1
+    assert {detail["kind"] for detail in receipt.details} == {"value_delta"}
+    assert {detail["label"] for detail in receipt.details} == {
+        "cash",
+        "time_minutes",
+        "damage",
+    }
+
+
+def test_vehicle_bay_service_offer_rejects_insufficient_cash_before_mutation() -> None:
+    bay = VehicleBay(cash=50)
+    tire = component("cheap_tires")
+    tire.damage = 3
+
+    offer = build_service_offer(
+        bay,
+        target=tire,
+        field_name="damage",
+        delta=-1,
+        cash_cost=150,
+        label="repair component damage",
+    )
+
+    check = offer.can_accept()
+
+    assert not check.accepted
+    assert check.reason == "pay cash: value below minimum: -100 < 0"
+    with pytest.raises(ValueError, match="pay cash"):
+        offer.accept()
+    assert bay.cash == 50
+    assert bay.time_minutes == 0
+    assert tire.damage == 3
+
+
+def test_vehicle_bay_service_offer_rolls_back_after_late_failure() -> None:
+    bay = VehicleBay(cash=500)
+    tire = component("cheap_tires")
+    tire.damage = 3
+
+    def fail_after_service() -> None:
+        raise RuntimeError("late service failure")
+
+    offer = build_service_offer(
+        bay,
+        target=tire,
+        field_name="damage",
+        delta=-2,
+        cash_cost=150,
+        label="repair component damage",
+        extra_commitments=[
+            CallbackCommitment("fail after service", apply=fail_after_service),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="late service failure"):
+        offer.accept()
+
+    assert bay.cash == 500
+    assert bay.time_minutes == 0
+    assert tire.damage == 3
+
+
+def test_vehicle_bay_installs_inventory_component() -> None:
+    bay = VehicleBay(cash=1000)
+    install_baseline(bay)
+    bay.inventory.add_asset(component("slicks"))
+
+    offer = build_inventory_install_offer(
+        bay,
+        component_key="slicks",
+        slot_name="tires",
+        price=350,
+    )
+    receipt = offer.accept()
+
+    assert bay.cash == 650
+    assert bay.time_minutes == INSTALL_TIME_MINUTES
+    assert not bay.inventory.has_asset("slicks")
+    assert bay.vehicle.loadout.get_slot("tires")[0].token_from == "slicks"
+    assert {detail["kind"] for detail in receipt.details} >= {
+        "asset_move",
+        "component_assignment",
+        "value_delta",
+    }
+
+
+def test_vehicle_bay_failed_inventory_install_keeps_cash_inventory_and_loadout() -> None:
+    bay = VehicleBay(cash=1000)
+    install_baseline(bay)
+    bay.inventory.add_asset(component("slicks"))
+
+    offer = build_inventory_install_offer(
+        bay,
+        component_key="slicks",
+        slot_name="powerplant",
+        price=350,
+    )
+
+    with pytest.raises(ValueError, match="Component doesn't match criteria"):
+        offer.accept()
+
+    assert bay.cash == 1000
+    assert bay.time_minutes == 0
+    assert bay.inventory.has_asset("slicks")
+    assert bay.vehicle.loadout.get_slot("powerplant")[0].token_from == "cheap_powerplant"
+
+
+def test_vehicle_bay_catalog_purchase_creates_graph_component_on_accept() -> None:
+    graph = Graph()
+    bay = VehicleBay(cash=1000)
+    created = []
+
+    def make_slicks():
+        item = component("slicks")
+        created.append(item)
+        return item
+
+    offer = build_catalog_purchase_offer(
+        bay,
+        label="slicks",
+        price=350,
+        supplier=make_slicks,
+        registry=graph,
+        stock={"slicks": 1},
+    )
+
+    assert offer.can_accept().accepted
+    assert created == []
+    receipt = offer.accept()
+
+    slicks = created[0]
+    assert bay.cash == 650
+    assert bay.inventory.get_asset("slicks") is slicks
+    assert graph.get(slicks.uid) is slicks
+    assert {detail["kind"] for detail in receipt.details} == {
+        "catalog_asset",
+        "value_delta",
+    }
+
+
+def test_vehicle_bay_catalog_purchase_rejects_unavailable_stock_before_creation() -> None:
+    bay = VehicleBay(cash=1000)
+    created = []
+
+    def make_slicks():
+        created.append(component("slicks"))
+        return created[-1]
+
+    offer = build_catalog_purchase_offer(
+        bay,
+        label="slicks",
+        price=350,
+        supplier=make_slicks,
+        stock={"slicks": 0},
+    )
+
+    check = offer.can_accept()
+
+    assert not check.accepted
+    assert check.reason == "create catalog asset: catalog item unavailable"
+    assert created == []
+    assert bay.cash == 1000
+    assert not bay.inventory.has_asset("slicks")
+
+
+def test_vehicle_bay_catalog_install_creates_installs_and_round_trips_component() -> None:
+    graph = Graph()
+    vehicle = graph.add_node(label="demo-car", kind=Vehicle)
+    bay = VehicleBay(vehicle=vehicle, cash=1000)
+    install_baseline(bay)
+    created = []
+
+    def make_slicks():
+        item = component("slicks")
+        created.append(item)
+        return item
+
+    offer = build_catalog_install_offer(
+        bay,
+        label="slicks",
+        slot_name="tires",
+        price=350,
+        supplier=make_slicks,
+    )
+
+    assert offer.can_accept().accepted
+    assert created == []
+    offer.accept()
+
+    slicks = created[0]
+    restored = Graph.structure(graph.unstructure())
+    restored_vehicle = restored.find_one(Selector(label="demo-car"))
+    restored_slicks = restored.get(slicks.uid)
+
+    assert bay.cash == 650
+    assert bay.time_minutes == INSTALL_TIME_MINUTES
+    assert graph.get(slicks.uid) is slicks
+    assert bay.vehicle.loadout.get_slot("tires") == [slicks]
+    assert restored_vehicle.loadout.get_slot("tires") == [restored_slicks]
+
+
+def test_vehicle_bay_catalog_install_rolls_back_after_late_failure() -> None:
+    graph = Graph()
+    vehicle = graph.add_node(label="demo-car", kind=Vehicle)
+    bay = VehicleBay(vehicle=vehicle, cash=1000)
+    install_baseline(bay)
+    created = []
+    starting_tires = list(bay.vehicle.loadout.get_slot("tires"))
+
+    def make_slicks():
+        item = component("slicks")
+        created.append(item)
+        return item
+
+    def fail_after_install() -> None:
+        raise RuntimeError("late install failure")
+
+    offer = build_catalog_install_offer(
+        bay,
+        label="slicks",
+        slot_name="tires",
+        price=350,
+        supplier=make_slicks,
+        extra_commitments=[
+            CallbackCommitment("fail after install", apply=fail_after_install),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="late install failure"):
+        offer.accept()
+
+    slicks = created[0]
+    assert bay.cash == 1000
+    assert bay.time_minutes == 0
+    assert bay.vehicle.loadout.get_slot("tires") == starting_tires
+    assert graph.get(slicks.uid) is None
+
+
+def test_catalog_install_commitment_rolls_back_assignment_validation_failure() -> None:
+    graph = Graph()
+    vehicle = graph.add_node(label="demo-car", kind=Vehicle)
+    bay = VehicleBay(vehicle=vehicle, cash=1000)
+    install_baseline(bay)
+    starting_tires = list(bay.vehicle.loadout.get_slot("tires"))
+
+    commitment = CatalogInstallCommitment(
+        bay.vehicle.loadout,
+        "tires",
+        supplier=lambda: component("truck_chassis"),
+        preview=component("truck_chassis"),
+        label="create invalid tires",
+    )
+
+    with pytest.raises(ValueError, match="Component doesn't match criteria"):
+        commitment.commit()
+
+    assert bay.vehicle.loadout.get_slot("tires") == starting_tires
+    assert len(graph.members) == 5

--- a/engine/tests/mechanics/test_vehicle_bay_example.py
+++ b/engine/tests/mechanics/test_vehicle_bay_example.py
@@ -133,6 +133,39 @@ def test_vehicle_bay_installs_inventory_component() -> None:
     }
 
 
+def test_vehicle_bay_stale_inventory_install_offer_returns_commit_time_replacement() -> None:
+    bay = VehicleBay(cash=1000)
+    bay.vehicle.loadout.assign("chassis", component("truck_chassis"))
+    bay.vehicle.loadout.assign("powerplant", component("big_powerplant"))
+    bay.vehicle.loadout.assign("suspension", component("cheap_suspension"))
+    bay.vehicle.loadout.assign("tires", component("cheap_tires"))
+    cheap_tires = bay.vehicle.loadout.get_slot("tires")[0]
+    bay.inventory.add_asset(component("slicks"))
+    bay.inventory.add_asset(component("all_terrain"))
+
+    slicks_offer = build_inventory_install_offer(
+        bay,
+        component_key="slicks",
+        slot_name="tires",
+        price=0,
+    )
+    all_terrain_offer = build_inventory_install_offer(
+        bay,
+        component_key="all_terrain",
+        slot_name="tires",
+        price=0,
+    )
+
+    all_terrain_offer.accept()
+    all_terrain = bay.vehicle.loadout.get_slot("tires")[0]
+    slicks_offer.accept()
+
+    assert bay.vehicle.loadout.get_slot("tires")[0].token_from == "slicks"
+    assert bay.inventory.get_asset("all_terrain") is all_terrain
+    assert bay.inventory.get_asset("cheap_tires") is cheap_tires
+    assert not bay.inventory.has_asset("slicks")
+
+
 def test_vehicle_bay_failed_inventory_install_keeps_cash_inventory_and_loadout() -> None:
     bay = VehicleBay(cash=1000)
     install_baseline(bay)
@@ -213,6 +246,33 @@ def test_vehicle_bay_catalog_purchase_rejects_unavailable_stock_before_creation(
     assert created == []
     assert bay.cash == 1000
     assert not bay.inventory.has_asset("slicks")
+
+
+def test_vehicle_bay_catalog_purchase_rejects_duplicate_key_before_creation() -> None:
+    bay = VehicleBay(cash=1000)
+    bay.inventory.add_asset(component("slicks"))
+    stock = {"slicks": 1}
+    created = []
+
+    def make_slicks():
+        created.append(component("slicks"))
+        return created[-1]
+
+    offer = build_catalog_purchase_offer(
+        bay,
+        label="slicks",
+        price=350,
+        supplier=make_slicks,
+        stock=stock,
+    )
+
+    check = offer.can_accept()
+
+    assert not check.accepted
+    assert check.reason == "create catalog asset: receiver already holds asset key"
+    assert created == []
+    assert bay.cash == 1000
+    assert stock == {"slicks": 1}
 
 
 def test_vehicle_bay_catalog_purchase_rolls_back_stock_and_inventory() -> None:
@@ -333,11 +393,16 @@ def test_catalog_install_commitment_rolls_back_assignment_validation_failure() -
     bay = VehicleBay(vehicle=vehicle, cash=1000)
     install_baseline(bay)
     starting_tires = list(bay.vehicle.loadout.get_slot("tires"))
+    created = []
+
+    def make_truck_chassis():
+        created.append(component("truck_chassis"))
+        return created[-1]
 
     commitment = CatalogInstallCommitment(
         bay.vehicle.loadout,
         "tires",
-        supplier=lambda: component("truck_chassis"),
+        supplier=make_truck_chassis,
         preview=component("truck_chassis"),
         label="create invalid tires",
     )
@@ -347,3 +412,32 @@ def test_catalog_install_commitment_rolls_back_assignment_validation_failure() -
 
     assert bay.vehicle.loadout.get_slot("tires") == starting_tires
     assert len(graph.members) == 5
+    assert created == []
+
+
+def test_catalog_install_commitment_rejects_supplier_preview_mismatch_without_graph_leak() -> None:
+    graph = Graph()
+    vehicle = graph.add_node(label="demo-car", kind=Vehicle)
+    bay = VehicleBay(vehicle=vehicle, cash=1000)
+    install_baseline(bay)
+    starting_tires = list(bay.vehicle.loadout.get_slot("tires"))
+    created = []
+
+    def make_truck_chassis():
+        created.append(component("truck_chassis"))
+        return created[-1]
+
+    commitment = CatalogInstallCommitment(
+        bay.vehicle.loadout,
+        "tires",
+        supplier=make_truck_chassis,
+        preview=component("slicks"),
+        label="create mismatched tires",
+    )
+
+    assert commitment.can_commit().accepted
+    with pytest.raises(ValueError, match="catalog supplier did not match preview"):
+        commitment.commit()
+
+    assert bay.vehicle.loadout.get_slot("tires") == starting_tires
+    assert graph.get(created[0].uid) is None

--- a/engine/tests/mechanics/test_vehicle_bay_example.py
+++ b/engine/tests/mechanics/test_vehicle_bay_example.py
@@ -109,6 +109,7 @@ def test_vehicle_bay_service_offer_rolls_back_after_late_failure() -> None:
 def test_vehicle_bay_installs_inventory_component() -> None:
     bay = VehicleBay(cash=1000)
     install_baseline(bay)
+    old_tires = bay.vehicle.loadout.get_slot("tires")[0]
     bay.inventory.add_asset(component("slicks"))
 
     offer = build_inventory_install_offer(
@@ -122,10 +123,12 @@ def test_vehicle_bay_installs_inventory_component() -> None:
     assert bay.cash == 650
     assert bay.time_minutes == INSTALL_TIME_MINUTES
     assert not bay.inventory.has_asset("slicks")
+    assert bay.inventory.get_asset("cheap_tires") is old_tires
     assert bay.vehicle.loadout.get_slot("tires")[0].token_from == "slicks"
     assert {detail["kind"] for detail in receipt.details} >= {
         "asset_move",
         "component_assignment",
+        "inventory_return",
         "value_delta",
     }
 
@@ -154,6 +157,7 @@ def test_vehicle_bay_failed_inventory_install_keeps_cash_inventory_and_loadout()
 def test_vehicle_bay_catalog_purchase_creates_graph_component_on_accept() -> None:
     graph = Graph()
     bay = VehicleBay(cash=1000)
+    stock = {"slicks": 1}
     created = []
 
     def make_slicks():
@@ -167,7 +171,7 @@ def test_vehicle_bay_catalog_purchase_creates_graph_component_on_accept() -> Non
         price=350,
         supplier=make_slicks,
         registry=graph,
-        stock={"slicks": 1},
+        stock=stock,
     )
 
     assert offer.can_accept().accepted
@@ -176,10 +180,12 @@ def test_vehicle_bay_catalog_purchase_creates_graph_component_on_accept() -> Non
 
     slicks = created[0]
     assert bay.cash == 650
+    assert stock == {"slicks": 0}
     assert bay.inventory.get_asset("slicks") is slicks
     assert graph.get(slicks.uid) is slicks
     assert {detail["kind"] for detail in receipt.details} == {
         "catalog_asset",
+        "mapping_delta",
         "value_delta",
     }
 
@@ -203,10 +209,46 @@ def test_vehicle_bay_catalog_purchase_rejects_unavailable_stock_before_creation(
     check = offer.can_accept()
 
     assert not check.accepted
-    assert check.reason == "create catalog asset: catalog item unavailable"
+    assert check.reason == "decrement catalog stock: value below minimum: -1 < 0"
     assert created == []
     assert bay.cash == 1000
     assert not bay.inventory.has_asset("slicks")
+
+
+def test_vehicle_bay_catalog_purchase_rolls_back_stock_and_inventory() -> None:
+    graph = Graph()
+    bay = VehicleBay(cash=1000)
+    stock = {"slicks": 1}
+    created = []
+
+    def make_slicks():
+        item = component("slicks")
+        created.append(item)
+        return item
+
+    def fail_after_purchase() -> None:
+        raise RuntimeError("late purchase failure")
+
+    offer = build_catalog_purchase_offer(
+        bay,
+        label="slicks",
+        price=350,
+        supplier=make_slicks,
+        registry=graph,
+        stock=stock,
+        extra_commitments=[
+            CallbackCommitment("fail after purchase", apply=fail_after_purchase),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="late purchase failure"):
+        offer.accept()
+
+    slicks = created[0]
+    assert bay.cash == 1000
+    assert stock == {"slicks": 1}
+    assert not bay.inventory.has_asset("slicks")
+    assert graph.get(slicks.uid) is None
 
 
 def test_vehicle_bay_catalog_install_creates_installs_and_round_trips_component() -> None:
@@ -214,6 +256,7 @@ def test_vehicle_bay_catalog_install_creates_installs_and_round_trips_component(
     vehicle = graph.add_node(label="demo-car", kind=Vehicle)
     bay = VehicleBay(vehicle=vehicle, cash=1000)
     install_baseline(bay)
+    old_tires = bay.vehicle.loadout.get_slot("tires")[0]
     created = []
 
     def make_slicks():
@@ -241,6 +284,7 @@ def test_vehicle_bay_catalog_install_creates_installs_and_round_trips_component(
     assert bay.cash == 650
     assert bay.time_minutes == INSTALL_TIME_MINUTES
     assert graph.get(slicks.uid) is slicks
+    assert bay.inventory.get_asset("cheap_tires") is old_tires
     assert bay.vehicle.loadout.get_slot("tires") == [slicks]
     assert restored_vehicle.loadout.get_slot("tires") == [restored_slicks]
 
@@ -279,6 +323,7 @@ def test_vehicle_bay_catalog_install_rolls_back_after_late_failure() -> None:
     assert bay.cash == 1000
     assert bay.time_minutes == 0
     assert bay.vehicle.loadout.get_slot("tires") == starting_tires
+    assert not bay.inventory.has_asset("cheap_tires")
     assert graph.get(slicks.uid) is None
 
 


### PR DESCRIPTION
## Summary

- add a neutral `assembly/examples/vehicle_bay.py` fixture inspired by the CarWars garage/service pattern
- model vehicle bay state, inventory holders, scalar service offers, inventory install offers, catalog purchase offers, and catalog buy+install writeback
- add rollback and graph round-trip tests covering service costs, insufficient cash, unavailable stock, invalid installs, staged inventory installs, and catalog-created installed components
- update the transaction design note now that the neutral shop/garage slice has landed

## Notes

- `VehicleBay` and `VehiclePartInventory` are explicit ephemeral example state (`guard_unstructure = True`); durable vehicle/component persistence remains graph-owned and is tested through `Graph.unstructure()` / `Graph.structure()`.
- `CatalogInstallCommitment` stays in the example layer for now. It proves the “catalog promise creates and installs the same component during accept” shape without promoting a new generic transaction leg before a second consumer asks for it.

## Verification

- `/Users/derek/.local/bin/coderabbit review --agent --base-commit 1fc1a8e5099a7dec18913f6548b1789b4dd853ef -c AGENTS.md` — 0 issues after follow-up fixes
- `poetry run pytest engine/tests/mechanics/test_vehicle_bay_example.py engine/tests/mechanics/test_vehicle_example.py engine/tests/mechanics/test_transaction_offer.py` — 47 passed
- `poetry run pytest engine/tests/mechanics` — 826 passed, 5 skipped, 4 xfailed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new vehicle bay flow covering servicing, inventory installs, catalog purchases, and catalog-based installs of vehicle components.
  * Users can now manage cash/time costs and apply value changes as part of transaction offers.
  * Receipts now include richer detail for these component moves and catalog-backed actions.
* **Bug Fixes**
  * Improved transaction acceptance safety: rejected and late-failure offers reliably prevent or roll back partial mutations, stock updates, and replaced-part returns.
* **Tests**
  * Expanded coverage for success, rejection, and rollback behavior across all vehicle bay offer types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->