### PR TITLE
Add ordered list asset holder adapter

### DIFF
--- a/engine/src/tangl/mechanics/TRANSACTION_OFFER_DESIGN.md
+++ b/engine/src/tangl/mechanics/TRANSACTION_OFFER_DESIGN.md
@@ -271,6 +271,9 @@ Core commitments cover common legs:
 - `StatDeltaCommitment` for progression/stat-like values that expose `fv`;
 - `AssetMoveCommitment` for moving one existing discrete graph asset/token
   between holder-like objects;
+- `ListAssetHolder` as a thin adapter over an ordered `list[Entity]` when a
+  world wants to keep list order for UI/projection but still expose the
+  `AssetHolder` protocol to transaction commitments;
 - `CatalogAssetCommitment` for creating one catalog-backed graph asset/token
   during offer acceptance, optionally registering it with a graph/registry;
 - `RegistryAddCommitment` for explicit graph/token materialization;
@@ -317,7 +320,10 @@ That should bind to transactions as:
   bound explicitly, e.g. `min_value=0` for cash;
 - `CountableTransferCommitment(player, garage, "cash", price)` only when both
   sides are real holders with meaningful bilateral wallet policy;
-- `CallbackCommitment("remove from inventory", ...)` for the selected part;
+- `AssetMoveCommitment(ListAssetHolder(inventory), installed_holder, part)` for
+  the selected part when the inventory is an ordered list. The adapter is not an
+  ownership model; it is the transaction-facing API over the domain collection
+  and restores holder-local labels and list position during rollback;
 - `ComponentAssignmentCommitment(vehicle.loadout, slot, part, allow_replace=True)`;
 - `CallbackCommitment("return replaced part", ...)` when a domain wants the
   replaced component in inventory rather than simply unassigned.
@@ -361,25 +367,28 @@ Landed proof:
    healing.
 5. `AssetMoveCommitment` proves existing discrete graph-token movement between
    holder-like objects with policy checks and rollback.
-6. `CatalogAssetCommitment` proves catalog-backed token creation during accepted
+6. `ListAssetHolder` proves ordered-list inventories can participate in the
+   same discrete asset transaction protocol without becoming a new ownership
+   model.
+7. `CatalogAssetCommitment` proves catalog-backed token creation during accepted
    writeback, with optional graph registration and rollback.
-7. `RegistryAddCommitment` proves explicit shape change during accepted
+8. `RegistryAddCommitment` proves explicit shape change during accepted
    writeback: a prepared graph item can enter the registry only when the offer
    commits.
-8. `ComponentAssignmentCommitment` proves owner-bound component manager
+9. `ComponentAssignmentCommitment` proves owner-bound component manager
    assignment, replacement, post-assignment validation, and rollback.
-9. `CallbackCommitment` marks the domain-local plug-in spot for inventory,
+10. `CallbackCommitment` marks the domain-local plug-in spot for inventory,
    service, and presentation-specific state that still needs transaction
    preflight/rollback.
-10. The neutral vehicle garage test buys and installs a component, then proves
+11. The neutral vehicle garage test buys and installs a component, then proves
    the resulting graph/loadout state survives `Graph.unstructure()` /
    `Graph.structure()`.
-11. The neutral vehicle bay example (`assembly/examples/vehicle_bay.py`) lifts
+12. The neutral vehicle bay example (`assembly/examples/vehicle_bay.py`) lifts
     the CarWars-shaped service/shop pattern into generic helpers: scalar service
     offers, staged inventory install offers, catalog purchase offers, and a
     catalog buy+install proof that creates and assigns the same component during
     accepted writeback.
-12. Rejection before mutation and mid-commit rollback are both covered.
+13. Rejection before mutation and mid-commit rollback are both covered.
 
 Still recommended for the next consumer-facing slices:
 

--- a/engine/src/tangl/mechanics/transaction.py
+++ b/engine/src/tangl/mechanics/transaction.py
@@ -275,6 +275,8 @@ class ListAssetHolder:
         return None
 
     def get_asset(self, label: str) -> Entity | None:
+        if not label:
+            return None
         for item in self.items:
             if label == self._local_label(item):
                 return item

--- a/engine/src/tangl/mechanics/transaction.py
+++ b/engine/src/tangl/mechanics/transaction.py
@@ -245,6 +245,100 @@ class AssetHolder(Protocol):
         ...
 
 
+@dataclass
+class ListAssetHolder:
+    """Adapter that exposes an ordered entity list as a discrete asset holder.
+
+    The adapter does not own persistence or graph membership. It is a
+    transaction-facing view over a domain list, useful when a mechanic wants to
+    preserve list order for UI projection while using `AssetMoveCommitment` or
+    `CatalogAssetCommitment` for preflight, commit, and rollback.
+    """
+
+    items: list[Entity]
+    _labels_by_uid: dict[object, str] = field(default_factory=dict)
+    _removed_indices_by_uid: dict[object, int] = field(default_factory=dict)
+
+    def _item_key(self, item: Entity, label: str | None = None) -> str:
+        key = _asset_holder_key(item, label)
+        if key is None:
+            raise ValueError("List asset holder item requires a label")
+        return key
+
+    def _local_label(self, item: Entity) -> str | None:
+        return self._labels_by_uid.get(item.uid)
+
+    def _index_of(self, asset: Entity) -> int | None:
+        for index, item in enumerate(self.items):
+            if item is asset:
+                return index
+        return None
+
+    def get_asset(self, label: str) -> Entity | None:
+        for item in self.items:
+            if label == self._local_label(item):
+                return item
+            if label == item.get_label():
+                return item
+            if isinstance(item, Token) and label == item.token_from:
+                return item
+        return None
+
+    def get_asset_key(self, asset: Entity | str) -> str | None:
+        resolved = self.get_asset(asset) if isinstance(asset, str) else asset
+        if resolved is None or not self.has_asset(resolved):
+            return None
+        local = self._local_label(resolved)
+        if local is not None:
+            return local
+        return _asset_holder_key(resolved)
+
+    def can_give_asset(
+        self,
+        asset: Entity,
+        receiver: object | None = None,
+    ) -> bool:
+        _ = receiver
+        return self.has_asset(asset)
+
+    def can_receive_asset(
+        self,
+        asset: Entity,
+        giver: object | None = None,
+    ) -> bool:
+        _ = asset, giver
+        return True
+
+    def add_asset(self, asset: Entity, *, label: str | None = None) -> None:
+        key = self._item_key(asset, label)
+        existing = self.get_asset(key)
+        if existing is not None and existing is not asset:
+            raise ValueError(f"List asset holder already contains key: {key}")
+        if self._index_of(asset) is None:
+            index = self._removed_indices_by_uid.pop(asset.uid, len(self.items))
+            self.items.insert(min(index, len(self.items)), asset)
+        if label is not None:
+            self._labels_by_uid[asset.uid] = label
+
+    def remove_asset(self, asset: Entity | str) -> Entity:
+        resolved = self.get_asset(asset) if isinstance(asset, str) else asset
+        if resolved is None:
+            raise KeyError(asset)
+        index = self._index_of(resolved)
+        if index is None:
+            key = resolved.get_label() or repr(resolved)
+            raise KeyError(f"Unknown list asset holder item: {key}")
+        self._removed_indices_by_uid[resolved.uid] = index
+        self.items.pop(index)
+        self._labels_by_uid.pop(resolved.uid, None)
+        return resolved
+
+    def has_asset(self, asset: Entity | str) -> bool:
+        if isinstance(asset, str):
+            return self.get_asset(asset) is not None
+        return any(item is asset for item in self.items)
+
+
 class StatLike(Protocol):
     """Minimal stat surface for transaction-backed stat deltas."""
 
@@ -959,6 +1053,7 @@ __all__ = [
     "ComponentAssignmentCommitment",
     "CountableHolder",
     "CountableTransferCommitment",
+    "ListAssetHolder",
     "MappingDeltaCommitment",
     "RegistryAddCommitment",
     "StatDeltaCommitment",

--- a/engine/src/tangl/mechanics/transaction.py
+++ b/engine/src/tangl/mechanics/transaction.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable, Mapping, MutableMapping
 from dataclasses import dataclass, field
 from typing import ClassVar, Protocol, TypeVar
+from uuid import UUID
 
 from pydantic import Field
 
@@ -256,8 +257,8 @@ class ListAssetHolder:
     """
 
     items: list[Entity]
-    _labels_by_uid: dict[object, str] = field(default_factory=dict)
-    _removed_indices_by_uid: dict[object, int] = field(default_factory=dict)
+    _labels_by_uid: ClassVar[dict[UUID, str]] = {}
+    _removed_indices_by_uid: dict[UUID, int] = field(default_factory=dict)
 
     def _item_key(self, item: Entity, label: str | None = None) -> str:
         key = _asset_holder_key(item, label)

--- a/engine/tests/mechanics/test_transaction_offer.py
+++ b/engine/tests/mechanics/test_transaction_offer.py
@@ -485,6 +485,21 @@ def test_list_asset_holder_rejects_empty_runtime_lookup_key() -> None:
     assert holder.has_asset(asset)
 
 
+def test_list_asset_holder_shares_local_labels_across_wrappers() -> None:
+    ShopItemType(label="medkit")
+    ShopItemType(label="permit")
+    medkit = Token[ShopItemType](token_from="medkit", label="medkit")
+    permit = Token[ShopItemType](token_from="permit", label="permit")
+    items = [medkit]
+
+    ListAssetHolder(items).add_asset(medkit, label="promo")
+    second_wrapper = ListAssetHolder(items)
+
+    assert second_wrapper.get_asset("promo") is medkit
+    with pytest.raises(ValueError, match="already contains key: promo"):
+        second_wrapper.add_asset(permit, label="promo")
+
+
 def test_list_asset_holder_accepts_catalog_asset_without_losing_order() -> None:
     graph = Graph()
     ShopItemType(label="medkit")

--- a/engine/tests/mechanics/test_transaction_offer.py
+++ b/engine/tests/mechanics/test_transaction_offer.py
@@ -22,6 +22,7 @@ from tangl.mechanics.transaction import (
     CatalogAssetCommitment,
     ComponentAssignmentCommitment,
     CountableTransferCommitment,
+    ListAssetHolder,
     MappingDeltaCommitment,
     RegistryAddCommitment,
     StatDeltaCommitment,
@@ -440,6 +441,137 @@ def test_asset_move_commitment_rolls_back_after_late_failure() -> None:
     assert giver.has_asset("medkit")
     assert giver.get_asset_key("medkit") == "sale-bin"
     assert not receiver.has_asset("medkit")
+
+
+def test_list_asset_holder_moves_tokens_and_restores_order_on_rollback() -> None:
+    ShopItemType(label="medkit")
+    ShopItemType(label="permit")
+    medkit = Token[ShopItemType](token_from="medkit", label="medkit")
+    permit = Token[ShopItemType](token_from="permit", label="permit")
+    source_items = [medkit, permit]
+    receiver_items: list[Token] = []
+    source = ListAssetHolder(source_items)
+    receiver = ListAssetHolder(receiver_items)
+    source.add_asset(medkit, label="front-bin")
+
+    offer = TransactionOffer(
+        label="move then fail",
+        commitments=[
+            AssetMoveCommitment(
+                source,
+                receiver,
+                "front-bin",
+                receiver_label="new-arrival",
+            ),
+            FailingCommitment(),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="late failure"):
+        offer.accept()
+
+    assert source_items == [medkit, permit]
+    assert receiver_items == []
+    assert source.get_asset_key(medkit) == "front-bin"
+
+
+def test_list_asset_holder_accepts_catalog_asset_without_losing_order() -> None:
+    graph = Graph()
+    ShopItemType(label="medkit")
+    ShopItemType(label="permit")
+    permit = Token[ShopItemType](token_from="permit", label="permit")
+    items: list[Token] = [permit]
+    holder = ListAssetHolder(items)
+    created: list[Token] = []
+
+    def make_medkit() -> Token:
+        token = Token[ShopItemType](token_from="medkit", label="medkit")
+        created.append(token)
+        return token
+
+    offer = TransactionOffer(
+        label="buy catalog medkit",
+        commitments=[
+            CatalogAssetCommitment(
+                holder,
+                make_medkit,
+                registry=graph,
+                preview=Token[ShopItemType](token_from="medkit", label="medkit"),
+            ),
+        ],
+    )
+
+    receipt = offer.accept()
+
+    assert items == [permit, created[0]]
+    assert holder.has_asset("medkit")
+    assert graph.get(created[0].uid) is created[0]
+    assert receipt.details[0]["kind"] == "catalog_asset"
+
+
+def test_list_asset_holder_rejects_duplicate_catalog_key_before_creation() -> None:
+    ShopItemType(label="medkit")
+    medkit = Token[ShopItemType](token_from="medkit", label="medkit")
+    holder = ListAssetHolder([medkit])
+    created: list[Token] = []
+
+    def make_medkit() -> Token:
+        token = Token[ShopItemType](token_from="medkit", label="medkit")
+        created.append(token)
+        return token
+
+    offer = TransactionOffer(
+        label="buy duplicate medkit",
+        commitments=[
+            CatalogAssetCommitment(
+                holder,
+                make_medkit,
+                preview=Token[ShopItemType](token_from="medkit", label="medkit"),
+            ),
+        ],
+    )
+
+    check = offer.can_accept()
+
+    assert not check.accepted
+    assert check.reason == "create catalog asset: receiver already holds asset key"
+    assert created == []
+    assert holder.has_asset(medkit)
+
+
+def test_list_asset_holder_rolls_back_catalog_asset_and_registry() -> None:
+    graph = Graph()
+    ShopItemType(label="medkit")
+    ShopItemType(label="permit")
+    permit = Token[ShopItemType](token_from="permit", label="permit")
+    items: list[Token] = [permit]
+    holder = ListAssetHolder(items)
+    created: list[Token] = []
+
+    def make_medkit() -> Token:
+        token = Token[ShopItemType](token_from="medkit", label="medkit")
+        created.append(token)
+        return token
+
+    offer = TransactionOffer(
+        label="buy catalog medkit then fail",
+        commitments=[
+            CatalogAssetCommitment(
+                holder,
+                make_medkit,
+                registry=graph,
+                preview=Token[ShopItemType](token_from="medkit", label="medkit"),
+            ),
+            FailingCommitment(),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="late failure"):
+        offer.accept()
+
+    assert items == [permit]
+    assert not holder.has_asset("medkit")
+    assert graph.get(created[0].uid) is None
 
 
 def test_catalog_asset_commitment_creates_registers_and_holds_token_on_accept() -> None:

--- a/engine/tests/mechanics/test_transaction_offer.py
+++ b/engine/tests/mechanics/test_transaction_offer.py
@@ -475,6 +475,16 @@ def test_list_asset_holder_moves_tokens_and_restores_order_on_rollback() -> None
     assert source.get_asset_key(medkit) == "front-bin"
 
 
+def test_list_asset_holder_rejects_empty_runtime_lookup_key() -> None:
+    asset = Node()
+    holder = ListAssetHolder([asset])
+
+    assert holder.get_asset("") is None
+    assert holder.get_asset(None) is None  # type: ignore[arg-type]
+    assert holder.get_asset(asset.get_label()) is asset
+    assert holder.has_asset(asset)
+
+
 def test_list_asset_holder_accepts_catalog_asset_without_losing_order() -> None:
     graph = Graph()
     ShopItemType(label="medkit")


### PR DESCRIPTION
## Summary
- add ListAssetHolder adapter for ordered Entity lists
- cover AssetMoveCommitment and CatalogAssetCommitment against list inventories
- document the CarWars-style binding as an adapter, not an ownership model

## Tests
- poetry run pytest engine/tests/mechanics/test_transaction_offer.py engine/tests/mechanics/test_vehicle_bay_example.py
- poetry run pytest engine/tests/mechanics
- /Users/derek/.local/bin/coderabbit review --agent --base-commit 7c84f95482c49f960ddf6b22c779b8dcfdc3b3da -c AGENTS.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ordered list-based asset holders, letting inventory items keep their UI order while still working with transaction commitments.
  * Improved asset moves and catalog-based item creation to work reliably with list-backed inventories.

* **Bug Fixes**
  * Preserved item order and labels when transactions roll back after a failed step.
  * Prevented duplicate item keys and rejected invalid lookup values more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->