### PR TITLE
Add wardrobe loadout transactions

### DIFF
--- a/engine/src/tangl/mechanics/assembly/base.py
+++ b/engine/src/tangl/mechanics/assembly/base.py
@@ -320,6 +320,7 @@ class ComponentManager(SlottedContainer[CT]):
 
     assignment_ids: dict[str, list[UUID]] = Field(default_factory=dict)
     _component_cache: dict[UUID, CT] = PrivateAttr(default_factory=dict)
+    _holder_labels: dict[str, dict[UUID, str]] = PrivateAttr(default_factory=dict)
 
     def bind_owner(self, owner: Any) -> "ComponentManager[CT]":
         self.owner = owner

--- a/engine/src/tangl/mechanics/assembly/base.py
+++ b/engine/src/tangl/mechanics/assembly/base.py
@@ -361,24 +361,33 @@ class ComponentManager(SlottedContainer[CT]):
     def _slot_count(self, slot_name: str) -> int:
         return len(self.assignment_ids.get(slot_name, []))
 
-    def _validate_component_registry(self, component: CT) -> None:
+    def can_accept_component_registry(self, component: CT) -> tuple[bool, str]:
         registry = self._owner_registry()
         if registry is None:
-            return
+            return True, ""
         component_registry = getattr(component, "registry", None)
         registered_component = registry.get(component.uid)
         if component_registry is None:
             if registered_component is not None and registered_component is not component:
-                raise ValueError("Assigned component UID is already registered to another item")
-            registry.add(component)
-            return
+                return False, "Assigned component UID is already registered to another item"
+            return True, ""
         if component_registry is not registry:
-            raise ValueError("Assigned component must belong to the owner's registry")
-        if registered_component is None:
+            return False, "Assigned component must belong to the owner's registry"
+        if registered_component is not None and registered_component is not component:
+            return False, "Assigned component UID is already registered to another item"
+        return True, ""
+
+    def _validate_component_registry(self, component: CT) -> None:
+        can_accept, reason = self.can_accept_component_registry(component)
+        if not can_accept:
+            raise ValueError(reason)
+
+        registry = self._owner_registry()
+        component_registry = getattr(component, "registry", None)
+        if registry is not None and (
+            component_registry is None or registry.get(component.uid) is None
+        ):
             registry.add(component)
-            return
-        if registered_component is not component:
-            raise ValueError("Assigned component UID is already registered to another item")
 
     def _add_to_slot(self, slot_name: str, component: CT) -> None:
         self._validate_component_registry(component)
@@ -394,6 +403,7 @@ class ComponentManager(SlottedContainer[CT]):
             self.assignment_ids.pop(slot_name, None)
         if not any(component.uid in ids for ids in self.assignment_ids.values()):
             self._component_cache.pop(component.uid, None)
+        self._holder_labels.get(slot_name, {}).pop(component.uid, None)
         return True
 
     def unstructure(self) -> UnstructuredData:

--- a/engine/src/tangl/mechanics/presence/PRESENCE_ASSEMBLY_DESIGN.md
+++ b/engine/src/tangl/mechanics/presence/PRESENCE_ASSEMBLY_DESIGN.md
@@ -24,6 +24,13 @@ constructor-form persistence with `json_schema_extra={"include": True,
 "unstructurable": True}`, so mutated outfit state survives graph round-trips without
 making the outfit manager a graph item.
 
+`WardrobeManager` applies the same identity rule to inactive clothing storage. It is
+embedded on `HasWardrobe`, persists by constructor-form recursion, stores wearable
+UUIDs in a single broad storage slot, and can expose that slot through the transaction
+layer's component-slot holder adapter. A dressing offer moves one stored wearable out
+of the wardrobe and assigns it into the active outfit; the outfit manager still owns
+body-region/layer legality and validation.
+
 This resolves the first serialization identity bug for outfits. The body-attachment
 generalization below remains the design target for ornaments, injuries, cybernetics,
 robot parts, vehicles, and credential packets.
@@ -32,6 +39,8 @@ robot parts, vehicles, and credential packets.
 
 - `OutfitManager` is a real `ComponentManager[Wearable]` using the shared
   `SlottedContainer` slot, validation, budget, and facet APIs.
+- `WardrobeManager` is a storage-side `ComponentManager[Wearable]` for graph-member
+  wearables not currently assigned to the active outfit.
 - `WearableType` is an `AssetType`; `Wearable` is a token wrapper over that type.
 - `Ornamentation` is still a plain `Node` with `collection: list[Ornament]`.
 - `Ornament` is an `Entity` with `body_part: BodyPart`, `ornament_type: OrnamentType`, `text: str`.

--- a/engine/src/tangl/mechanics/presence/outfit.py
+++ b/engine/src/tangl/mechanics/presence/outfit.py
@@ -218,6 +218,8 @@ def build_wardrobe_dress_offer(
     if wearable is None:
         raise ValueError(f"Wardrobe item not found: {wearable_key}")
 
+    # Move first, then assign, so ComponentAssignmentCommitment can run
+    # outfit-wide validation and rollback the wardrobe move if it fails.
     worn = ListAssetHolder([])
     commitments: list[TransactionCommitment] = [
         AssetMoveCommitment(
@@ -242,9 +244,9 @@ def build_wardrobe_dress_offer(
 
 
 __all__ = [
+    "WARDROBE_SLOT",
     "HasWardrobe",
     "OutfitManager",
-    "WARDROBE_SLOT",
     "WardrobeManager",
     "build_wardrobe_dress_offer",
 ]

--- a/engine/src/tangl/mechanics/presence/outfit.py
+++ b/engine/src/tangl/mechanics/presence/outfit.py
@@ -9,11 +9,27 @@ facets such as `look`. It belongs in the `presence` family rather than behind an
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
+from pydantic import Field, model_validator
+
+from tangl.core import Entity, contribute_ns
 from tangl.lang.helpers import oxford_join
 from tangl.lang.body_parts import BodyPart, BodyRegion
 from tangl.mechanics.assembly import ComponentManager, Slot
 from tangl.mechanics.presence.wearable import Wearable
 from tangl.mechanics.presence.wearable.enums import WearableLayer, WearableState
+from tangl.mechanics.transaction import (
+    AssetMoveCommitment,
+    ComponentAssignmentCommitment,
+    ComponentSlotAssetHolder,
+    ListAssetHolder,
+    TransactionCommitment,
+    TransactionOffer,
+)
+
+
+WARDROBE_SLOT = "stored"
 
 
 class OutfitManager(ComponentManager[Wearable]):
@@ -120,4 +136,115 @@ class OutfitManager(ComponentManager[Wearable]):
         return errors
 
 
-__all__ = ["OutfitManager"]
+class WardrobeManager(ComponentManager[Wearable]):
+    """Owner-bound storage for wearable graph members not currently worn."""
+
+    slots = {
+        WARDROBE_SLOT: Slot.for_type(
+            WARDROBE_SLOT,
+            Wearable,
+            max_count=1000,
+        )
+    }
+
+    def holder(self) -> ComponentSlotAssetHolder:
+        """Return the transaction holder view over stored wearables."""
+        return ComponentSlotAssetHolder(self, WARDROBE_SLOT)
+
+    def components(self) -> list[Wearable]:
+        """Return a stable list of stored wearables."""
+        result = list(self.get_slot(WARDROBE_SLOT))
+        result.sort(
+            key=lambda wearable: (
+                wearable.label or "",
+                wearable.noun or "",
+            )
+        )
+        return result
+
+    def describe_items(self) -> list[str]:
+        """Return concise labels for stored wearables."""
+        return [
+            desc
+            for component in self.components()
+            if (desc := component.render_desc())
+        ]
+
+    def describe(self) -> str:
+        """Return a compact phrase describing the current wardrobe."""
+        return oxford_join(self.describe_items())
+
+
+class HasWardrobe(Entity):
+    """Direct facet exposing inactive wearable storage."""
+
+    wardrobe: WardrobeManager = Field(
+        default_factory=WardrobeManager,
+        json_schema_extra={"include": True, "unstructurable": True},
+    )
+
+    @model_validator(mode="after")
+    def _bind_wardrobe_owner(self) -> "HasWardrobe":
+        self.wardrobe.bind_owner(self)
+        return self
+
+    def describe_wardrobe(self) -> str:
+        """Return a compact phrase describing stored wearables."""
+        return self.wardrobe.describe()
+
+    @contribute_ns
+    def provide_wardrobe_symbols(self) -> dict[str, object]:
+        """Publish direct wardrobe symbols into the entity-local namespace."""
+        return {
+            "wardrobe": self.wardrobe,
+            "wardrobe_description": self.describe_wardrobe(),
+            "wardrobe_tokens": self.wardrobe.describe_items(),
+        }
+
+
+def build_wardrobe_dress_offer(
+    *,
+    wardrobe: WardrobeManager,
+    outfit: OutfitManager,
+    wearable_key: str,
+    slot_name: str,
+    label: str | None = None,
+    extra_commitments: Iterable[TransactionCommitment] = (),
+) -> TransactionOffer:
+    """Build a transaction that moves one stored wearable onto an outfit slot."""
+
+    holder = wardrobe.holder()
+    wearable = holder.get_asset(wearable_key)
+    if wearable is None:
+        raise ValueError(f"Wardrobe item not found: {wearable_key}")
+
+    worn = ListAssetHolder([])
+    commitments: list[TransactionCommitment] = [
+        AssetMoveCommitment(
+            holder,
+            worn,
+            wearable,
+            label="remove selected wearable from wardrobe",
+        ),
+        ComponentAssignmentCommitment(
+            outfit,
+            slot_name,
+            wearable,
+            label="assign wearable to outfit",
+            validate_after=True,
+        ),
+    ]
+    commitments.extend(extra_commitments)
+    return TransactionOffer(
+        label=label or f"wear {wearable.get_label()}",
+        commitments=commitments,
+    )
+
+
+__all__ = [
+    "HasWardrobe",
+    "OutfitManager",
+    "WARDROBE_SLOT",
+    "WardrobeManager",
+    "build_wardrobe_dress_offer",
+]

--- a/engine/src/tangl/mechanics/transaction.py
+++ b/engine/src/tangl/mechanics/transaction.py
@@ -348,7 +348,6 @@ class ComponentSlotAssetHolder:
 
     manager: ComponentManager
     slot_name: str
-    _labels_by_uid: dict[UUID, str] = field(default_factory=dict)
     _removed_indices_by_uid: dict[UUID, int] = field(default_factory=dict)
 
     def _item_key(self, item: Entity, label: str | None = None) -> str:
@@ -358,10 +357,13 @@ class ComponentSlotAssetHolder:
         return key
 
     def _local_label(self, item: Entity) -> str | None:
-        return self._labels_by_uid.get(item.uid)
+        return self._slot_labels().get(item.uid)
 
     def _slot_ids(self) -> list[UUID]:
         return self.manager.assignment_ids.setdefault(self.slot_name, [])
+
+    def _slot_labels(self) -> dict[UUID, str]:
+        return self.manager._holder_labels.setdefault(self.slot_name, {})
 
     def _index_of(self, asset: Entity) -> int | None:
         for index, item in enumerate(self.manager.get_slot(self.slot_name)):
@@ -372,8 +374,9 @@ class ComponentSlotAssetHolder:
     def get_asset(self, label: str) -> Entity | None:
         if not label:
             return None
+        slot_labels = self._slot_labels()
         for item in self.manager.get_slot(self.slot_name):
-            if label == self._local_label(item):
+            if label == slot_labels.get(item.uid):
                 return item
             if label == item.get_label():
                 return item
@@ -423,7 +426,7 @@ class ComponentSlotAssetHolder:
                 slot_ids.remove(asset.uid)
                 slot_ids.insert(min(index, len(slot_ids)), asset.uid)
         if label is not None:
-            self._labels_by_uid[asset.uid] = label
+            self._slot_labels()[asset.uid] = label
 
     def remove_asset(self, asset: Entity | str) -> Entity:
         resolved = self.get_asset(asset) if isinstance(asset, str) else asset
@@ -435,7 +438,7 @@ class ComponentSlotAssetHolder:
             raise KeyError(f"Unknown component slot holder item: {key}")
         self._removed_indices_by_uid[resolved.uid] = index
         self.manager.unassign(self.slot_name, resolved)
-        self._labels_by_uid.pop(resolved.uid, None)
+        self._slot_labels().pop(resolved.uid, None)
         return resolved
 
     def has_asset(self, asset: Entity | str) -> bool:

--- a/engine/src/tangl/mechanics/transaction.py
+++ b/engine/src/tangl/mechanics/transaction.py
@@ -344,7 +344,11 @@ class ListAssetHolder:
 
 @dataclass
 class ComponentSlotAssetHolder:
-    """Expose one component-manager slot as a transaction asset holder."""
+    """Expose one component-manager slot as a transaction asset holder.
+
+    Holder labels are live transaction aliases, not constructor-form state.
+    Persist durable item identity through the manager's component UUIDs.
+    """
 
     manager: ComponentManager
     slot_name: str
@@ -409,6 +413,9 @@ class ComponentSlotAssetHolder:
         _ = giver
         if self.has_asset(asset):
             return True
+        can_accept_registry, _reason = self.manager.can_accept_component_registry(asset)
+        if not can_accept_registry:
+            return False
         can_assign, _reason = self.manager.can_assign(self.slot_name, asset)
         return can_assign
 
@@ -423,6 +430,8 @@ class ComponentSlotAssetHolder:
             index = self._removed_indices_by_uid.pop(asset.uid, None)
             if index is not None:
                 slot_ids = self._slot_ids()
+                if asset.uid not in slot_ids:
+                    raise ValueError("Component slot assignment did not record asset UID")
                 slot_ids.remove(asset.uid)
                 slot_ids.insert(min(index, len(slot_ids)), asset.uid)
         if label is not None:

--- a/engine/src/tangl/mechanics/transaction.py
+++ b/engine/src/tangl/mechanics/transaction.py
@@ -342,6 +342,111 @@ class ListAssetHolder:
         return any(item is asset for item in self.items)
 
 
+@dataclass
+class ComponentSlotAssetHolder:
+    """Expose one component-manager slot as a transaction asset holder."""
+
+    manager: ComponentManager
+    slot_name: str
+    _labels_by_uid: dict[UUID, str] = field(default_factory=dict)
+    _removed_indices_by_uid: dict[UUID, int] = field(default_factory=dict)
+
+    def _item_key(self, item: Entity, label: str | None = None) -> str:
+        key = _asset_holder_key(item, label)
+        if key is None:
+            raise ValueError("Component slot holder item requires a label")
+        return key
+
+    def _local_label(self, item: Entity) -> str | None:
+        return self._labels_by_uid.get(item.uid)
+
+    def _slot_ids(self) -> list[UUID]:
+        return self.manager.assignment_ids.setdefault(self.slot_name, [])
+
+    def _index_of(self, asset: Entity) -> int | None:
+        for index, item in enumerate(self.manager.get_slot(self.slot_name)):
+            if item is asset:
+                return index
+        return None
+
+    def get_asset(self, label: str) -> Entity | None:
+        if not label:
+            return None
+        for item in self.manager.get_slot(self.slot_name):
+            if label == self._local_label(item):
+                return item
+            if label == item.get_label():
+                return item
+            if isinstance(item, Token) and label == item.token_from:
+                return item
+        return None
+
+    def get_asset_key(self, asset: Entity | str) -> str | None:
+        resolved = self.get_asset(asset) if isinstance(asset, str) else asset
+        if resolved is None or not self.has_asset(resolved):
+            return None
+        local = self._local_label(resolved)
+        if local is not None:
+            return local
+        return _asset_holder_key(resolved)
+
+    def can_give_asset(
+        self,
+        asset: Entity,
+        receiver: object | None = None,
+    ) -> bool:
+        _ = receiver
+        return self.has_asset(asset)
+
+    def can_receive_asset(
+        self,
+        asset: Entity,
+        giver: object | None = None,
+    ) -> bool:
+        _ = giver
+        if self.has_asset(asset):
+            return True
+        can_assign, _reason = self.manager.can_assign(self.slot_name, asset)
+        return can_assign
+
+    def add_asset(self, asset: Entity, *, label: str | None = None) -> None:
+        key = self._item_key(asset, label)
+        existing = self.get_asset(key)
+        if existing is not None and existing is not asset:
+            raise ValueError(f"Component slot holder already contains key: {key}")
+
+        if self._index_of(asset) is None:
+            self.manager.assign(self.slot_name, asset)
+            index = self._removed_indices_by_uid.pop(asset.uid, None)
+            if index is not None:
+                slot_ids = self._slot_ids()
+                slot_ids.remove(asset.uid)
+                slot_ids.insert(min(index, len(slot_ids)), asset.uid)
+        if label is not None:
+            self._labels_by_uid[asset.uid] = label
+
+    def remove_asset(self, asset: Entity | str) -> Entity:
+        resolved = self.get_asset(asset) if isinstance(asset, str) else asset
+        if resolved is None:
+            raise KeyError(asset)
+        index = self._index_of(resolved)
+        if index is None:
+            key = resolved.get_label() or repr(resolved)
+            raise KeyError(f"Unknown component slot holder item: {key}")
+        self._removed_indices_by_uid[resolved.uid] = index
+        self.manager.unassign(self.slot_name, resolved)
+        self._labels_by_uid.pop(resolved.uid, None)
+        return resolved
+
+    def has_asset(self, asset: Entity | str) -> bool:
+        if isinstance(asset, str):
+            return self.get_asset(asset) is not None
+        return any(item is asset for item in self.manager.get_slot(self.slot_name))
+
+    def all_items(self) -> list[Entity]:
+        return list(self.manager.get_slot(self.slot_name))
+
+
 class StatLike(Protocol):
     """Minimal stat surface for transaction-backed stat deltas."""
 
@@ -1054,6 +1159,7 @@ __all__ = [
     "CallbackCommitment",
     "CatalogAssetCommitment",
     "ComponentAssignmentCommitment",
+    "ComponentSlotAssetHolder",
     "CountableHolder",
     "CountableTransferCommitment",
     "ListAssetHolder",

--- a/engine/tests/mechanics/presence/test_wardrobe.py
+++ b/engine/tests/mechanics/presence/test_wardrobe.py
@@ -1,0 +1,208 @@
+"""Tests for presence wardrobe loadouts.
+
+Organized by functionality:
+- storage: owner-bound inactive wearable storage
+- dressing: transaction-backed moves from wardrobe to active outfit
+- serialization: graph round-trips preserve wearable graph identity
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tangl.core import Graph, Selector
+from tangl.lang.body_parts import BodyRegion
+from tangl.mechanics.presence.outfit import (
+    HasWardrobe,
+    WARDROBE_SLOT,
+    build_wardrobe_dress_offer,
+)
+from tangl.mechanics.presence.look import HasOutfit
+from tangl.mechanics.presence.wearable import (
+    Wearable,
+    WearableLayer,
+    WearableState,
+    WearableType,
+)
+from tangl.story.concepts import Actor as StoryActor
+
+
+@pytest.fixture(autouse=True)
+def reset_wearable_types():
+    WearableType.clear_instances()
+    yield
+    WearableType.clear_instances()
+
+
+class WardrobeActor(StoryActor, HasOutfit, HasWardrobe):
+    """Story actor with both inactive wardrobe storage and an active outfit."""
+
+
+def wearable_type(
+    label: str,
+    noun: str,
+    *,
+    region: BodyRegion = BodyRegion.TOP,
+    layer: WearableLayer = WearableLayer.OUTER,
+    tags: set[str] | None = None,
+) -> WearableType:
+    return WearableType(
+        label=label,
+        noun=noun,
+        covers={region},
+        layer=layer,
+        tags=tags or set(),
+    )
+
+
+class TestWardrobeStorage:
+    """Tests for owner-bound wardrobe storage."""
+
+    def test_wardrobe_publishes_namespace_symbols(self) -> None:
+        shirt_type = wearable_type("wardrobe_symbol_shirt", "shirt")
+        actor = WardrobeActor(label="guide")
+        shirt = Wearable(
+            label="guide-shirt",
+            token_from=shirt_type.label,
+        )
+
+        actor.wardrobe.assign(WARDROBE_SLOT, shirt)
+        namespace = actor.get_ns()
+
+        assert actor.wardrobe.owner is actor
+        assert namespace["wardrobe"] is actor.wardrobe
+        assert namespace["wardrobe_description"] == "shirt"
+        assert namespace["wardrobe_tokens"] == ["shirt"]
+
+    def test_graph_roundtrip_preserves_wardrobe_and_outfit_assignments_by_id(self) -> None:
+        shirt_type = wearable_type("wardrobe_roundtrip_shirt", "shirt")
+        coat_type = wearable_type(
+            "wardrobe_roundtrip_coat",
+            "coat",
+            layer=WearableLayer.OVER,
+        )
+        graph = Graph()
+        actor = graph.add_node(kind=WardrobeActor, label="guide")
+        shirt = graph.add_node(
+            kind=Wearable,
+            label="guide-shirt",
+            token_from=shirt_type.label,
+        )
+        coat = graph.add_node(
+            kind=Wearable,
+            label="guide-coat",
+            token_from=coat_type.label,
+        )
+
+        actor.wardrobe.assign(WARDROBE_SLOT, shirt)
+        actor.outfit.assign("top_80", coat)
+
+        actor_data = actor.unstructure()
+        restored = Graph.structure(graph.unstructure())
+        restored_actor = restored.find_one(Selector(label="guide"))
+        restored_shirt = restored.find_one(Selector(label="guide-shirt"))
+        restored_coat = restored.find_one(Selector(label="guide-coat"))
+
+        assert actor_data["wardrobe"]["assignment_ids"] == {
+            WARDROBE_SLOT: [shirt.uid],
+        }
+        assert actor_data["outfit"]["assignment_ids"] == {
+            "top_80": [coat.uid],
+        }
+        assert restored_actor.wardrobe.owner is restored_actor
+        assert restored_actor.outfit.owner is restored_actor
+        assert restored_actor.wardrobe.get_slot(WARDROBE_SLOT) == [restored_shirt]
+        assert restored_actor.outfit.get_slot("top_80") == [restored_coat]
+        assert sum(1 for item in restored.members.values() if item.uid == shirt.uid) == 1
+        assert sum(1 for item in restored.members.values() if item.uid == coat.uid) == 1
+
+
+class TestWardrobeDressing:
+    """Tests for transaction-backed dressing from wardrobe storage."""
+
+    def test_dress_offer_moves_wearable_from_wardrobe_to_outfit(self) -> None:
+        shirt_type = wearable_type("wardrobe_dress_shirt", "shirt")
+        graph = Graph()
+        actor = graph.add_node(kind=WardrobeActor, label="guide")
+        shirt = graph.add_node(
+            kind=Wearable,
+            label="guide-shirt",
+            token_from=shirt_type.label,
+        )
+        actor.wardrobe.assign(WARDROBE_SLOT, shirt)
+
+        offer = build_wardrobe_dress_offer(
+            wardrobe=actor.wardrobe,
+            outfit=actor.outfit,
+            wearable_key="guide-shirt",
+            slot_name="top_60",
+        )
+
+        assert offer.can_accept().accepted
+        receipt = offer.accept()
+
+        assert receipt.offer_label == "wear guide-shirt"
+        assert actor.wardrobe.get_slot(WARDROBE_SLOT) == []
+        assert actor.outfit.get_slot("top_60") == [shirt]
+        assert actor.describe_outfit() == "shirt"
+
+    def test_dress_offer_rejects_slot_incompatible_wearable(self) -> None:
+        pants_type = wearable_type(
+            "wardrobe_dress_pants",
+            "pants",
+            region=BodyRegion.BOTTOM,
+        )
+        actor = WardrobeActor(label="guide")
+        pants = Wearable(
+            label="guide-pants",
+            token_from=pants_type.label,
+        )
+        actor.wardrobe.assign(WARDROBE_SLOT, pants)
+
+        offer = build_wardrobe_dress_offer(
+            wardrobe=actor.wardrobe,
+            outfit=actor.outfit,
+            wearable_key="guide-pants",
+            slot_name="top_60",
+        )
+
+        check = offer.can_accept()
+
+        assert not check.accepted
+        assert "Component doesn't match criteria" in (check.reason or "")
+        assert actor.wardrobe.get_slot(WARDROBE_SLOT) == [pants]
+        assert actor.outfit.get_slot("top_60") == []
+
+    def test_dress_offer_rolls_back_wardrobe_move_when_outfit_validation_fails(
+        self,
+    ) -> None:
+        shirt_type = wearable_type(
+            "wardrobe_open_shirt",
+            "shirt",
+            layer=WearableLayer.INNER,
+        )
+        coat_type = wearable_type("wardrobe_closed_coat", "coat")
+        actor = WardrobeActor(label="guide")
+        coat = Wearable(label="guide-coat", token_from=coat_type.label)
+        shirt = Wearable(
+            label="guide-shirt",
+            token_from=shirt_type.label,
+            state=WearableState.OPEN,
+        )
+        actor.outfit.assign("top_60", coat)
+        actor.wardrobe.assign(WARDROBE_SLOT, shirt)
+
+        offer = build_wardrobe_dress_offer(
+            wardrobe=actor.wardrobe,
+            outfit=actor.outfit,
+            wearable_key="guide-shirt",
+            slot_name="top_40",
+        )
+
+        assert offer.can_accept().accepted
+        with pytest.raises(ValueError, match="open but covered"):
+            offer.accept()
+
+        assert actor.wardrobe.get_slot(WARDROBE_SLOT) == [shirt]
+        assert actor.outfit.get_slot("top_40") == []
+        assert actor.outfit.get_slot("top_60") == [coat]

--- a/engine/tests/mechanics/presence/test_wardrobe.py
+++ b/engine/tests/mechanics/presence/test_wardrobe.py
@@ -15,6 +15,7 @@ from tangl.lang.body_parts import BodyRegion
 from tangl.mechanics.presence.outfit import (
     HasWardrobe,
     WARDROBE_SLOT,
+    WardrobeManager,
     build_wardrobe_dress_offer,
 )
 from tangl.mechanics.presence.look import HasOutfit
@@ -73,6 +74,20 @@ class TestWardrobeStorage:
         assert namespace["wardrobe"] is actor.wardrobe
         assert namespace["wardrobe_description"] == "shirt"
         assert namespace["wardrobe_tokens"] == ["shirt"]
+
+    def test_holder_labels_are_shared_across_fresh_wardrobe_views(self) -> None:
+        shirt_type = wearable_type("wardrobe_labeled_shirt", "shirt")
+        coat_type = wearable_type("wardrobe_labeled_coat", "coat")
+        manager = WardrobeManager()
+        shirt = Wearable(label="guide-shirt", token_from=shirt_type.label)
+        coat = Wearable(label="guide-coat", token_from=coat_type.label)
+
+        manager.holder().add_asset(shirt, label="favorite")
+        fresh_holder = manager.holder()
+
+        assert fresh_holder.get_asset("favorite") is shirt
+        with pytest.raises(ValueError, match="already contains key"):
+            fresh_holder.add_asset(coat, label="favorite")
 
     def test_graph_roundtrip_preserves_wardrobe_and_outfit_assignments_by_id(self) -> None:
         shirt_type = wearable_type("wardrobe_roundtrip_shirt", "shirt")

--- a/engine/tests/mechanics/presence/test_wardrobe.py
+++ b/engine/tests/mechanics/presence/test_wardrobe.py
@@ -89,6 +89,16 @@ class TestWardrobeStorage:
         with pytest.raises(ValueError, match="already contains key"):
             fresh_holder.add_asset(coat, label="favorite")
 
+    def test_direct_unassign_clears_holder_label(self) -> None:
+        shirt_type = wearable_type("wardrobe_unassign_shirt", "shirt")
+        manager = WardrobeManager()
+        shirt = Wearable(label="guide-shirt", token_from=shirt_type.label)
+
+        manager.holder().add_asset(shirt, label="favorite")
+        manager.unassign(WARDROBE_SLOT, shirt)
+
+        assert manager._holder_labels.get(WARDROBE_SLOT) == {}
+
     def test_graph_roundtrip_preserves_wardrobe_and_outfit_assignments_by_id(self) -> None:
         shirt_type = wearable_type("wardrobe_roundtrip_shirt", "shirt")
         coat_type = wearable_type(
@@ -135,6 +145,17 @@ class TestWardrobeStorage:
 class TestWardrobeDressing:
     """Tests for transaction-backed dressing from wardrobe storage."""
 
+    def test_build_dress_offer_raises_for_unknown_wardrobe_item(self) -> None:
+        actor = WardrobeActor(label="guide")
+
+        with pytest.raises(ValueError, match="Wardrobe item not found"):
+            build_wardrobe_dress_offer(
+                wardrobe=actor.wardrobe,
+                outfit=actor.outfit,
+                wearable_key="missing-item",
+                slot_name="top_60",
+            )
+
     def test_dress_offer_moves_wearable_from_wardrobe_to_outfit(self) -> None:
         shirt_type = wearable_type("wardrobe_dress_shirt", "shirt")
         graph = Graph()
@@ -160,6 +181,21 @@ class TestWardrobeDressing:
         assert actor.wardrobe.get_slot(WARDROBE_SLOT) == []
         assert actor.outfit.get_slot("top_60") == [shirt]
         assert actor.describe_outfit() == "shirt"
+
+    def test_wardrobe_holder_rejects_cross_registry_wearable_during_preflight(
+        self,
+    ) -> None:
+        shirt_type = wearable_type("wardrobe_foreign_shirt", "shirt")
+        actor_graph = Graph()
+        foreign_graph = Graph()
+        actor = actor_graph.add_node(kind=WardrobeActor, label="guide")
+        shirt = foreign_graph.add_node(
+            kind=Wearable,
+            label="foreign-shirt",
+            token_from=shirt_type.label,
+        )
+
+        assert not actor.wardrobe.holder().can_receive_asset(shirt)
 
     def test_dress_offer_rejects_slot_incompatible_wearable(self) -> None:
         pants_type = wearable_type(


### PR DESCRIPTION
Summary:
- Add ComponentSlotAssetHolder so one component-manager slot can participate in transaction asset moves.
- Add WardrobeManager, HasWardrobe, and a dress-from-wardrobe offer that moves a stored wearable into an active OutfitManager slot.
- Document wardrobe as inactive owner-bound clothing storage and add graph round-trip, preflight, and rollback tests.

Verification:
- /Users/derek/.local/bin/coderabbit review --agent --base-commit a0360f7643989770f76607e72fce26ddba8c6072 -c AGENTS.md: 0 issues on final pass
- poetry run pytest engine/tests/mechanics/presence/test_wardrobe.py engine/tests/mechanics/test_transaction_offer.py: 40 passed
- poetry run pytest engine/tests/mechanics: 841 passed, 5 skipped, 4 xfailed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added wardrobe storage for inactive wearables separate from the active outfit, including clearer listing/description and deterministic ordering.
  * Introduced a wardrobe-to-outfit dressing flow that moves a selected stored wearable into a target outfit slot via transactional offers.
  * Added a slot-based asset-holder adapter so wardrobe entries can participate cleanly in transaction exchanges.
* **Bug Fixes**
  * Improved slot label handling for stored items, including consistent sharing across views, duplicate-label protection, and label cleanup on removal.
  * Strengthened validation and rollback when a move fails outfit compatibility checks.
* **Tests**
  * Added comprehensive wardrobe/dressing flow coverage and serialization round-trip checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->