### PR TITLE
Materialize credential packets through game state

### DIFF
--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_ASSEMBLY_RETROFIT.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_ASSEMBLY_RETROFIT.md
@@ -64,6 +64,9 @@ Current implementation checkpoint:
   delegate to it. Otherwise the legacy flat fields remain authoritative.
 - `HasGame.game_state` embeds the hosted `Game` through constructor-form recursion;
   `HasGame.game` binds embedded component managers to the block on access.
+- Generated packets use the finite default `CredentialDefinition` catalog loaded by
+  `tangl.mechanics.credentials`; those singleton labels therefore resolve before a
+  restored graph structures its credential components.
 
 ## Resolved Review Constraints
 

--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_ASSEMBLY_RETROFIT.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_ASSEMBLY_RETROFIT.md
@@ -10,9 +10,11 @@
 **Status:** PARTIALLY IMPLEMENTED. The first retrofit slice landed the global
 credentials domain import surface, graph-backed credential components, an
 owner-bound assembly packet manager, and a `CredentialCase` bridge behind the
-existing disposition protocol. Factory/materialization, move facets, expression
-narrative, contraband graph identity, and status decomposition remain future
-slices.
+existing disposition protocol. Phase 5 now materializes sampled offers into an
+authoritative packet manager at setup and case-advance boundaries, and persists
+the hosted game through the normal constructor-form graph path. Move facets,
+expression narrative, contraband graph identity, and status decomposition remain
+future slices.
 
 **Dependency:** the owner-bound manager and wardrobe transaction substrate provides the
 storage and offer semantics this retrofit relies on: `ComponentManager` stores
@@ -60,8 +62,8 @@ Current implementation checkpoint:
   value-object adapter for flat legacy cases.
 - `CredentialCase.packet_manager` is optional; when present, case discovery methods
   delegate to it. Otherwise the legacy flat fields remain authoritative.
-- `HasGame.game` asks hosted games to bind embedded component managers to the block
-  when the game exposes `bind_component_managers(owner)`.
+- `HasGame.game_state` embeds the hosted `Game` through constructor-form recursion;
+  `HasGame.game` binds embedded component managers to the block on access.
 
 ## Resolved Review Constraints
 
@@ -396,6 +398,14 @@ Acceptance:
   access, without changing the broader `HasGame` private-game persistence path.
 
 ### Phase 5: Retrofit Factory And Roster Materialization
+
+Status: landed for sampled offers. Factory generation remains value-based and
+deterministic. A hosted game materializes its arriving offer into graph credential
+components and an owner-bound packet manager during setup or case advance; planning
+only reads that prepared manager. The source case clears its flat packet fields once
+the manager becomes authoritative. `HasGame.game_state` now persists through the
+normal `unstructure()` / `structure()` path, so the embedded manager and its component
+references survive graph restore.
 
 Keep `build_valid()` and `degrade()` value-based initially. Convert their output into
 an owned packet manager at the committed case-arrival boundary, then migrate game-loop

--- a/engine/src/tangl/mechanics/credentials/__init__.py
+++ b/engine/src/tangl/mechanics/credentials/__init__.py
@@ -7,6 +7,7 @@ from .assembly import (
     CredentialComponentToken,
     CredentialDefinition,
     CredentialPacketManager,
+    ensure_default_credential_definitions,
     materialize_packet,
 )
 from .domain import (
@@ -40,6 +41,7 @@ __all__ = [
     "CredentialComponentToken",
     "CredentialDefinition",
     "CredentialPacketManager",
+    "ensure_default_credential_definitions",
     "materialize_packet",
     "CredentialStatus",
     "CredentialToken",

--- a/engine/src/tangl/mechanics/credentials/__init__.py
+++ b/engine/src/tangl/mechanics/credentials/__init__.py
@@ -7,6 +7,7 @@ from .assembly import (
     CredentialComponentToken,
     CredentialDefinition,
     CredentialPacketManager,
+    materialize_packet,
 )
 from .domain import (
     COMMON_ALLIED_RESTRICTIONS,
@@ -39,6 +40,7 @@ __all__ = [
     "CredentialComponentToken",
     "CredentialDefinition",
     "CredentialPacketManager",
+    "materialize_packet",
     "CredentialStatus",
     "CredentialToken",
     "ContrabandItem",

--- a/engine/src/tangl/mechanics/credentials/assembly.py
+++ b/engine/src/tangl/mechanics/credentials/assembly.py
@@ -98,24 +98,34 @@ class CredentialPacketManager(ComponentManager[CredentialComponent]):
         return self.purpose
 
     def id_status(self) -> CredentialStatus | None:
-        id_card = self._id_component()
+        id_card = self.id_credential()
         return id_card.status if id_card is not None else None
 
+    def id_credential(self) -> CredentialToken | None:
+        """Project the bearer-id component to the game compatibility shape."""
+
+        id_card = self._id_component()
+        return id_card.to_credential_token() if id_card is not None else None
+
     def credential_for(self, indication: Indication) -> CredentialToken | None:
-        for credential in self.get_slot(CREDENTIAL_PACKET_SLOT):
-            token = credential.to_credential_token()
+        for token in self.document_credentials():
             if token.indication is indication:
                 return token
         return None
+
+    def document_credentials(self) -> list[CredentialToken]:
+        """Project non-id credential components to the game compatibility shape."""
+
+        return [
+            credential.to_credential_token()
+            for credential in self.get_slot(CREDENTIAL_PACKET_SLOT)
+        ]
 
     def get_contraband(self) -> list[ContrabandItem]:
         return list(self.possessions)
 
     def all_credentials(self) -> list[CredentialToken]:
-        credentials = [
-            credential.to_credential_token()
-            for credential in self.get_slot(CREDENTIAL_PACKET_SLOT)
-        ]
+        credentials = self.document_credentials()
         id_card = self._id_component()
         if id_card is None:
             return credentials
@@ -126,6 +136,85 @@ class CredentialPacketManager(ComponentManager[CredentialComponent]):
         return components[0] if components else None
 
 
+def _definition_for(
+    token: CredentialToken,
+    *,
+    document_kind: str,
+) -> CredentialDefinition:
+    """Return the stable definition behind one materialized document token."""
+
+    label = ":".join(
+        (
+            "credential",
+            document_kind,
+            token.indication.value,
+            "requires-id" if token.requires_id else "standalone",
+        )
+    )
+    existing = CredentialDefinition.get_instance(label)
+    if existing is not None:
+        return existing
+    return CredentialDefinition(
+        label=label,
+        indication=token.indication,
+        document_kind=document_kind,
+        requires_id=token.requires_id,
+    )
+
+
+def materialize_packet(
+    *,
+    owner: object,
+    region: Region,
+    purpose: Indication,
+    id_card: CredentialToken | None,
+    credentials: list[CredentialToken],
+    possessions: list[ContrabandItem],
+    label_prefix: str,
+) -> CredentialPacketManager:
+    """Create an owner-bound graph packet from a factory's value-shaped output."""
+
+    manager = CredentialPacketManager(
+        region=region,
+        purpose=purpose,
+        possessions=list(possessions),
+    ).bind_owner(owner)
+
+    def add_component(
+        token: CredentialToken,
+        *,
+        document_kind: str,
+        slot: str,
+        index: int,
+    ) -> None:
+        definition = _definition_for(token, document_kind=document_kind)
+        manager.assign(
+            slot,
+            CredentialComponent(
+                label=f"{label_prefix}:{document_kind}:{index}",
+                token_from=definition.label,
+                status=token.status,
+                holder_matches=token.holder_matches,
+            ),
+        )
+
+    if id_card is not None:
+        add_component(
+            id_card,
+            document_kind="id",
+            slot=CREDENTIAL_ID_SLOT,
+            index=0,
+        )
+    for index, credential in enumerate(credentials):
+        add_component(
+            credential,
+            document_kind="document",
+            slot=CREDENTIAL_PACKET_SLOT,
+            index=index,
+        )
+    return manager
+
+
 __all__ = [
     "CREDENTIAL_ID_SLOT",
     "CREDENTIAL_PACKET_SLOT",
@@ -133,4 +222,5 @@ __all__ = [
     "CredentialComponentToken",
     "CredentialDefinition",
     "CredentialPacketManager",
+    "materialize_packet",
 ]

--- a/engine/src/tangl/mechanics/credentials/assembly.py
+++ b/engine/src/tangl/mechanics/credentials/assembly.py
@@ -19,6 +19,7 @@ from .domain import (
 
 CREDENTIAL_ID_SLOT = "id"
 CREDENTIAL_PACKET_SLOT = "credentials"
+_DEFAULT_DOCUMENT_KINDS = ("id", "document")
 
 
 class CredentialDefinition(Singleton):
@@ -126,10 +127,10 @@ class CredentialPacketManager(ComponentManager[CredentialComponent]):
 
     def all_credentials(self) -> list[CredentialToken]:
         credentials = self.document_credentials()
-        id_card = self._id_component()
+        id_card = self.id_credential()
         if id_card is None:
             return credentials
-        return [id_card.to_credential_token(), *credentials]
+        return [id_card, *credentials]
 
     def _id_component(self) -> CredentialComponent | None:
         components = self.get_slot(CREDENTIAL_ID_SLOT)
@@ -143,13 +144,10 @@ def _definition_for(
 ) -> CredentialDefinition:
     """Return the stable definition behind one materialized document token."""
 
-    label = ":".join(
-        (
-            "credential",
-            document_kind,
-            token.indication.value,
-            "requires-id" if token.requires_id else "standalone",
-        )
+    label = _definition_label(
+        document_kind=document_kind,
+        indication=token.indication,
+        requires_id=token.requires_id,
     )
     existing = CredentialDefinition.get_instance(label)
     if existing is not None:
@@ -160,6 +158,42 @@ def _definition_for(
         document_kind=document_kind,
         requires_id=token.requires_id,
     )
+
+
+def _definition_label(
+    *,
+    document_kind: str,
+    indication: Indication,
+    requires_id: bool,
+) -> str:
+    return ":".join(
+        (
+            "credential",
+            document_kind,
+            indication.value,
+            "requires-id" if requires_id else "standalone",
+        )
+    )
+
+
+def ensure_default_credential_definitions() -> None:
+    """Load the finite definition catalog used by generated credential packets."""
+
+    for document_kind in _DEFAULT_DOCUMENT_KINDS:
+        for indication in Indication:
+            for requires_id in (False, True):
+                label = _definition_label(
+                    document_kind=document_kind,
+                    indication=indication,
+                    requires_id=requires_id,
+                )
+                if CredentialDefinition.get_instance(label) is None:
+                    CredentialDefinition(
+                        label=label,
+                        indication=indication,
+                        document_kind=document_kind,
+                        requires_id=requires_id,
+                    )
 
 
 def materialize_packet(
@@ -222,5 +256,9 @@ __all__ = [
     "CredentialComponentToken",
     "CredentialDefinition",
     "CredentialPacketManager",
+    "ensure_default_credential_definitions",
     "materialize_packet",
 ]
+
+
+ensure_default_credential_definitions()

--- a/engine/src/tangl/mechanics/games/credentials_factory.py
+++ b/engine/src/tangl/mechanics/games/credentials_factory.py
@@ -182,12 +182,13 @@ def render_narrative(case: CredentialCase) -> CredentialCase:
     documents: dict[str, str] = {}
     findings: dict[str, str] = {}
 
-    if case.id_card is not None:
+    id_card = case.id_credential()
+    if id_card is not None:
         documents["passport"] = "An identity document."
-        if not case.id_card.status.is_valid:
-            findings["passport"] = _STATUS_FINDINGS[case.id_card.status]
+        if not id_card.status.is_valid:
+            findings["passport"] = _STATUS_FINDINGS[id_card.status]
 
-    for token in case.packet:
+    for token in case.document_credentials():
         label = f"{token.indication.value} permit"
         documents[label] = f"A {token.indication.value} permit."
         if not token.status.is_valid:

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from .credentials_roster import ScenarioOffer
 
 from tangl.core import BaseFragment
-from tangl.core.bases import BaseModelPlus
+from tangl.core.bases import BaseModelPlus, Unstructurable
 from tangl.journal.intent import PieceConstraints, PiecesAccepts, PickAccepts
 from tangl.journal.fragments import (
     ContentFragment,
@@ -34,6 +34,7 @@ from tangl.journal.fragments import (
 )
 from tangl.mechanics.credentials.assembly import (
     CredentialPacketManager as AssemblyCredentialPacketManager,
+    materialize_packet,
 )
 
 from .credentials_enums import (
@@ -46,7 +47,7 @@ from .credentials_enums import (
     Restrictions,
     RestrictionLevel,
 )
-from .enums import GameResult, RoundResult
+from .enums import GamePhase, GameResult, RoundResult
 from .game import Game
 from .picking_game import PickingGame, PickingGameHandler, PickingMove
 
@@ -199,7 +200,7 @@ class CredentialPacketManager(BaseModelPlus):
         return [self.id_card, *self.credentials]
 
 
-class CredentialCase(BaseModelPlus):
+class CredentialCase(Unstructurable):
     """One candidate, with an opaque credential packet behind a discovery API.
 
     The narrative strings (``presented_documents`` / ``hidden_facts`` /
@@ -267,6 +268,25 @@ class CredentialCase(BaseModelPlus):
         if self.packet_manager is not None:
             self.packet_manager.bind_owner(owner)
 
+    def materialize_packet_manager(self, owner: object) -> None:
+        """Replace this factory-shaped packet with its graph-owned assembly form."""
+
+        if self.packet_manager is not None:
+            self.packet_manager.bind_owner(owner)
+            return
+        self.packet_manager = materialize_packet(
+            owner=owner,
+            region=self.region,
+            purpose=self.purpose,
+            id_card=self.id_card,
+            credentials=self.packet,
+            possessions=self.possessions,
+            label_prefix=self.candidate_name,
+        )
+        self.id_card = None
+        self.packet = []
+        self.possessions = []
+
     def to_packet_manager(self) -> CredentialPacketProtocol:
         if self.packet_manager is not None:
             return self.packet_manager
@@ -291,9 +311,15 @@ class CredentialCase(BaseModelPlus):
     def id_status(self) -> CredentialStatus | None:
         """Status of the bearer id, or ``None`` if no id was presented."""
 
+        id_card = self.id_credential()
+        return id_card.status if id_card is not None else None
+
+    def id_credential(self) -> CredentialToken | None:
+        """Project the bearer id without exposing packet storage."""
+
         if self.packet_manager is not None:
-            return self.packet_manager.id_status()
-        return self.id_card.status if self.id_card is not None else None
+            return self.packet_manager.id_credential()
+        return self.id_card
 
     def credential_for(self, indication: Indication) -> CredentialToken | None:
         """The presented credential satisfying ``indication``, if any."""
@@ -313,6 +339,13 @@ class CredentialCase(BaseModelPlus):
         if self.id_card is None:
             return list(self.packet)
         return [self.id_card, *self.packet]
+
+    def document_credentials(self) -> list[CredentialToken]:
+        """Project visible non-id documents without exposing packet storage."""
+
+        if self.packet_manager is not None:
+            return self.packet_manager.document_credentials()
+        return list(self.packet)
 
 
 class CredentialCaseResult(BaseModelPlus):
@@ -637,11 +670,17 @@ class CredentialsGame(PickingGame):
     """A checkpoint shift: a roster of candidates inspected one at a time."""
 
     # --- Shift configuration (authored; never reset between candidates) ------
-    roster: list[CredentialCase] = Field(default_factory=_default_roster)
+    roster: list[CredentialCase] = Field(
+        default_factory=_default_roster,
+        json_schema_extra={"include": True, "unstructurable": True},
+    )
     # Optional lazy roster: when set, candidates are sampled offers materialized
     # on arrival (Phase A.3), and `offers` is the source of truth instead of
     # `roster`. See credentials_roster.py.
-    offers: list["ScenarioOffer"] = Field(default_factory=list)
+    offers: list["ScenarioOffer"] = Field(
+        default_factory=list,
+        json_schema_extra={"include": True, "unstructurable": True},
+    )
     allow_arrest: bool = True
     # The shift is lost when accumulated penalty exceeds this. 0 is the strict
     # default (any wrong call ends the shift); a world raises it for a more
@@ -711,7 +750,11 @@ class CredentialsGame(PickingGame):
     # Lazy cache of materialized offers (cleared on setup; rebuilt on arrival).
     materialized: list[CredentialCase] = Field(
         default_factory=list,
-        json_schema_extra={"reset_field": True},
+        json_schema_extra={
+            "include": True,
+            "reset_field": True,
+            "unstructurable": True,
+        },
     )
     _component_manager_owner: object | None = PrivateAttr(default=None)
 
@@ -727,6 +770,21 @@ class CredentialsGame(PickingGame):
             if offer.pinned_case is not None:
                 offer.pinned_case.bind_packet_manager_owner(owner)
 
+    def prepare_active_case(self) -> CredentialCase:
+        """Materialize the arriving sampled case at setup or UPDATE time."""
+
+        if not self.offers:
+            return self.roster[self.case_index]
+        from .credentials_roster import materialize
+
+        while len(self.materialized) <= self.case_index:
+            offer = self.offers[len(self.materialized)]
+            self.materialized.append(materialize(offer, self.restriction_map))
+        case = self.materialized[self.case_index]
+        if self._component_manager_owner is not None:
+            case.materialize_packet_manager(self._component_manager_owner)
+        return case
+
     # ----- active case access ----------------------------------------------
     def _total_cases(self) -> int:
         """Number of candidates this shift: sampled offers if any, else roster."""
@@ -737,15 +795,13 @@ class CredentialsGame(PickingGame):
     def active_case(self) -> CredentialCase:
         if not self.offers:
             return self.roster[self.case_index]
-        # Lazy: materialize each offer's packet only when the candidate arrives.
-        from .credentials_roster import materialize
-
-        while len(self.materialized) <= self.case_index:
-            offer = self.offers[len(self.materialized)]
-            case = materialize(offer, self.restriction_map)
-            if self._component_manager_owner is not None:
-                case.bind_packet_manager_owner(self._component_manager_owner)
-            self.materialized.append(case)
+        if len(self.materialized) <= self.case_index:
+            if (
+                self._component_manager_owner is not None
+                and self.phase is GamePhase.READY
+            ):
+                raise RuntimeError("Sampled credential cases must be prepared before PLANNING")
+            return self.prepare_active_case()
         return self.materialized[self.case_index]
 
     @property
@@ -881,6 +937,8 @@ class CredentialsGame(PickingGame):
         self.packet_findings = {}
         self.committed_decision = None
         self.finding_status = {}
+        if self._component_manager_owner is not None and not self.shift_complete:
+            self.prepare_active_case()
 
     def to_namespace(self) -> dict[str, object]:
         namespace = super().to_namespace()
@@ -923,6 +981,12 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
 
     game_cls: ClassVar[type[Game]] = CredentialsGame
 
+    def on_setup(self, game: CredentialsGame) -> None:
+        """Prepare the first sampled packet before move provisioning begins."""
+
+        if game._component_manager_owner is not None and game.offers:
+            game.prepare_active_case()
+
     def resolve_round(self, game, player_move, opponent_move):
         # Charge the move's time cost to the shift budget before resolving it.
         # Soft budget: actions are never blocked; overtime converts to penalty.
@@ -948,13 +1012,13 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         # outcome is disclosed by running the move, not by its presence.)
         #
         # request_document: offer for every presented permit not yet requested.
-        for token in case.packet:
+        for token in case.document_credentials():
             key = token.indication.value
             if key in game.finding_status:
                 continue
             moves.append(CredentialsMove(kind="request_document", target=key))
         # verify_id: offer whenever an id is presented and not yet verified.
-        if case.id_card is not None and FindingKey.ID not in game.finding_status:
+        if case.id_status() is not None and FindingKey.ID not in game.finding_status:
             moves.append(CredentialsMove(kind="verify_id", target=""))
         # request_search: single move, once per case.
         if FindingKey.SEARCH not in game.finding_status:
@@ -1258,10 +1322,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         #   valid       -> they re-present the same sound permit ("verified");
         #   crime        -> the forgery cannot be reissued; it stands ("confirmed").
         # Only a cleared mitigatable finding upgrades derive_disposition.
-        permit = next(
-            (t for t in game.active_case.packet if t.indication.value == indication_value),
-            None,
-        )
+        permit = game.active_case.credential_for(Indication(indication_value))
         if permit is None:  # off-menu safety; receive_move does not validate
             detail["outcome"] = "request_document_not_applicable"
             detail["target_indication"] = indication_value

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -765,10 +765,16 @@ class CredentialsGame(PickingGame):
         for case in self.roster:
             case.bind_packet_manager_owner(owner)
         for case in self.materialized:
-            case.bind_packet_manager_owner(owner)
+            case.materialize_packet_manager(owner)
         for offer in self.offers:
             if offer.pinned_case is not None:
                 offer.pinned_case.bind_packet_manager_owner(owner)
+
+    @property
+    def has_component_manager_owner(self) -> bool:
+        """Whether sampled cases can materialize into graph credential components."""
+
+        return self._component_manager_owner is not None
 
     def prepare_active_case(self) -> CredentialCase:
         """Materialize the arriving sampled case at setup or UPDATE time."""
@@ -781,7 +787,7 @@ class CredentialsGame(PickingGame):
             offer = self.offers[len(self.materialized)]
             self.materialized.append(materialize(offer, self.restriction_map))
         case = self.materialized[self.case_index]
-        if self._component_manager_owner is not None:
+        if self.has_component_manager_owner:
             case.materialize_packet_manager(self._component_manager_owner)
         return case
 
@@ -797,7 +803,7 @@ class CredentialsGame(PickingGame):
             return self.roster[self.case_index]
         if len(self.materialized) <= self.case_index:
             if (
-                self._component_manager_owner is not None
+                self.has_component_manager_owner
                 and self.phase is GamePhase.READY
             ):
                 raise RuntimeError("Sampled credential cases must be prepared before PLANNING")
@@ -937,7 +943,7 @@ class CredentialsGame(PickingGame):
         self.packet_findings = {}
         self.committed_decision = None
         self.finding_status = {}
-        if self._component_manager_owner is not None and not self.shift_complete:
+        if self.has_component_manager_owner and not self.shift_complete:
             self.prepare_active_case()
 
     def to_namespace(self) -> dict[str, object]:
@@ -984,7 +990,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
     def on_setup(self, game: CredentialsGame) -> None:
         """Prepare the first sampled packet before move provisioning begins."""
 
-        if game._component_manager_owner is not None and game.offers:
+        if game.has_component_manager_owner and game.offers:
             game.prepare_active_case()
 
     def resolve_round(self, game, player_move, opponent_move):

--- a/engine/src/tangl/mechanics/games/credentials_roster.py
+++ b/engine/src/tangl/mechanics/games/credentials_roster.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, field
 
 from pydantic import Field
 
-from tangl.core.bases import BaseModelPlus
+from tangl.core.bases import Unstructurable
 
 from .credentials_enums import (
     FailureClass,
@@ -49,7 +49,7 @@ _DEFAULT_DISPOSITIONS = {
 }
 
 
-class ScenarioOffer(BaseModelPlus):
+class ScenarioOffer(Unstructurable):
     """A promised encounter -- enough to materialize a candidate on arrival.
 
     Sampling (origin / disposition / failure mode) happens once at roster
@@ -65,7 +65,10 @@ class ScenarioOffer(BaseModelPlus):
     failure_modes: list[FailureMode] = Field(default_factory=list)
     whitelist: bool = False
     blacklist: bool = False
-    pinned_case: CredentialCase | None = None
+    pinned_case: CredentialCase | None = Field(
+        default=None,
+        json_schema_extra={"include": True, "unstructurable": True},
+    )
 
 
 @dataclass(frozen=True)

--- a/engine/src/tangl/mechanics/games/has_game.py
+++ b/engine/src/tangl/mechanics/games/has_game.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 """Facet mixin for blocks hosting game instances."""
 
-from typing import Any, ClassVar, Optional, TYPE_CHECKING
+from typing import Any, ClassVar, TYPE_CHECKING
 from uuid import UUID
+
+from pydantic import Field
 
 from tangl.mechanics.games import Game, GameHandler
 
 if TYPE_CHECKING:
     from tangl.core import Graph, Node
+
 
 def _add_node_compat(graph: Graph, *, kind: type, label: str | None, **kwargs: Any):
     """Create a node using the canonical ``kind=`` graph API."""
@@ -24,14 +27,14 @@ class HasGame:
     Wraps Layer 2 game state (:class:`~tangl.mechanics.games.Game`) inside story
     nodes so the VM can drive rounds and post-requisite exits. Mirrors
     :class:`~tangl.mechanics.assembly.base.HasSlottedContainer` with lazy
-    initialization, serialization hooks, and a convenience factory.
+    initialization, constructor-form persistence, and a convenience factory.
 
     Key Features
     ------------
     - **Lazy accessors**: instantiate the game and handler on first property
       access.
-    - **Serializable game state**: persist ``_game`` with the block; handler is
-      recreated when needed.
+    - **Serializable game state**: embed ``game_state`` in the block's normal
+      constructor form; handler is recreated when needed.
     - **Factory wiring**: :meth:`create_game_block` adds POSTREQS edges for
       victory/defeat/draw exits.
 
@@ -46,8 +49,11 @@ class HasGame:
     _game_class: ClassVar[type[Game]] = Game
     _game_handler_class: ClassVar[type[GameHandler]] = GameHandler
 
-    _game: Optional[Game] = None
-    _game_handler: Optional[GameHandler] = None
+    game_state: Game | None = Field(
+        default=None,
+        json_schema_extra={"include": True, "unstructurable": True},
+    )
+    _game_handler: GameHandler | None = None
 
     victory_edge_id: UUID | None = None
     defeat_edge_id: UUID | None = None
@@ -57,10 +63,10 @@ class HasGame:
     def game(self) -> Game:
         """Return the game instance, creating it on first access."""
 
-        if self._game is None:
-            self._game = self._game_class()
+        if self.game_state is None:
+            self.game_state = self._game_class()
         self._bind_game_component_managers()
-        return self._game
+        return self.game_state
 
     @property
     def game_handler(self) -> GameHandler:
@@ -70,31 +76,12 @@ class HasGame:
             self._game_handler = self._game_handler_class()
         return self._game_handler
 
-    def model_dump(self, **kwargs: Any) -> dict[str, Any]:  # type: ignore[override]
-        """Serialize the block, including game state if initialized."""
-
-        data = super().model_dump(**kwargs)  # type: ignore[misc]
-        if self._game is not None:
-            data["_game"] = self._game.model_dump()
-        return data
-
-    @classmethod
-    def model_validate(cls, obj: Any, **kwargs: Any):  # type: ignore[override]
-        """Deserialize the block and restore game state when present."""
-
-        instance = super().model_validate(obj, **kwargs)  # type: ignore[misc]
-        if "_game" in obj:
-            game_data = obj["_game"]
-            instance._game = instance._game_class.model_validate(game_data)
-            instance._bind_game_component_managers()
-        return instance
-
     def _bind_game_component_managers(self) -> None:
         """Let game state bind embedded component managers to this graph owner."""
 
-        if self._game is None:
+        if self.game_state is None:
             return
-        self._game.bind_component_managers(self)
+        self.game_state.bind_component_managers(self)
 
     @classmethod
     def create_game_block(

--- a/engine/tests/mechanics/credentials/test_credential_packet_manager.py
+++ b/engine/tests/mechanics/credentials/test_credential_packet_manager.py
@@ -281,7 +281,7 @@ def test_has_game_block_binds_roster_packet_manager_to_graph_owner() -> None:
     manager = AssemblyCredentialPacketManager(purpose=IND.WORK)
     manager.assign(CREDENTIAL_ID_SLOT, id_card)
     manager.assign(CREDENTIAL_PACKET_SLOT, work_permit)
-    block._game = CredentialsGame(
+    block.game_state = CredentialsGame(
         roster=[CredentialCase(candidate_name="Mara", packet_manager=manager)],
         restriction_map=LOCAL_RULES,
     )
@@ -294,15 +294,15 @@ def test_has_game_block_binds_roster_packet_manager_to_graph_owner() -> None:
     assert restored_manager.get_slot(CREDENTIAL_PACKET_SLOT) == [work_permit]
 
 
-def test_has_game_model_validate_binds_roster_packet_manager_to_restored_owner() -> None:
+def test_has_game_structure_binds_roster_packet_manager_to_restored_owner() -> None:
     manager = AssemblyCredentialPacketManager(purpose=IND.WORK)
     block = CredentialsBlock(label="checkpoint")
-    block._game = CredentialsGame(
+    block.game_state = CredentialsGame(
         roster=[CredentialCase(candidate_name="Mara", packet_manager=manager)],
         restriction_map=LOCAL_RULES,
     )
 
-    restored = CredentialsBlock.model_validate(block.model_dump())
+    restored = CredentialsBlock.structure(block.unstructure())
     restored_manager = restored.game.roster[0].packet_manager
 
     assert restored_manager is not None
@@ -325,7 +325,7 @@ def test_has_game_binds_pinned_offer_packet_manager_before_materialization() -> 
     manager = AssemblyCredentialPacketManager(purpose=IND.TRAVEL)
     manager.assign(CREDENTIAL_ID_SLOT, id_card)
     pinned_case = CredentialCase(candidate_name="Pinned", packet_manager=manager)
-    block._game = CredentialsGame(
+    block.game_state = CredentialsGame(
         offers=[ScenarioOffer(candidate_name="Pinned", pinned_case=pinned_case)],
         restriction_map=LOCAL_RULES,
     )
@@ -337,3 +337,95 @@ def test_has_game_binds_pinned_offer_packet_manager_before_materialization() -> 
     assert restored_manager is manager
     assert restored_manager.owner is block
     assert restored_manager.get_slot(CREDENTIAL_ID_SLOT) == [id_card]
+
+
+def test_sampled_offers_materialize_once_at_game_lifecycle_boundaries() -> None:
+    graph = Graph()
+    block = graph.add_node(kind=CredentialsBlock, label="checkpoint")
+    block.game_state = CredentialsGame(
+        offers=[
+            ScenarioOffer(
+                candidate_name="Mara",
+                region=Region.LOCAL,
+                purpose=IND.WORK,
+            ),
+            ScenarioOffer(
+                candidate_name="Tomas",
+                region=Region.LOCAL,
+                purpose=IND.TRAVEL,
+            ),
+        ],
+        restriction_map=LOCAL_RULES,
+    )
+    handler = block.game_handler
+    handler.setup(block.game)
+
+    first_case = block.game.active_case
+    first_packet = first_case.packet_manager
+    assert first_packet is not None
+    assert first_packet.owner is block
+    assert first_case.id_card is None
+    assert first_case.packet == []
+    assert first_packet.get_slot(CREDENTIAL_ID_SLOT)
+    assert first_packet.get_slot(CREDENTIAL_PACKET_SLOT)
+    component_count = sum(
+        isinstance(item, CredentialComponent)
+        for item in graph.members.values()
+    )
+
+    assert handler.get_available_moves(block.game)
+    assert (
+        sum(isinstance(item, CredentialComponent) for item in graph.members.values())
+        == component_count
+    )
+
+    handler.receive_move(block.game, ("inspect", "passport"))
+    handler.receive_move(block.game, ("decide", "pass"))
+
+    second_case = block.game.active_case
+    assert second_case.candidate_name == "Tomas"
+    assert second_case.packet_manager is not None
+    assert second_case.packet_manager.owner is block
+    assert (
+        sum(isinstance(item, CredentialComponent) for item in graph.members.values())
+        > component_count
+    )
+
+
+def test_sampled_packet_graph_roundtrip_keeps_component_references() -> None:
+    graph = Graph()
+    block = graph.add_node(kind=CredentialsBlock, label="checkpoint")
+    block.game_state = CredentialsGame(
+        offers=[
+            ScenarioOffer(
+                candidate_name="Mara",
+                region=Region.LOCAL,
+                purpose=IND.WORK,
+            ),
+        ],
+        restriction_map=LOCAL_RULES,
+    )
+    block.game_handler.setup(block.game)
+    packet = block.game.active_case.packet_manager
+    assert packet is not None
+    component_ids = {
+        component.uid
+        for slot_name in (CREDENTIAL_ID_SLOT, CREDENTIAL_PACKET_SLOT)
+        for component in packet.get_slot(slot_name)
+    }
+
+    restored = Graph.structure(graph.unstructure())
+    restored_block = restored.find_one(Selector(label="checkpoint"))
+    restored_packet = restored_block.game.active_case.packet_manager
+
+    assert restored_packet is not None
+    assert restored_packet.owner is restored_block
+    assert {
+        component.uid
+        for slot_name in (CREDENTIAL_ID_SLOT, CREDENTIAL_PACKET_SLOT)
+        for component in restored_packet.get_slot(slot_name)
+    } == component_ids
+    assert (
+        sum(item.uid in component_ids for item in restored.members.values())
+        == len(component_ids)
+    )

--- a/engine/tests/mechanics/credentials/test_credential_packet_manager.py
+++ b/engine/tests/mechanics/credentials/test_credential_packet_manager.py
@@ -14,6 +14,7 @@ from tangl.mechanics.credentials import (
     CredentialComponent,
     CredentialDefinition,
     CredentialPacketManager as AssemblyCredentialPacketManager,
+    ensure_default_credential_definitions,
 )
 from tangl.mechanics.credentials.domain import (
     ContrabandItem,
@@ -414,7 +415,10 @@ def test_sampled_packet_graph_roundtrip_keeps_component_references() -> None:
         for component in packet.get_slot(slot_name)
     }
 
-    restored = Graph.structure(graph.unstructure())
+    payload = graph.unstructure()
+    CredentialDefinition.clear_instances()
+    ensure_default_credential_definitions()
+    restored = Graph.structure(payload)
     restored_block = restored.find_one(Selector(label="checkpoint"))
     restored_packet = restored_block.game.active_case.packet_manager
 
@@ -429,3 +433,29 @@ def test_sampled_packet_graph_roundtrip_keeps_component_references() -> None:
         sum(item.uid in component_ids for item in restored.members.values())
         == len(component_ids)
     )
+
+
+def test_binding_a_prepared_game_materializes_its_cached_sample() -> None:
+    game = CredentialsGame(
+        offers=[
+            ScenarioOffer(
+                candidate_name="Mara",
+                region=Region.LOCAL,
+                purpose=IND.WORK,
+            ),
+        ],
+        restriction_map=LOCAL_RULES,
+    )
+    handler = CredentialsGameHandler()
+    handler.setup(game)
+    cached_case = game.active_case
+    assert cached_case.packet_manager is None
+
+    graph = Graph()
+    block = graph.add_node(kind=CredentialsBlock, label="checkpoint", game_state=game)
+    packet = block.game.active_case.packet_manager
+
+    assert packet is not None
+    assert packet.owner is block
+    assert packet.get_slot(CREDENTIAL_ID_SLOT)
+    assert packet.get_slot(CREDENTIAL_PACKET_SLOT)

--- a/engine/tests/mechanics/games/test_has_game.py
+++ b/engine/tests/mechanics/games/test_has_game.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from tangl.core import Graph
+from tangl.core import Graph, Selector
 from tangl.mechanics.games import Game, GameHandler, GamePhase, RoundResult, HasGame
 from tangl.story import Block
 from tangl.vm import ResolutionPhase as P
@@ -49,7 +49,7 @@ class TestHasGameFacet:
         graph = Graph(label="test")
         block = _add_node(graph, kind=GameBlock, label="game_block")
 
-        assert block._game is None
+        assert block.game_state is None
 
         game = block.game
         assert isinstance(game, SampleGame)
@@ -65,7 +65,7 @@ class TestHasGameFacet:
         assert isinstance(handler, SampleGameHandler)
         assert block.game_handler is handler
 
-    def test_game_state_serialization(self) -> None:
+    def test_game_state_uses_constructor_form(self) -> None:
         graph = Graph(label="test")
         block = _add_node(graph, kind=GameBlock, label="game_block")
 
@@ -73,23 +73,37 @@ class TestHasGameFacet:
         block.game.phase = GamePhase.READY
         block.game.round = 5
 
-        data = block.model_dump()
-        assert data["_game"]["phase"] is GamePhase.READY
-        assert data["_game"]["round"] == 5
+        data = block.unstructure()
+        assert data["game_state"]["phase"] is GamePhase.READY
+        assert data["game_state"]["round"] == 5
+        assert data["game_state"]["kind"] is SampleGame
 
-        restored = GameBlock.model_validate(data)
+        restored = GameBlock.structure(data)
         assert restored.game.phase is GamePhase.READY
         assert restored.game.round == 5
+
+    def test_game_state_survives_graph_roundtrip(self) -> None:
+        graph = Graph(label="test")
+        block = _add_node(graph, kind=GameBlock, label="game_block")
+        block.game.phase = GamePhase.READY
+        block.game.round = 5
+
+        restored = Graph.structure(graph.unstructure())
+        restored_block = restored.find_one(Selector(label="game_block"))
+
+        assert isinstance(restored_block.game, SampleGame)
+        assert restored_block.game.phase is GamePhase.READY
+        assert restored_block.game.round == 5
 
     def test_handler_not_serialized(self) -> None:
         graph = Graph(label="test")
         block = _add_node(graph, kind=GameBlock, label="game_block")
 
         _ = block.game_handler
-        data = block.model_dump()
+        data = block.unstructure()
         assert "_game_handler" not in data
 
-        restored = GameBlock.model_validate(data)
+        restored = GameBlock.structure(data)
         assert restored._game_handler is None
         assert isinstance(restored.game_handler, SampleGameHandler)
 

--- a/engine/tests/mechanics/games/test_incremental_game.py
+++ b/engine/tests/mechanics/games/test_incremental_game.py
@@ -116,7 +116,7 @@ class TestIncrementalIntegration:
     def test_move_labels_cover_assign_build_and_cycle(self) -> None:
         graph = Graph(label="incremental_labels")
         block = graph.add_node(kind=IncrementalBlock, label="yard")
-        block._game = _sample_game()
+        block.game_state = _sample_game()
         block.game_handler.setup(block.game)
 
         frame = Frame(graph=graph, cursor=block)
@@ -144,7 +144,7 @@ class TestIncrementalIntegration:
             defeat_dest=defeat,
             label="yard",
         )
-        block._game = _sample_game(
+        block.game_state = _sample_game(
             starting_resources={"food": 0, "scrap": 0},
             build_specs={"signal_fire": BuildSpec(cost={"scrap": 1}, resource_gain={"prestige": 1})},
             unlocked_tasks=["scavenge"],
@@ -196,7 +196,7 @@ class TestIncrementalIntegration:
     def test_context_exports_shell_state(self) -> None:
         graph = Graph(label="incremental_context")
         block = graph.add_node(kind=IncrementalBlock, label="yard")
-        block._game = _sample_game()
+        block.game_state = _sample_game()
         block.game_handler.setup(block.game)
 
         frame = Frame(graph=graph, cursor=block)

--- a/engine/tests/mechanics/simulation/test_queueing.py
+++ b/engine/tests/mechanics/simulation/test_queueing.py
@@ -195,7 +195,7 @@ def test_queueing_hasgame_provisions_self_loop_and_journals_fragments() -> None:
     graph = Graph(label="queueing_flow")
     intro = graph.add_node(kind=Block, label="intro")
     block = graph.add_node(kind=QueueBlock, label="queue")
-    block._game = _ed_game()
+    block.game_state = _ed_game()
     ChoiceEdge(
         graph=graph,
         predecessor_id=intro.uid,


### PR DESCRIPTION
Summary:
- Persist hosted games through the canonical constructor-form game_state field.
- Materialize sampled credential offers into owner-bound graph packet managers at setup and case advance.
- Add graph round-trip coverage for hosted games and credential component identity.

Verification:
- pytest -q engine/tests/mechanics/games: 300 passed, 4 skipped.
- Focused credentials, persistence, integration, loader, and service suite: 237 passed, 4 skipped.

Review:
- CodeRabbit incremental review against da6fa1ad reported no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Credential packets are now assembled into authoritative, owner-bound records during game setup and case progression.
  * Credential discovery and verification consistently reflect the assembled packet, including identity documents, permits, and possessions.
  * Embedded game state now persists and restores correctly across graph save/load operations.
* **Bug Fixes**
  * Prevented sampled credential cases from being used before their packet data is prepared.
  * Improved continuity of credential references and ownership after restoring saved games.
* **Documentation**
  * Updated the credential packet assembly specification with the revised lifecycle and persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->