### PR TITLE
Add credential token facet discovery

### DIFF
--- a/.agents/skills/storytangl-feature/SKILL.md
+++ b/.agents/skills/storytangl-feature/SKILL.md
@@ -9,6 +9,26 @@ Run exactly one mode per task: `plan`, `implement`, `review`, or `close`.
 Do not advance through multiple modes autonomously. Read the root and applicable
 local `AGENTS.md` files plus the named design documents before editing.
 
+## Local Environment Fallback
+
+Prefer `poetry run`. If it fails only because Poetry cannot create or write its
+virtualenv cache, do not install dependencies or treat that as a feature blocker.
+Locate a pre-existing StoryTangl Python 3.13 venv, verify it imports `tangl`, then
+run tools with explicit source paths:
+
+```text
+PYTHONPATH=engine/src:apps/cli/src:apps/renpy/src:apps/server/src \
+  <verified-python> -m tangl.devref <command>
+```
+
+Do not hard-code a machine-specific venv path in committed docs. If no suitable
+venv exists, planning may use targeted `rg` plus the named canonical files; report
+the missing index rather than creating a new retrieval system.
+
+If Git LFS prevents broad `git status`, use scoped `git diff -- <paths>` and
+`git diff --check -- <paths>` for the current slice. Do not spend a planning task
+repairing unrelated local Git/LFS environment state.
+
 ## Plan
 
 1. Use `tangl-devref find` and `map` to identify canonical docs, code, tests,

--- a/.agents/skills/storytangl-feature/SKILL.md
+++ b/.agents/skills/storytangl-feature/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: storytangl-feature
+description: Plan, implement, review, or close one bounded StoryTangl feature slice using devref, architectural chokepoints, and constructor-form persistence checks. Use for substantial mechanics, VM, story, service, or cross-surface changes; do not use for trivial edits.
+---
+
+# StoryTangl Feature Slice
+
+Run exactly one mode per task: `plan`, `implement`, `review`, or `close`.
+Do not advance through multiple modes autonomously. Read the root and applicable
+local `AGENTS.md` files plus the named design documents before editing.
+
+## Plan
+
+1. Use `tangl-devref find` and `map` to identify canonical docs, code, tests,
+   and related work. Use `pack` only for selected topics.
+2. Write a compact feature contract using
+   [feature-contract.md](references/feature-contract.md).
+3. Name existing mechanisms to reuse, canonical chokepoints, non-goals, affected
+   surfaces, acceptance checks, and any dependency that is not yet landed.
+4. Stop for approval. Do not edit implementation code.
+
+## Implement
+
+Require an approved contract and one named milestone. Read only its selected
+devref pack, local design docs, and code surface.
+
+Before editing, state:
+
+- capability needed;
+- canonical chokepoint and reuse mechanism;
+- expected files and validation;
+- whether a new pathway is required.
+
+Never create a parallel serializer, persistence route, dispatch system, registry,
+factory, or lifecycle path without explicit contract authorization.
+
+For graph-owned state, prove `unstructure()` / `structure()` through the owning
+graph. `model_dump()` / `model_validate()` may inspect a Pydantic snapshot but
+do not establish persistence correctness.
+
+On an unexpected test failure, first state the failed design assumption. Check
+the existing extension point and utilities before editing. Stop and report after
+two failed corrections to the same cause, or when the correction needs a new
+architectural pathway.
+
+## Review
+
+Compare the contract, actual diff, and selected canonical sources. Start with:
+
+- layer-boundary and existing-mechanism reuse;
+- graph/reference round trips and fresh-process singleton availability;
+- setup/UPDATE versus PLANNING mutation boundaries;
+- owner attachment after prior preparation or materialization;
+- public, demo, widget, documentation, and test surfaces.
+
+For PR review, use the actual PR base SHA for incremental CodeRabbit. Treat a
+clean agent review as supplementary evidence, never as a substitute for a
+targeted behavioral probe. Retrieve unresolved inline threads only; avoid
+loading generated review walkthroughs or entire discussion dumps unless needed.
+
+## Close
+
+Run the contract's focused verification, inspect the diff, update a touched
+design document's status, and record concise workflow observations in the
+contract. Do not broaden closure into a new feature phase.
+
+## Communication Economy
+
+Use terse labeled status and diagnostic reports. Preserve exact APIs, commands,
+errors, modality, and uncertainty. Do not compress canonical prose or load a
+large historical thread when a fresh task can use the approved contract.

--- a/.agents/skills/storytangl-feature/agents/openai.yaml
+++ b/.agents/skills/storytangl-feature/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "StoryTangl Feature"
+  short_description: "Plan bounded StoryTangl feature slices"
+  default_prompt: "Use $storytangl-feature to plan or review a StoryTangl feature slice."

--- a/.agents/skills/storytangl-feature/references/feature-contract.md
+++ b/.agents/skills/storytangl-feature/references/feature-contract.md
@@ -1,0 +1,44 @@
+# StoryTangl Feature Contract
+
+## Status
+
+Proposed | Approved | Implementing | Reviewing | Complete
+
+## Intent and constraints
+
+- Capability and user-visible outcome:
+- Applicable architectural invariants:
+- Canonical chokepoints and existing mechanisms to reuse:
+- Non-goals and deferred dependencies:
+
+## Context selected
+
+- `devref` topics and pack:
+- Canonical documents:
+- Existing symbols and tests:
+- Related work considered but excluded:
+
+## One milestone
+
+- Allowed files/surfaces:
+- Expected state transition and owner:
+- Persistence/reference form:
+- PLANNING read contract and UPDATE write contract:
+- Acceptance criteria and exact validation command:
+
+## Review matrix
+
+| Surface | Expected evidence |
+| --- | --- |
+| Architecture/reuse | Existing mechanism used; no parallel path |
+| Persistence | Owning graph round-trip; no duplicate members |
+| Fresh process | Required Singleton catalog/authority exists before structure |
+| Lifecycle | Setup/UPDATE writes; repeated PLANNING reads are pure |
+| Owner transition | Previously prepared state adopts the eventual owner correctly |
+| Integration | Relevant demo, widget, client, docs, and tests checked |
+
+## Discoveries and workflow observations
+
+- Failed assumption or design conflict:
+- Correction or escalation:
+- Context/review lesson for the next fresh task:

--- a/engine/src/tangl/mechanics/credentials/PHASE_6A_FACET_BRIDGE_CONTRACT.md
+++ b/engine/src/tangl/mechanics/credentials/PHASE_6A_FACET_BRIDGE_CONTRACT.md
@@ -1,0 +1,133 @@
+# Credentials Phase 6a: Token Facet Bridge Contract
+
+## Status
+
+Implemented for the Phase 6a pure-discovery milestone only. No credential game
+integration is implemented by this contract.
+
+## Intent and constraints
+
+- **Capability:** prove that an owner-bound credential packet can *purely discover*
+  facets supplied by its credential tokens, retaining document and packet-slot
+  provenance. This is the prerequisite to any credentials move contribution.
+- **Applicable invariants:** facets are context-bound value data, not graph members or
+  a dispatch system. PLANNING reads are repeatable and do not prepare packets, mutate
+  game state, add actions, or reveal hidden document state. The existing game handler
+  remains the move/choice factory; UPDATE remains the only write boundary.
+- **Canonical chokepoints:** reuse `ComponentFacet`,
+  `SlottedContainer.component_facets()`, and `CredentialPacketManager`; later reuse
+  `CredentialsGameHandler.get_available_moves()` / `get_provisioned_moves()` and the
+  existing `HasGame` PLANNING/UPDATE handlers. Do not add a credentials phase bus,
+  registry, serializer, or action factory.
+- **Persistence:** credential tokens remain graph members and packet membership remains
+  UUID-backed through the owner-bound manager. Any persistence proof is
+  `Graph.unstructure()` / `Graph.structure()`, never a Pydantic dump/validate pair.
+  A world using facet-bearing `CredentialDefinition` singletons must load that authored
+  catalogue before graph structure; fresh-process restoration must not depend on a
+  singleton created incidentally at runtime. Generated default definitions may remain
+  facet-free.
+
+## Context selected
+
+- `devref` was rebuilt with the project Python (`862` sources, `3,703` artifacts). Its
+  `credentials assembly facet` search and `assembly` map identify
+  `ComponentFacet`, `SlottedContainer`, `ComponentManager`, `CredentialDefinition`,
+  `CredentialComponentToken`, and `CredentialPacketManager` as the relevant current
+  code, with `COMPONENT_DESIGN.md` as design context. The sources below were then
+  checked directly.
+- **Canonical current code:**
+  `mechanics/assembly/component.py` (`ComponentFacet` and `Component`),
+  `mechanics/assembly/base.py` (slot-aware facet gather and provenance),
+  `mechanics/credentials/assembly.py` (the Token-wrapped credential component and
+  packet manager), `mechanics/games/credentials_game.py` (choice factory), and
+  `mechanics/games/handlers.py` (the existing game PLANNING/UPDATE path).
+- **Canonical tests:** `engine/tests/mechanics/test_assembly.py` and
+  `engine/tests/mechanics/credentials/test_credential_packet_manager.py`.
+- **Design notes, not current behavior:** `COMPONENT_DESIGN.md` describes intended
+  channel/handler adoption; `CREDENTIAL_ASSEMBLY_RETROFIT.md` defers Phase 6 until the
+  contribution contract is settled. Neither establishes a live VM facet consumer.
+
+## Current contract and gap
+
+`ComponentFacet` currently supplies only `channel`, `facet_type`, opaque `payload`,
+and optional `source_id` / `subject_id`. Its `matches()` filters the first two; its
+`with_provenance()` fills missing provenance. `Component.component_facets()` supplies
+its own UID as source, while `SlottedContainer.component_facets()` supplies its slot
+name as subject. The assembly tests prove that a consumer may fold those returned data
+objects, but no VM, provisioning, or choice handler gathers them today.
+
+`CredentialComponent` cannot use that path directly: it is a `Token` wrapper over
+`CredentialDefinition`, not a subclass of `Component`; it has neither `facets` nor
+`component_facets()`. The packet manager's generic gather consequently reaches a
+method that credential tokens do not provide. Making credentials a second component
+hierarchy or adding a credentials-only handler would violate the reuse boundary.
+
+## One milestone: pure token-to-packet discovery proof
+
+- **Allowed surfaces:** `credentials/assembly.py`, narrowly focused credential/assembly
+  tests, and this contract's status if implementation is later approved. No VM,
+  `HasGame`, game-handler, journal, widget, or persistence-framework edits.
+- **Facet data:** authored, immutable facet templates belong on the
+  `CredentialDefinition` singleton catalogue. They are not copied into packet state,
+  cached as derived state, or stored on `CredentialCase`. Per-document facts such as
+  status remain on the `CredentialComponent` token; this milestone does not define
+  dynamic activation from those facts.
+- **Bridge:** `CredentialComponentToken` exposes the same narrow
+  `component_facets(channel=..., facet_type=..., subject_id=...)` read protocol as
+  `Component`. It derives each returned template's `source_id` from the token's UID.
+  The existing `CredentialPacketManager.component_facets()` gather then supplies the
+  assigned slot as `subject_id`. It returns copied value objects and never alters the
+  definition template, token, manager, game, or graph.
+- **Proof:** assign one graph credential token whose definition has one opaque test
+  facet into a packet slot; gathering by channel returns that payload with
+  `source_id == str(token.uid)` and `subject_id == slot`. Repeating the same read
+  returns equivalent data and leaves packet assignment IDs, token state, and graph
+  constructor form unchanged. Mutating the gathered facet must not alter the authored
+  singleton template or a later gather result. A fresh-process graph round-trip fixture
+  must load its facet-bearing definition catalogue before `Graph.structure()` and then
+  prove the restored token resolves the authored definition. The existing owner-bound
+  graph round-trip test remains the persistence guard; do not add
+  `model_dump()`/`model_validate()` as evidence.
+- **Validation when implemented:**
+  `poetry run pytest engine/tests/mechanics/test_assembly.py engine/tests/mechanics/credentials/test_credential_packet_manager.py`
+
+## Explicitly deferred: choice and writeback integration
+
+The first consumer must be a separate approved slice. It may let
+`CredentialsGameHandler` inspect the active packet's *visible* credential facets and
+create its own `CredentialsMove` values through its existing move factory. The generic
+`HasGame` PLANNING handler then continues to project those moves into dynamic actions;
+it is not a facet consumer or factory. UPDATE continues through `process_game_move()`
+and the game handler, with atomic multi-object effects delegated to `TransactionOffer`
+when needed.
+
+That slice must decide the credential-specific payload schema, duplicate/override
+policy, labels/accepts, selected-move validation, receipt/journal provenance, and
+whether a mutation requires a transaction. It must prove that visibly equivalent valid
+and invalid documents give the same menu, that repeated move discovery is pure, and
+that a selected action writes exactly once in UPDATE.
+
+## Unresolved design decisions
+
+The shared VM/choice contribution contract is **not sufficiently settled** for live
+adoption. `ComponentFacet` has no `when`, target selector, fold/precedence rule,
+parameterized-choice contract, or phase-safe `vm_phase` payload schema; the design
+notes describe these as future intended shape rather than implemented behavior. Phase
+6a therefore authorizes only opaque discovery. It deliberately does not choose between
+`channel="vm_phase"` data and lowering into existing dispatch, and it does not let
+facets register handlers or generate actions themselves.
+
+## Review matrix
+
+| Surface | Required evidence |
+| --- | --- |
+| Architecture/reuse | Token adapter feeds existing manager gather; no new dispatch or lifecycle path |
+| Provenance | Token UID is source; manager slot is subject; templates remain unmodified |
+| Lifecycle | Repeated discovery is pure; setup/UPDATE, not read discovery, owns materialization and writes |
+| Persistence | Catalogue is loaded before structure; graph round-trip retains authored singleton resolution, one member per token, and UUID slot references |
+| Integration | Deferred slice proves handler-owned visible-choice factory and UPDATE-only writeback |
+
+## Workflow observation
+
+Phase 5's sampled-offer preparation and `game_state` constructor-form work are
+prerequisites assumed by this contract, not surfaces to recreate or modify.

--- a/engine/src/tangl/mechanics/credentials/assembly.py
+++ b/engine/src/tangl/mechanics/credentials/assembly.py
@@ -7,7 +7,7 @@ from typing import ClassVar
 from pydantic import Field
 
 from tangl.core import Singleton, Token
-from tangl.mechanics.assembly import ComponentManager, Slot
+from tangl.mechanics.assembly import ComponentFacet, ComponentManager, Slot
 
 from .domain import (
     ContrabandItem,
@@ -28,6 +28,7 @@ class CredentialDefinition(Singleton):
     indication: Indication
     document_kind: str = "document"
     requires_id: bool = False
+    facets: tuple[ComponentFacet, ...] = ()
     status: CredentialStatus = Field(
         default=CredentialStatus.VALID,
         json_schema_extra={"instance_var": True},
@@ -40,6 +41,24 @@ class CredentialDefinition(Singleton):
 
 class CredentialComponentToken(Token):
     """Graph credential token that projects to the legacy packet value shape."""
+
+    def component_facets(
+        self,
+        *,
+        channel: str | None = None,
+        facet_type: str | None = None,
+        subject_id: str | None = None,
+    ) -> list[ComponentFacet]:
+        """Return copied definition facets with token and packet provenance."""
+
+        return [
+            facet.model_copy(deep=True).with_provenance(
+                source_id=str(self.uid),
+                subject_id=subject_id,
+            )
+            for facet in self.facets
+            if facet.matches(channel=channel, facet_type=facet_type)
+        ]
 
     def get_label(self) -> str:
         return self.token_from or self.label

--- a/engine/src/tangl/mechanics/credentials/assembly.py
+++ b/engine/src/tangl/mechanics/credentials/assembly.py
@@ -52,9 +52,12 @@ class CredentialComponentToken(Token):
         """Return copied definition facets with token and packet provenance."""
 
         return [
-            facet.model_copy(deep=True).with_provenance(
-                source_id=str(self.uid),
-                subject_id=subject_id,
+            facet.model_copy(
+                deep=True,
+                update={
+                    "source_id": str(self.uid),
+                    "subject_id": subject_id,
+                },
             )
             for facet in self.facets
             if facet.matches(channel=channel, facet_type=facet_type)

--- a/engine/tests/mechanics/credentials/test_credential_packet_manager.py
+++ b/engine/tests/mechanics/credentials/test_credential_packet_manager.py
@@ -296,6 +296,31 @@ def test_credential_token_facets_are_isolated_and_keep_packet_provenance() -> No
     }
 
 
+def test_credential_token_facets_replace_authored_provenance() -> None:
+    definition = credential_definition(
+        "provenance_work_permit",
+        IND.WORK,
+        facets=(
+            ComponentFacet(
+                channel="credential_test",
+                facet_type="giver",
+                source_id="authored-source",
+                subject_id="authored-subject",
+            ),
+        ),
+    )
+    credential = credential_component("provenance-permit", definition)
+    manager = AssemblyCredentialPacketManager()
+    manager.assign(CREDENTIAL_PACKET_SLOT, credential)
+
+    gathered = manager.component_facets(channel="credential_test")
+
+    assert gathered[0].source_id == str(credential.uid)
+    assert gathered[0].subject_id == CREDENTIAL_PACKET_SLOT
+    assert definition.facets[0].source_id == "authored-source"
+    assert definition.facets[0].subject_id == "authored-subject"
+
+
 def test_repeated_credential_facet_discovery_does_not_mutate_graph_state() -> None:
     definition = credential_definition(
         "pure_faceted_permit",

--- a/engine/tests/mechanics/credentials/test_credential_packet_manager.py
+++ b/engine/tests/mechanics/credentials/test_credential_packet_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from uuid import UUID
 
 import pytest
@@ -16,6 +17,7 @@ from tangl.mechanics.credentials import (
     CredentialPacketManager as AssemblyCredentialPacketManager,
     ensure_default_credential_definitions,
 )
+from tangl.mechanics.assembly import ComponentFacet
 from tangl.mechanics.credentials.domain import (
     ContrabandItem,
     CredentialStatus,
@@ -93,12 +95,14 @@ def credential_definition(
     *,
     document_kind: str = "document",
     requires_id: bool = False,
+    facets: tuple[ComponentFacet, ...] = (),
 ) -> CredentialDefinition:
     return CredentialDefinition(
         label=label,
         indication=indication,
         document_kind=document_kind,
         requires_id=requires_id,
+        facets=facets,
     )
 
 
@@ -254,6 +258,120 @@ def test_packet_manager_graph_roundtrip_preserves_credential_assignments_by_id()
     assert derive_disposition(restored_manager, LOCAL_RULES) is D.PASS
     assert sum(1 for item in restored.members.values() if item.uid == id_card.uid) == 1
     assert sum(1 for item in restored.members.values() if item.uid == work_permit.uid) == 1
+
+
+def test_credential_token_facets_are_isolated_and_keep_packet_provenance() -> None:
+    definition = credential_definition(
+        "faceted_work_permit",
+        IND.WORK,
+        facets=(
+            ComponentFacet(
+                channel="credential_test",
+                facet_type="giver",
+                payload={"label": "authored"},
+            ),
+        ),
+    )
+    credential = credential_component("faceted-permit", definition)
+    manager = AssemblyCredentialPacketManager()
+    manager.assign(CREDENTIAL_PACKET_SLOT, credential)
+
+    gathered = manager.component_facets(channel="credential_test")
+
+    assert gathered == [
+        ComponentFacet(
+            channel="credential_test",
+            facet_type="giver",
+            payload={"label": "authored"},
+            source_id=str(credential.uid),
+            subject_id=CREDENTIAL_PACKET_SLOT,
+        )
+    ]
+    assert isinstance(gathered[0].payload, dict)
+    gathered[0].payload["label"] = "mutated"
+
+    assert definition.facets[0].payload == {"label": "authored"}
+    assert manager.component_facets(channel="credential_test")[0].payload == {
+        "label": "authored"
+    }
+
+
+def test_repeated_credential_facet_discovery_does_not_mutate_graph_state() -> None:
+    definition = credential_definition(
+        "pure_faceted_permit",
+        IND.WORK,
+        facets=(
+            ComponentFacet(
+                channel="credential_test",
+                facet_type="giver",
+                payload="permit",
+            ),
+        ),
+    )
+    graph = Graph()
+    owner = graph.add_node(kind=CredentialPacketNode, label="checkpoint")
+    credential = graph.add_node(
+        kind=CredentialComponent,
+        label="pure-faceted-permit",
+        token_from=definition.label,
+    )
+    owner.packet_manager.assign(CREDENTIAL_PACKET_SLOT, credential)
+    before = deepcopy(graph.unstructure())
+
+    first = owner.packet_manager.component_facets(channel="credential_test")
+    second = owner.packet_manager.component_facets(channel="credential_test")
+
+    assert first == second
+    assert graph.unstructure() == before
+
+
+def test_facet_catalogue_loads_before_graph_structure() -> None:
+    definition = credential_definition(
+        "catalogued_faceted_permit",
+        IND.WORK,
+        facets=(
+            ComponentFacet(
+                channel="credential_test",
+                facet_type="giver",
+                payload="catalogued",
+            ),
+        ),
+    )
+    graph = Graph()
+    owner = graph.add_node(kind=CredentialPacketNode, label="checkpoint")
+    credential = graph.add_node(
+        kind=CredentialComponent,
+        label="catalogued-faceted-permit",
+        token_from=definition.label,
+    )
+    owner.packet_manager.assign(CREDENTIAL_PACKET_SLOT, credential)
+    payload = graph.unstructure()
+
+    CredentialDefinition.clear_instances()
+    reloaded_definition = credential_definition(
+        "catalogued_faceted_permit",
+        IND.WORK,
+        facets=(
+            ComponentFacet(
+                channel="credential_test",
+                facet_type="giver",
+                payload="catalogued",
+            ),
+        ),
+    )
+    restored = Graph.structure(payload)
+    restored_owner = restored.find_one(Selector(label="checkpoint"))
+    restored_credential = restored.find_one(Selector(label="catalogued-faceted-permit"))
+
+    assert restored_owner.packet_manager.assignment_ids == {
+        CREDENTIAL_PACKET_SLOT: [credential.uid],
+    }
+    assert restored_owner.packet_manager.get_slot(CREDENTIAL_PACKET_SLOT) == [restored_credential]
+    assert restored_credential.reference_singleton is reloaded_definition
+    assert (
+        restored_credential.component_facets(channel="credential_test")[0].payload
+        == "catalogued"
+    )
 
 
 def test_has_game_block_binds_roster_packet_manager_to_graph_owner() -> None:


### PR DESCRIPTION
## Summary

- add authored facet templates to `CredentialDefinition`
- expose copied, provenance-stamped credential token facets through the existing packet-manager gather path
- prove template isolation, pure repeated discovery, catalogue loading before graph restoration, and constructor-form graph round trips

## Scope

Implements Credentials Retrofit Phase 6a only. VM/choice contribution schemas, action generation, precedence, and UPDATE write-back remain deferred.

## Verification

- `PYTHONPATH=engine/src:apps/cli/src:apps/renpy/src:apps/server/src /Users/derek/Library/Caches/pypoetry/virtualenvs/storytangl-KhFGjfPj-py3.13/bin/python -m pytest engine/tests/mechanics/test_assembly.py engine/tests/mechanics/credentials/test_credential_packet_manager.py engine/tests/persistence/test_component_manager_persistence.py`
- 52 passed, 4 skipped
- scoped `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering credential component facets with filtering and provenance details.
  * Credential facet data is isolated during discovery, allowing safe edits without changing authored definitions or future results.
  * Credential facet information now remains available after saved data is reloaded.

* **Documentation**
  * Added guidance and contracts for planning, implementing, reviewing, and validating StoryTangl feature slices and credential facet discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->