### PR TITLE
Adopt credential facets for request document moves

### DIFF
--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_ASSEMBLY_RETROFIT.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_ASSEMBLY_RETROFIT.md
@@ -12,10 +12,13 @@ credentials domain import surface, graph-backed credential components, an
 owner-bound assembly packet manager, and a `CredentialCase` bridge behind the
 existing disposition protocol. Phase 5 now materializes sampled offers into an
 authoritative packet manager at setup and case-advance boundaries, and persists
-the hosted game through the normal constructor-form graph path. Phase 6a has landed
-the pure credential-token facet bridge; `PHASE_6B_REQUEST_DOCUMENT_HANDOFF.md`
-specifies the first game-handler adoption slice. Expression narrative, contraband
-graph identity, and status decomposition remain future slices.
+the hosted game through the normal constructor-form graph path. Phase 6a landed the
+pure credential-token facet bridge, and Phase 6b landed its first consumer:
+`CredentialsGameHandler` derives the existing `request_document` move from the exact
+`choice / giver / request_document` facet on a manager-backed document. The handler
+remains the choice and resolution authority; flat cases remain a temporary fallback.
+Expression narrative, contraband graph identity, document-identity receipts, and
+status decomposition remain future slices.
 
 **Dependency:** the owner-bound manager and wardrobe transaction substrate provides the
 storage and offer semantics this retrofit relies on: `ComponentManager` stores
@@ -431,9 +434,18 @@ Acceptance:
 
 ### Phase 6: Adopt Component Facets For Contributions
 
-Only after the VM phase-trigger/component-contribution shape is settled:
+Status: Phase 6a and the bounded 6b `request_document` adoption are landed. Phase 6a
+added pure token-to-packet facet discovery with constructor-form persistence proof.
+Phase 6b adds the generated non-id document `choice / giver / request_document`
+contribution and lets `CredentialsGameHandler` lower it into the existing
+indication-based move only when an assembly packet manager is present. It preserves
+the flat compatibility case path, existing labels, accepts, time cost, outcomes, and
+journal prose. A facetless manager document contributes no move, and the selected
+move path uses the same availability rule.
 
-- model credential-provided inspection moves as component facets;
+Later slices may:
+
+- model further credential-provided inspection moves as component facets;
 - model document media projection as a media facet or direct adapter;
 - model score/disposition modifiers as game/credential channels;
 - keep mutation in the existing game UPDATE path or transaction offers.

--- a/engine/src/tangl/mechanics/credentials/PHASE_6B_REQUEST_DOCUMENT_HANDOFF.md
+++ b/engine/src/tangl/mechanics/credentials/PHASE_6B_REQUEST_DOCUMENT_HANDOFF.md
@@ -1,5 +1,20 @@
 # Credentials Phase 6b: Facet-Backed `request_document`
 
+## Status
+
+Implemented 2026-07-14. Generated non-id document definitions now contribute the
+exact `choice / giver / request_document` facet. `CredentialsGameHandler` consumes
+that contribution only for manager-backed cases, resolves token provenance back to the
+packet slot, and retains the flat case loop only when no manager exists. The same
+availability rule protects selected moves, so a facetless manager-backed document is
+non-applicable even if a client submits the legacy move directly.
+
+The slice preserves the existing labels, accepts, time cost, finding outcomes, and
+journal text. Tests cover flat/manager parity, facetless suppression, visible-status
+secrecy, pure repeated availability/provisioning, constructor-form graph round trips,
+and the normal `HasGame` UPDATE path. Document identity remains intentionally deferred:
+the existing move and receipt contract is indication-based.
+
 ## Implementation prompt
 
 Implement the first credentials game consumer of the Phase 6a facet bridge on current

--- a/engine/src/tangl/mechanics/credentials/assembly.py
+++ b/engine/src/tangl/mechanics/credentials/assembly.py
@@ -179,6 +179,7 @@ def _definition_for(
         indication=token.indication,
         document_kind=document_kind,
         requires_id=token.requires_id,
+        facets=_default_definition_facets(document_kind),
     )
 
 
@@ -198,6 +199,18 @@ def _definition_label(
     )
 
 
+def _default_definition_facets(document_kind: str) -> tuple[ComponentFacet, ...]:
+    if document_kind == "document":
+        return (
+            ComponentFacet(
+                channel="choice",
+                facet_type="giver",
+                payload="request_document",
+            ),
+        )
+    return ()
+
+
 def ensure_default_credential_definitions() -> None:
     """Load the finite definition catalog used by generated credential packets."""
 
@@ -215,6 +228,7 @@ def ensure_default_credential_definitions() -> None:
                         indication=indication,
                         document_kind=document_kind,
                         requires_id=requires_id,
+                        facets=_default_definition_facets(document_kind),
                     )
 
 

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -34,6 +34,7 @@ from tangl.journal.fragments import (
 )
 from tangl.mechanics.credentials.assembly import (
     CREDENTIAL_PACKET_SLOT,
+    CredentialComponent,
     CredentialPacketManager as AssemblyCredentialPacketManager,
     materialize_packet,
 )
@@ -1047,12 +1048,26 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         if case.packet_manager is None:
             return [credential.indication for credential in case.document_credentials()]
 
+        return [
+            component.indication
+            for component in CredentialsGameHandler._request_document_components(
+                case.packet_manager
+            )
+        ]
+
+    @staticmethod
+    def _request_document_components(
+        manager: AssemblyCredentialPacketManager,
+    ) -> list[CredentialComponent]:
+        """Return the first packet component contributing each request target."""
+
         components_by_id = {
             str(component.uid): component
-            for component in case.packet_manager.get_slot(CREDENTIAL_PACKET_SLOT)
+            for component in manager.get_slot(CREDENTIAL_PACKET_SLOT)
         }
-        indications: list[Indication] = []
-        for facet in case.packet_manager.component_facets(
+        components: list[CredentialComponent] = []
+        indications: set[Indication] = set()
+        for facet in manager.component_facets(
             channel="choice",
             facet_type="giver",
         ):
@@ -1062,10 +1077,32 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             ):
                 continue
             assert facet.source_id is not None
-            indication = components_by_id[facet.source_id].indication
-            if indication not in indications:
-                indications.append(indication)
-        return indications
+            component = components_by_id[facet.source_id]
+            if component.indication not in indications:
+                components.append(component)
+                indications.add(component.indication)
+        return components
+
+    @staticmethod
+    def _request_document_credential(
+        case: CredentialCase,
+        indication: Indication,
+    ) -> CredentialToken | None:
+        """Return the credential whose facet contributed this request target."""
+
+        if case.packet_manager is None:
+            return case.credential_for(indication)
+        component = next(
+            (
+                component
+                for component in CredentialsGameHandler._request_document_components(
+                    case.packet_manager
+                )
+                if component.indication is indication
+            ),
+            None,
+        )
+        return component.to_credential_token() if component is not None else None
 
     def get_provisioned_moves(self, game: CredentialsGame) -> list[CredentialsMove]:
         moves = list(self.get_available_moves(game))
@@ -1362,7 +1399,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             detail["target_indication"] = indication_value
             return RoundResult.CONTINUE
 
-        permit = game.active_case.credential_for(indication)
+        permit = self._request_document_credential(game.active_case, indication)
         if permit is None:  # off-menu safety; receive_move does not validate
             detail["outcome"] = "request_document_not_applicable"
             detail["target_indication"] = indication_value

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -33,6 +33,7 @@ from tangl.journal.fragments import (
     PresentationHints,
 )
 from tangl.mechanics.credentials.assembly import (
+    CREDENTIAL_PACKET_SLOT,
     CredentialPacketManager as AssemblyCredentialPacketManager,
     materialize_packet,
 )
@@ -1017,9 +1018,9 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         # mediation is indistinguishable from a dud until it is committed. (The
         # outcome is disclosed by running the move, not by its presence.)
         #
-        # request_document: offer for every presented permit not yet requested.
-        for token in case.document_credentials():
-            key = token.indication.value
+        # request_document: offer for every contributing permit not yet requested.
+        for indication in self._request_document_indications(case):
+            key = indication.value
             if key in game.finding_status:
                 continue
             moves.append(CredentialsMove(kind="request_document", target=key))
@@ -1038,6 +1039,33 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         if FindingKey.RELINQUISH not in game.finding_status and self._has_declared_contraband(game):
             moves.append(CredentialsMove(kind="request_relinquish", target=""))
         return moves
+
+    @staticmethod
+    def _request_document_indications(case: CredentialCase) -> list[Indication]:
+        """Return visible document indications that semantically offer reissue."""
+
+        if case.packet_manager is None:
+            return [credential.indication for credential in case.document_credentials()]
+
+        components_by_id = {
+            str(component.uid): component
+            for component in case.packet_manager.get_slot(CREDENTIAL_PACKET_SLOT)
+        }
+        indications: list[Indication] = []
+        for facet in case.packet_manager.component_facets(
+            channel="choice",
+            facet_type="giver",
+        ):
+            if (
+                facet.payload != "request_document"
+                or facet.subject_id != CREDENTIAL_PACKET_SLOT
+            ):
+                continue
+            assert facet.source_id is not None
+            indication = components_by_id[facet.source_id].indication
+            if indication not in indications:
+                indications.append(indication)
+        return indications
 
     def get_provisioned_moves(self, game: CredentialsGame) -> list[CredentialsMove]:
         moves = list(self.get_available_moves(game))
@@ -1328,7 +1356,13 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         #   valid       -> they re-present the same sound permit ("verified");
         #   crime        -> the forgery cannot be reissued; it stands ("confirmed").
         # Only a cleared mitigatable finding upgrades derive_disposition.
-        permit = game.active_case.credential_for(Indication(indication_value))
+        indication = Indication(indication_value)
+        if indication not in self._request_document_indications(game.active_case):
+            detail["outcome"] = "request_document_not_applicable"
+            detail["target_indication"] = indication_value
+            return RoundResult.CONTINUE
+
+        permit = game.active_case.credential_for(indication)
         if permit is None:  # off-menu safety; receive_move does not validate
             detail["outcome"] = "request_document_not_applicable"
             detail["target_indication"] = indication_value

--- a/engine/tests/mechanics/credentials/test_credential_packet_manager.py
+++ b/engine/tests/mechanics/credentials/test_credential_packet_manager.py
@@ -35,6 +35,7 @@ from tangl.mechanics.games.credentials_game import (
     CredentialsMove,
     CredentialsGame,
     CredentialsGameHandler,
+    Finding,
     derive_disposition,
 )
 from tangl.mechanics.games.credentials_roster import ScenarioOffer
@@ -274,6 +275,45 @@ def test_facetless_manager_document_cannot_request_reissue() -> None:
     assert moves == []
     handler.receive_move(game, ("request_document", IND.WORK.value))
     assert game.finding_status == {}
+
+
+def test_manager_request_document_resolves_the_contributing_component() -> None:
+    facetless_definition = credential_definition("facetless_work_permit", IND.WORK)
+    contributing_definition = credential_definition(
+        "contributing_work_permit",
+        IND.WORK,
+        facets=(
+            ComponentFacet(
+                channel="choice",
+                facet_type="giver",
+                payload="request_document",
+            ),
+        ),
+    )
+    manager = AssemblyCredentialPacketManager(purpose=IND.WORK)
+    manager.assign(
+        CREDENTIAL_PACKET_SLOT,
+        credential_component(
+            "facetless-forged-work-permit",
+            facetless_definition,
+            status=S.FORGED,
+        ),
+    )
+    manager.assign(
+        CREDENTIAL_PACKET_SLOT,
+        credential_component(
+            "contributing-missing-seal-work-permit",
+            contributing_definition,
+            status=S.MISSING_SEAL,
+        ),
+    )
+    game, handler, moves = staged_request_document_moves(CredentialCase(packet_manager=manager))
+
+    assert moves == [CredentialsMove(kind="request_document", target=IND.WORK.value)]
+
+    handler.receive_move(game, ("request_document", IND.WORK.value))
+
+    assert game.finding_status == {IND.WORK.value: Finding.CLEARED}
 
 
 def test_manager_request_document_menu_does_not_reveal_credential_status() -> None:

--- a/engine/tests/mechanics/credentials/test_credential_packet_manager.py
+++ b/engine/tests/mechanics/credentials/test_credential_packet_manager.py
@@ -16,6 +16,7 @@ from tangl.mechanics.credentials import (
     CredentialDefinition,
     CredentialPacketManager as AssemblyCredentialPacketManager,
     ensure_default_credential_definitions,
+    materialize_packet,
 )
 from tangl.mechanics.assembly import ComponentFacet
 from tangl.mechanics.credentials.domain import (
@@ -31,6 +32,7 @@ from tangl.mechanics.games import HasGame
 from tangl.mechanics.games.credentials_game import (
     CredentialCase,
     CredentialDisposition,
+    CredentialsMove,
     CredentialsGame,
     CredentialsGameHandler,
     derive_disposition,
@@ -144,6 +146,44 @@ def valid_work_packet() -> tuple[
     return manager, id_card, work_permit
 
 
+def materialized_work_packet(
+    status: CredentialStatus = CredentialStatus.VALID,
+) -> AssemblyCredentialPacketManager:
+    return materialize_packet(
+        owner=object(),
+        region=Region.LOCAL,
+        purpose=IND.WORK,
+        id_card=CredentialToken(indication=IND.TRAVEL),
+        credentials=[
+            CredentialToken(
+                indication=IND.WORK,
+                status=status,
+                requires_id=True,
+            ),
+        ],
+        possessions=[],
+        label_prefix="candidate",
+    )
+
+
+def staged_request_document_moves(
+    case: CredentialCase,
+) -> tuple[CredentialsGame, CredentialsGameHandler, list[CredentialsMove]]:
+    game = CredentialsGame(roster=[case], restriction_map=LOCAL_RULES)
+    handler = CredentialsGameHandler()
+    handler.setup(game)
+    handler.receive_move(game, ("inspect", "passport"))
+    return (
+        game,
+        handler,
+        [
+            move
+            for move in handler.get_available_moves(game)
+            if move.kind == "request_document"
+        ],
+    )
+
+
 def test_assembly_packet_projects_legacy_discovery_surface() -> None:
     manager, id_card, work_permit = valid_work_packet()
 
@@ -182,6 +222,118 @@ def test_assembly_packet_preserves_failure_parity() -> None:
 
     assert derive_disposition(manager, LOCAL_RULES) is D.ARREST
     assert derive_disposition(case, LOCAL_RULES) is D.ARREST
+
+
+def test_default_document_definitions_offer_request_document() -> None:
+    manager = materialized_work_packet()
+    id_card = manager.get_slot(CREDENTIAL_ID_SLOT)[0]
+    permit = manager.get_slot(CREDENTIAL_PACKET_SLOT)[0]
+
+    assert id_card.component_facets(channel="choice") == []
+    assert permit.component_facets(channel="choice") == [
+        ComponentFacet(
+            channel="choice",
+            facet_type="giver",
+            payload="request_document",
+            source_id=str(permit.uid),
+        )
+    ]
+
+
+def test_manager_backed_request_document_matches_flat_case_contract() -> None:
+    flat_case = CredentialCase(
+        purpose=IND.WORK,
+        id_card=CredentialToken(indication=IND.TRAVEL),
+        packet=[CredentialToken(indication=IND.WORK, requires_id=True)],
+    )
+    manager_case = CredentialCase(packet_manager=materialized_work_packet())
+
+    flat_game, flat_handler, flat_moves = staged_request_document_moves(flat_case)
+    manager_game, manager_handler, manager_moves = staged_request_document_moves(manager_case)
+
+    assert manager_moves == flat_moves == [
+        CredentialsMove(kind="request_document", target=IND.WORK.value),
+    ]
+    assert manager_handler.get_move_label(manager_game, manager_moves[0]) == (
+        flat_handler.get_move_label(flat_game, flat_moves[0])
+    )
+    assert manager_handler.get_move_accepts(manager_game, manager_moves[0]).model_dump() == (
+        flat_handler.get_move_accepts(flat_game, flat_moves[0]).model_dump()
+    )
+
+
+def test_facetless_manager_document_cannot_request_reissue() -> None:
+    definition = credential_definition("facetless_work_permit", IND.WORK)
+    manager = AssemblyCredentialPacketManager(purpose=IND.WORK)
+    manager.assign(
+        CREDENTIAL_PACKET_SLOT,
+        credential_component("facetless-work-permit", definition),
+    )
+    game, handler, moves = staged_request_document_moves(CredentialCase(packet_manager=manager))
+
+    assert moves == []
+    handler.receive_move(game, ("request_document", IND.WORK.value))
+    assert game.finding_status == {}
+
+
+def test_manager_request_document_menu_does_not_reveal_credential_status() -> None:
+    menus = []
+    for status in (S.VALID, S.MISSING_SEAL, S.FORGED):
+        _, _, moves = staged_request_document_moves(
+            CredentialCase(packet_manager=materialized_work_packet(status)),
+        )
+        menus.append(moves)
+
+    assert menus == [
+        [CredentialsMove(kind="request_document", target=IND.WORK.value)],
+    ] * 3
+
+
+def test_manager_request_document_availability_is_pure_and_roundtrips() -> None:
+    graph = Graph()
+    block = graph.add_node(kind=CredentialsBlock, label="checkpoint")
+    block.game_state = CredentialsGame(
+        roster=[
+            CredentialCase(
+                packet_manager=materialize_packet(
+                    owner=block,
+                    region=Region.LOCAL,
+                    purpose=IND.WORK,
+                    id_card=CredentialToken(indication=IND.TRAVEL),
+                    credentials=[CredentialToken(indication=IND.WORK, requires_id=True)],
+                    possessions=[],
+                    label_prefix="Mara",
+                ),
+            ),
+        ],
+        restriction_map=LOCAL_RULES,
+    )
+    handler = block.game_handler
+    handler.setup(block.game)
+    handler.receive_move(block.game, ("inspect", "passport"))
+    before = deepcopy(graph.unstructure())
+
+    first = handler.get_available_moves(block.game)
+    provisioned = handler.get_provisioned_moves(block.game)
+
+    assert [move for move in first if move.kind == "request_document"] == [
+        CredentialsMove(kind="request_document", target=IND.WORK.value),
+    ]
+    assert [move for move in provisioned if move.kind == "request_document"] == [
+        CredentialsMove(kind="request_document", target=IND.WORK.value),
+    ]
+    assert graph.unstructure() == before
+
+    CredentialDefinition.clear_instances()
+    ensure_default_credential_definitions()
+    restored = Graph.structure(before)
+    restored_block = restored.find_one(Selector(label="checkpoint"))
+    restored_moves = restored_block.game_handler.get_available_moves(restored_block.game)
+
+    assert restored_block.game.active_case.packet_manager.owner is restored_block
+    assert [move for move in restored_moves if move.kind == "request_document"] == [
+        CredentialsMove(kind="request_document", target=IND.WORK.value),
+    ]
 
 
 def test_packet_manager_keeps_contraband_value_shaped_for_now() -> None:

--- a/engine/tests/mechanics/games/test_credentials_game.py
+++ b/engine/tests/mechanics/games/test_credentials_game.py
@@ -5,7 +5,15 @@ from __future__ import annotations
 import pytest
 
 from tangl.core import Graph
-from tangl.mechanics.games import GameResult, HasGame
+from tangl.mechanics.credentials import materialize_packet
+from tangl.mechanics.games import (
+    CredentialStatus,
+    CredentialToken,
+    GameResult,
+    HasGame,
+    Indication,
+    Region,
+)
 from tangl.mechanics.games.credentials_game import (
     CredentialCase,
     CredentialDisposition,
@@ -356,3 +364,58 @@ class TestCredentialsIntegration:
         assert "passport" in namespace["credential_discovered_findings"]
         assert namespace["credential_stage"] == "packet"
         assert namespace["credential_roster_size"] == 2
+
+    def test_faceted_request_document_uses_existing_has_game_update_path(self) -> None:
+        graph = Graph(label="credential_facets")
+        intro = graph.add_node(kind=Block, label="intro")
+        victory = graph.add_node(kind=Block, label="victory")
+        defeat = graph.add_node(kind=Block, label="defeat")
+        block = CredentialsBlock.create_game_block(
+            graph=graph,
+            game_class=CredentialsGame,
+            handler_class=CredentialsGameHandler,
+            victory_dest=victory,
+            defeat_dest=defeat,
+            label="checkpoint",
+        )
+        block.game.roster = [
+            CredentialCase(
+                packet_manager=materialize_packet(
+                    owner=block,
+                    region=Region.LOCAL,
+                    purpose=Indication.WORK,
+                    id_card=CredentialToken(indication=Indication.TRAVEL),
+                    credentials=[
+                        CredentialToken(
+                            indication=Indication.WORK,
+                            status=CredentialStatus.MISSING_SEAL,
+                            requires_id=True,
+                        ),
+                    ],
+                    possessions=[],
+                    label_prefix="Mara",
+                ),
+            ),
+        ]
+        block.game_handler.setup(block.game)
+        intro_to_checkpoint = ChoiceEdge(
+            graph=graph,
+            predecessor_id=intro.uid,
+            successor_id=block.uid,
+            label="Open the gate ledger",
+        )
+        ledger = Ledger.from_graph(graph=graph, entry_id=intro.uid)
+        ledger.resolve_choice(intro_to_checkpoint.uid)
+
+        self._inspect(ledger, "passport")
+        action = next(
+            action
+            for action in self._actions(ledger)
+            if action.label == "Request reissue of work permit"
+        )
+        history_size = len(block.game.history)
+        ledger.resolve_choice(action.uid)
+
+        assert len(block.game.history) == history_size + 1
+        assert block.game.finding_status == {Indication.WORK.value: "cleared"}
+        assert block.game.time_spent == 3


### PR DESCRIPTION
## Summary

- add the authored `choice / giver / request_document` facet to generated non-id credential definitions
- have `CredentialsGameHandler` derive manager-backed request-document availability from packet facets and token provenance
- preserve the flat compatibility path and existing labels, accepts, outcomes, time cost, and journal behavior
- prove facet authority, visible-status secrecy, pure availability, graph round-trip restoration, and the normal HasGame UPDATE path

## Validation

- focused credential, mediation, integration, world, and Sphinx suite: 58 passed
- full engine suite (Python 3.13): 2,736 passed, 69 skipped, 9 xfailed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Credential document definitions now include component facets to drive manager-backed document request actions.
  - “Request reissue of work permit” is now available for eligible manager-backed cases, while flat-case behavior remains compatible.
  - Facetless credential managers no longer offer document reissue actions.
  - Request-document availability is computed safely and does not reveal credential status.

- **Bug Fixes**
  - Unavailable/forged document requests no longer resolve permits and instead result in non-applicable outcomes.
  - Request flows preserve existing game history/state updates when using the has-game update path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->