### PR TITLE
Add Hall Monitor credentials conformance world

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,6 @@ name: "CodeQL Advanced"
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
   schedule:
     - cron: '16 23 * * 5'
 

--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_ASSEMBLY_RETROFIT.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_ASSEMBLY_RETROFIT.md
@@ -22,8 +22,8 @@ origin/indication ids compile into named, bounded token catalogs exposed by the 
 world. A scenario type selects one world-local catalog, and packet materialization
 searches only that catalog rather than a game-owned world namespace or the global
 Singleton population. Qualified definition labels remain an internal persistence detail.
-Phase 6d is planned as the real Hall Monitor conformance vertical: a bespoke scenario
-type selects the school catalog, a script-configured shift narrows it to one scenario
+Phase 6d landed as the real Hall Monitor conformance vertical: a bespoke scenario type
+selects the school catalog, a script-configured shift narrows it to one scenario
 instance, and generated plus pinned student encounters reuse the same logical packet,
 disposition, handler, and persistence path under a school-specific projection.
 Expression narrative beyond that first skin seam, contraband graph identity,

--- a/engine/src/tangl/mechanics/credentials/PHASE_6D_HALL_MONITOR_SCENARIO_HANDOFF.md
+++ b/engine/src/tangl/mechanics/credentials/PHASE_6D_HALL_MONITOR_SCENARIO_HANDOFF.md
@@ -2,12 +2,13 @@
 
 ## Status
 
-**READY FOR IMPLEMENTATION (2026-07-19).** Phase 6c landed in PR #311 with named,
-bounded world catalogs, world-local `catalog_ref` selection, qualified persistence
-identity, open origin/indication coordinates, and skin-aware `request_document`
-realization. Its temporary Hall Monitor fixture proves catalog and wording isolation,
-but it is not a playable world and does not prove the lower half of the mechanics
-adoption model.
+**LANDED (2026-07-19).** Phase 6c landed in PR #311 with named, bounded world
+catalogs, world-local `catalog_ref` selection, qualified persistence identity, open
+origin/indication coordinates, and skin-aware `request_document` realization. Phase 6d
+adds the playable `worlds/hall_monitor` conformance world: its script configures a
+seeded school shift with a pinned student, while generated encounters use the existing
+offer, packet, disposition, game-handler, planning, and persistence lifecycle. School
+presentation realizes the same logical statuses without changing checkpoint behavior.
 
 Phase 6d proves:
 

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -14,9 +14,9 @@ from __future__ import annotations
 
 import uuid
 from enum import Enum
-from typing import TYPE_CHECKING, ClassVar, Protocol
+from typing import TYPE_CHECKING, ClassVar, Protocol, Self
 
-from pydantic import Field, PrivateAttr
+from pydantic import Field, PrivateAttr, model_validator
 
 if TYPE_CHECKING:
     from .credentials_roster import ScenarioOffer
@@ -714,6 +714,22 @@ class CredentialPresentationProfile(BaseModelPlus):
             "request_document_not_applicable": "There is nothing to reissue.",
         }
     )
+
+    @model_validator(mode="after")
+    def validate_status_text(self) -> Self:
+        """Require authored profiles to name every invalid credential status."""
+
+        missing = [
+            status.value
+            for status in CredentialStatus
+            if not status.is_valid and status not in self.status_text
+        ]
+        if missing:
+            raise ValueError(
+                "status_text must define every invalid credential status; "
+                f"missing: {', '.join(missing)}"
+            )
+        return self
 
     def document_label(
         self,

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -682,11 +682,29 @@ class CredentialPresentationProfile(BaseModelPlus):
 
     indication_labels: dict[IndicationId, str] = Field(default_factory=dict)
     document_labels: dict[IndicationId, str] = Field(default_factory=dict)
+    identity_label: str = "passport"
+    identity_description: str = "An identity document."
+    document_description: str = "A {document}."
+    possession_description: str = "Openly declared {indication}."
+    status_text: dict[CredentialStatus, str] = Field(
+        default_factory=lambda: {
+            CredentialStatus.MISSING_SEAL: "The issuing seal is missing.",
+            CredentialStatus.BAD_DATE: "The issue date is wrong.",
+            CredentialStatus.EXPIRED: "The credential has expired.",
+            CredentialStatus.FORGED: "The seal is a forgery.",
+            CredentialStatus.WRONG_HOLDER: "The holder does not match this document.",
+        }
+    )
+    holder_mismatch_text: str = "The permit's holder does not match the bearer id."
+    packet_inconsistency_text: str = (
+        "The packet does not satisfy the checkpoint rules as presented."
+    )
     move_labels: dict[str, str] = Field(
         default_factory=lambda: {
             "request_document": "Request reissue of {document}",
         }
     )
+    decision_labels: dict[str, str] = Field(default_factory=dict)
     journal_text: dict[str, str] = Field(
         default_factory=lambda: {
             "request_document": "You request a reissue of the {document}.",
@@ -713,6 +731,39 @@ class CredentialPresentationProfile(BaseModelPlus):
             document=document,
             indication=self.indication_labels.get(indication, indication),
         )
+
+    def render_case(self, case: CredentialCase) -> CredentialCase:
+        """Project compatibility inspection text from logical packet truth."""
+
+        documents: dict[str, str] = {}
+        findings: dict[str, str] = {}
+
+        id_card = case.id_credential()
+        if id_card is not None:
+            documents[self.identity_label] = self.identity_description
+            if not id_card.status.is_valid:
+                findings[self.identity_label] = self.status_text[id_card.status]
+
+        for token in case.document_credentials():
+            document = self.document_label(token.indication)
+            documents[document] = self.document_description.format(document=document)
+            if not token.status.is_valid:
+                findings[document] = self.status_text[token.status]
+            elif not token.holder_matches:
+                findings[document] = self.holder_mismatch_text
+
+        for item in case.possessions:
+            indication = self.indication_labels.get(item.indication, item.indication)
+            documents[f"declared {indication}"] = self.possession_description.format(
+                indication=indication,
+            )
+
+        case.presented_documents = documents
+        case.hidden_facts = findings
+        case.packet_hidden_facts = (
+            {"packet consistency": self.packet_inconsistency_text} if findings else {}
+        )
+        return case
 
 
 class CredentialsGame(PickingGame):
@@ -855,7 +906,13 @@ class CredentialsGame(PickingGame):
 
         while len(self.materialized) <= self.case_index:
             offer = self.offers[len(self.materialized)]
-            self.materialized.append(materialize(offer, self.restriction_map))
+            self.materialized.append(
+                materialize(
+                    offer,
+                    self.restriction_map,
+                    narrative_renderer=self.presentation.render_case,
+                )
+            )
         case = self.materialized[self.case_index]
         if self.has_component_manager_owner:
             case.materialize_packet_manager(
@@ -1252,6 +1309,11 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             return "Ask for anything to declare"
         if move.kind == "request_relinquish":
             return "Have the contraband surrendered"
+        if move.kind == "decide":
+            return game.presentation.decision_labels.get(
+                move.target,
+                f"Choose {move.target}",
+            )
         return f"Choose {move.target}"
 
     def get_move_accepts(

--- a/engine/src/tangl/mechanics/games/credentials_roster.py
+++ b/engine/src/tangl/mechanics/games/credentials_roster.py
@@ -16,7 +16,7 @@ repeated generation and ordinary list edits on the offers; no extra machinery.
 from __future__ import annotations
 
 import random
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 
 from pydantic import Field
@@ -86,6 +86,7 @@ class ShiftSpec:
         default_factory=lambda: dict(_DEFAULT_DISPOSITIONS)
     )
     purpose_pool: Sequence[IndicationId] = tuple(sorted(PURPOSES))
+    allowed_failure_modes: Sequence[FailureMode] | None = None
     pinned: Sequence[ScenarioOffer] = ()
     seed: int | None = None
 
@@ -100,6 +101,7 @@ def _verified_offer(
     target: CredentialDisposition,
     rules: Restrictions,
     rng: random.Random,
+    allowed_failure_modes: Sequence[FailureMode] | None = None,
 ) -> ScenarioOffer | None:
     """Build an offer for ``(region, purpose)`` that derives to ``target``, or None.
 
@@ -122,6 +124,8 @@ def _verified_offer(
         FailureClass.MITIGATABLE if target is CredentialDisposition.DENY else FailureClass.CRIME
     )
     candidates = applicable_modes(base, failure_class)
+    if allowed_failure_modes is not None:
+        candidates = [mode for mode in candidates if mode in allowed_failure_modes]
     rng.shuffle(candidates)
     for mode in candidates:
         trial = degrade(build_valid(region, purpose, rules), [mode])
@@ -175,7 +179,14 @@ def generate_roster(spec: ShiftSpec, rng: random.Random | None = None) -> list[S
 
         offer = None
         for purpose in purposes:
-            offer = _verified_offer(region, purpose, target, spec.rules, rng)
+            offer = _verified_offer(
+                region,
+                purpose,
+                target,
+                spec.rules,
+                rng,
+                spec.allowed_failure_modes,
+            )
             if offer is not None:
                 break
         roster.append(offer or make_offer(region, purposes[0], target, spec.rules, rng))
@@ -185,7 +196,12 @@ def generate_roster(spec: ShiftSpec, rng: random.Random | None = None) -> list[S
     return roster
 
 
-def materialize(offer: ScenarioOffer, rules: Restrictions) -> CredentialCase:
+def materialize(
+    offer: ScenarioOffer,
+    rules: Restrictions,
+    *,
+    narrative_renderer: Callable[[CredentialCase], CredentialCase] | None = None,
+) -> CredentialCase:
     """Build the concrete candidate for ``offer`` (deterministic).
 
     Replays the offer's verified failure modes onto a fresh valid packet, so the
@@ -204,7 +220,7 @@ def materialize(offer: ScenarioOffer, rules: Restrictions) -> CredentialCase:
         contraband=list(offer.contraband),
     )
     degrade(case, offer.failure_modes)
-    render_narrative(case)
+    (narrative_renderer or render_narrative)(case)
     case.whitelist = offer.whitelist
     case.blacklist = offer.blacklist
     return case

--- a/engine/src/tangl/mechanics/games/credentials_roster.py
+++ b/engine/src/tangl/mechanics/games/credentials_roster.py
@@ -75,7 +75,11 @@ class ScenarioOffer(Unstructurable):
 
 @dataclass(frozen=True)
 class ShiftSpec:
-    """Generation-time recipe for one shift's roster (not persisted game state)."""
+    """Generation-time recipe for one shift's roster (not persisted game state).
+
+    When ``allowed_failure_modes`` is set, it must still permit every requested
+    disposition for the configured origin and purpose pools.
+    """
 
     rules: Restrictions
     encounters: int = 5
@@ -189,7 +193,12 @@ def generate_roster(spec: ShiftSpec, rng: random.Random | None = None) -> list[S
             )
             if offer is not None:
                 break
-        roster.append(offer or make_offer(region, purposes[0], target, spec.rules, rng))
+        if offer is None:
+            raise ValueError(
+                f"No configured purpose can produce {target.value!r} for {region!r} "
+                "under the configured failure policy."
+            )
+        roster.append(offer)
 
     for offer in pinned:
         roster.insert(rng.randint(0, len(roster)), offer)

--- a/engine/tests/loaders/test_credential_gate_world.py
+++ b/engine/tests/loaders/test_credential_gate_world.py
@@ -193,8 +193,8 @@ class TestCredentialGateWorld:
             )
 
     def test_compiled_hall_monitor_uses_authored_ids_and_wording(self, tmp_path: Path) -> None:
-        root = tmp_path / "hall_monitor"
-        package = root / "hall_monitor"
+        root = tmp_path / "hall_monitor_fixture"
+        package = root / "hall_monitor_fixture"
         package.mkdir(parents=True)
         (package / "__init__.py").write_text("", encoding="utf-8")
         (package / "domain.py").write_text(
@@ -202,9 +202,9 @@ class TestCredentialGateWorld:
             encoding="utf-8",
         )
         (root / "world.yaml").write_text(
-            """label: hall_monitor
+            """label: hall_monitor_fixture
 scripts: script.yaml
-domain_module: hall_monitor.domain
+domain_module: hall_monitor_fixture.domain
 assets:
   - asset_kind: CredentialDefinition
     catalog: border
@@ -216,7 +216,7 @@ assets:
             encoding="utf-8",
         )
         (root / "script.yaml").write_text(
-            """label: hall_monitor
+            """label: hall_monitor_fixture
 metadata:
   title: Hall Monitor
 scenes:

--- a/engine/tests/loaders/test_hall_monitor_world.py
+++ b/engine/tests/loaders/test_hall_monitor_world.py
@@ -1,0 +1,153 @@
+"""Conformance tests for the Hall Monitor credentials world."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tangl.core import Graph, Selector
+from tangl.loaders import WorldBundle
+from tangl.loaders.compiler import WorldCompiler
+from tangl.mechanics.credentials import (
+    CREDENTIAL_PACKET_SLOT,
+    CredentialDefinition,
+    FailureMode,
+)
+from tangl.mechanics.games.credentials_game import CredentialDisposition, derive_disposition
+from tangl.mechanics.games.credentials_roster import materialize
+from tangl.service.world_registry import WorldRegistry
+from tangl.story import Action, InitMode, StoryGraph
+from tangl.vm import Ledger
+
+
+def _repo_worlds_dir() -> Path:
+    return Path(__file__).resolve().parents[3] / "worlds"
+
+
+def _hall_monitor_root() -> Path:
+    return _repo_worlds_dir() / "hall_monitor"
+
+
+def _actions(ledger: Ledger) -> list[Action]:
+    return list(ledger.cursor.edges_out(Selector(has_kind=Action, trigger_phase=None)))
+
+
+def _choose(ledger: Ledger, label: str) -> None:
+    action = next(action for action in _actions(ledger) if action.label == label or action.text == label)
+    ledger.resolve_choice(action.uid)
+
+
+def _inspect(ledger: Ledger, target: str) -> None:
+    action = next(action for action in _actions(ledger) if action.label == "Inspect a document")
+    game = ledger.cursor.game
+    ledger.resolve_choice(
+        action.uid,
+        choice_payload={"piece_ids": [f"{game.case_index}:{target}"]},
+    )
+
+
+def _started_shift() -> tuple[StoryGraph, Ledger]:
+    world = WorldCompiler().compile(WorldBundle.load(_hall_monitor_root()))
+    result = world.create_story("hall_monitor", init_mode=InitMode.EAGER)
+    ledger = Ledger.from_graph(result.graph, entry_id=result.graph.initial_cursor_id)
+    _choose(ledger, "Monitor the morning halls")
+    return result.graph, ledger
+
+
+class TestHallMonitorWorld:
+    """The school skin exercises the shared credentials lifecycle."""
+
+    def test_registry_discovers_hall_monitor(self) -> None:
+        registry = WorldRegistry([_repo_worlds_dir()])
+
+        assert registry.bundles["hall_monitor"].manifest.metadata["title"] == "Hall Monitor"
+
+    def test_compiles_school_catalog_without_checkpoint_definitions(self) -> None:
+        world = WorldCompiler().compile(WorldBundle.load(_hall_monitor_root()))
+        catalog = world.assets.values["school"]
+
+        assert catalog.label == "school"
+        assert CredentialDefinition.get_instance("hall_monitor:school:activity_pass") in catalog.members
+        assert all("credential_gate" not in definition.label for definition in catalog.members)
+        assert {definition.indication for definition in catalog.members} >= {
+            "academic",
+            "activity",
+            "off_campus",
+            "uniform",
+            "medicine",
+            "records",
+        }
+
+    def test_script_configures_a_seeded_shift_with_a_pinned_student(self) -> None:
+        graph, ledger = _started_shift()
+        block = graph.find_one(Selector(label="morning_shift"))
+        game = ledger.cursor.game
+
+        assert block is ledger.cursor
+        assert block.encounters == 5
+        assert block.seed == 20260719
+        assert block.disposition_distribution == {
+            CredentialDisposition.PASS: 0.5,
+            CredentialDisposition.DENY: 0.3,
+            CredentialDisposition.ARREST: 0.2,
+        }
+        assert len(game.offers) == 5
+        assert any(offer.pinned_case is not None for offer in game.offers)
+        assert all(
+            set(offer.failure_modes).isdisjoint(
+                {FailureMode.UNPERMITTED_CONTRABAND, FailureMode.CONCEALED_CONTRABAND}
+            )
+            for offer in game.offers
+        )
+
+        for offer in game.offers:
+            case = materialize(
+                offer,
+                game.restriction_map,
+                narrative_renderer=game.presentation.render_case,
+            )
+            assert derive_disposition(case, game.restriction_map) is offer.target_disposition
+
+    def test_school_projection_and_full_shift_keep_the_shared_loop(self) -> None:
+        _, ledger = _started_shift()
+        first_case = ledger.cursor.game.active_case
+
+        assert "student ID" in first_case.presented_documents
+        assert "activity pass" in first_case.presented_documents
+        assert "passport" not in first_case.presented_documents
+
+        while ledger.cursor.label == "morning_shift":
+            game = ledger.cursor.game
+            target = next(iter(game.presented_documents))
+            _inspect(ledger, target)
+            decision = game.expected_disposition(game.active_case).value
+            _choose(ledger, game.presentation.decision_labels[decision])
+
+        assert ledger.cursor.label == "victory"
+
+    def test_active_school_packet_round_trips_with_bound_catalog_components(self) -> None:
+        graph, ledger = _started_shift()
+        game = ledger.cursor.game
+        manager = game.active_case.packet_manager
+        assert manager is not None
+
+        restored = Graph.structure(graph.unstructure())
+        block = restored.find_one(Selector(label="morning_shift"))
+        assert block is not None
+        restored_manager = block.game.active_case.packet_manager
+        assert restored_manager is not None
+        assert restored_manager.get_slot(CREDENTIAL_PACKET_SLOT)
+        assert all(
+            component.reference_singleton.label.startswith("hall_monitor:school:")
+            for component in restored_manager.get_slot(CREDENTIAL_PACKET_SLOT)
+        )
+
+    def test_repeated_provisioning_does_not_materialize_another_case(self) -> None:
+        _, ledger = _started_shift()
+        game = ledger.cursor.game
+        handler = ledger.cursor.game_handler
+
+        first = handler.get_provisioned_moves(game)
+        second = handler.get_provisioned_moves(game)
+
+        assert first == second
+        assert len(game.materialized) == 1

--- a/engine/tests/mechanics/games/test_credentials_game.py
+++ b/engine/tests/mechanics/games/test_credentials_game.py
@@ -16,6 +16,7 @@ from tangl.mechanics.games import (
 )
 from tangl.mechanics.games.credentials_game import (
     CredentialCase,
+    CredentialPresentationProfile,
     CredentialDisposition,
     CredentialsGame,
     CredentialsGameHandler,
@@ -67,6 +68,13 @@ class CredentialsBlock(HasGame, Block):
 
     _game_class = CredentialsGame
     _game_handler_class = CredentialsGameHandler
+
+
+def test_presentation_requires_text_for_every_invalid_status() -> None:
+    with pytest.raises(ValueError, match="status_text must define every invalid credential status"):
+        CredentialPresentationProfile(
+            status_text={CredentialStatus.MISSING_SEAL: "The seal is missing."}
+        )
 
 
 class TestCredentialsCore:

--- a/engine/tests/mechanics/games/test_credentials_roster.py
+++ b/engine/tests/mechanics/games/test_credentials_roster.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import random
 
+import pytest
+
 from tangl.mechanics.games import (
     CredentialCase,
     CredentialDisposition,
@@ -63,6 +65,18 @@ class TestGenerateRoster:
         a = generate_roster(_spec(seed=7))
         b = generate_roster(_spec(seed=7))
         assert [o.model_dump() for o in a] == [o.model_dump() for o in b]
+
+    def test_rejects_an_unsatisfiable_allowed_failure_policy(self) -> None:
+        spec = _spec(
+            encounters=1,
+            origin_distribution={Region.LOCAL: 1.0},
+            purpose_pool=[IND.WORK],
+            disposition_distribution={D.ARREST: 1.0},
+            allowed_failure_modes=[FailureMode.MISSING_PERMIT],
+        )
+
+        with pytest.raises(ValueError, match="No configured purpose"):
+            generate_roster(spec)
 
 
 class TestLinchpinInvariant:

--- a/worlds/credential_gate/README.md
+++ b/worlds/credential_gate/README.md
@@ -11,6 +11,10 @@ selects that catalog through its local `catalog_ref`; it does not query the proc
 singleton population. The shared compiler/loader contract is
 `engine/src/tangl/mechanics/credentials/PHASE_6C_AUTHORED_CATALOG_HANDOFF.md`.
 
+Together with `worlds/hall_monitor`, this is a conformance surface for the same
+credentials kernel: each world supplies only its catalog, scenario policy, and
+presentation while packet, disposition, game, and persistence lifecycle stay shared.
+
 ## Semantic operations versus skin vocabulary
 
 The checkpoint and hall-monitor skins use the same normalized operations but

--- a/worlds/hall_monitor/README.md
+++ b/worlds/hall_monitor/README.md
@@ -1,0 +1,12 @@
+# Hall Monitor
+
+`hall_monitor` is the school conformance world for the reusable credentials
+mechanic. It exposes a world-local `school` catalog, fixes that catalog on its
+Hall Monitor scenario type, and lets the script configure one sampled morning
+shift with a deterministic seed, disposition distribution, and recurring
+student encounter.
+
+The world keeps school vocabulary—student IDs, teacher signatures, activity
+passes, and office referrals—in its catalog and presentation profile. The shared
+credentials game still owns packet materialization, availability, inspection,
+mediation, disposition resolution, scoring, and persistence.

--- a/worlds/hall_monitor/credential_types.yaml
+++ b/worlds/hall_monitor/credential_types.yaml
@@ -1,0 +1,116 @@
+# School-owned credential catalog. Local item ids and names are world content;
+# the compiler qualifies their singleton labels by world and catalog.
+
+student_id_academic:
+  name: Student ID
+  origin_ids: [upper, lower, exchange]
+  indication: academic
+  document_kind: id
+  requires_id: false
+
+student_id_activity:
+  name: Student ID
+  origin_ids: [upper, lower, exchange]
+  indication: activity
+  document_kind: id
+  requires_id: false
+
+student_id_off_campus:
+  name: Student ID
+  origin_ids: [upper, lower, exchange]
+  indication: off_campus
+  document_kind: id
+  requires_id: false
+
+student_id_uniform:
+  name: Student ID
+  origin_ids: [upper, lower, exchange]
+  indication: uniform
+  document_kind: id
+  requires_id: false
+
+student_id_medicine:
+  name: Student ID
+  origin_ids: [upper, lower, exchange]
+  indication: medicine
+  document_kind: id
+  requires_id: false
+
+student_id_records:
+  name: Student ID
+  origin_ids: [upper, lower, exchange]
+  indication: records
+  document_kind: id
+  requires_id: false
+
+hall_pass:
+  name: Hall Pass
+  origin_ids: [upper, lower, exchange]
+  indication: academic
+  issuer_group: classroom
+  document_kind: document
+  requires_id: true
+  facets:
+    - channel: choice
+      facet_type: giver
+      payload: request_document
+
+activity_pass:
+  name: Activity Pass
+  origin_ids: [upper, lower, exchange]
+  indication: activity
+  issuer_group: activities_office
+  document_kind: document
+  requires_id: true
+  facets:
+    - channel: choice
+      facet_type: giver
+      payload: request_document
+
+off_campus_pass:
+  name: Off-Campus Pass
+  origin_ids: [upper, lower, exchange]
+  indication: off_campus
+  issuer_group: attendance_office
+  document_kind: document
+  requires_id: true
+  facets:
+    - channel: choice
+      facet_type: giver
+      payload: request_document
+
+uniform_waiver:
+  name: Uniform Waiver
+  origin_ids: [upper, lower, exchange]
+  indication: uniform
+  issuer_group: dean
+  document_kind: document
+  requires_id: true
+  facets:
+    - channel: choice
+      facet_type: giver
+      payload: request_document
+
+doctors_note:
+  name: Doctor's Note
+  origin_ids: [upper, lower, exchange]
+  indication: medicine
+  issuer_group: nurses_office
+  document_kind: document
+  requires_id: true
+  facets:
+    - channel: choice
+      facet_type: giver
+      payload: request_document
+
+office_pass:
+  name: Office Pass
+  origin_ids: [upper, lower, exchange]
+  indication: records
+  issuer_group: front_office
+  document_kind: document
+  requires_id: true
+  facets:
+    - channel: choice
+      facet_type: giver
+      payload: request_document

--- a/worlds/hall_monitor/hall_monitor/__init__.py
+++ b/worlds/hall_monitor/hall_monitor/__init__.py
@@ -1,0 +1,1 @@
+"""Hall Monitor world domain."""

--- a/worlds/hall_monitor/hall_monitor/domain.py
+++ b/worlds/hall_monitor/hall_monitor/domain.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import Field, model_validator
+
+from tangl.mechanics.credentials import (
+    CredentialDefinition,
+    CredentialStatus,
+    CredentialToken,
+    FailureMode,
+    Restrictions,
+    RestrictionLevel,
+)
+from tangl.mechanics.games import HasGame
+from tangl.mechanics.games.credentials_game import (
+    CredentialCase,
+    CredentialDisposition,
+    CredentialPresentationProfile,
+    CredentialsGame,
+    CredentialsGameHandler,
+)
+from tangl.mechanics.games.credentials_roster import (
+    ScenarioOffer,
+    ShiftSpec,
+    generate_roster,
+)
+from tangl.story import Block
+
+
+HALL_RULES = {
+    "upper": {
+        "academic": RestrictionLevel.WITH_PERMIT,
+        "activity": RestrictionLevel.WITH_PERMIT,
+        "off_campus": RestrictionLevel.WITH_PERMIT,
+        "uniform": RestrictionLevel.WITH_ID,
+        "medicine": RestrictionLevel.WITH_PERMIT,
+        "records": RestrictionLevel.WITH_PERMIT,
+    },
+    "lower": {
+        "academic": RestrictionLevel.WITH_PERMIT,
+        "activity": RestrictionLevel.WITH_PERMIT,
+        "off_campus": RestrictionLevel.WITH_PERMIT,
+        "uniform": RestrictionLevel.WITH_PERMIT,
+        "medicine": RestrictionLevel.WITH_PERMIT,
+        "records": RestrictionLevel.WITH_PERMIT,
+    },
+    "exchange": {
+        "academic": RestrictionLevel.WITH_PERMIT,
+        "activity": RestrictionLevel.WITH_PERMIT,
+        "off_campus": RestrictionLevel.WITH_PERMIT,
+        "uniform": RestrictionLevel.WITH_PERMIT,
+        "medicine": RestrictionLevel.WITH_PERMIT,
+        "records": RestrictionLevel.WITH_PERMIT,
+    },
+}
+
+HALL_PRESENTATION = CredentialPresentationProfile(
+    indication_labels={
+        "academic": "academic",
+        "activity": "activity",
+        "off_campus": "off-campus",
+        "uniform": "uniform",
+        "medicine": "medicine",
+        "records": "records",
+    },
+    document_labels={
+        "academic": "hall pass",
+        "activity": "activity pass",
+        "off_campus": "off-campus pass",
+        "uniform": "uniform waiver",
+        "medicine": "doctor's note",
+        "records": "office pass",
+    },
+    identity_label="student ID",
+    identity_description="A laminated student identification card.",
+    document_description="{document}. Signed for this period.",
+    possession_description="A student openly declares {indication}.",
+    status_text={
+        CredentialStatus.MISSING_SEAL: "The required teacher signature is missing.",
+        CredentialStatus.BAD_DATE: "The date on the pass is wrong.",
+        CredentialStatus.EXPIRED: "The pass has expired.",
+        CredentialStatus.FORGED: "The teacher signature is forged.",
+        CredentialStatus.WRONG_HOLDER: "The student ID does not match this document.",
+    },
+    holder_mismatch_text="The student ID does not match this pass.",
+    packet_inconsistency_text="The student's papers do not satisfy the hall rules.",
+    move_labels={"request_document": "Ask for a corrected {document}"},
+    decision_labels={
+        "pass": "Allow onward",
+        "deny": "Send back to class",
+        "arrest": "Send to the office",
+    },
+    journal_text={
+        "request_document": "You ask for a corrected {document}.",
+        "request_document_cleared": "A teacher-signed replacement is produced.",
+        "request_document_verified": "The student presents the same sound pass.",
+        "request_document_confirmed": "No valid school document is forthcoming.",
+        "request_document_not_applicable": "There is no school pass to correct.",
+    },
+)
+
+_HALL_FAILURES = (
+    FailureMode.MISSING_PERMIT,
+    FailureMode.UNSEALED_PERMIT,
+    FailureMode.FORGED_PERMIT,
+    FailureMode.WRONG_HOLDER_PERMIT,
+    FailureMode.MISSING_ID,
+    FailureMode.EXPIRED_ID,
+    FailureMode.FAKE_ID,
+)
+
+
+def _special_student() -> ScenarioOffer:
+    """Return the recurring lower-school activity-pass case for every shift."""
+
+    return ScenarioOffer(
+        target_disposition=CredentialDisposition.DENY,
+        candidate_name="Mira Quill",
+        pinned_case=CredentialCase(
+            candidate_name="Mira Quill",
+            presented_documents={
+                "student ID": "A laminated lower-school student identification card.",
+                "activity pass": "An activity pass lacking the teacher's signature.",
+            },
+            hidden_facts={
+                "activity pass": "The required teacher signature is missing.",
+            },
+            packet_hidden_facts={
+                "packet consistency": "The student's papers do not satisfy the hall rules.",
+            },
+            region="lower",
+            purpose="activity",
+            id_card=CredentialToken(indication="activity"),
+            packet=[
+                CredentialToken(
+                    indication="activity",
+                    status=CredentialStatus.MISSING_SEAL,
+                    requires_id=True,
+                )
+            ],
+        ),
+    )
+
+
+def _hall_offers(
+    *,
+    encounters: int,
+    disposition_distribution: dict[CredentialDisposition, float],
+    seed: int,
+) -> list[ScenarioOffer]:
+    """Generate one configured school shift through the shared roster funnel."""
+
+    return generate_roster(
+        ShiftSpec(
+            rules=Restrictions.from_map(HALL_RULES),
+            encounters=encounters,
+            origin_distribution={"upper": 0.4, "lower": 0.4, "exchange": 0.2},
+            disposition_distribution=disposition_distribution,
+            purpose_pool=("academic", "activity", "off_campus"),
+            allowed_failure_modes=_HALL_FAILURES,
+            pinned=(_special_student(),),
+            seed=seed,
+        )
+    )
+
+
+class HallMonitorCredentialsGame(CredentialsGame):
+    """School-specific credentials shift with the bounded school catalog."""
+
+    restriction_map: Restrictions = Field(
+        default_factory=lambda: Restrictions.from_map(HALL_RULES)
+    )
+    catalog_ref: str = "school"
+    presentation: CredentialPresentationProfile = Field(
+        default_factory=lambda: HALL_PRESENTATION.model_copy(deep=True)
+    )
+
+
+class HallMonitorBlock(HasGame, Block):
+    """Script-configured Hall Monitor scenario instance."""
+
+    encounters: int = 5
+    disposition_distribution: dict[CredentialDisposition, float] = Field(
+        default_factory=lambda: {
+            CredentialDisposition.PASS: 0.5,
+            CredentialDisposition.DENY: 0.3,
+            CredentialDisposition.ARREST: 0.2,
+        }
+    )
+    seed: int = 20260719
+
+    _game_class = HallMonitorCredentialsGame
+    _game_handler_class = CredentialsGameHandler
+
+    @model_validator(mode="after")
+    def _configure_game(self) -> HallMonitorBlock:
+        if self.game_state is None:
+            self.game_state = HallMonitorCredentialsGame(
+                offers=_hall_offers(
+                    encounters=self.encounters,
+                    disposition_distribution=self.disposition_distribution,
+                    seed=self.seed,
+                )
+            )
+        return self
+
+
+HallMonitorBlock.model_rebuild(_types_namespace={"UUID": UUID})

--- a/worlds/hall_monitor/script.yaml
+++ b/worlds/hall_monitor/script.yaml
@@ -1,0 +1,45 @@
+label: hall_monitor
+
+metadata:
+  title: "Hall Monitor"
+  description: "Run a morning hallway shift with school-specific passes and rulings."
+  start_at: halls.entrance
+
+scenes:
+  halls:
+    title: "Main Hall"
+    blocks:
+      entrance:
+        content: |
+          The warning bell has rung. Students begin moving between classrooms,
+          activities, and the front office.
+        actions:
+          - text: "Monitor the morning halls"
+            successor: morning_shift
+
+      morning_shift:
+        kind: "hall_monitor.domain.HallMonitorBlock"
+        encounters: 5
+        disposition_distribution:
+          pass: 0.50
+          deny: 0.30
+          arrest: 0.20
+        seed: 20260719
+        content: |
+          Check each student’s identification and pass before deciding whether
+          to allow them onward, send them back to class, or refer them to office.
+        continues:
+          - successor: victory
+            trigger: last
+            predicate: game_won
+          - successor: defeat
+            trigger: last
+            predicate: game_lost
+
+      victory:
+        content: |
+          The morning bell settles the halls. Every student was handled correctly.
+
+      defeat:
+        content: |
+          The passing period ends with an unresolved mistake on the attendance sheet.

--- a/worlds/hall_monitor/world.yaml
+++ b/worlds/hall_monitor/world.yaml
@@ -1,0 +1,10 @@
+label: hall_monitor
+scripts: script.yaml
+domain_module: hall_monitor.domain
+assets:
+  - asset_kind: CredentialDefinition
+    catalog: school
+    source: credential_types.yaml
+metadata:
+  title: "Hall Monitor"
+  description: "Inspect student passes and decide who may proceed through the halls."


### PR DESCRIPTION
## Summary

- Add a real `worlds/hall_monitor` credentials conformance world with a school-specific catalog, scripted shift, deterministic offers, and a pinned special encounter.
- Reuse the credentials kernel while projecting school-specific narrative and decision labels.
- Restrict school roster failures so checkpoint contraband vocabulary cannot enter the school scenario.

## Why

Phase 6d proves that credentials logic is generic while catalog, policy, presentation, and authored scenario configuration remain world-specific. It validates the world → scenario type → scenario instance → encounter boundary without introducing a universal scenario framework.

## Validation

- `poetry run pytest engine/tests/loaders/test_hall_monitor_world.py engine/tests/loaders/test_credential_gate_world.py engine/tests/mechanics/games/test_credentials_roster.py engine/tests/mechanics/games/test_credentials_game.py engine/tests/mechanics/credentials/test_credential_packet_manager.py -q` (64 passed)
- `poetry run pytest engine/tests -q`
- `PATH="$(poetry env info --path)/bin:$PATH" poetry run sphinx-build -W --keep-going -b html docs/src /tmp/storytangl-docs-6d`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Hall Monitor school scenario with student credentials, seeded morning shifts, inspections, and victory/defeat outcomes.
  * Enhanced credential case presentations with authored labels/descriptions, improved invalid-status explanations, and customizable decision labels.
  * Added configurable failure-mode constraints and optional narrative rendering during roster/case materialization.
* **Documentation**
  * Added Hall Monitor world documentation.
  * Updated credentials implementation-status wording for Phase 6d and related handoff guidance.
* **Tests**
  * Added conformance and validation coverage for the Hall Monitor world and roster/presentation behavior.
* **Chores**
  * Adjusted the security analysis workflow to run on pushes to the main branch only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->