### PR TITLE
Prove intra-world credentials scenario isolation

### DIFF
--- a/docs/src/design/story/MECHANICS_FAMILIES.md
+++ b/docs/src/design/story/MECHANICS_FAMILIES.md
@@ -430,8 +430,11 @@ Each should exercise one or two pieces of the shared vocabulary before later
 worlds compose a broader range:
 
 - the credentials world exercises hidden-information inspection and mediation;
-- the hall-monitor reskin must prove that the credentials loop is
+- the hall-monitor reskin proves that the credentials loop is
   genre-neutral;
+- a combined credentials conformance world proves that one world can host
+  multiple locally authored scenario types, each selecting a bounded local catalog
+  without mutating the shared kernel;
 - the logical-adder reskin exercises the same underlying logic through different
   content and feeling;
 - the separate Twine-loader demo remains a codec surface while round-trip
@@ -510,17 +513,16 @@ grammars** rather than just “minigames.”
 
 ## Current Implementation Priorities
 
-1. Make token catalogs explicit bounded collections exposed by a world authority;
-   scenario types select a local catalog reference without naming or searching a
-   world.
-2. Continue the credentials vertical through that corrected authority seam: one
-   world can expose both border and school catalogs, while two separately loaded
-   worlds remain isolated even when local catalog and item ids collide.
-3. Build the full hall-monitor conformance scenario through the four-layer
-   world/type/instance/encounter model without adding credentials-specific engine
-   vocabulary.
-4. Retire credential compatibility fields only after the manager-backed border and
-   hall-monitor paths have been exercised side by side.
+1. Complete: token catalogs are explicit bounded collections exposed by a world
+   authority; scenario types select a local catalog reference without naming or
+   searching a world.
+2. Complete: one combined world exposes both border and school catalogs, while two
+   separately loaded worlds remain isolated even when local catalog and item ids
+   collide.
+3. Complete: the Hall Monitor conformance scenario exercises the four-layer
+   world/type/instance/encounter model without credentials-specific engine vocabulary.
+4. Retire credential compatibility fields now that the manager-backed border and
+   hall-monitor paths have been exercised both separately and in one world.
 5. Normalize credential defects and connect credential components to presence and
    media projection.
 6. Reconcile vehicle and loadout vocabulary with assembly, transactions, and

--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_ASSEMBLY_RETROFIT.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_ASSEMBLY_RETROFIT.md
@@ -26,6 +26,9 @@ Phase 6d landed as the real Hall Monitor conformance vertical: a bespoke scenari
 selects the school catalog, a script-configured shift narrows it to one scenario
 instance, and generated plus pinned student encounters reuse the same logical packet,
 disposition, handler, and persistence path under a school-specific projection.
+Phase 6e then proves the same authority boundary inside one compiled world: distinct
+border and school scenario types each select their own local catalog, policy, and
+presentation while sharing the credentials game and handler lifecycle.
 Expression narrative beyond that first skin seam, contraband graph identity,
 document-identity receipts, and status decomposition remain future slices.
 
@@ -461,7 +464,8 @@ selects a world-local catalog reference, while a scenario instance configures ro
 encounter composition. Packet materialization resolves only within the selected catalog;
 it must not search the process-global Singleton population or carry a world label as game
 state. Phase 6d applies that hierarchy in the real Hall Monitor conformance world; see
-`PHASE_6D_HALL_MONITOR_SCENARIO_HANDOFF.md`.
+`PHASE_6D_HALL_MONITOR_SCENARIO_HANDOFF.md`. Phase 6e proves that two locally authored
+scenario types can make those selections independently inside one compiled world.
 
 Later slices may:
 
@@ -484,8 +488,8 @@ Acceptance:
 
 ### Phase 7: Retire Compatibility Fields
 
-Once manager-backed Credential Gate and Hall Monitor paths have run side by side and
-their scenario-specific projections are covered:
+Now that manager-backed Credential Gate and Hall Monitor paths have run both side by
+side and through an intra-world two-catalog conformance story:
 
 - remove direct packet lists from `CredentialCase`;
 - remove duplicated discovery methods from the case, or make them pure delegation;

--- a/engine/src/tangl/mechanics/credentials/PHASE_6D_HALL_MONITOR_SCENARIO_HANDOFF.md
+++ b/engine/src/tangl/mechanics/credentials/PHASE_6D_HALL_MONITOR_SCENARIO_HANDOFF.md
@@ -9,6 +9,9 @@ adds the playable `worlds/hall_monitor` conformance world: its script configures
 seeded school shift with a pinned student, while generated encounters use the existing
 offer, packet, disposition, game-handler, planning, and persistence lifecycle. School
 presentation realizes the same logical statuses without changing checkpoint behavior.
+Phase 6e then proves intra-world plurality: one compiled conformance world exposes both
+`border` and `school` catalogs, and locally authored block types select their own
+catalog, policy, and presentation through the shared credentials lifecycle.
 
 Phase 6d proves:
 
@@ -250,8 +253,8 @@ hide a new generic game-configuration framework inside the Hall Monitor domain m
 
 ## Follow-up
 
-After the manager-backed Credential Gate and Hall Monitor worlds run side by side, Phase
-7 may remove the flat packet compatibility representation. Only after that identity
-cutover should a later slice replace checkpoint-flavored status/failure names with
-normalized evidence defects and connect those defects to richer presence and media
-projection.
+With the manager-backed Credential Gate and Hall Monitor paths now proven both across
+separate worlds and inside one combined-world story, Phase 7 may remove the flat packet
+compatibility representation. Only after that identity cutover should a later slice
+replace checkpoint-flavored status/failure names with normalized evidence defects and
+connect those defects to richer presence and media projection.

--- a/engine/tests/loaders/test_combined_credentials_world.py
+++ b/engine/tests/loaders/test_combined_credentials_world.py
@@ -7,7 +7,11 @@ from pathlib import Path
 from tangl.core import Graph, Selector
 from tangl.loaders import WorldBundle
 from tangl.loaders.compiler import WorldCompiler
-from tangl.mechanics.credentials import CREDENTIAL_PACKET_SLOT, CredentialDefinition
+from tangl.mechanics.credentials import (
+    CREDENTIAL_ID_SLOT,
+    CREDENTIAL_PACKET_SLOT,
+    CredentialDefinition,
+)
 from tangl.mechanics.games.credentials_game import CredentialsGame, CredentialsGameHandler
 from tangl.story import Action, InitMode, World
 from tangl.vm import Ledger
@@ -17,18 +21,25 @@ def _actions(ledger: Ledger) -> list[Action]:
     return list(ledger.cursor.edges_out(Selector(has_kind=Action, trigger_phase=None)))
 
 
+def _action(ledger: Ledger, label: str) -> Action:
+    """Return an authored or game-provisioned action by its player-facing label."""
+
+    actions = _actions(ledger)
+    for action in actions:
+        if action.label == label or action.text == label:
+            return action
+    available = [(action.label, action.text) for action in actions]
+    raise AssertionError(f"Action {label!r} not found; available: {available!r}")
+
+
 def _choose(ledger: Ledger, label: str) -> None:
-    action = next(
-        action for action in _actions(ledger) if action.label == label or action.text == label
-    )
-    ledger.resolve_choice(action.uid)
+    ledger.resolve_choice(_action(ledger, label).uid)
 
 
 def _inspect(ledger: Ledger, target: str) -> None:
-    action = next(action for action in _actions(ledger) if action.label == "Inspect a document")
     game = ledger.cursor.game
     ledger.resolve_choice(
-        action.uid,
+        _action(ledger, "Inspect a document").uid,
         choice_payload={"piece_ids": [f"{game.case_index}:{target}"]},
     )
 
@@ -307,7 +318,7 @@ def test_compiled_story_selects_its_local_credentials_scenarios(tmp_path: Path) 
         assert ledger.cursor is block
         game = ledger.cursor.game
         assert isinstance(game, CredentialsGame)
-        assert type(ledger.cursor.game_handler) is CredentialsGameHandler
+        assert isinstance(ledger.cursor.game_handler, CredentialsGameHandler)
         assert game.catalog_ref == catalog_ref
 
         first = ledger.cursor.game_handler.get_provisioned_moves(game)
@@ -321,18 +332,35 @@ def test_compiled_story_selects_its_local_credentials_scenarios(tmp_path: Path) 
         assert finding in case.hidden_facts.values()
         manager = case.packet_manager
         assert manager is not None
+        component_ids = {
+            component.uid
+            for slot_name in (CREDENTIAL_ID_SLOT, CREDENTIAL_PACKET_SLOT)
+            for component in manager.get_slot(slot_name)
+        }
+        packet_components = manager.get_slot(CREDENTIAL_PACKET_SLOT)
+        assert packet_components
         assert all(
             component.reference_singleton.label.startswith(prefix)
-            for component in manager.get_slot(CREDENTIAL_PACKET_SLOT)
+            for component in packet_components
         )
 
         restored = Graph.structure(result.graph.unstructure())
         restored_block = restored.find_one(Selector(label=block_label))
         restored_manager = restored_block.game.active_case.packet_manager
         assert restored_manager is not None
+        restored_components = [
+            component
+            for slot_name in (CREDENTIAL_ID_SLOT, CREDENTIAL_PACKET_SLOT)
+            for component in restored_manager.get_slot(slot_name)
+        ]
+        assert {component.uid for component in restored_components} == component_ids
         assert all(
             component.reference_singleton.label.startswith(prefix)
-            for component in restored_manager.get_slot(CREDENTIAL_PACKET_SLOT)
+            for component in restored_components
+        )
+        assert (
+            sum(item.uid in component_ids for item in restored.members.values())
+            == len(component_ids)
         )
 
         _inspect(ledger, identity_label)

--- a/engine/tests/loaders/test_combined_credentials_world.py
+++ b/engine/tests/loaders/test_combined_credentials_world.py
@@ -1,0 +1,340 @@
+"""Compiled-story proof that one world can host two credentials scenario types."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tangl.core import Graph, Selector
+from tangl.loaders import WorldBundle
+from tangl.loaders.compiler import WorldCompiler
+from tangl.mechanics.credentials import CREDENTIAL_PACKET_SLOT, CredentialDefinition
+from tangl.mechanics.games.credentials_game import CredentialsGame, CredentialsGameHandler
+from tangl.story import Action, InitMode, World
+from tangl.vm import Ledger
+
+
+def _actions(ledger: Ledger) -> list[Action]:
+    return list(ledger.cursor.edges_out(Selector(has_kind=Action, trigger_phase=None)))
+
+
+def _choose(ledger: Ledger, label: str) -> None:
+    action = next(
+        action for action in _actions(ledger) if action.label == label or action.text == label
+    )
+    ledger.resolve_choice(action.uid)
+
+
+def _inspect(ledger: Ledger, target: str) -> None:
+    action = next(action for action in _actions(ledger) if action.label == "Inspect a document")
+    game = ledger.cursor.game
+    ledger.resolve_choice(
+        action.uid,
+        choice_payload={"piece_ids": [f"{game.case_index}:{target}"]},
+    )
+
+
+def _compile_combined_world(root: Path) -> World:
+    """Compile the two-catalog conformance world once for both story branches."""
+
+    root = root / "combined_credentials"
+    root.mkdir()
+    package = root / "combined_credentials"
+    package.mkdir()
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "domain.py").write_text(
+        '''from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import Field
+
+from tangl.mechanics.credentials import (
+    CredentialDefinition,
+    CredentialStatus,
+    FailureMode,
+    Restrictions,
+    RestrictionLevel,
+)
+from tangl.mechanics.games import HasGame
+from tangl.mechanics.games.credentials_game import (
+    CredentialDisposition,
+    CredentialPresentationProfile,
+    CredentialsGame,
+    CredentialsGameHandler,
+)
+from tangl.mechanics.games.credentials_roster import ScenarioOffer
+from tangl.story import Block
+
+
+BORDER_RULES = {"border": {"work": RestrictionLevel.WITH_PERMIT}}
+SCHOOL_RULES = {"school": {"activity": RestrictionLevel.WITH_PERMIT}}
+
+BORDER_PRESENTATION = CredentialPresentationProfile(
+    indication_labels={"work": "work"},
+    document_labels={"work": "work permit"},
+    identity_label="passport",
+    identity_description="A border identity document.",
+    document_description="A {document}.",
+    status_text={
+        CredentialStatus.MISSING_SEAL: "The issuing stamp is missing.",
+        CredentialStatus.BAD_DATE: "The issue date is wrong.",
+        CredentialStatus.EXPIRED: "The credential has expired.",
+        CredentialStatus.FORGED: "The seal is a forgery.",
+        CredentialStatus.WRONG_HOLDER: "The holder does not match this document.",
+    },
+    decision_labels={"pass": "Clear the checkpoint", "deny": "Turn away", "arrest": "Detain"},
+)
+
+SCHOOL_PRESENTATION = CredentialPresentationProfile(
+    indication_labels={"activity": "activity"},
+    document_labels={"activity": "activity pass"},
+    identity_label="student ID",
+    identity_description="A laminated student identification card.",
+    document_description="A {document}.",
+    status_text={
+        CredentialStatus.MISSING_SEAL: "The required teacher signature is missing.",
+        CredentialStatus.BAD_DATE: "The date on the pass is wrong.",
+        CredentialStatus.EXPIRED: "The pass has expired.",
+        CredentialStatus.FORGED: "The teacher signature is forged.",
+        CredentialStatus.WRONG_HOLDER: "The student ID does not match this document.",
+    },
+    decision_labels={
+        "pass": "Allow onward",
+        "deny": "Send back to class",
+        "arrest": "Send to office",
+    },
+)
+
+
+class CombinedBorderGame(CredentialsGame):
+    restriction_map: Restrictions = Field(
+        default_factory=lambda: Restrictions.from_map(BORDER_RULES)
+    )
+    catalog_ref: str = "border"
+    presentation: CredentialPresentationProfile = Field(
+        default_factory=lambda: BORDER_PRESENTATION.model_copy(deep=True)
+    )
+    offers: list[ScenarioOffer] = Field(
+        default_factory=lambda: [
+            ScenarioOffer(
+                target_disposition=CredentialDisposition.DENY,
+                region="border",
+                purpose="work",
+                candidate_name="Tomas Vey",
+                failure_modes=[FailureMode.UNSEALED_PERMIT],
+            )
+        ]
+    )
+
+
+class CombinedSchoolGame(CredentialsGame):
+    restriction_map: Restrictions = Field(
+        default_factory=lambda: Restrictions.from_map(SCHOOL_RULES)
+    )
+    catalog_ref: str = "school"
+    presentation: CredentialPresentationProfile = Field(
+        default_factory=lambda: SCHOOL_PRESENTATION.model_copy(deep=True)
+    )
+    offers: list[ScenarioOffer] = Field(
+        default_factory=lambda: [
+            ScenarioOffer(
+                target_disposition=CredentialDisposition.DENY,
+                region="school",
+                purpose="activity",
+                candidate_name="Mira Quill",
+                failure_modes=[FailureMode.UNSEALED_PERMIT],
+            )
+        ]
+    )
+
+
+class CombinedBorderBlock(HasGame, Block):
+    _game_class = CombinedBorderGame
+    _game_handler_class = CredentialsGameHandler
+
+
+class CombinedSchoolBlock(HasGame, Block):
+    _game_class = CombinedSchoolGame
+    _game_handler_class = CredentialsGameHandler
+
+
+CombinedBorderBlock.model_rebuild(_types_namespace={"UUID": UUID})
+CombinedSchoolBlock.model_rebuild(_types_namespace={"UUID": UUID})
+''',
+        encoding="utf-8",
+    )
+    (root / "world.yaml").write_text(
+        '''label: combined_credentials
+scripts: script.yaml
+domain_module: combined_credentials.domain
+assets:
+  - asset_kind: CredentialDefinition
+    catalog: border
+    source: border_credentials.yaml
+  - asset_kind: CredentialDefinition
+    catalog: school
+    source: school_credentials.yaml
+''',
+        encoding="utf-8",
+    )
+    (root / "border_credentials.yaml").write_text(
+        '''identity_card:
+  name: Border Identity Card
+  origin_ids: [border]
+  indication: work
+  document_kind: id
+  requires_id: false
+activity_pass:
+  name: Work Permit
+  origin_ids: [border]
+  indication: work
+  document_kind: document
+  requires_id: true
+  facets:
+    - channel: choice
+      facet_type: giver
+      payload: request_document
+''',
+        encoding="utf-8",
+    )
+    (root / "school_credentials.yaml").write_text(
+        '''identity_card:
+  name: Student ID
+  origin_ids: [school]
+  indication: activity
+  document_kind: id
+  requires_id: false
+activity_pass:
+  name: Activity Pass
+  origin_ids: [school]
+  indication: activity
+  document_kind: document
+  requires_id: true
+  facets:
+    - channel: choice
+      facet_type: giver
+      payload: request_document
+''',
+        encoding="utf-8",
+    )
+    (root / "script.yaml").write_text(
+        '''label: combined_credentials
+metadata:
+  title: Combined Credentials
+  start_at: activity.entrance
+scenes:
+  activity:
+    blocks:
+      entrance:
+        content: Choose an inspection assignment.
+        actions:
+          - text: Work the border checkpoint
+            successor: border_shift
+          - text: Monitor the school halls
+            successor: school_shift
+      border_shift:
+        kind: combined_credentials.domain.CombinedBorderBlock
+        content: Check a traveler at the border.
+        continues:
+          - successor: victory
+            trigger: last
+            predicate: game_won
+          - successor: defeat
+            trigger: last
+            predicate: game_lost
+      school_shift:
+        kind: combined_credentials.domain.CombinedSchoolBlock
+        content: Check a student in the hall.
+        continues:
+          - successor: victory
+            trigger: last
+            predicate: game_won
+          - successor: defeat
+            trigger: last
+            predicate: game_lost
+      victory:
+        content: The assignment ends correctly.
+      defeat:
+        content: The assignment ends with the wrong call.
+''',
+        encoding="utf-8",
+    )
+    return WorldCompiler().compile(WorldBundle.load(root))
+
+
+def test_compiled_story_selects_its_local_credentials_scenarios(tmp_path: Path) -> None:
+    """One compiled world yields fresh, catalog-isolated stories for both activities."""
+
+    combined_world = _compile_combined_world(tmp_path)
+    assert set(combined_world.assets.values) == {"border", "school"}
+    assert CredentialDefinition.get_instance("combined_credentials:border:activity_pass") in (
+        combined_world.assets.values["border"].members
+    )
+    assert CredentialDefinition.get_instance("combined_credentials:school:activity_pass") in (
+        combined_world.assets.values["school"].members
+    )
+
+    for choice, block_label, catalog_ref, prefix, identity_label, finding, decision in (
+        (
+            "Work the border checkpoint",
+            "border_shift",
+            "border",
+            "combined_credentials:border:",
+            "passport",
+            "The issuing stamp is missing.",
+            "Turn away",
+        ),
+        (
+            "Monitor the school halls",
+            "school_shift",
+            "school",
+            "combined_credentials:school:",
+            "student ID",
+            "The required teacher signature is missing.",
+            "Send back to class",
+        ),
+    ):
+        result = combined_world.create_story("combined_credentials", init_mode=InitMode.EAGER)
+        ledger = Ledger.from_graph(result.graph, entry_id=result.graph.initial_cursor_id)
+
+        assert {action.text for action in _actions(ledger)} == {
+            "Work the border checkpoint",
+            "Monitor the school halls",
+        }
+        _choose(ledger, choice)
+
+        block = result.graph.find_one(Selector(label=block_label))
+        assert ledger.cursor is block
+        game = ledger.cursor.game
+        assert isinstance(game, CredentialsGame)
+        assert type(ledger.cursor.game_handler) is CredentialsGameHandler
+        assert game.catalog_ref == catalog_ref
+
+        first = ledger.cursor.game_handler.get_provisioned_moves(game)
+        second = ledger.cursor.game_handler.get_provisioned_moves(game)
+        assert first == second
+        assert len(game.materialized) == 1
+        assert [move.kind for move in first] == ["inspect"]
+
+        case = game.active_case
+        assert identity_label in case.presented_documents
+        assert finding in case.hidden_facts.values()
+        manager = case.packet_manager
+        assert manager is not None
+        assert all(
+            component.reference_singleton.label.startswith(prefix)
+            for component in manager.get_slot(CREDENTIAL_PACKET_SLOT)
+        )
+
+        restored = Graph.structure(result.graph.unstructure())
+        restored_block = restored.find_one(Selector(label=block_label))
+        restored_manager = restored_block.game.active_case.packet_manager
+        assert restored_manager is not None
+        assert all(
+            component.reference_singleton.label.startswith(prefix)
+            for component in restored_manager.get_slot(CREDENTIAL_PACKET_SLOT)
+        )
+
+        _inspect(ledger, identity_label)
+        _choose(ledger, decision)
+        assert ledger.cursor.label == "victory"


### PR DESCRIPTION
## Summary

- Add a compiled conformance world hosting independent border and school credential scenarios.
- Verify local catalog selection, presentation, provisioning, handler reuse, and graph persistence.
- Update mechanics documentation to mark Phase 6e and the related compatibility-field milestone complete.

## Testing

- Added loader integration coverage for both scenario branches, including catalog isolation and graph round-tripping.
- Not run (not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the conformance guidance for combined worlds with multiple credential scenario types, including a combined credentials conformance world.
  * Reworded current implementation priorities (1–4) to explicitly describe bounded, local catalog selection and updated credential compatibility retirement sequencing.
* **Tests**
  * Added coverage for combined credential worlds, verifying catalog isolation, correct routing, identity presentation, consistent credential label prefixing, round-trip graph reconstruction, and successful story completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->