### PR TITLE
Bind credential documents to explicit subjects

### DIFF
--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_ASSEMBLY_RETROFIT.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_ASSEMBLY_RETROFIT.md
@@ -226,7 +226,7 @@ generic slot list. The manager should own:
 
 - required id rules;
 - purpose permit rules;
-- `requires_id` / `holder_matches` checks;
+- subject-reference checks between the packet bearer, id, and id-bound permits;
 - document status aggregation;
 - credentialed contraband requirements;
 - declared vs concealed item rules;
@@ -362,12 +362,14 @@ Status: landed without changing the game loop:
 
 - `CredentialDefinition` definition singleton;
 - `CredentialComponent` graph token wrapper;
-- fields equivalent to current `CredentialToken` for indication, status,
-  `requires_id`, and holder-match compatibility.
+- fields for indication and status, plus a `subject_id` binding for each runtime
+  document; the packet manager owns the presenting `bearer_id`.
 
-Presence snapshots and derived holder matching are intentionally not implemented in
-this slice. `holder_matches` remains compatibility state until the presence binding
-surface exists.
+Phase 9 landed the presence binding: procedural packets materialize minimal
+`HasSimpleLook` graph entities through their owner registry, and compatibility
+`CredentialToken.holder_matches` / `CredentialStatus.WRONG_HOLDER` inputs compile
+to distinct subject ids at materialization. Runtime evaluators and presentation do
+not consult those compatibility values.
 
 Acceptance:
 

--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
@@ -1,8 +1,9 @@
 # Credential Mechanic — Design Note
 
-**Status:** PLANNED for the global document/media mechanic; Phases 7 and 8 landed
-the game-facing packet-authority cutover and transient shared defect vocabulary
-(2026-07-20/21), but not the full extraction.
+**Status:** PLANNED for the global document/media mechanic; Phases 7–9 landed the
+game-facing packet-authority cutover, transient shared defect vocabulary, and
+graph-bound bearer/document subject references (2026-07-20/22), but not media
+composition or card extraction.
 **Scope:** the *global* credential mechanic — `Credential → Document → Media`,
 with carrier/bearer binding — that the credentials checkpoint **game**
 (`tangl.mechanics.games.credentials_game`) becomes one consumer of.
@@ -46,17 +47,17 @@ with **carrier binding** threaded through every layer.
 
 ### Credential
 An attestation: issuer / indication (purpose or contraband) / validity status.
-This is today's `CredentialToken` (`VALID` / `MISSING_SEAL` / `EXPIRED` /
-`FORGED` / `WRONG_HOLDER`).
+This is today's component status (`VALID` / `MISSING_SEAL` / `EXPIRED` /
+`FORGED`). `CredentialToken.WRONG_HOLDER` remains accepted only as a compatibility
+input and compiles to subject references during materialization.
 
 ### Document — the carrier form
 A credential rendered as a concrete document type. Two carrier modes:
 
-- **Self-carrying** — an *id card* identifies its own holder; the bearer *is* the
-  carrier.
-- **Carrier-bound by reference** — a *permit* references an id; the binding is the
-  `holder_matches` axis, and a broken binding is `WRONG_HOLDER`. ("Carrier-bound
-  id" = the permit-references-id relationship.)
+- **Self-carrying** — an *id card* names a subject; it is valid for the presenter
+  when `id.subject_id == packet.bearer_id`.
+- **Carrier-bound by reference** — an *id-bound permit* names the same subject as
+  the id when `permit.subject_id == id.subject_id`.
 
 ### Media — the visible card
 A `CredentialCardSpec(MediaSpec)` composes the card: frame + seal(issuer,
@@ -83,7 +84,9 @@ exactly this seam:
 So:
 
 ```text
-id_photo  =  bearer.adapt_look_media_spec(media_role="id_photo")
+id_photo = packet.resolve_subject(id.subject_id).adapt_look_media_spec(
+    media_role="id_photo"
+)
 ```
 
 **Division of ownership:** credentials owns the *card* (frame, seal, layout,
@@ -92,15 +95,13 @@ face — it asks the bearer's presence for one.
 
 This makes discrepancy rendering fall out for free:
 
-- **valid** → bind the *true bearer's* look.
-- **`WRONG_HOLDER`** → bind a *different* entity's look (or a mismatched
-  demographic), so the photo doesn't match the declared identity — a thing the
-  player can *spot*.
+- **valid** → the id subject is the presenting bearer.
+- **subject mismatch** → the id (or permit) names a distinct subject entity, even
+  if the two subjects currently have identical looks.
 
-This is the visual arm of the **build-correct-then-degrade** factory the game
-already has: the same `degrade` step that sets a token's status drives which look
-the card binds. The credential mechanic reads token status; it does not maintain
-a parallel error flag.
+This is the visual arm of the **build-correct-then-degrade** factory: degradation
+changes a component's subject binding. The evaluator compares bindings; presence
+only projects those independently resolved subjects for prose and media.
 
 ---
 
@@ -261,8 +262,8 @@ under LFS and reverse the policy deliberately. The rule is really "no
 ## 6 · Disclosure discipline carries over
 
 The card renders the candidate's **presentation**: a forged seal draws a subtly
-wrong seal, a wrong-holder card draws a mismatched portrait, an expired card
-shows a past date. These are *visible to a careful look* — but the *finding*
+wrong seal, a subject-mismatched card names a different presence entity, and an
+expired card shows a past date. These are *visible to a careful look* — but the *finding*
 ("this seal is forged") is revealed only by inspecting. The image is the visual
 analog of `presented_documents` (visible) vs. `hidden_facts` (revealed on
 inspection). The card must **not** flag "FORGED" in red; the player must notice.
@@ -277,14 +278,14 @@ artifact, and the widget vocab's CLI-floor rule requires every interaction be
 reachable by a text client. So a "visual" discrepancy cannot live *only* in
 pixels. The resolution is that **the discrepancy lives in the structured truth,
 not in any one rendering channel**: a portrait mismatch is a difference in the
-`Look` data and the token status, and presence already projects that truth to
+`Look` data and the subject references, and presence already projects that truth to
 *both* channels —
 
 - **prose** via `Look.describe()` / `trait_tokens()`,
 - **media** via `adapt_look_media_spec()`.
 
 MEDIA_DESIGN frames these as symmetric output dimensions of one adapted intent.
-So a wrong-holder card is, for a text client, a **prose look-diff**: the id reads
+So a subject-mismatched card is, for a text client, a **prose look-diff**: the id reads
 "a fair-skinned woman, blonde, neutral"; the traveler at the counter reads "a
 fair-skinned woman, dark hair." The player compares two *descriptions* exactly as
 a rich client compares two *faces*. The discrepancy is reachable at the CLI
@@ -344,8 +345,7 @@ outfits, vehicles, and connector groups.
    the *simplest consumer* of the composition framework.
 2. **Extract primitives** (`Credential`, `Document`, carrier binding) into
    `tangl.mechanics.credentials` — partially landed for the current enum/value
-   vocabulary and assembly packet proof. Carrier binding still waits on the
-   presence-snapshot surface.
+   vocabulary, assembly packet proof, and graph-owned presence binding.
 3. **Re-point the game** at the promoted primitives; the game adds its overrides
    (regions, seals, permits).
 4. **Default assets** land alongside (1) so the projection is provable from day
@@ -358,14 +358,9 @@ the one genuine dependency, and it is a media-subsystem concern in its own right
 
 ## 8 · Open questions
 
-- **Portrait pool keying.** Demographic descriptor → portrait identity mapping for
-  the world pre-render pool (so `WRONG_HOLDER` can deterministically bind a
-  *different* pool entry, and so a base portrait can be re-used as the img2img
-  reference for the side-by-side live figure). Likely a `demographics`-driven key.
-- **Where bearer identity lives for procedural candidates.** A sampled candidate
-  has no `HasLook` entity yet; the factory may need to materialize a minimal
-  presence (a `Look`) per candidate so the card can bind a portrait — and so the
-  base-identity-vs-mutable-presentation split (§3b) has somewhere to live.
+- **Portrait pool keying.** Phase 9 materializes a minimal `HasSimpleLook` subject
+  per procedural candidate. The remaining question is how a world later maps
+  those stable subject ids to reusable portrait-pool entries.
 - **RIT registry + composition-strategy surface (media-layer, §3a step 0).** The
   one genuine dependency. Unifies the legacy `svg_forge` catalog-assembler and the
   `raster_forge`/file-forge stub into registries of mini-RITs + interchangeable

--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
@@ -48,7 +48,7 @@ with **carrier binding** threaded through every layer.
 ### Credential
 An attestation: issuer / indication (purpose or contraband) / validity status.
 This is today's component status (`VALID` / `MISSING_SEAL` / `EXPIRED` /
-`FORGED`). `CredentialToken.WRONG_HOLDER` remains accepted only as a compatibility
+`FORGED`). `CredentialStatus.WRONG_HOLDER` remains accepted only as a compatibility
 input and compiles to subject references during materialization.
 
 ### Document — the carrier form

--- a/engine/src/tangl/mechanics/credentials/assembly.py
+++ b/engine/src/tangl/mechanics/credentials/assembly.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from typing import ClassVar
+from uuid import UUID, uuid4
 
 from pydantic import ConfigDict, Field
 
 from tangl.core import Selector, Singleton, Token, TokenCatalog
 from tangl.mechanics.assembly import ComponentFacet, ComponentManager, Slot
+from tangl.mechanics.presence.look import HasSimpleLook
 
 from .domain import (
     ContrabandItem,
@@ -42,14 +44,12 @@ class CredentialDefinition(Singleton):
         default=CredentialStatus.VALID,
         json_schema_extra={"instance_var": True},
     )
-    holder_matches: bool = Field(
-        default=True,
-        json_schema_extra={"instance_var": True},
-    )
 
 
 class CredentialComponentToken(Token):
     """Graph credential token that projects to the legacy packet value shape."""
+
+    subject_id: UUID = Field(default_factory=uuid4)
 
     def component_facets(
         self,
@@ -76,13 +76,13 @@ class CredentialComponentToken(Token):
         return self.token_from or self.label
 
     def to_credential_token(self) -> CredentialToken:
-        """Return the compatibility value read by disposition derivation."""
+        """Return the legacy value projection for compatibility callers."""
 
         return CredentialToken(
             indication=self.indication,
             status=self.status,
             requires_id=self.requires_id,
-            holder_matches=self.holder_matches,
+            holder_matches=True,
         )
 
 
@@ -118,6 +118,7 @@ class CredentialPacketManager(ComponentManager[CredentialComponent]):
 
     region: OriginId = Region.LOCAL
     purpose: IndicationId = Indication.TRAVEL
+    bearer_id: UUID = Field(default_factory=uuid4, json_schema_extra={"include": True})
     possessions: list[ContrabandItem] = Field(
         default_factory=list,
         json_schema_extra={"include": True},
@@ -125,6 +126,32 @@ class CredentialPacketManager(ComponentManager[CredentialComponent]):
 
     def get_region(self) -> OriginId:
         return self.region
+
+    def has_resolved_subject(self, subject_id: UUID) -> bool:
+        """Whether ``subject_id`` resolves to a registered presence entity."""
+
+        registry = self._owner_registry()
+        return registry is not None and isinstance(registry.get(subject_id), HasSimpleLook)
+
+    def resolve_subject(self, subject_id: UUID) -> HasSimpleLook:
+        """Resolve one bound subject through the manager owner's graph registry."""
+
+        registry = self._owner_registry()
+        if registry is None:
+            raise KeyError("Credential subjects require a graph-bound packet manager")
+        subject = registry.get(subject_id)
+        if not isinstance(subject, HasSimpleLook):
+            raise KeyError(f"Credential subject {subject_id} is not a presence entity")
+        return subject
+
+    def materialize_subject(self, label: str) -> HasSimpleLook:
+        """Create one minimal presence subject and register it when graph-bound."""
+
+        subject = HasSimpleLook(label=label)
+        registry = self._owner_registry()
+        if registry is not None:
+            registry.add(subject)
+        return subject
 
     def get_purpose(self) -> IndicationId:
         return self.purpose
@@ -296,6 +323,11 @@ def materialize_packet(
         purpose=purpose,
         possessions=list(possessions),
     ).bind_owner(owner)
+    bearer = manager.materialize_subject(f"{label_prefix}:bearer")
+    manager.bearer_id = bearer.uid
+    id_subject = bearer
+    if id_card is not None and id_card.status is CredentialStatus.WRONG_HOLDER:
+        id_subject = manager.materialize_subject(f"{label_prefix}:id-subject")
 
     def add_component(
         token: CredentialToken,
@@ -303,6 +335,7 @@ def materialize_packet(
         document_kind: str,
         slot: str,
         index: int,
+        subject_id: UUID,
     ) -> None:
         definition = _definition_for(
             token,
@@ -314,8 +347,12 @@ def materialize_packet(
             CredentialComponent(
                 label=f"{label_prefix}:{document_kind}:{index}",
                 token_from=definition.label,
-                status=token.status,
-                holder_matches=token.holder_matches,
+                status=(
+                    CredentialStatus.VALID
+                    if token.status is CredentialStatus.WRONG_HOLDER
+                    else token.status
+                ),
+                subject_id=subject_id,
             ),
         )
 
@@ -325,13 +362,23 @@ def materialize_packet(
             document_kind="id",
             slot=CREDENTIAL_ID_SLOT,
             index=0,
+            subject_id=id_subject.uid,
         )
     for index, credential in enumerate(credentials):
+        subject = id_subject if id_card is not None else bearer
+        if (
+            credential.status is CredentialStatus.WRONG_HOLDER
+            or not credential.holder_matches
+        ):
+            subject = manager.materialize_subject(
+                f"{label_prefix}:document-subject:{index}"
+            )
         add_component(
             credential,
             document_kind="document",
             slot=CREDENTIAL_PACKET_SLOT,
             index=index,
+            subject_id=subject.uid,
         )
     return manager
 

--- a/engine/src/tangl/mechanics/credentials/assembly.py
+++ b/engine/src/tangl/mechanics/credentials/assembly.py
@@ -124,6 +124,30 @@ class CredentialPacketManager(ComponentManager[CredentialComponent]):
         json_schema_extra={"include": True},
     )
 
+    def bind_owner(self, owner: object) -> "CredentialPacketManager":
+        """Bind cached components and subject references to a graph owner."""
+
+        super().bind_owner(owner)
+        registry = self._owner_registry()
+        if registry is None:
+            return self
+
+        subject_ids = {self.bearer_id}
+        for component_ids in self.assignment_ids.values():
+            for component_id in component_ids:
+                component = registry.get(component_id) or self._component_cache.get(component_id)
+                if component is not None:
+                    subject_ids.add(component.subject_id)
+        for subject_id in subject_ids:
+            if registry.get(subject_id) is None:
+                registry.add(
+                    HasSimpleLook(
+                        uid=subject_id,
+                        label=f"credential-subject-{subject_id}",
+                    )
+                )
+        return self
+
     def get_region(self) -> OriginId:
         return self.region
 
@@ -322,9 +346,10 @@ def materialize_packet(
         region=region,
         purpose=purpose,
         possessions=list(possessions),
-    ).bind_owner(owner)
+    )
     bearer = manager.materialize_subject(f"{label_prefix}:bearer")
     manager.bearer_id = bearer.uid
+    manager.bind_owner(owner)
     id_subject = bearer
     if id_card is not None and id_card.status is CredentialStatus.WRONG_HOLDER:
         id_subject = manager.materialize_subject(f"{label_prefix}:id-subject")

--- a/engine/src/tangl/mechanics/credentials/domain.py
+++ b/engine/src/tangl/mechanics/credentials/domain.py
@@ -113,7 +113,7 @@ class CredentialStatus(Enum):
     EXPIRED = "expired"
     # crimes
     FORGED = "forged"            # bad / fake seal
-    WRONG_HOLDER = "wrong_holder"  # fake or mismatched id
+    WRONG_HOLDER = "wrong_holder"  # compatibility input; compiles to subject bindings
 
     @property
     def is_valid(self) -> bool:
@@ -242,9 +242,10 @@ _CRIME_MODES = frozenset(
 class CredentialToken(BaseModelPlus):
     """A single presented credential.
 
-    ``holder_matches`` models the id-linkage surface for permits: a permit may be
-    intrinsically valid yet reference a different bearer than the presented id (a
-    crime), independent of the permit's own ``status``.
+    ``holder_matches`` is accepted only at the factory compatibility boundary.
+    Packet materialization turns it into a distinct component ``subject_id``;
+    runtime assessment compares those subject references instead of consulting
+    this value.
     """
 
     indication: IndicationId

--- a/engine/src/tangl/mechanics/credentials/domain.py
+++ b/engine/src/tangl/mechanics/credentials/domain.py
@@ -121,7 +121,7 @@ class CredentialStatus(Enum):
 
     @property
     def is_crime(self) -> bool:
-        return self in (CredentialStatus.FORGED, CredentialStatus.WRONG_HOLDER)
+        return self is CredentialStatus.FORGED
 
 
 class FailureClass(Enum):

--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -599,8 +599,9 @@ Adds three move kinds and a per-case ``finding_status: dict[str, str]``
   reissued). Maps to ``accepts.kind="pieces"`` in the rendering contract
   (`bundles/credentials/EXTENSIONS.md`).
 - **``verify_id``** — single Action, available whenever an id is presented.
-  Answers only the holder question: ``confirmed`` for WRONG_HOLDER (a crime),
-  ``verified`` otherwise. It never repairs a stale id, so an expired/mis-dated
+  Answers only the subject-binding question: ``confirmed`` for an effective
+  `SUBJECT_MISMATCH` defect sourced by the id (a crime), ``verified`` otherwise.
+  It never repairs a stale id, so an expired/mis-dated
   id stays a deny (id-reissue is B.2).
 - **``request_search``** — single Action; reveals concealed contraband if any.
 

--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -463,10 +463,11 @@ on one packet); a correct candidate is `degrade(..., [])`.
 **Failure-mode catalog.** `degrade` is driven by an explicit `FailureMode` set,
 and the same catalog is what A.3's sampler draws from. Each mode carries:
 
-- a **class** -- *mitigatable* (-> deny if unfixed) vs *crime* (-> arrest), matching
-  `CredentialStatus.is_crime` and the concealed-contraband case from A.1;
-- the **mutation** it applies (which token/id status it sets, or contraband it
-  conceals); and
+- a **class** -- *mitigatable* (-> deny if unfixed) vs *crime* (-> arrest),
+  matching forged evidence, subject-mismatch defects, and the concealed-
+  contraband case from A.1;
+- the **mutation** it applies (which component status or subject binding it sets,
+  or which contraband it conceals); and
 - an **applicability** predicate: which modes a given indication can even exhibit
   at its current restriction level (you can only "miss a permit" where a permit is
   required; only "forge a seal" where a credential exists; only conceal contraband

--- a/engine/src/tangl/mechanics/games/credentials_factory.py
+++ b/engine/src/tangl/mechanics/games/credentials_factory.py
@@ -78,7 +78,6 @@ def build_valid(
                 indication=purpose,
                 status=CredentialStatus.VALID,
                 requires_id=True,
-                holder_matches=True,
             )
         )
 
@@ -95,7 +94,6 @@ def build_valid(
                     indication=c_ind,
                     status=CredentialStatus.VALID,
                     requires_id=True,
-                    holder_matches=True,
                 )
             )
         possessions.append(ContrabandItem(indication=c_ind, concealed=False))
@@ -163,7 +161,9 @@ def apply_failure(mode: FailureMode, case: CredentialCase) -> None:
                 permit.status = CredentialStatus.FORGED
         case FailureMode.WRONG_HOLDER_PERMIT:
             if permit is not None:
-                permit.holder_matches = False
+                permit.subject_id = case.packet_manager.materialize_subject(
+                    f"{case.candidate_name}:permit-subject"
+                ).uid
         case FailureMode.MISSING_ID | FailureMode.EXPIRED_ID | FailureMode.FAKE_ID:
             id_components = case.packet_manager.get_slot(CREDENTIAL_ID_SLOT)
             if id_components:
@@ -173,7 +173,13 @@ def apply_failure(mode: FailureMode, case: CredentialCase) -> None:
                 elif mode is FailureMode.EXPIRED_ID:
                     id_component.status = CredentialStatus.EXPIRED
                 else:
-                    id_component.status = CredentialStatus.WRONG_HOLDER
+                    subject_id = case.packet_manager.materialize_subject(
+                        f"{case.candidate_name}:id-subject"
+                    ).uid
+                    id_component.subject_id = subject_id
+                    for component in case.packet_manager.get_slot(CREDENTIAL_PACKET_SLOT):
+                        if component.requires_id:
+                            component.subject_id = subject_id
         case FailureMode.UNPERMITTED_CONTRABAND:
             case.packet_manager.possessions.append(
                 ContrabandItem(indication=_DEFAULT_CONTRABAND, concealed=False)

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -384,6 +384,7 @@ def _document_defect(
     *,
     subject: Literal["identity", "authorization"],
     indication: IndicationId,
+    expected_subject_id: uuid.UUID | None,
     cleared: bool,
     invalid_kind: CredentialDefectKind,
     invalid_subject: Literal["identity", "authorization", "possession"],
@@ -399,18 +400,13 @@ def _document_defect(
             source_id=component.uid,
             cause=component.status,
         )
-    if component.status is CredentialStatus.WRONG_HOLDER or not component.holder_matches:
+    if expected_subject_id is not None and component.subject_id != expected_subject_id:
         return CredentialDefect(
             kind=CredentialDefectKind.SUBJECT_MISMATCH,
             failure_class=FailureClass.CRIME,
             subject=subject,
             indication=indication,
             source_id=component.uid,
-            cause=(
-                component.status
-                if component.status is CredentialStatus.WRONG_HOLDER
-                else None
-            ),
         )
     if component.status.is_valid or cleared:
         return None
@@ -437,6 +433,7 @@ def _requirement_defects(
     """Derive defects for one authorization requirement without choosing a result."""
 
     defects: list[CredentialDefect] = []
+    id_card = _id_component(packet)
     if level.requires_permit:
         permit = _permit_component(packet, indication)
         if permit is None:
@@ -453,6 +450,7 @@ def _requirement_defects(
                 permit,
                 subject="authorization",
                 indication=indication,
+                expected_subject_id=(id_card.subject_id if id_card is not None else None),
                 cleared=finding_status.get(indication) == Finding.CLEARED,
                 invalid_kind=invalid_kind,
                 invalid_subject=missing_subject or "authorization",
@@ -460,7 +458,6 @@ def _requirement_defects(
             if defect is not None:
                 defects.append(defect)
     if level.requires_id:
-        id_card = _id_component(packet)
         if id_card is None:
             defects.append(
                 CredentialDefect(
@@ -475,6 +472,7 @@ def _requirement_defects(
                 id_card,
                 subject="identity",
                 indication=indication,
+                expected_subject_id=packet.bearer_id,
                 cleared=finding_status.get(FindingKey.ID) == Finding.CLEARED,
                 invalid_kind=invalid_kind,
                 invalid_subject=missing_subject or "identity",
@@ -611,8 +609,6 @@ def derive_defects(
         )
 
     # A forged document is criminal even when the day's rules did not require it.
-    # ``holder_matches`` is meaningful only while assessing a required document,
-    # matching the pre-Phase-8 policy.
     for component, subject in [
         *[(component, "identity") for component in packet.get_slot(CREDENTIAL_ID_SLOT)],
         *[
@@ -620,11 +616,12 @@ def derive_defects(
             for component in packet.get_slot(CREDENTIAL_PACKET_SLOT)
         ],
     ]:
-        if component.status.is_crime:
+        if component.status is CredentialStatus.FORGED:
             defect = _document_defect(
                 component,
                 subject=subject,
                 indication=component.indication,
+                expected_subject_id=None,
                 cleared=False,
                 invalid_kind=CredentialDefectKind.INVALID_EVIDENCE,
                 invalid_subject=subject,
@@ -743,6 +740,8 @@ class CredentialPresentationProfile(BaseModelPlus):
             defect = defects_by_source.get(id_card.uid)
             if defect is not None and defect.cause is not None:
                 findings[self.identity_label] = self.status_text[defect.cause]
+            elif defect is not None and defect.kind is CredentialDefectKind.SUBJECT_MISMATCH:
+                findings[self.identity_label] = self.holder_mismatch_text
             elif not id_card.status.is_valid:
                 findings[self.identity_label] = self.status_text[id_card.status]
 
@@ -756,8 +755,6 @@ class CredentialPresentationProfile(BaseModelPlus):
                 findings[document] = self.holder_mismatch_text
             elif not component.status.is_valid:
                 findings[document] = self.status_text[component.status]
-            elif not component.holder_matches:
-                findings[document] = self.holder_mismatch_text
 
         for item in case.get_contraband():
             if item.concealed:
@@ -1214,16 +1211,6 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         return components
 
     @staticmethod
-    def _request_document_credential(
-        case: CredentialCase,
-        indication: IndicationId,
-    ) -> CredentialToken | None:
-        """Return the credential whose facet contributed this request target."""
-
-        component = CredentialsGameHandler._request_document_component(case, indication)
-        return component.to_credential_token() if component is not None else None
-
-    @staticmethod
     def _request_document_component(
         case: CredentialCase,
         indication: IndicationId,
@@ -1551,21 +1538,33 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             detail["target_indication"] = indication_value
             return RoundResult.CONTINUE
 
-        permit = self._request_document_credential(game.active_case, indication)
+        permit = self._request_document_component(game.active_case, indication)
         if permit is None:  # off-menu safety; receive_move does not validate
             detail["outcome"] = "request_document_not_applicable"
             detail["target_indication"] = indication_value
             return RoundResult.CONTINUE
 
-        if permit.status.is_crime:
+        defect = next(
+            (
+                defect
+                for defect in derive_defects(
+                    game.active_case.packet_manager,
+                    game.restriction_map,
+                    game.finding_status,
+                )
+                if defect.source_id == permit.uid
+            ),
+            None,
+        )
+        if defect is not None and defect.failure_class is FailureClass.CRIME:
             game.finding_status[indication_value] = Finding.CONFIRMED
             detail["outcome"] = "request_document_confirmed"
-        elif permit.status.is_valid:
-            game.finding_status[indication_value] = Finding.VERIFIED
-            detail["outcome"] = "request_document_verified"
-        else:
+        elif defect is not None:
             game.finding_status[indication_value] = Finding.CLEARED
             detail["outcome"] = "request_document_cleared"
+        else:
+            game.finding_status[indication_value] = Finding.VERIFIED
+            detail["outcome"] = "request_document_verified"
         detail["target_indication"] = indication_value
         return RoundResult.CONTINUE
 
@@ -1575,14 +1574,23 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         detail: dict[str, object],
     ) -> RoundResult:
         # verify_id answers only "does the id match the bearer?". It discloses a
-        # holder mismatch (a crime) but never mechanically repairs a stale id --
+        # subject mismatch (a crime) but never mechanically repairs a stale id --
         # an expired or mis-dated id stays a deny until a future id-reissue move
         # (B.2). So it records VERIFIED / CONFIRMED, never CLEARED.
-        status = game.active_case.id_status()
-        if status is None:  # off-menu safety; the menu offers this only with an id
+        id_card = _id_component(game.active_case.packet_manager)
+        if id_card is None:  # off-menu safety; the menu offers this only with an id
             detail["outcome"] = "id_verified_not_applicable"
             return RoundResult.CONTINUE
-        if status is CredentialStatus.WRONG_HOLDER:
+        mismatch = any(
+            defect.kind is CredentialDefectKind.SUBJECT_MISMATCH
+            and defect.source_id == id_card.uid
+            for defect in derive_defects(
+                game.active_case.packet_manager,
+                game.restriction_map,
+                game.finding_status,
+            )
+        )
+        if mismatch:
             game.finding_status[FindingKey.ID] = Finding.CONFIRMED
             detail["outcome"] = "id_verified_problem"
         else:
@@ -1833,24 +1841,51 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         case = game.active_case
         idx = game.case_index
         packet_uid = _piece_uid(game.uid, idx, "packet")
+        candidate_properties: dict[str, object] = {
+            "declared_purpose": str(case.get_purpose()),
+            "declared_region": str(case.get_region()),
+        }
+        if case.packet_manager.has_resolved_subject(case.packet_manager.bearer_id):
+            bearer = case.packet_manager.resolve_subject(case.packet_manager.bearer_id)
+            candidate_properties.update(
+                {
+                    "look_description": bearer.describe_look(subject=case.candidate_name),
+                    "look_media_payload": bearer.adapt_look_media_spec(
+                        media_role="candidate"
+                    ),
+                }
+            )
 
         candidate = PieceFragment(
             uid=_piece_uid(game.uid, idx, "candidate"),
             piece_id=f"candidate-{idx}",
             piece_kind="candidate",
             content=case.candidate_name,
-            properties={
-                "declared_purpose": str(case.get_purpose()),
-                "declared_region": str(case.get_region()),
-            },
+            properties=candidate_properties,
             hints=PresentationHints(label_text=case.candidate_name),
         )
 
+        id_card = _id_component(case.packet_manager)
         doc_uids: list[uuid.UUID] = []
         doc_pieces: list[BaseFragment] = []
         for label, description in case.presented_documents.items():
             doc_uid = _piece_uid(game.uid, idx, f"doc:{label}")
             doc_uids.append(doc_uid)
+            properties: dict[str, object] = {}
+            if (
+                id_card is not None
+                and label == game.presentation.identity_label
+                and case.packet_manager.has_resolved_subject(id_card.subject_id)
+            ):
+                subject = case.packet_manager.resolve_subject(id_card.subject_id)
+                properties.update(
+                    {
+                        "look_description": subject.describe_look(),
+                        "look_media_payload": subject.adapt_look_media_spec(
+                            media_role="id_photo"
+                        ),
+                    }
+                )
             doc_pieces.append(
                 PieceFragment(
                     uid=doc_uid,
@@ -1858,6 +1893,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                     piece_kind=_document_kind(label),
                     content=description,
                     zone_ref=packet_uid,
+                    properties=properties,
                     hints=PresentationHints(label_text=label),
                 )
             )

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -663,6 +663,7 @@ class CredentialPresentationProfile(BaseModelPlus):
             CredentialStatus.WRONG_HOLDER: "The holder does not match this document.",
         }
     )
+    identity_mismatch_text: str = "The identity document does not name this bearer."
     holder_mismatch_text: str = "The permit's holder does not match the bearer id."
     packet_inconsistency_text: str = (
         "The packet does not satisfy the checkpoint rules as presented."
@@ -741,7 +742,7 @@ class CredentialPresentationProfile(BaseModelPlus):
             if defect is not None and defect.cause is not None:
                 findings[self.identity_label] = self.status_text[defect.cause]
             elif defect is not None and defect.kind is CredentialDefectKind.SUBJECT_MISMATCH:
-                findings[self.identity_label] = self.holder_mismatch_text
+                findings[self.identity_label] = self.identity_mismatch_text
             elif not id_card.status.is_valid:
                 findings[self.identity_label] = self.status_text[id_card.status]
 
@@ -1544,17 +1545,15 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             detail["target_indication"] = indication_value
             return RoundResult.CONTINUE
 
-        defect = next(
-            (
-                defect
-                for defect in derive_defects(
-                    game.active_case.packet_manager,
-                    game.restriction_map,
-                    game.finding_status,
-                )
-                if defect.source_id == permit.uid
-            ),
-            None,
+        id_card = _id_component(game.active_case.packet_manager)
+        defect = _document_defect(
+            permit,
+            subject="authorization",
+            indication=indication,
+            expected_subject_id=(id_card.subject_id if id_card is not None else None),
+            cleared=game.finding_status.get(indication) == Finding.CLEARED,
+            invalid_kind=CredentialDefectKind.INVALID_EVIDENCE,
+            invalid_subject="authorization",
         )
         if defect is not None and defect.failure_class is FailureClass.CRIME:
             game.finding_status[indication_value] = Finding.CONFIRMED

--- a/engine/tests/loaders/test_combined_credentials_world.py
+++ b/engine/tests/loaders/test_combined_credentials_world.py
@@ -11,8 +11,15 @@ from tangl.mechanics.credentials import (
     CREDENTIAL_ID_SLOT,
     CREDENTIAL_PACKET_SLOT,
     CredentialDefinition,
+    CredentialDefectKind,
+    FailureMode,
 )
-from tangl.mechanics.games.credentials_game import CredentialsGame, CredentialsGameHandler
+from tangl.mechanics.games.credentials_game import (
+    CredentialDisposition,
+    CredentialsGame,
+    CredentialsGameHandler,
+    derive_defects,
+)
 from tangl.story import Action, InitMode, World
 from tangl.vm import Ledger
 
@@ -93,6 +100,7 @@ BORDER_PRESENTATION = CredentialPresentationProfile(
         CredentialStatus.FORGED: "The seal is a forgery.",
         CredentialStatus.WRONG_HOLDER: "The holder does not match this document.",
     },
+    holder_mismatch_text="The passport does not name this bearer.",
     decision_labels={"pass": "Clear the checkpoint", "deny": "Turn away", "arrest": "Detain"},
 )
 
@@ -109,6 +117,7 @@ SCHOOL_PRESENTATION = CredentialPresentationProfile(
         CredentialStatus.FORGED: "The teacher signature is forged.",
         CredentialStatus.WRONG_HOLDER: "The student ID does not match this document.",
     },
+    holder_mismatch_text="The student ID does not name this student.",
     decision_labels={
         "pass": "Allow onward",
         "deny": "Send back to class",
@@ -366,3 +375,42 @@ def test_compiled_story_selects_its_local_credentials_scenarios(tmp_path: Path) 
         _inspect(ledger, identity_label)
         _choose(ledger, decision)
         assert ledger.cursor.label == "victory"
+
+
+def test_combined_world_profiles_one_subject_mismatch_per_skin(tmp_path: Path) -> None:
+    combined_world = _compile_combined_world(tmp_path)
+
+    for choice, block_label, identity_label, finding in (
+        (
+            "Work the border checkpoint",
+            "border_shift",
+            "passport",
+            "The passport does not name this bearer.",
+        ),
+        (
+            "Monitor the school halls",
+            "school_shift",
+            "student ID",
+            "The student ID does not name this student.",
+        ),
+    ):
+        result = combined_world.create_story("combined_credentials", init_mode=InitMode.EAGER)
+        block = result.graph.find_one(Selector(label=block_label))
+        offer = block.game.offers[0].model_copy(
+            update={
+                "failure_modes": [FailureMode.FAKE_ID],
+                "target_disposition": CredentialDisposition.ARREST,
+            }
+        )
+        block.game.offers = [offer]
+        ledger = Ledger.from_graph(result.graph, entry_id=result.graph.initial_cursor_id)
+
+        _choose(ledger, choice)
+
+        case = block.game.active_case
+        id_card = case.packet_manager.get_slot(CREDENTIAL_ID_SLOT)[0]
+        defects = derive_defects(case.packet_manager, block.game.restriction_map)
+        assert [(defect.kind, defect.source_id) for defect in defects] == [
+            (CredentialDefectKind.SUBJECT_MISMATCH, id_card.uid),
+        ]
+        assert case.hidden_facts == {identity_label: finding}

--- a/engine/tests/loaders/test_combined_credentials_world.py
+++ b/engine/tests/loaders/test_combined_credentials_world.py
@@ -100,6 +100,7 @@ BORDER_PRESENTATION = CredentialPresentationProfile(
         CredentialStatus.FORGED: "The seal is a forgery.",
         CredentialStatus.WRONG_HOLDER: "The holder does not match this document.",
     },
+    identity_mismatch_text="The passport does not name this bearer.",
     holder_mismatch_text="The passport does not name this bearer.",
     decision_labels={"pass": "Clear the checkpoint", "deny": "Turn away", "arrest": "Detain"},
 )
@@ -117,6 +118,7 @@ SCHOOL_PRESENTATION = CredentialPresentationProfile(
         CredentialStatus.FORGED: "The teacher signature is forged.",
         CredentialStatus.WRONG_HOLDER: "The student ID does not match this document.",
     },
+    identity_mismatch_text="The student ID does not name this student.",
     holder_mismatch_text="The student ID does not name this student.",
     decision_labels={
         "pass": "Allow onward",

--- a/engine/tests/mechanics/credentials/test_credential_packet_manager.py
+++ b/engine/tests/mechanics/credentials/test_credential_packet_manager.py
@@ -116,13 +116,11 @@ def credential_component(
     definition: CredentialDefinition,
     *,
     status: CredentialStatus = CredentialStatus.VALID,
-    holder_matches: bool = True,
 ) -> CredentialComponent:
     return CredentialComponent(
         label=label,
         token_from=definition.label,
         status=status,
-        holder_matches=holder_matches,
     )
 
 
@@ -144,6 +142,8 @@ def valid_work_packet() -> tuple[
     id_card = credential_component("candidate-id", id_definition)
     work_permit = credential_component("candidate-work-permit", permit_definition)
     manager = AssemblyCredentialPacketManager(purpose=IND.WORK)
+    id_card.subject_id = manager.bearer_id
+    work_permit.subject_id = id_card.subject_id
     manager.assign(CREDENTIAL_ID_SLOT, id_card)
     manager.assign(CREDENTIAL_PACKET_SLOT, work_permit)
     return manager, id_card, work_permit
@@ -303,7 +303,7 @@ def test_manager_request_document_resolves_the_contributing_component() -> None:
 
     handler.receive_move(game, ("request_document", IND.WORK.value))
 
-    assert game.finding_status == {IND.WORK.value: Finding.CLEARED}
+    assert game.finding_status == {IND.WORK.value: Finding.VERIFIED}
 
 
 def test_manager_request_document_menu_does_not_reveal_credential_status() -> None:
@@ -421,6 +421,8 @@ def test_packet_manager_graph_roundtrip_preserves_credential_assignments_by_id()
     )
     manager = owner.packet_manager
     manager.purpose = IND.WORK
+    id_card.subject_id = manager.bearer_id
+    work_permit.subject_id = id_card.subject_id
     manager.assign(CREDENTIAL_ID_SLOT, id_card)
     manager.assign(CREDENTIAL_PACKET_SLOT, work_permit)
 
@@ -468,6 +470,8 @@ def test_defects_recompute_from_a_restored_packet_manager() -> None:
     )
     manager = owner.packet_manager
     manager.purpose = IND.WORK
+    id_card.subject_id = manager.bearer_id
+    permit.subject_id = id_card.subject_id
     manager.assign(CREDENTIAL_ID_SLOT, id_card)
     manager.assign(CREDENTIAL_PACKET_SLOT, permit)
 
@@ -481,6 +485,48 @@ def test_defects_recompute_from_a_restored_packet_manager() -> None:
         (CredentialDefectKind.INVALID_EVIDENCE, permit.uid, S.MISSING_SEAL),
     ]
     assert after == before
+
+
+def test_graph_bound_subjects_roundtrip_and_look_changes_do_not_affect_identity() -> None:
+    graph = Graph()
+    owner = graph.add_node(kind=CredentialPacketNode, label="checkpoint")
+    manager = materialize_packet(
+        owner=owner,
+        region=Region.LOCAL,
+        purpose=IND.TRAVEL,
+        id_card=CredentialToken(indication=IND.TRAVEL),
+        credentials=[],
+        possessions=[],
+        label_prefix="Mara",
+    )
+    owner.packet_manager = manager
+    id_card = manager.get_slot(CREDENTIAL_ID_SLOT)[0]
+    bearer = manager.resolve_subject(manager.bearer_id)
+
+    assert id_card.subject_id == manager.bearer_id
+    assert manager.resolve_subject(id_card.subject_id) is bearer
+
+    recorded_subject = manager.materialize_subject("Mara:recorded-subject")
+    id_card.subject_id = recorded_subject.uid
+    assert (
+        bearer.adapt_look_media_spec().traits
+        == recorded_subject.adapt_look_media_spec().traits
+    )
+    assert derive_disposition(manager, LOCAL_RULES) is D.ARREST
+
+    recorded_subject.look.reference_model = "changed-after-issuance"
+    assert derive_disposition(manager, LOCAL_RULES) is D.ARREST
+
+    restored = Graph.structure(graph.unstructure())
+    restored_owner = restored.find_one(Selector(label="checkpoint"))
+    restored_manager = restored_owner.packet_manager
+    restored_id = restored_manager.get_slot(CREDENTIAL_ID_SLOT)[0]
+
+    assert restored_manager.bearer_id == manager.bearer_id
+    assert restored_id.subject_id == recorded_subject.uid
+    assert restored_manager.resolve_subject(restored_manager.bearer_id).uid == manager.bearer_id
+    assert restored_manager.resolve_subject(restored_id.subject_id).uid == recorded_subject.uid
+    assert derive_disposition(restored_manager, LOCAL_RULES) is D.ARREST
 
 
 def test_credential_token_facets_are_isolated_and_keep_packet_provenance() -> None:

--- a/engine/tests/mechanics/credentials/test_credential_packet_manager.py
+++ b/engine/tests/mechanics/credentials/test_credential_packet_manager.py
@@ -20,6 +20,7 @@ from tangl.mechanics.credentials import (
     materialize_packet,
 )
 from tangl.mechanics.assembly import ComponentFacet
+from tangl.mechanics.presence.look import HasSimpleLook
 from tangl.mechanics.credentials.domain import (
     ContrabandItem,
     CredentialStatus,
@@ -303,7 +304,7 @@ def test_manager_request_document_resolves_the_contributing_component() -> None:
 
     handler.receive_move(game, ("request_document", IND.WORK.value))
 
-    assert game.finding_status == {IND.WORK.value: Finding.VERIFIED}
+    assert game.finding_status == {IND.WORK.value: Finding.CLEARED}
 
 
 def test_manager_request_document_menu_does_not_reveal_credential_status() -> None:
@@ -444,6 +445,27 @@ def test_packet_manager_graph_roundtrip_preserves_credential_assignments_by_id()
     assert sum(1 for item in restored.members.values() if item.uid == work_permit.uid) == 1
 
 
+def test_unbound_packet_materializes_subjects_when_its_owner_becomes_graph_bound() -> None:
+    manager = materialized_work_packet()
+    graph = Graph()
+    owner = graph.add_node(kind=CredentialPacketNode, label="checkpoint")
+    owner.packet_manager = manager
+    manager.bind_owner(owner)
+    id_card = manager.get_slot(CREDENTIAL_ID_SLOT)[0]
+    permit = manager.get_slot(CREDENTIAL_PACKET_SLOT)[0]
+
+    assert manager.resolve_subject(manager.bearer_id).uid == manager.bearer_id
+    assert manager.resolve_subject(id_card.subject_id).uid == id_card.subject_id
+    assert manager.resolve_subject(permit.subject_id).uid == permit.subject_id
+
+    restored = Graph.structure(graph.unstructure())
+    restored_manager = restored.find_one(Selector(label="checkpoint")).packet_manager
+    restored_id = restored_manager.get_slot(CREDENTIAL_ID_SLOT)[0]
+
+    assert restored_manager.resolve_subject(restored_manager.bearer_id).uid == manager.bearer_id
+    assert restored_manager.resolve_subject(restored_id.subject_id).uid == id_card.subject_id
+
+
 def test_defects_recompute_from_a_restored_packet_manager() -> None:
     id_definition = credential_definition(
         "defect_roundtrip_id",
@@ -505,6 +527,9 @@ def test_graph_bound_subjects_roundtrip_and_look_changes_do_not_affect_identity(
 
     assert id_card.subject_id == manager.bearer_id
     assert manager.resolve_subject(id_card.subject_id) is bearer
+    assert [item.uid for item in graph.members.values() if isinstance(item, HasSimpleLook)] == [
+        manager.bearer_id,
+    ]
 
     recorded_subject = manager.materialize_subject("Mara:recorded-subject")
     id_card.subject_id = recorded_subject.uid

--- a/engine/tests/mechanics/games/test_credentials_derive.py
+++ b/engine/tests/mechanics/games/test_credentials_derive.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from tangl.mechanics.credentials import CREDENTIAL_PACKET_SLOT
+from tangl.mechanics.credentials import CREDENTIAL_ID_SLOT, CREDENTIAL_PACKET_SLOT
 from tangl.mechanics.games import (
     ContrabandItem,
     CredentialDefectKind,
@@ -132,6 +132,45 @@ class TestStructuredDefects:
             {IND.WORK.value: "cleared"},
         ) == []
         assert case.credential_for(IND.WORK).status is S.MISSING_SEAL
+
+    def test_wrong_id_compiles_to_one_subject_mismatch(self) -> None:
+        case = CredentialCase(purpose=IND.TRAVEL, id_card=_id(S.WRONG_HOLDER))
+        id_card = case.packet_manager.get_slot(CREDENTIAL_ID_SLOT)[0]
+
+        defects = derive_defects(case.packet_manager, LOCAL_RULES)
+
+        assert id_card.status is S.VALID
+        assert id_card.subject_id != case.packet_manager.bearer_id
+        assert [(defect.kind, defect.failure_class, defect.source_id) for defect in defects] == [
+            (CredentialDefectKind.SUBJECT_MISMATCH, FailureClass.CRIME, id_card.uid),
+        ]
+
+    def test_wrong_permit_compiles_to_a_document_subject_mismatch(self) -> None:
+        case = CredentialCase(
+            purpose=IND.WORK,
+            id_card=_id(S.VALID),
+            packet=[_permit(IND.WORK, holder_matches=False)],
+        )
+        id_card = case.packet_manager.get_slot(CREDENTIAL_ID_SLOT)[0]
+        permit = case.packet_manager.get_slot(CREDENTIAL_PACKET_SLOT)[0]
+
+        defects = derive_defects(case.packet_manager, LOCAL_RULES)
+
+        assert permit.subject_id != id_card.subject_id
+        assert [(defect.kind, defect.failure_class, defect.source_id) for defect in defects] == [
+            (CredentialDefectKind.SUBJECT_MISMATCH, FailureClass.CRIME, permit.uid),
+        ]
+
+    def test_missing_id_does_not_manufacture_a_subject_mismatch(self) -> None:
+        case = CredentialCase(
+            purpose=IND.WORK,
+            id_card=None,
+            packet=[_permit(IND.WORK, holder_matches=False)],
+        )
+
+        defects = derive_defects(case.packet_manager, LOCAL_RULES)
+
+        assert [defect.kind for defect in defects] == [CredentialDefectKind.MISSING_EVIDENCE]
 
 
 class TestAnonymousAndId:

--- a/engine/tests/mechanics/games/test_credentials_derive.py
+++ b/engine/tests/mechanics/games/test_credentials_derive.py
@@ -145,6 +145,16 @@ class TestStructuredDefects:
             (CredentialDefectKind.SUBJECT_MISMATCH, FailureClass.CRIME, id_card.uid),
         ]
 
+    def test_wrong_id_uses_identity_specific_presentation_text(self) -> None:
+        case = CredentialCase(purpose=IND.TRAVEL, id_card=_id(S.WRONG_HOLDER))
+        game = CredentialsGame()
+
+        game.presentation.render_case(case, derive_defects(case.packet_manager, LOCAL_RULES))
+
+        assert case.hidden_facts == {
+            "passport": "The identity document does not name this bearer.",
+        }
+
     def test_wrong_permit_compiles_to_a_document_subject_mismatch(self) -> None:
         case = CredentialCase(
             purpose=IND.WORK,

--- a/engine/tests/mechanics/games/test_credentials_game.py
+++ b/engine/tests/mechanics/games/test_credentials_game.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import pytest
 
 from tangl.core import Graph
-from tangl.mechanics.credentials import materialize_packet
+from tangl.journal.fragments import PieceFragment
+from tangl.mechanics.credentials import CREDENTIAL_ID_SLOT, materialize_packet
 from tangl.mechanics.games import (
     CredentialStatus,
     CredentialToken,
@@ -428,3 +429,41 @@ class TestCredentialsIntegration:
         assert block.game.finding_status == {Indication.WORK.value: "cleared"}
         assert type(next(iter(block.game.finding_status))) is str
         assert block.game.time_spent == 3
+
+
+def test_graph_bound_packet_projects_neutral_bearer_and_id_photo_looks() -> None:
+    graph = Graph(label="credential_presence")
+    block = graph.add_node(kind=CredentialsBlock, label="checkpoint")
+    manager = materialize_packet(
+        owner=block,
+        region=Region.LOCAL,
+        purpose=Indication.TRAVEL,
+        id_card=CredentialToken(indication=Indication.TRAVEL),
+        credentials=[],
+        possessions=[],
+        label_prefix="Mara",
+    )
+    id_card = manager.get_slot(CREDENTIAL_ID_SLOT)[0]
+    id_card.subject_id = manager.materialize_subject("Mara:recorded-subject").uid
+    block.game.roster = [
+        CredentialCase(
+            candidate_name="Mara",
+            packet_manager=manager,
+            presented_documents={"passport": "A passport."},
+        ),
+    ]
+    block.game_handler.setup(block.game)
+
+    pieces = [
+        fragment
+        for fragment in block.game_handler.get_journal_fragments(block.game)
+        if isinstance(fragment, PieceFragment)
+    ]
+    candidate = next(piece for piece in pieces if piece.piece_kind == "candidate")
+    passport = next(piece for piece in pieces if piece.piece_kind == "id_card")
+
+    assert candidate.properties["look_description"] == "Mara"
+    assert candidate.properties["look_media_payload"].media_role == "candidate"
+    assert passport.properties["look_description"] == ""
+    assert passport.properties["look_media_payload"].media_role == "id_photo"
+    assert "mismatch" not in str([candidate.content, passport.content]).lower()

--- a/engine/tests/mechanics/games/test_credentials_mediation.py
+++ b/engine/tests/mechanics/games/test_credentials_mediation.py
@@ -37,8 +37,17 @@ def _id(status: S = S.VALID) -> CredentialToken:
     return CredentialToken(indication=IND.TRAVEL, status=status)
 
 
-def _permit(indication: IND, status: S = S.VALID) -> CredentialToken:
-    return CredentialToken(indication=indication, status=status, requires_id=True)
+def _permit(
+    indication: IND,
+    status: S = S.VALID,
+    holder_matches: bool = True,
+) -> CredentialToken:
+    return CredentialToken(
+        indication=indication,
+        status=status,
+        requires_id=True,
+        holder_matches=holder_matches,
+    )
 
 
 def _game(*cases: CredentialCase, **overrides) -> tuple[CredentialsGame, CredentialsGameHandler]:
@@ -112,6 +121,19 @@ class TestMediationAvailability:
         # it won't hold up, but never upgrades the disposition.
         case = CredentialCase(
             purpose=IND.WORK, id_card=_id(), packet=[_permit(IND.WORK, S.FORGED)]
+        )
+        game, handler = _game(case)
+        handler.receive_move(game, ("inspect", "passport"))
+        handler.receive_move(game, ("request_document", IND.WORK.value))
+
+        assert game.finding_status[IND.WORK.value] == "confirmed"
+        assert game.expected_disposition(case) is D.ARREST
+
+    def test_request_document_confirms_a_subject_mismatch(self) -> None:
+        case = CredentialCase(
+            purpose=IND.WORK,
+            id_card=_id(),
+            packet=[_permit(IND.WORK, holder_matches=False)],
         )
         game, handler = _game(case)
         handler.receive_move(game, ("inspect", "passport"))


### PR DESCRIPTION
## Summary

- bind credential packets, IDs, and permits through explicit graph-owned subject UUIDs
- compile legacy wrong-holder inputs into those bindings, with derived subject-mismatch defects as the sole runtime authority
- project neutral bearer and ID-photo presence data through existing journal pieces
- prove convergence across mediation, graph round-trips, and border/Hall Monitor presentation skins

## Validation

- `poetry run pytest engine/tests -q` — 2762 passed, 69 skipped, 9 xfailed
- `git diff --check`

Local CodeRabbit could not start its local review server (port-0 startup/auth failure).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Credential validation now binds matching to subject identity across IDs and permits, enabling more consistent subject-specific display (including look text and media).
  * Subject mismatches are now rendered as dedicated findings, with the mediation flow confirming them correctly.
* **Bug Fixes**
  * Improved handling for forged evidence and mismatched subject bindings, avoiding incorrect “crime” classification for compatibility-only inputs.
  * Prevented false mismatch outcomes when identity evidence is missing.
  * Preserved identity mappings and presentation consistency through graph serialization and look updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->