### PR TITLE
Fix recursive rendering identity and undefined symbols

### DIFF
--- a/engine/src/tangl/prose/rendering.py
+++ b/engine/src/tangl/prose/rendering.py
@@ -16,6 +16,12 @@ from tangl.utils.rejinja import RecursiveTemplate
 from tangl.vm.ctx import VmPhaseCtx
 
 Scope: TypeAlias = dict[str, object]
+IdentityKey: TypeAlias = tuple[str, str | int]
+RenderFrameKey: TypeAlias = tuple[str, IdentityKey, IdentityKey]
+
+
+def _default_environment() -> jinja2.Environment:
+    return jinja2.Environment(undefined=jinja2.StrictUndefined)
 
 
 class RecursiveRenderError(RuntimeError):
@@ -40,7 +46,7 @@ class RecursiveRenderError(RuntimeError):
 class _RecursiveRenderState:
     """Active template and output values for one recursive render tree."""
 
-    templates: set[str] = field(default_factory=set)
+    frames: set[RenderFrameKey] = field(default_factory=set)
     outputs: set[str] = field(default_factory=set)
 
 
@@ -76,7 +82,7 @@ class TextRenderSession:
     ctx: VmPhaseCtx
     discourse: Scope = field(default_factory=dict)
     max_depth: int = 32
-    environment: jinja2.Environment = field(default_factory=jinja2.Environment)
+    environment: jinja2.Environment = field(default_factory=_default_environment)
     _active_state: _RecursiveRenderState | None = field(default=None, init=False, repr=False)
 
     def render(
@@ -102,14 +108,15 @@ class TextRenderSession:
         if subject is not None:
             scope["subject"] = subject
 
+        frame_identity = _frame_identity(subject, scope_source)
         state = self._active_state
         if state is not None:
-            return self._render_recursive(content, scope, state)
+            return self._render_recursive(content, scope, frame_identity, state)
 
         state = _RecursiveRenderState()
         self._active_state = state
         try:
-            return self._render_recursive(content, scope, state)
+            return self._render_recursive(content, scope, frame_identity, state)
         finally:
             self._active_state = None
 
@@ -142,22 +149,24 @@ class TextRenderSession:
         self,
         content: str,
         scope: Scope,
+        frame_identity: tuple[IdentityKey, IdentityKey],
         state: _RecursiveRenderState,
     ) -> str:
         current = content
-        templates: list[str] = []
+        frames: list[RenderFrameKey] = []
         outputs: list[str] = []
 
         try:
             while True:
-                if len(state.templates) >= self.max_depth:
+                if len(state.frames) >= self.max_depth:
                     raise RecursiveRenderError(
                         f"Recursive template exceeded maximum depth ({self.max_depth})",
                     )
-                if current in state.templates:
+                frame = (current, *frame_identity)
+                if frame in state.frames:
                     raise RecursiveRenderError("Recursive template cycle detected")
-                state.templates.add(current)
-                templates.append(current)
+                state.frames.add(frame)
+                frames.append(frame)
 
                 template = self.environment.from_string(
                     current,
@@ -172,8 +181,8 @@ class TextRenderSession:
                 outputs.append(rendered)
                 current = rendered
         finally:
-            for template in templates:
-                state.templates.remove(template)
+            for frame in frames:
+                state.frames.remove(frame)
             for output in outputs:
                 state.outputs.remove(output)
 
@@ -206,6 +215,22 @@ def _contains_template_syntax(content: str, environment: jinja2.Environment) -> 
             environment.comment_start_string,
         )
     )
+
+
+def _frame_identity(
+    subject: object | None,
+    source: object | None,
+) -> tuple[IdentityKey, IdentityKey]:
+    return _identity_key(subject), _identity_key(source)
+
+
+def _identity_key(value: object | None) -> IdentityKey:
+    if value is None:
+        return "none", 0
+    uid = getattr(value, "uid", None)
+    if uid is not None:
+        return "uid", str(uid)
+    return "object", id(value)
 
 
 __all__ = ["RecursiveRenderError", "TextRenderSession", "render_text"]

--- a/engine/tests/prose/test_rendering.py
+++ b/engine/tests/prose/test_rendering.py
@@ -25,6 +25,16 @@ class _Child:
     content: str = "{{ subject.name }}"
 
 
+@dataclass
+class _TreeSubject:
+    name: str
+    child: _TreeSubject | None = None
+    content: str = (
+        "{{ subject.name }}"
+        "{% if subject.child %} {{ render_child(subject.content, subject.child) }}{% endif %}"
+    )
+
+
 def test_render_text_returns_literal_text() -> None:
     assert render_text("A quiet room.", ctx=_Ctx({})) == "A quiet room."
 
@@ -60,6 +70,20 @@ def test_render_child_shares_recursive_cycle_protection() -> None:
 
     with pytest.raises(RecursiveRenderError, match="cycle"):
         session.render("{{ render_child(subject.content, subject) }}", subject=child)
+
+
+def test_render_child_allows_one_template_for_distinct_tree_subjects() -> None:
+    three = _TreeSubject("three")
+    two = _TreeSubject("two", child=three)
+    one = _TreeSubject("one", child=two)
+    session = TextRenderSession(ctx=_Ctx({}))
+
+    rendered = session.render(
+        "{{ render_child(subject.content, subject) }}",
+        subject=one,
+    )
+
+    assert rendered == "one two three"
 
 
 def test_consecutive_segments_share_ephemeral_discourse() -> None:
@@ -115,3 +139,14 @@ def test_render_text_honors_custom_environment_delimiters() -> None:
     )
 
     assert session.render("[[ first ]]") == "Done"
+
+
+def test_render_text_raises_for_undefined_symbols_by_default() -> None:
+    with pytest.raises(jinja2.UndefinedError):
+        render_text("A {{ missing }} arrives.", ctx=_Ctx({}))
+
+
+def test_render_text_accepts_an_explicit_permissive_environment() -> None:
+    session = TextRenderSession(ctx=_Ctx({}), environment=jinja2.Environment())
+
+    assert session.render("A {{ missing }} arrives.") == "A  arrives."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recursive rendering so the same template can be reused safely for different subjects.
  * Strengthened cycle and depth detection during nested rendering.
  * Missing template variables now raise a clear error by default, helping identify incomplete templates.
  * Permissive rendering remains available when explicitly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->