### PR TITLE
Add typed text presentation dispatch

### DIFF
--- a/docs/src/design/story/EPISODE_SYUZHET_RENDERING.md
+++ b/docs/src/design/story/EPISODE_SYUZHET_RENDERING.md
@@ -8,7 +8,11 @@
 **Implementation status:** Phase 10.1 provides the text-only floor:
 ``TextRenderSession`` renders bounded recursive Jinja text against a
 ``PhaseCtx`` namespace and carries ephemeral discourse state. It is not yet a
-general content request or JOURNAL adapter.
+general content request or JOURNAL adapter. Phase 11 adds the text-specific
+``tangl.story.presentation.render_text_as(...)`` invocation seam: it selects a
+``str`` source through ``story_dispatch``, exposes that resolver to recursive
+text templates, and ships replaceable presence defaults. It remains separate
+from fragment and media products.
 
 ## Purpose
 

--- a/engine/src/tangl/prose/rendering.py
+++ b/engine/src/tangl/prose/rendering.py
@@ -6,9 +6,9 @@ does not own graph state, journal emission, or a general content-product model.
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
-from typing import Protocol, TypeAlias
+from typing import Protocol, TypeAlias, cast
 
 import jinja2
 
@@ -32,6 +32,18 @@ class TextAspectResolver(Protocol):
         session: TextRenderSession,
         content: str | None = None,
     ) -> str: ...
+
+
+@jinja2.pass_context
+def _render_as_filter(
+    context: jinja2.runtime.Context,
+    target: object,
+    aspect: str,
+    content: str | None = None,
+) -> str:
+    """Delegate Jinja's ``render_as`` filter to this render scope's callback."""
+    render_as = cast(Callable[..., str], context["render_as"])
+    return render_as(target, aspect, content=content)
 
 
 def _default_environment() -> jinja2.Environment:
@@ -99,6 +111,10 @@ class TextRenderSession:
     environment: jinja2.Environment = field(default_factory=_default_environment)
     text_resolver: TextAspectResolver | None = None
     _active_state: _RecursiveRenderState | None = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        """Install the documented filter on this session's environment."""
+        self.environment.filters["render_as"] = _render_as_filter
 
     def render(
         self,

--- a/engine/src/tangl/prose/rendering.py
+++ b/engine/src/tangl/prose/rendering.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
-from typing import TypeAlias
+from typing import Protocol, TypeAlias
 
 import jinja2
 
@@ -18,6 +18,20 @@ from tangl.vm.ctx import VmPhaseCtx
 Scope: TypeAlias = dict[str, object]
 IdentityKey: TypeAlias = tuple[str, str | int]
 RenderFrameKey: TypeAlias = tuple[str, IdentityKey, IdentityKey]
+
+
+class TextAspectResolver(Protocol):
+    """Resolve one typed textual aspect through a render session."""
+
+    def __call__(
+        self,
+        target: object,
+        aspect: str,
+        *,
+        ctx: VmPhaseCtx,
+        session: TextRenderSession,
+        content: str | None = None,
+    ) -> str: ...
 
 
 def _default_environment() -> jinja2.Environment:
@@ -83,6 +97,7 @@ class TextRenderSession:
     discourse: Scope = field(default_factory=dict)
     max_depth: int = 32
     environment: jinja2.Environment = field(default_factory=_default_environment)
+    text_resolver: TextAspectResolver | None = None
     _active_state: _RecursiveRenderState | None = field(default=None, init=False, repr=False)
 
     def render(
@@ -105,6 +120,8 @@ class TextRenderSession:
             scope.update(bindings)
         scope["discourse"] = self.discourse
         scope["render_child"] = self.render_child
+        if self.text_resolver is not None:
+            scope["render_as"] = self._render_as
         if subject is not None:
             scope["subject"] = subject
 
@@ -135,6 +152,19 @@ class TextRenderSession:
             subject=subject,
             bindings=bindings,
         )
+
+    def _render_as(
+        self,
+        target: object,
+        aspect: str,
+        *,
+        content: str | None = None,
+    ) -> str:
+        """Resolve a nested text aspect through the injected story callback."""
+        resolver = self.text_resolver
+        if resolver is None:
+            raise RuntimeError("No text-aspect resolver is configured")
+        return resolver(target, aspect, ctx=self.ctx, session=self, content=content)
 
     def render_segments(
         self,
@@ -233,4 +263,9 @@ def _identity_key(value: object | None) -> IdentityKey:
     return "object", id(value)
 
 
-__all__ = ["RecursiveRenderError", "TextRenderSession", "render_text"]
+__all__ = [
+    "RecursiveRenderError",
+    "TextAspectResolver",
+    "TextRenderSession",
+    "render_text",
+]

--- a/engine/src/tangl/story/__init__.py
+++ b/engine/src/tangl/story/__init__.py
@@ -111,10 +111,12 @@ from .analysis import (
 from .story_graph import StoryGraph
 from .dispatch import (
     do_find_edges,
+    do_render_text,
     on_compose_journal,
     on_find_edges,
     on_gather_ns,
     on_journal,
+    on_render_text,
     story_dispatch,
 )
 from .fragments import ChoiceFragment, ContentFragment, MediaFragment
@@ -165,6 +167,7 @@ __all__ = [
     "collapse_linear_chains",
     "cluster_by_scene",
     "do_find_edges",
+    "do_render_text",
     "episode_only_selector",
     "episode_plus_concepts_selector",
     "focus_runtime_window",
@@ -175,6 +178,7 @@ __all__ = [
     "on_find_edges",
     "on_gather_ns",
     "on_journal",
+    "on_render_text",
     "project_story_graph",
     "project_world_graph",
     "projected_graph_to_dict",

--- a/engine/src/tangl/story/dispatch.py
+++ b/engine/src/tangl/story/dispatch.py
@@ -60,18 +60,21 @@ def do_render_text(
     ctx: VmPhaseCtx,
 ) -> str | None:
     """Select the last applicable textual source for a presentation aspect."""
-    receipts = story_dispatch.execute_all(
-        task="render_text",
-        call_kwargs={"caller": caller, "aspect": aspect},
-        ctx=ctx,
-        selector=Selector(caller_kind=type(caller)),
-    )
-    result = CallReceipt.last_result(*receipts)
-    if result is not None and not isinstance(result, str):
-        raise TypeError(
-            "render_text handlers must return str or None, "
-            f"got {type(result).__name__}",
+    receipts = list(
+        story_dispatch.execute_all(
+            task="render_text",
+            call_kwargs={"caller": caller, "aspect": aspect},
+            ctx=ctx,
+            selector=Selector(caller_kind=type(caller)),
         )
+    )
+    for result in CallReceipt.iter_results(*receipts):
+        if not isinstance(result, str):
+            raise TypeError(
+                "render_text handlers must return str or None, "
+                f"got {type(result).__name__}",
+            )
+    result = CallReceipt.last_result(*receipts)
     return result
 
 

--- a/engine/src/tangl/story/dispatch.py
+++ b/engine/src/tangl/story/dispatch.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from tangl.core import BehaviorRegistry, CallReceipt, DispatchLayer, Selector
+from tangl.vm.ctx import VmPhaseCtx
 
 from .episode import Action
 
@@ -45,6 +46,35 @@ def on_find_edges(func=None, **kwargs):
     return story_dispatch.register(func=func, task="find_edges", **kwargs)
 
 
+def on_render_text(func=None, **kwargs):
+    """Register a story-level text-presentation handler."""
+    if func is None:
+        return lambda f: story_dispatch.register(func=f, task="render_text", **kwargs)
+    return story_dispatch.register(func=func, task="render_text", **kwargs)
+
+
+def do_render_text(
+    caller: object,
+    *,
+    aspect: str,
+    ctx: VmPhaseCtx,
+) -> str | None:
+    """Select the last applicable textual source for a presentation aspect."""
+    receipts = story_dispatch.execute_all(
+        task="render_text",
+        call_kwargs={"caller": caller, "aspect": aspect},
+        ctx=ctx,
+        selector=Selector(caller_kind=type(caller)),
+    )
+    result = CallReceipt.last_result(*receipts)
+    if result is not None and not isinstance(result, str):
+        raise TypeError(
+            "render_text handlers must return str or None, "
+            f"got {type(result).__name__}",
+        )
+    return result
+
+
 def do_find_edges(
     caller: object,
     *,
@@ -79,9 +109,11 @@ def do_find_edges(
 
 __all__ = [
     "do_find_edges",
+    "do_render_text",
     "on_find_edges",
     "on_compose_journal",
     "story_dispatch",
     "on_gather_ns",
     "on_journal",
+    "on_render_text",
 ]

--- a/engine/src/tangl/story/presentation.py
+++ b/engine/src/tangl/story/presentation.py
@@ -1,0 +1,113 @@
+"""Text presentation selection over the story dispatch chain."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from tangl.mechanics.presence.look import HasLook, HasSimpleLook, Look
+from tangl.mechanics.presence.ornaments import Ornamentation
+from tangl.mechanics.presence.outfit import OutfitManager
+from tangl.prose import TextRenderSession
+from tangl.vm.ctx import VmPhaseCtx
+
+from .dispatch import do_render_text, on_render_text
+
+
+def render_text_as(
+    target: object,
+    aspect: str,
+    *,
+    ctx: VmPhaseCtx,
+    session: TextRenderSession | None = None,
+    content: str | None = None,
+    bindings: Mapping[str, object] | None = None,
+) -> str:
+    """Render one named textual aspect through story dispatch.
+
+    Explicit ``content`` is a complete authored replacement. Otherwise the
+    selected source is the last non-``None`` result from the active authority
+    chain, with the shipped mechanic handler as the application-level default.
+    """
+    session = session or TextRenderSession(ctx=ctx, text_resolver=render_text_as)
+    if session.text_resolver is None:
+        session.text_resolver = render_text_as
+
+    source = content if content is not None else do_render_text(target, aspect=aspect, ctx=ctx)
+    if source is None:
+        raise LookupError(
+            f"No text presentation adapter for {type(target).__name__}.{aspect}",
+        )
+    return session.render(
+        source,
+        source=ctx.cursor,
+        subject=target,
+        bindings=dict(bindings or {}),
+    )
+
+
+@on_render_text(wants_caller_kind=Look, wants_exact_kind=False)
+def render_look_text(*, caller: Look, aspect: str, ctx: VmPhaseCtx) -> str | None:
+    """Provide the default body-description leaf."""
+    _ = ctx
+    return caller.describe() if aspect == "body_description" else None
+
+
+@on_render_text(wants_caller_kind=OutfitManager, wants_exact_kind=False)
+def render_outfit_text(
+    *,
+    caller: OutfitManager,
+    aspect: str,
+    ctx: VmPhaseCtx,
+) -> str | None:
+    """Provide the default outfit-description leaf."""
+    _ = ctx
+    return caller.describe() if aspect == "outfit_description" else None
+
+
+@on_render_text(wants_caller_kind=Ornamentation, wants_exact_kind=False)
+def render_ornament_text(
+    *,
+    caller: Ornamentation,
+    aspect: str,
+    ctx: VmPhaseCtx,
+) -> str | None:
+    """Provide the default ornament-description leaf."""
+    _ = ctx
+    return caller.describe_summary() if aspect == "ornament_description" else None
+
+
+@on_render_text(wants_caller_kind=HasSimpleLook, wants_exact_kind=False)
+def render_simple_presence_text(
+    *,
+    caller: HasSimpleLook,
+    aspect: str,
+    ctx: VmPhaseCtx,
+) -> str | None:
+    """Render direct presence by delegating to the body-description leaf."""
+    _ = caller, ctx
+    if aspect != "presence_description":
+        return None
+    return "{{ render_as(subject.look, 'body_description') }}"
+
+
+@on_render_text(wants_caller_kind=HasLook, wants_exact_kind=False)
+def render_bundle_presence_text(
+    *,
+    caller: HasLook,
+    aspect: str,
+    ctx: VmPhaseCtx,
+) -> str | None:
+    """Compose a bundled look through the body, outfit, and ornament adapters."""
+    _ = caller, ctx
+    if aspect != "presence_description":
+        return None
+    return (
+        "{% set body = render_as(subject.look, 'body_description') %}"
+        "{% set outfit = render_as(subject.outfit, 'outfit_description') %}"
+        "{% set ornaments = render_as(subject.ornamentation, 'ornament_description') %}"
+        "{{ body }}{% if outfit %}, wearing {{ outfit }}{% endif %}"
+        "{% if ornaments %}, marked by {{ ornaments }}{% endif %}"
+    )
+
+
+__all__ = ["render_text_as"]

--- a/engine/tests/story/test_text_presentation.py
+++ b/engine/tests/story/test_text_presentation.py
@@ -1,0 +1,220 @@
+"""Focused tests for typed story text presentation."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import jinja2
+import pytest
+
+from tangl.core import BehaviorRegistry, DispatchLayer
+from tangl.lang.body_parts import BodyPart, BodyRegion
+from tangl.mechanics.presence.look import (
+    HairColor,
+    HairStyle,
+    HasLook,
+    HasSimpleLook,
+    Look,
+    SkinTone,
+)
+from tangl.mechanics.presence.ornaments import Ornament, OrnamentType
+from tangl.mechanics.presence.wearable import Wearable, WearableLayer, WearableType
+from tangl.prose import TextRenderSession
+from tangl.story import Actor
+from tangl.story.presentation import render_text_as
+
+
+class _TextCtx:
+    cursor = SimpleNamespace(label="text-render")
+
+    def __init__(
+        self,
+        namespace: dict[str, object] | None = None,
+        authorities: list[BehaviorRegistry] | None = None,
+    ) -> None:
+        self.namespace = namespace or {}
+        self.authorities = authorities or []
+
+    def get_ns(self, _source: object | None = None) -> dict[str, object]:
+        return self.namespace
+
+    def get_authorities(self) -> list[BehaviorRegistry]:
+        return self.authorities
+
+    def get_inline_behaviors(self) -> list[object]:
+        return []
+
+
+class _SimpleActor(Actor, HasSimpleLook):
+    """Pinned actor with the direct look facet."""
+
+
+class _LookActor(Actor, HasLook):
+    """Pinned actor with the bundled visual facets."""
+
+
+@pytest.fixture(autouse=True)
+def _reset_wearable_types():
+    WearableType.clear_instances()
+    yield
+    WearableType.clear_instances()
+
+
+def _actor_look(*, hair_color: HairColor = HairColor.RED) -> Look:
+    return Look(
+        hair_color=hair_color,
+        hair_style=HairStyle.LONG,
+        skin_tone=SkinTone.OLIVE,
+    )
+
+
+def _dress(actor: _LookActor) -> None:
+    shirt_type = WearableType(
+        label="presentation_shirt",
+        noun="shirt",
+        covers={BodyRegion.TOP},
+        layer=WearableLayer.OUTER,
+    )
+    coat_type = WearableType(
+        label="presentation_coat",
+        noun="coat",
+        covers={BodyRegion.TOP},
+        layer=WearableLayer.OVER,
+    )
+    actor.outfit.assign("top_60", Wearable(token_from=shirt_type.label))
+    actor.outfit.assign("top_80", Wearable(token_from=coat_type.label))
+
+
+def _mark(actor: _LookActor) -> None:
+    actor.ornamentation.add_ornament(
+        Ornament(
+            body_part=BodyPart.LEFT_ARM,
+            ornament_type=OrnamentType.TATTOO,
+            text="a dragon",
+        ),
+    )
+
+
+def test_simple_look_renders_through_presence_aspect() -> None:
+    actor = _SimpleActor(label="guide", look=_actor_look())
+
+    rendered = render_text_as(actor, "presence_description", ctx=_TextCtx())
+
+    assert "olive skin" in rendered
+    assert "red long hair" in rendered
+
+
+def test_has_look_recursively_composes_body_outfit_and_ornaments() -> None:
+    actor = _LookActor(label="guide", look=_actor_look())
+    _dress(actor)
+    _mark(actor)
+
+    rendered = render_text_as(actor, "presence_description", ctx=_TextCtx())
+
+    assert "olive skin" in rendered
+    assert "wearing shirt and coat" in rendered
+    assert "a dragon tattoo on their left arm" in rendered
+
+
+def test_empty_presence_components_do_not_leave_grammar_debris() -> None:
+    actor = _LookActor(label="guide", look=_actor_look())
+
+    rendered = render_text_as(actor, "presence_description", ctx=_TextCtx())
+
+    assert "wearing" not in rendered
+    assert "marked by" not in rendered
+    assert not rendered.endswith(",")
+
+
+def test_presence_rendering_reflects_live_look_and_outfit_state() -> None:
+    actor = _LookActor(label="guide", look=_actor_look())
+
+    initial = render_text_as(actor, "presence_description", ctx=_TextCtx())
+    actor.look.hair_color = HairColor.BLUE
+    _dress(actor)
+    updated = render_text_as(actor, "presence_description", ctx=_TextCtx())
+
+    assert "red long hair" in initial
+    assert "blue long hair" in updated
+    assert "wearing shirt and coat" in updated
+
+
+def test_shared_session_renders_multiple_presence_subjects() -> None:
+    first = _SimpleActor(label="first", look=_actor_look(hair_color=HairColor.RED))
+    second = _SimpleActor(label="second", look=_actor_look(hair_color=HairColor.BLUE))
+    ctx = _TextCtx(namespace={"actors": [first, second]})
+    session = TextRenderSession(ctx=ctx)
+
+    rendered = render_text_as(
+        first,
+        "presence_description",
+        ctx=ctx,
+        session=session,
+        content="{% for actor in actors %}[{{ render_as(actor, 'presence_description') }}]{% endfor %}",
+    )
+
+    assert "red long hair" in rendered
+    assert "blue long hair" in rendered
+
+
+def test_authored_content_replaces_recursive_presence_composition() -> None:
+    target = object()
+
+    rendered = render_text_as(
+        target,
+        "presence_description",
+        ctx=_TextCtx(),
+        content="A silhouette in a borrowed coat.",
+    )
+
+    assert rendered == "A silhouette in a borrowed coat."
+
+
+def test_authority_dispatch_can_override_presence_text() -> None:
+    actor = _LookActor(label="guide", look=_actor_look())
+    authority = BehaviorRegistry(
+        label="presentation.override",
+        default_dispatch_layer=DispatchLayer.AUTHOR,
+    )
+
+    def _override(*, caller: object, aspect: str, ctx: _TextCtx) -> str | None:
+        _ = caller, ctx
+        return "The school librarian." if aspect == "presence_description" else None
+
+    authority.register(
+        _override,
+        task="render_text",
+        wants_caller_kind=_LookActor,
+        wants_exact_kind=False,
+    )
+
+    assert render_text_as(
+        actor,
+        "presence_description",
+        ctx=_TextCtx(authorities=[authority]),
+    ) == "The school librarian."
+
+
+def test_missing_adapter_and_symbol_fail_explicitly() -> None:
+    actor = _SimpleActor(label="guide", look=_actor_look())
+
+    with pytest.raises(LookupError, match="missing_description"):
+        render_text_as(actor, "missing_description", ctx=_TextCtx())
+    with pytest.raises(jinja2.UndefinedError):
+        render_text_as(
+            actor,
+            "presence_description",
+            ctx=_TextCtx(),
+            content="{{ missing }}",
+        )
+
+
+def test_presence_rendering_does_not_mutate_the_actor() -> None:
+    actor = _LookActor(label="guide", look=_actor_look())
+    _dress(actor)
+    _mark(actor)
+    before = actor.unstructure()
+
+    render_text_as(actor, "presence_description", ctx=_TextCtx())
+
+    assert actor.unstructure() == before

--- a/engine/tests/story/test_text_presentation.py
+++ b/engine/tests/story/test_text_presentation.py
@@ -21,6 +21,7 @@ from tangl.mechanics.presence.ornaments import Ornament, OrnamentType
 from tangl.mechanics.presence.wearable import Wearable, WearableLayer, WearableType
 from tangl.prose import TextRenderSession
 from tangl.story import Actor
+from tangl.story.dispatch import do_render_text
 from tangl.story.presentation import render_text_as
 
 
@@ -157,6 +158,20 @@ def test_shared_session_renders_multiple_presence_subjects() -> None:
     assert "blue long hair" in rendered
 
 
+def test_render_as_filter_matches_documented_authoring_syntax() -> None:
+    actor = _SimpleActor(label="guide", look=_actor_look())
+
+    rendered = render_text_as(
+        actor,
+        "presence_description",
+        ctx=_TextCtx(),
+        content="{{ subject | render_as('presence_description') }}",
+    )
+
+    assert "olive skin" in rendered
+    assert "red long hair" in rendered
+
+
 def test_authored_content_replaces_recursive_presence_composition() -> None:
     target = object()
 
@@ -193,6 +208,34 @@ def test_authority_dispatch_can_override_presence_text() -> None:
         "presence_description",
         ctx=_TextCtx(authorities=[authority]),
     ) == "The school librarian."
+
+
+def test_dispatch_rejects_an_invalid_non_winning_handler_result() -> None:
+    target = object()
+    authority = BehaviorRegistry(
+        label="presentation.invalid-result",
+        default_dispatch_layer=DispatchLayer.AUTHOR,
+    )
+
+    authority.register(
+        lambda **_kwargs: 42,
+        task="render_text",
+        wants_caller_kind=object,
+        wants_exact_kind=False,
+    )
+    authority.register(
+        lambda **_kwargs: "valid override",
+        task="render_text",
+        wants_caller_kind=object,
+        wants_exact_kind=False,
+    )
+
+    with pytest.raises(TypeError, match="must return str or None"):
+        do_render_text(
+            target,
+            aspect="presence_description",
+            ctx=_TextCtx(authorities=[authority]),
+        )
 
 
 def test_missing_adapter_and_symbol_fail_explicitly() -> None:


### PR DESCRIPTION
## Summary

Implements Phase 11's text-only presentation selection seam:

- `tangl.story.presentation.render_text_as(...)` selects a text source through the existing `story_dispatch` authority chain.
- `TextRenderSession` exposes an injected `render_as(...)` callback for recursive templates without importing Story.
- Shipped `Look`, outfit, ornament, `HasSimpleLook`, and `HasLook` defaults compose a presence description recursively.
- Explicit authored content and AUTHOR/local dispatch handlers replace default composition.

## Validation

- `poetry run pytest engine/tests/story/test_text_presentation.py engine/tests/prose/test_rendering.py engine/tests/mechanics/presence/test_look.py engine/tests/mechanics/presence/test_wardrobe.py engine/tests/story/test_presence_prose_contract.py -q`
- `poetry run pytest engine/tests -q`
- `poetry run sphinx-build -W --keep-going -b html docs/src /tmp/storytangl-docs-phase11`
- `git diff --check`

## Deferred

JOURNAL/fragments, credentials, media, catalog schemas, and migration of existing `format_map` block rendering are intentionally deferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added text-based aspect rendering for character presence, look, outfits, and ornaments.
  * Introduced extensible, session-driven resolution for nested text templates via a `render_as` hook.
  * Added story dispatch hooks to power text rendering and enable overrides by author handlers.
  * Authored `content` can bypass automatic recursive presence composition.
* **Bug Fixes**
  * Rendering now fails explicitly when no adapter is found, when template symbols are missing, or when handlers return non-`str` results.
* **Documentation**
  * Updated the Episode-to-Syuzhet rendering design doc to clarify the text invocation seam and boundaries.
* **Tests**
  * Added comprehensive coverage for presence text rendering, recursion, session reuse, and override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->