### PR TITLE
Render credential documents through story presentation

### DIFF
--- a/docs/src/design/story/EPISODE_SYUZHET_RENDERING.md
+++ b/docs/src/design/story/EPISODE_SYUZHET_RENDERING.md
@@ -12,7 +12,10 @@ general content request or JOURNAL adapter. Phase 11 adds the text-specific
 ``tangl.story.presentation.render_text_as(...)`` invocation seam: it selects a
 ``str`` source through ``story_dispatch``, exposes that resolver to recursive
 text templates, and ships replaceable presence defaults. It remains separate
-from fragment and media products.
+from fragment and media products. Phase 12 adds one credential-owned
+``document_description`` adapter: an identity document resolves its bound
+subject through its packet manager and recursively projects that presence,
+without interpreting credential validity or rendering a packet.
 
 ## Purpose
 

--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
@@ -2,8 +2,10 @@
 
 **Status:** PLANNED for the global document/media mechanic; Phases 7–9 landed the
 game-facing packet-authority cutover, transient shared defect vocabulary, and
-graph-bound bearer/document subject references (2026-07-20/22), but not media
-composition or card extraction.
+graph-bound bearer/document subject references (2026-07-20/22). Phase 12 adds a
+text-only identity-document projection through the shared story presentation
+chain; it resolves the bound presence subject but does not evaluate validity,
+render a packet, compose a card, or produce media.
 **Scope:** the *global* credential mechanic — `Credential → Document → Media`,
 with carrier/bearer binding — that the credentials checkpoint **game**
 (`tangl.mechanics.games.credentials_game`) becomes one consumer of.

--- a/engine/src/tangl/mechanics/credentials/__init__.py
+++ b/engine/src/tangl/mechanics/credentials/__init__.py
@@ -35,6 +35,9 @@ from .domain import (
     Restrictions,
 )
 
+# Register the credential-owned default text presentation handlers.
+from . import presentation as _presentation  # noqa: F401
+
 __all__ = [
     "COMMON_ALLIED_RESTRICTIONS",
     "COMMON_HOSTILE_RESTRICTIONS",

--- a/engine/src/tangl/mechanics/credentials/presentation.py
+++ b/engine/src/tangl/mechanics/credentials/presentation.py
@@ -1,0 +1,29 @@
+"""Text presentation defaults for graph-backed credential documents."""
+
+from __future__ import annotations
+
+from tangl.story.dispatch import on_render_text
+from tangl.vm.ctx import VmPhaseCtx
+
+from .assembly import CredentialComponent
+
+
+@on_render_text(wants_caller_kind=CredentialComponent, wants_exact_kind=False)
+def render_identity_document_text(
+    *,
+    caller: CredentialComponent,
+    aspect: str,
+    ctx: VmPhaseCtx,
+) -> str | None:
+    """Provide a neutral document description for one identity component."""
+    _ = ctx
+    if aspect != "document_description" or caller.document_kind != "id":
+        return None
+    return (
+        "{{ subject.name or 'identity document' }}, bearing a portrait of "
+        "{{ render_as(packet.resolve_subject(subject.subject_id), "
+        "'presence_description') }}"
+    )
+
+
+__all__ = ["render_identity_document_text"]

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -1092,6 +1092,8 @@ class CredentialsGame(PickingGame):
                 "credential_stage": self.current_stage,
                 "credential_packet_findings": dict(self.packet_findings),
                 "credential_num_packet_findings": len(self.packet_findings),
+                # Graph-bound context for recursive document presentation.
+                "packet": self.active_case.packet_manager,
                 "credential_allow_arrest": self.allow_arrest,
                 "credential_disposition": (
                     self.disposition.value if self.disposition is not None else None

--- a/engine/tests/mechanics/credentials/test_credential_text_presentation.py
+++ b/engine/tests/mechanics/credentials/test_credential_text_presentation.py
@@ -17,8 +17,12 @@ from tangl.mechanics.credentials import (
     CredentialStatus,
     Indication,
 )
+from tangl.mechanics.games import CredentialsGame, HasGame
+from tangl.mechanics.games.credentials_game import CredentialCase
 from tangl.mechanics.presence.look import HairColor, HairStyle, Look, SkinTone
+from tangl.story import Block
 from tangl.story.presentation import render_text_as
+from tangl.vm.runtime.frame import PhaseCtx
 
 
 class _TextCtx:
@@ -52,6 +56,15 @@ class CredentialPacketOwner(Node):
 
 
 CredentialPacketOwner.model_rebuild(_types_namespace={"UUID": UUID})
+
+
+class CredentialsBlock(HasGame, Block):
+    """Story host for a credentials game namespace integration test."""
+
+    _game_class = CredentialsGame
+
+
+CredentialsBlock.model_rebuild(_types_namespace={"UUID": UUID})
 
 
 @pytest.fixture(autouse=True)
@@ -117,6 +130,37 @@ def test_graph_bound_identity_document_renders_its_named_subject() -> None:
     assert "travel passport" in rendered
     assert "olive skin" in rendered
     assert "red long hair" in rendered
+
+
+def test_document_renders_from_the_hosted_credentials_namespace() -> None:
+    definition = CredentialDefinition(
+        label="hosted_presentation_id",
+        name="travel passport",
+        indication=Indication.TRAVEL,
+        document_kind="id",
+    )
+    manager = CredentialPacketManager()
+    game = CredentialsGame(roster=[CredentialCase(packet_manager=manager)])
+    graph = Graph()
+    block = graph.add_node(
+        kind=CredentialsBlock,
+        label="checkpoint",
+        game_state=game,
+    )
+    packet = block.game.active_case.packet_manager
+    bearer = packet.resolve_subject(packet.bearer_id)
+    bearer.look = _look(HairColor.RED)
+    document = graph.add_node(
+        kind=CredentialComponent,
+        label="hosted-candidate-id",
+        token_from=definition.label,
+        subject_id=packet.bearer_id,
+    )
+    packet.assign(CREDENTIAL_ID_SLOT, document)
+    ctx = PhaseCtx(graph=graph, cursor_id=block.uid)
+
+    assert ctx.get_ns(block)["packet"] is packet
+    assert "red long hair" in render_text_as(document, "document_description", ctx=ctx)
 
 
 def test_identity_document_uses_a_neutral_fallback_name() -> None:

--- a/engine/tests/mechanics/credentials/test_credential_text_presentation.py
+++ b/engine/tests/mechanics/credentials/test_credential_text_presentation.py
@@ -1,0 +1,232 @@
+"""Narrative projection tests for graph-backed credential documents."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import Field, model_validator
+
+from tangl.core import BehaviorRegistry, DispatchLayer, Graph, Node, Selector
+from tangl.mechanics.credentials import (
+    CREDENTIAL_ID_SLOT,
+    CredentialComponent,
+    CredentialDefinition,
+    CredentialPacketManager,
+    CredentialStatus,
+    Indication,
+)
+from tangl.mechanics.presence.look import HairColor, HairStyle, Look, SkinTone
+from tangl.story.presentation import render_text_as
+
+
+class _TextCtx:
+    cursor = SimpleNamespace(label="credential-presentation")
+
+    def __init__(self, authorities: list[BehaviorRegistry] | None = None) -> None:
+        self.authorities = authorities or []
+
+    def get_ns(self, _source: object | None = None) -> dict[str, object]:
+        return {}
+
+    def get_authorities(self) -> list[BehaviorRegistry]:
+        return self.authorities
+
+    def get_inline_behaviors(self) -> list[object]:
+        return []
+
+
+class CredentialPacketOwner(Node):
+    """Graph owner for one embedded credential packet in presentation tests."""
+
+    packet_manager: CredentialPacketManager = Field(
+        default_factory=CredentialPacketManager,
+        json_schema_extra={"include": True, "unstructurable": True},
+    )
+
+    @model_validator(mode="after")
+    def _bind_packet_owner(self) -> "CredentialPacketOwner":
+        self.packet_manager.bind_owner(self)
+        return self
+
+
+CredentialPacketOwner.model_rebuild(_types_namespace={"UUID": UUID})
+
+
+@pytest.fixture(autouse=True)
+def _reset_credential_definitions():
+    CredentialDefinition.clear_instances()
+    yield
+    CredentialDefinition.clear_instances()
+
+
+def _look(hair_color: HairColor) -> Look:
+    return Look(
+        hair_color=hair_color,
+        hair_style=HairStyle.LONG,
+        skin_tone=SkinTone.OLIVE,
+    )
+
+
+def _identity_document_graph(
+    *,
+    name: str | None = "travel passport",
+) -> tuple[Graph, CredentialPacketOwner, CredentialComponent]:
+    definition = CredentialDefinition(
+        label="presentation_id",
+        name=name,
+        indication=Indication.TRAVEL,
+        document_kind="id",
+    )
+    graph = Graph()
+    owner = graph.add_node(kind=CredentialPacketOwner, label="checkpoint")
+    packet = owner.packet_manager
+    packet.bind_owner(owner)
+    bearer = packet.resolve_subject(packet.bearer_id)
+    bearer.look = _look(HairColor.RED)
+    document = graph.add_node(
+        kind=CredentialComponent,
+        label="candidate-id",
+        token_from=definition.label,
+        subject_id=packet.bearer_id,
+    )
+    packet.assign(CREDENTIAL_ID_SLOT, document)
+    return graph, owner, document
+
+
+def _render_document(
+    document: CredentialComponent,
+    packet: CredentialPacketManager,
+    *,
+    ctx: _TextCtx | None = None,
+) -> str:
+    return render_text_as(
+        document,
+        "document_description",
+        ctx=ctx or _TextCtx(),
+        bindings={"packet": packet},
+    )
+
+
+def test_graph_bound_identity_document_renders_its_named_subject() -> None:
+    _, owner, document = _identity_document_graph()
+
+    rendered = _render_document(document, owner.packet_manager)
+
+    assert "travel passport" in rendered
+    assert "olive skin" in rendered
+    assert "red long hair" in rendered
+
+
+def test_identity_document_uses_a_neutral_fallback_name() -> None:
+    _, owner, document = _identity_document_graph(name=None)
+
+    assert "identity document" in _render_document(document, owner.packet_manager)
+
+
+def test_candidate_and_document_share_one_subject_when_their_uuids_match() -> None:
+    _, owner, document = _identity_document_graph()
+    packet = owner.packet_manager
+    bearer = packet.resolve_subject(packet.bearer_id)
+
+    candidate = render_text_as(bearer, "presence_description", ctx=_TextCtx())
+    document_description = _render_document(document, packet)
+
+    assert document.subject_id == packet.bearer_id == bearer.uid
+    assert "red long hair" in candidate
+    assert "red long hair" in document_description
+
+
+def test_mismatched_subjects_render_visible_facts_without_validity_language() -> None:
+    _, owner, document = _identity_document_graph()
+    packet = owner.packet_manager
+    recorded_subject = packet.materialize_subject("recorded-subject")
+    recorded_subject.look = _look(HairColor.BLUE)
+    document.subject_id = recorded_subject.uid
+
+    candidate = render_text_as(
+        packet.resolve_subject(packet.bearer_id),
+        "presence_description",
+        ctx=_TextCtx(),
+    )
+    document_description = _render_document(document, packet)
+
+    assert document.subject_id != packet.bearer_id
+    assert "red long hair" in candidate
+    assert "blue long hair" in document_description
+    assert not any(
+        forbidden in document_description.lower()
+        for forbidden in ("wrong holder", "invalid", "valid", "forged", "arrest", "deny")
+    )
+
+
+def test_document_projection_reads_live_subject_state_and_ignores_status() -> None:
+    _, owner, document = _identity_document_graph()
+    packet = owner.packet_manager
+    subject = packet.resolve_subject(document.subject_id)
+    initial = _render_document(document, packet)
+
+    subject.look.hair_color = HairColor.BLUE
+    updated = _render_document(document, packet)
+    document.status = CredentialStatus.FORGED
+    status_changed = _render_document(document, packet)
+
+    assert "red long hair" in initial
+    assert "blue long hair" in updated
+    assert status_changed == updated
+
+
+def test_authority_can_reskin_the_document_without_changing_its_component() -> None:
+    _, owner, document = _identity_document_graph()
+    authority = BehaviorRegistry(
+        label="credential-presentation-author",
+        default_dispatch_layer=DispatchLayer.AUTHOR,
+    )
+
+    authority.register(
+        lambda **_kwargs: "student ID, bearing a campus portrait",
+        task="render_text",
+        wants_caller_kind=CredentialComponent,
+        wants_exact_kind=False,
+    )
+
+    assert _render_document(
+        document,
+        owner.packet_manager,
+        ctx=_TextCtx(authorities=[authority]),
+    ) == "student ID, bearing a campus portrait"
+
+
+def test_unresolved_document_subject_fails_explicitly() -> None:
+    _, owner, document = _identity_document_graph()
+    document.subject_id = uuid4()
+
+    with pytest.raises(KeyError, match="not a presence entity"):
+        _render_document(document, owner.packet_manager)
+
+
+def test_document_rendering_preserves_graph_constructor_form_state() -> None:
+    graph, owner, document = _identity_document_graph()
+    before = graph.unstructure()
+
+    _render_document(document, owner.packet_manager)
+
+    assert graph.unstructure() == before
+
+
+def test_document_subject_binding_and_projection_survive_graph_roundtrip() -> None:
+    graph, owner, document = _identity_document_graph()
+    before = _render_document(document, owner.packet_manager)
+
+    restored = Graph.structure(graph.unstructure())
+    restored_owner = restored.find_one(Selector(label="checkpoint"))
+    restored_document = restored.find_one(Selector(label="candidate-id"))
+    restored_packet = restored_owner.packet_manager
+    after = _render_document(restored_document, restored_packet)
+
+    assert restored_document.uid == document.uid
+    assert restored_document.subject_id == document.subject_id
+    assert restored_packet.bearer_id == owner.packet_manager.bearer_id
+    assert restored_packet.resolve_subject(restored_document.subject_id).uid == document.subject_id
+    assert after == before


### PR DESCRIPTION
## Summary

Implements Phase 12's first graph-backed credential narrative projection:

- registers a credential-owned `document_description` adapter through the existing story text dispatch chain;
- renders an identity document's authored name, or a neutral fallback, with the recursively resolved recorded subject;
- keeps the packet manager strictly as graph-owned subject-resolution context;
- allows AUTHOR authorities to reskin document wording without changing component or evaluator state;
- records the Phase 12 boundary in the rendering and credential design notes.

The projection deliberately does not reveal status, defects, holder mismatch, disposition, or any packet-level interpretation.

## Validation

- `poetry run pytest engine/tests/mechanics/credentials/test_credential_text_presentation.py engine/tests/story/test_text_presentation.py engine/tests/prose/test_rendering.py engine/tests/mechanics/presence/test_look.py engine/tests/mechanics/credentials/test_credential_packet_manager.py -q` — 67 passed
- `poetry run pytest engine/tests -q` — 2798 passed, 69 skipped, 9 xfailed
- `poetry run sphinx-build -W --keep-going -b html docs/src /tmp/storytangl-docs-phase12`
- `git diff --check`
- Scoped local CodeRabbit review against `129f6891` — zero findings

## Deferred

Packet rendering, JOURNAL integration, document findings, visible degradation details, and media/card composition remain deferred to later phases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added text-only identity-document descriptions that project the resolved subject’s presence.
  * Document descriptions omit credential validity/status and avoid rendering packet/card/media content.
  * Rendering now supports authority-specific text variations.
  * The current case namespace now includes packet context for richer client presentation.
* **Documentation**
  * Updated credential and episode rendering docs to specify Phase 12 identity-document projection behavior.
* **Tests**
  * Added tests covering subject resolution, neutral fallback naming, live updates, authority-specific output, unresolved-subject errors, and graph round-trip stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->