### PR TITLE
Render credential packets through text presentation

### DIFF
--- a/docs/src/design/story/EPISODE_SYUZHET_RENDERING.md
+++ b/docs/src/design/story/EPISODE_SYUZHET_RENDERING.md
@@ -16,6 +16,9 @@ from fragment and media products. Phase 12 adds one credential-owned
 ``document_description`` adapter: an identity document resolves its bound
 subject through its packet manager and recursively projects that presence,
 without interpreting credential validity or rendering a packet.
+Phase 13 adds a credential-owned ``inspection_description`` adapter that
+recursively composes a packet's ordered identity and ordinary documents, with
+explicit child bindings and no JOURNAL, media, or disposition interpretation.
 
 ## Purpose
 

--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
@@ -5,7 +5,9 @@ game-facing packet-authority cutover, transient shared defect vocabulary, and
 graph-bound bearer/document subject references (2026-07-20/22). Phase 12 adds a
 text-only identity-document projection through the shared story presentation
 chain; it resolves the bound presence subject but does not evaluate validity,
-render a packet, compose a card, or produce media.
+compose a card, or produce media. Phase 13 adds a text-only packet projection
+that composes the packet's assigned document components through the same chain,
+without findings, JOURNAL, or game-owned presentation labels.
 **Scope:** the *global* credential mechanic — `Credential → Document → Media`,
 with carrier/bearer binding — that the credentials checkpoint **game**
 (`tangl.mechanics.games.credentials_game`) becomes one consumer of.

--- a/engine/src/tangl/mechanics/credentials/presentation.py
+++ b/engine/src/tangl/mechanics/credentials/presentation.py
@@ -5,25 +5,56 @@ from __future__ import annotations
 from tangl.story.dispatch import on_render_text
 from tangl.vm.ctx import VmPhaseCtx
 
-from .assembly import CredentialComponent
+from .assembly import (
+    CREDENTIAL_ID_SLOT,
+    CREDENTIAL_PACKET_SLOT,
+    CredentialComponent,
+    CredentialPacketManager,
+)
+
+
+@on_render_text(wants_caller_kind=CredentialPacketManager, wants_exact_kind=False)
+def render_packet_text(
+    *,
+    caller: CredentialPacketManager,
+    aspect: str,
+    ctx: VmPhaseCtx,
+) -> str | None:
+    """Compose one packet through its ordered document descriptions."""
+    _ = caller, ctx
+    if aspect != "inspection_description":
+        return None
+    return (
+        f"{{% set identity = subject.get_slot('{CREDENTIAL_ID_SLOT}') %}}"
+        f"{{% set documents = subject.get_slot('{CREDENTIAL_PACKET_SLOT}') %}}"
+        "{% set presented = identity + documents %}"
+        "{% if presented %}"
+        "{% for document in presented %}"
+        "{{ render_as(document, 'document_description', bindings={'packet': subject}) }}"
+        "{% if not loop.last %}; {% endif %}"
+        "{% endfor %}"
+        "{% else %}No documents.{% endif %}"
+    )
 
 
 @on_render_text(wants_caller_kind=CredentialComponent, wants_exact_kind=False)
-def render_identity_document_text(
+def render_document_text(
     *,
     caller: CredentialComponent,
     aspect: str,
     ctx: VmPhaseCtx,
 ) -> str | None:
-    """Provide a neutral document description for one identity component."""
+    """Provide a neutral document description for one credential component."""
     _ = ctx
-    if aspect != "document_description" or caller.document_kind != "id":
+    if aspect != "document_description":
         return None
-    return (
-        "{{ subject.name or 'identity document' }}, bearing a portrait of "
-        "{{ render_as(packet.resolve_subject(subject.subject_id), "
-        "'presence_description') }}"
-    )
+    if caller.document_kind == "id":
+        return (
+            "{{ subject.name or 'identity document' }}, bearing a portrait of "
+            "{{ render_as(packet.resolve_subject(subject.subject_id), "
+            "'presence_description') }}"
+        )
+    return "{{ subject.name or (subject.indication | replace('_', ' ') ~ ' document') }}"
 
 
-__all__ = ["render_identity_document_text"]
+__all__ = ["render_document_text", "render_packet_text"]

--- a/engine/src/tangl/prose/rendering.py
+++ b/engine/src/tangl/prose/rendering.py
@@ -31,6 +31,7 @@ class TextAspectResolver(Protocol):
         ctx: VmPhaseCtx,
         session: TextRenderSession,
         content: str | None = None,
+        bindings: Mapping[str, object] | None = None,
     ) -> str: ...
 
 
@@ -40,10 +41,11 @@ def _render_as_filter(
     target: object,
     aspect: str,
     content: str | None = None,
+    bindings: Mapping[str, object] | None = None,
 ) -> str:
     """Delegate Jinja's ``render_as`` filter to this render scope's callback."""
     render_as = cast(Callable[..., str], context["render_as"])
-    return render_as(target, aspect, content=content)
+    return render_as(target, aspect, content=content, bindings=bindings)
 
 
 def _default_environment() -> jinja2.Environment:
@@ -175,12 +177,20 @@ class TextRenderSession:
         aspect: str,
         *,
         content: str | None = None,
+        bindings: Mapping[str, object] | None = None,
     ) -> str:
         """Resolve a nested text aspect through the injected story callback."""
         resolver = self.text_resolver
         if resolver is None:
             raise RuntimeError("No text-aspect resolver is configured")
-        return resolver(target, aspect, ctx=self.ctx, session=self, content=content)
+        return resolver(
+            target,
+            aspect,
+            ctx=self.ctx,
+            session=self,
+            content=content,
+            bindings=bindings,
+        )
 
     def render_segments(
         self,

--- a/engine/tests/loaders/test_combined_credentials_world.py
+++ b/engine/tests/loaders/test_combined_credentials_world.py
@@ -21,7 +21,9 @@ from tangl.mechanics.games.credentials_game import (
     derive_defects,
 )
 from tangl.story import Action, InitMode, World
+from tangl.story.presentation import render_text_as
 from tangl.vm import Ledger
+from tangl.vm.runtime.frame import PhaseCtx
 
 
 def _actions(ledger: Ledger) -> list[Action]:
@@ -296,7 +298,17 @@ def test_compiled_story_selects_its_local_credentials_scenarios(tmp_path: Path) 
         combined_world.assets.values["school"].members
     )
 
-    for choice, block_label, catalog_ref, prefix, identity_label, finding, decision in (
+    for (
+        choice,
+        block_label,
+        catalog_ref,
+        prefix,
+        identity_label,
+        finding,
+        decision,
+        expected_names,
+        excluded_names,
+    ) in (
         (
             "Work the border checkpoint",
             "border_shift",
@@ -305,6 +317,8 @@ def test_compiled_story_selects_its_local_credentials_scenarios(tmp_path: Path) 
             "passport",
             "The issuing stamp is missing.",
             "Turn away",
+            ("Border Identity Card", "Work Permit"),
+            ("Student ID", "Activity Pass"),
         ),
         (
             "Monitor the school halls",
@@ -314,6 +328,8 @@ def test_compiled_story_selects_its_local_credentials_scenarios(tmp_path: Path) 
             "student ID",
             "The required teacher signature is missing.",
             "Send back to class",
+            ("Student ID", "Activity Pass"),
+            ("Border Identity Card", "Work Permit"),
         ),
     ):
         result = combined_world.create_story("combined_credentials", init_mode=InitMode.EAGER)
@@ -354,6 +370,13 @@ def test_compiled_story_selects_its_local_credentials_scenarios(tmp_path: Path) 
             component.reference_singleton.label.startswith(prefix)
             for component in packet_components
         )
+        packet_description = render_text_as(
+            manager,
+            "inspection_description",
+            ctx=PhaseCtx(graph=result.graph, cursor_id=block.uid),
+        )
+        assert all(name in packet_description for name in expected_names)
+        assert not any(name in packet_description for name in excluded_names)
 
         restored = Graph.structure(result.graph.unstructure())
         restored_block = restored.find_one(Selector(label=block_label))

--- a/engine/tests/mechanics/credentials/test_credential_text_presentation.py
+++ b/engine/tests/mechanics/credentials/test_credential_text_presentation.py
@@ -11,6 +11,7 @@ from pydantic import Field, model_validator
 from tangl.core import BehaviorRegistry, DispatchLayer, Graph, Node, Selector
 from tangl.mechanics.credentials import (
     CREDENTIAL_ID_SLOT,
+    CREDENTIAL_PACKET_SLOT,
     CredentialComponent,
     CredentialDefinition,
     CredentialPacketManager,
@@ -122,6 +123,45 @@ def _render_document(
     )
 
 
+def _render_packet(
+    packet: CredentialPacketManager,
+    *,
+    ctx: _TextCtx | None = None,
+    content: str | None = None,
+) -> str:
+    return render_text_as(
+        packet,
+        "inspection_description",
+        ctx=ctx or _TextCtx(),
+        content=content,
+    )
+
+
+def _add_document(
+    graph: Graph,
+    owner: CredentialPacketOwner,
+    *,
+    label: str,
+    name: str | None,
+    indication: Indication = Indication.WORK,
+) -> CredentialComponent:
+    definition = CredentialDefinition(
+        label=f"presentation_{label}",
+        name=name,
+        indication=indication,
+        document_kind="document",
+        requires_id=True,
+    )
+    document = graph.add_node(
+        kind=CredentialComponent,
+        label=label,
+        token_from=definition.label,
+        subject_id=owner.packet_manager.bearer_id,
+    )
+    owner.packet_manager.assign(CREDENTIAL_PACKET_SLOT, document)
+    return document
+
+
 def test_graph_bound_identity_document_renders_its_named_subject() -> None:
     _, owner, document = _identity_document_graph()
 
@@ -130,6 +170,124 @@ def test_graph_bound_identity_document_renders_its_named_subject() -> None:
     assert "travel passport" in rendered
     assert "olive skin" in rendered
     assert "red long hair" in rendered
+
+
+def test_id_only_packet_renders_through_its_document_aspect() -> None:
+    _, owner, document = _identity_document_graph()
+
+    rendered = _render_packet(owner.packet_manager)
+
+    assert "travel passport" in rendered
+    assert "red long hair" in rendered
+    assert document.uid in {
+        component.uid for component in owner.packet_manager.get_slot(CREDENTIAL_ID_SLOT)
+    }
+
+
+def test_packet_renders_identity_before_ordered_ordinary_documents() -> None:
+    graph, owner, identity = _identity_document_graph()
+    first = _add_document(graph, owner, label="first-permit", name="Work Permit")
+    second = _add_document(graph, owner, label="second-permit", name="Travel Visa")
+
+    rendered = _render_packet(owner.packet_manager)
+
+    assert [component.uid for component in owner.packet_manager.get_slot(CREDENTIAL_PACKET_SLOT)] == [
+        first.uid,
+        second.uid,
+    ]
+    assert rendered.index("travel passport") < rendered.index("Work Permit")
+    assert rendered.index("Work Permit") < rendered.index("Travel Visa")
+    assert identity.subject_id == owner.packet_manager.bearer_id
+
+
+def test_packet_omits_empty_slots_and_has_a_neutral_empty_rendering() -> None:
+    _, owner, _ = _identity_document_graph()
+    packet = owner.packet_manager
+    assert ";" not in _render_packet(packet)
+
+    graph = Graph()
+    empty_owner = graph.add_node(kind=CredentialPacketOwner, label="empty-checkpoint")
+    empty_owner.packet_manager.bind_owner(empty_owner)
+    assert _render_packet(empty_owner.packet_manager) == "No documents."
+
+
+def test_non_id_document_uses_authored_name_or_neutral_indication_fallback() -> None:
+    graph, owner, _ = _identity_document_graph()
+    named = _add_document(graph, owner, label="work-permit", name="Work Permit")
+    fallback = _add_document(
+        graph,
+        owner,
+        label="travel-document",
+        name=None,
+        indication=Indication.TRAVEL,
+    )
+
+    assert _render_document(named, owner.packet_manager) == "Work Permit"
+    assert _render_document(fallback, owner.packet_manager) == "travel document"
+
+
+def test_packet_bindings_are_explicit_and_status_does_not_change_output() -> None:
+    _, owner, document = _identity_document_graph()
+    packet = owner.packet_manager
+    initial = _render_packet(packet)
+    document.status = CredentialStatus.FORGED
+    status_changed = _render_packet(packet)
+
+    assert "red long hair" in initial
+    assert status_changed == initial
+    assert not any(
+        forbidden in initial.lower()
+        for forbidden in ("invalid", "valid", "forged", "expired", "missing seal", "arrest")
+    )
+
+
+def test_authority_can_replace_or_wrap_packet_presentation() -> None:
+    _, owner, _ = _identity_document_graph()
+    authority = BehaviorRegistry(
+        label="credential-packet-presentation-author",
+        default_dispatch_layer=DispatchLayer.AUTHOR,
+    )
+
+    authority.register(
+        lambda **_kwargs: "They arrange their school papers on the desk.",
+        task="render_text",
+        wants_caller_kind=CredentialPacketManager,
+        wants_exact_kind=False,
+    )
+    assert _render_packet(owner.packet_manager, ctx=_TextCtx(authorities=[authority])) == (
+        "They arrange their school papers on the desk."
+    )
+
+    authority.clear()
+    authority.register(
+        lambda **_kwargs: (
+            "Packet: {{ render_as(subject.get_slot('id')[0], "
+            "'document_description', bindings={'packet': subject}) }}"
+        ),
+        task="render_text",
+        wants_caller_kind=CredentialPacketManager,
+        wants_exact_kind=False,
+    )
+    rendered = _render_packet(owner.packet_manager, ctx=_TextCtx(authorities=[authority]))
+    assert rendered.startswith("Packet: travel passport, bearing a portrait of")
+
+
+def test_packet_rendering_preserves_graph_state_and_roundtrips_in_order() -> None:
+    graph, owner, identity = _identity_document_graph()
+    first = _add_document(graph, owner, label="first-permit", name="Work Permit")
+    second = _add_document(graph, owner, label="second-permit", name="Travel Visa")
+    before_state = graph.unstructure()
+    before = _render_packet(owner.packet_manager)
+
+    assert graph.unstructure() == before_state
+    restored = Graph.structure(graph.unstructure())
+    restored_owner = restored.find_one(Selector(label="checkpoint"))
+    restored_packet = restored_owner.packet_manager
+    restored_documents = restored_packet.get_slot(CREDENTIAL_PACKET_SLOT)
+
+    assert [component.uid for component in restored_documents] == [first.uid, second.uid]
+    assert restored_packet.get_slot(CREDENTIAL_ID_SLOT)[0].uid == identity.uid
+    assert _render_packet(restored_packet) == before
 
 
 def test_document_renders_from_the_hosted_credentials_namespace() -> None:

--- a/engine/tests/story/test_text_presentation.py
+++ b/engine/tests/story/test_text_presentation.py
@@ -172,6 +172,32 @@ def test_render_as_filter_matches_documented_authoring_syntax() -> None:
     assert "red long hair" in rendered
 
 
+def test_render_as_filter_forwards_explicit_child_bindings() -> None:
+    target = object()
+    authority = BehaviorRegistry(
+        label="presentation.child-bindings",
+        default_dispatch_layer=DispatchLayer.AUTHOR,
+    )
+    authority.register(
+        lambda **_kwargs: "{{ packet.label }}",
+        task="render_text",
+        wants_caller_kind=object,
+        wants_exact_kind=False,
+    )
+    bindings = {"packet": SimpleNamespace(label="bound packet")}
+
+    rendered = render_text_as(
+        target,
+        "outer",
+        ctx=_TextCtx(authorities=[authority]),
+        content="{{ subject | render_as('nested', bindings={'packet': packet}) }}",
+        bindings=bindings,
+    )
+
+    assert rendered == "bound packet"
+    assert bindings == {"packet": SimpleNamespace(label="bound packet")}
+
+
 def test_authored_content_replaces_recursive_presence_composition() -> None:
     target = object()
 


### PR DESCRIPTION
## Summary

Implements Phase 13's recursive, narrative-only credential packet projection:

- adds `CredentialPacketManager.inspection_description`, composing the ID slot first and ordinary credential documents in stable assignment order;
- extends nested `render_as(...)` and its Jinja filter with explicit, isolated child bindings;
- keeps identity portrait resolution explicit as `bindings={"packet": subject}` at the packet-to-document boundary;
- adds neutral non-ID document names, using catalog-authored names before an indication-based fallback;
- proves border and school packet terminology remains isolated through their existing world-local catalogs.

The projection does not narrate status, defects, disposition, findings, dates, seals, or any media/JOURNAL product.

## Validation

- `poetry run pytest engine/tests/prose/test_rendering.py engine/tests/story/test_text_presentation.py engine/tests/mechanics/credentials/test_credential_text_presentation.py engine/tests/mechanics/credentials/test_credential_packet_manager.py engine/tests/loaders/test_combined_credentials_world.py -q` — 70 passed
- `poetry run pytest engine/tests -q` — 2807 passed, 69 skipped, 9 xfailed
- `poetry run sphinx-build -W --keep-going -b html docs/src /tmp/storytangl-docs-phase13`
- `git diff --check`

## Deferred

JOURNAL/setup rendering, findings narration, degradation detail, media/card composition, and template catalogs remain deferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added inspection descriptions for credential packets, combining identity and associated documents in their defined order.
  - Added neutral labels for unnamed documents and a clear message for empty packets.
  - Supports explicit customization of packet presentation while preserving document order and content.
  - Inspection descriptions remain focused on document contents and do not include status, validity, or disposition language.

- **Documentation**
  - Updated credential design documentation to describe the new packet text presentation phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->