### PR TITLE
Render credential interactions in the JOURNAL phase

### DIFF
--- a/docs/src/design/story/EPISODE_SYUZHET_RENDERING.md
+++ b/docs/src/design/story/EPISODE_SYUZHET_RENDERING.md
@@ -19,6 +19,12 @@ without interpreting credential validity or rendering a packet.
 Phase 13 adds a credential-owned ``inspection_description`` adapter that
 recursively composes a packet's ordered identity and ordinary documents, with
 explicit child bindings and no JOURNAL, media, or disposition interpretation.
+Phase 14 makes credentials the first vertical JOURNAL consumer: game-owned
+arrival and packet templates invoke those text adapters through the live phase
+context, then emit attributed ``ContentFragment`` values before the existing
+candidate, packet-zone, and document-piece surfaces. The templates disclose
+only ordinary appearance and visible documents; findings and disposition remain
+on their committed interaction paths.
 
 ## Purpose
 

--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
@@ -7,7 +7,10 @@ text-only identity-document projection through the shared story presentation
 chain; it resolves the bound presence subject but does not evaluate validity,
 compose a card, or produce media. Phase 13 adds a text-only packet projection
 that composes the packet's assigned document components through the same chain,
-without findings, JOURNAL, or game-owned presentation labels.
+without findings, JOURNAL, or game-owned presentation labels. Phase 14 invokes
+those projections from the credentials game's JOURNAL path through scenario
+arrival and packet templates, while preserving the existing typed candidate,
+packet, document, choice, and finding surfaces.
 **Scope:** the *global* credential mechanic — `Credential → Document → Media`,
 with carrier/bearer binding — that the credentials checkpoint **game**
 (`tangl.mechanics.games.credentials_game`) becomes one consumer of.

--- a/engine/src/tangl/mechanics/games/GAME_MECHANICS_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/GAME_MECHANICS_DESIGN.md
@@ -39,8 +39,9 @@ The current games package revolves around a small, stable contract:
 - **`GameHandler`** is the rule object that sets up a game, offers moves, receives
   moves, resolves rounds, and evaluates terminal state
 - **optional handler hooks** like `get_move_label()`, `build_round_notes()`, and
-  `get_journal_fragments()` let concrete games project richer choices and narration
-  without bypassing the shared VM handlers
+  `get_journal_fragments(game, ctx=...)` let concrete games project richer
+  choices and narration through the live phase namespace without bypassing the
+  shared VM handlers
 - **`HasGame`** is the author-facing facade that attaches a game to a story node
 - **package handlers** connect games to VM PREREQS, PLANNING, UPDATE, JOURNAL,
   and CONTEXT phases

--- a/engine/src/tangl/mechanics/games/README.md
+++ b/engine/src/tangl/mechanics/games/README.md
@@ -17,7 +17,12 @@ Concrete games can optionally refine the shared VM presentation hooks too:
 
 - `get_move_label`
 - `build_round_notes`
-- `get_journal_fragments`
+- `get_journal_fragments(game, *, ctx: VmPhaseCtx | None = None)`
+
+The VM supplies ``ctx`` to this hook during JOURNAL so a game may render against
+the phase namespace. Overrides must accept the optional keyword; direct library
+callers may omit it. Returning ``None`` retains the generic round-summary
+fallback.
 
 Some game families expose narrower public operations for non-modal hosts. For
 example, `IncrementalGameHandler.resolve_cycle_tick()` resolves one

--- a/engine/src/tangl/mechanics/games/aggregate_force_game.py
+++ b/engine/src/tangl/mechanics/games/aggregate_force_game.py
@@ -15,6 +15,8 @@ from pydantic import Field
 
 from tangl.journal.fragments import ContentFragment
 
+from tangl.vm.ctx import VmPhaseCtx
+
 from .enums import GameResult, RoundResult
 from .game import Game
 from .handler import GameHandler
@@ -212,7 +214,13 @@ class AggregateForceGameHandler(GameHandler[AggregateForceGameT]):
         )
         return detail
 
-    def get_journal_fragments(self, game: AggregateForceGameT) -> list[ContentFragment] | None:
+    def get_journal_fragments(
+        self,
+        game: AggregateForceGameT,
+        *,
+        ctx: VmPhaseCtx | None = None,
+    ) -> list[ContentFragment] | None:
+        _ = ctx
         last_round = game.last_round
         if last_round is None:
             return []

--- a/engine/src/tangl/mechanics/games/blackjack_game.py
+++ b/engine/src/tangl/mechanics/games/blackjack_game.py
@@ -15,6 +15,7 @@ from pydantic import Field
 
 from tangl.core.bases import BaseModelPlus
 from tangl.journal.fragments import ContentFragment
+from tangl.vm.ctx import VmPhaseCtx
 
 from .enums import GameResult, RoundResult
 from .game import Game
@@ -239,7 +240,13 @@ class BlackjackGameHandler(GameHandler[BlackjackGame]):
             detail["dealer_hand"] = [card.short_name for card in game.dealer_hand]
         return detail
 
-    def get_journal_fragments(self, game: BlackjackGame) -> list[ContentFragment] | None:
+    def get_journal_fragments(
+        self,
+        game: BlackjackGame,
+        *,
+        ctx: VmPhaseCtx | None = None,
+    ) -> list[ContentFragment] | None:
+        _ = ctx
         last_round = game.last_round
         if last_round is None:
             return []

--- a/engine/src/tangl/mechanics/games/corridor_game.py
+++ b/engine/src/tangl/mechanics/games/corridor_game.py
@@ -12,6 +12,7 @@ from typing import ClassVar
 from pydantic import Field
 
 from tangl.journal.fragments import ContentFragment
+from tangl.vm.ctx import VmPhaseCtx
 
 from .enums import GameResult, RoundResult
 from .game import Game
@@ -155,7 +156,13 @@ class CorridorGameHandler(GameHandler[CorridorGame]):
         detail["next_value"] = game.next_source_value()
         return detail
 
-    def get_journal_fragments(self, game: CorridorGame) -> list[ContentFragment] | None:
+    def get_journal_fragments(
+        self,
+        game: CorridorGame,
+        *,
+        ctx: VmPhaseCtx | None = None,
+    ) -> list[ContentFragment] | None:
+        _ = ctx
         last_round = game.last_round
         if last_round is None:
             return []

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -224,12 +224,19 @@ def _default_roster() -> list[CredentialCase]:
 
     return [
         CredentialCase(
+            presented_documents={
+                "passport": "A worn passport with a blurred seal.",
+                "travel permit": "A permit stamped for this week.",
+            },
             packet_manager=materialize_packet(
                 owner=object(),
                 region=Region.LOCAL,
                 purpose=Indication.TRAVEL,
-                id_card=None,
-                credentials=[],
+                id_card=CredentialToken(
+                    indication=Indication.TRAVEL,
+                    status=CredentialStatus.MISSING_SEAL,
+                ),
+                credentials=[CredentialToken(indication=Indication.TRAVEL)],
                 possessions=[],
                 label_prefix="Traveler",
             ),
@@ -248,7 +255,7 @@ def _default_roster() -> list[CredentialCase]:
                 region=Region.LOCAL,
                 purpose=Indication.TRAVEL,
                 id_card=CredentialToken(indication=Indication.TRAVEL),
-                credentials=[],
+                credentials=[CredentialToken(indication=Indication.TRAVEL)],
                 possessions=[],
                 label_prefix="Tomas Vey",
             ),

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -57,6 +57,9 @@ from tangl.mechanics.credentials import (
     Restrictions,
     RestrictionLevel,
 )
+from tangl.prose import TextRenderSession
+from tangl.story.presentation import render_text_as
+from tangl.vm.ctx import VmPhaseCtx
 from .enums import GamePhase, GameResult, RoundResult
 from .game import Game
 from .picking_game import PickingGame, PickingGameHandler, PickingMove
@@ -654,6 +657,13 @@ class CredentialPresentationProfile(BaseModelPlus):
     identity_description: str = "An identity document."
     document_description: str = "A {document}."
     possession_description: str = "Openly declared {indication}."
+    candidate_arrival_template: str = (
+        "{{ candidate_name }}{% set description = render_as(candidate, 'presence_description') %}"
+        "{% if description %}, {{ description }}{% endif %} steps forward."
+    )
+    packet_presentation_template: str = (
+        "They present their documents: {{ render_as(packet, 'inspection_description') }}"
+    )
     status_text: dict[CredentialStatus, str] = Field(
         default_factory=lambda: {
             CredentialStatus.MISSING_SEAL: "The issuing seal is missing.",
@@ -1693,21 +1703,36 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         detail["shift_complete"] = game.shift_complete
         return detail
 
-    def get_journal_fragments(self, game: CredentialsGame) -> list[BaseFragment] | None:
+    def get_journal_fragments(
+        self,
+        game: CredentialsGame,
+        *,
+        ctx: VmPhaseCtx | None = None,
+    ) -> list[BaseFragment] | None:
         last_round = game.last_round
         if last_round is None:
-            return [] if game.shift_complete else self._candidate_fragments(game)
+            if game.shift_complete:
+                return []
+            return [
+                *self._arrival_fragments(game, ctx=ctx),
+                *self._candidate_fragments(game, ctx=ctx),
+            ]
 
         move = self._normalize_move(last_round.player_move)
         prose = self._prose_fragments(game, last_round, move.kind, move.target, last_round.notes or {})
 
+        if not game.shift_complete and move.kind == "decide":
+            return [
+                *prose,
+                *self._arrival_fragments(game, ctx=ctx),
+                *self._candidate_fragments(game, ctx=ctx),
+            ]
+
         fragments: list[BaseFragment] = []
         # Structured candidate / packet view (Bridge.1). Skip once the shift is
-        # over -- there is no next candidate to present. On a non-final decision
-        # this is the *arriving* candidate, which lands alongside the
-        # "next traveler steps up" prose.
+        # over -- there is no next candidate to present.
         if not game.shift_complete:
-            fragments.extend(self._candidate_fragments(game))
+            fragments.extend(self._candidate_fragments(game, ctx=ctx))
         # Findings table for the active case; present on inspect / mediation
         # rounds, empty after a decision resets the working state.
         findings = self._findings_fragment(game)
@@ -1824,15 +1849,61 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                     )
                 )
             )
-        else:
-            fragments.append(
-                ContentFragment(content="The next traveler steps up to the counter.")
-            )
         return fragments
 
     # ----- Bridge.1: structured (typed) fragment projection ----------------
 
-    def _candidate_fragments(self, game: CredentialsGame) -> list[BaseFragment]:
+    def _arrival_fragments(
+        self,
+        game: CredentialsGame,
+        *,
+        ctx: VmPhaseCtx | None,
+    ) -> list[ContentFragment]:
+        """Render the current candidate and packet once on arrival."""
+
+        if ctx is None:
+            return []
+
+        case = game.active_case
+        packet = case.packet_manager
+        candidate = packet.resolve_subject(packet.bearer_id)
+        session = TextRenderSession(ctx=ctx, text_resolver=render_text_as)
+        bindings = {
+            "candidate_name": case.candidate_name,
+            "candidate": candidate,
+            "packet": packet,
+        }
+        return [
+            ContentFragment(
+                content=render_text_as(
+                    candidate,
+                    "arrival_description",
+                    ctx=ctx,
+                    session=session,
+                    content=game.presentation.candidate_arrival_template,
+                    bindings=bindings,
+                ),
+                source_id=candidate.uid,
+            ),
+            ContentFragment(
+                content=render_text_as(
+                    packet,
+                    "packet_presentation",
+                    ctx=ctx,
+                    session=session,
+                    content=game.presentation.packet_presentation_template,
+                    bindings=bindings,
+                ),
+                source_id=ctx.cursor.uid,
+            ),
+        ]
+
+    def _candidate_fragments(
+        self,
+        game: CredentialsGame,
+        *,
+        ctx: VmPhaseCtx | None = None,
+    ) -> list[BaseFragment]:
         """Project the active candidate + packet zone + document pieces.
 
         Deterministic uids (per game + case index) let the client update these
@@ -1848,14 +1919,15 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         }
         if case.packet_manager.has_resolved_subject(case.packet_manager.bearer_id):
             bearer = case.packet_manager.resolve_subject(case.packet_manager.bearer_id)
-            candidate_properties.update(
-                {
-                    "look_description": bearer.describe_look(subject=case.candidate_name),
-                    "look_media_payload": bearer.adapt_look_media_spec(
-                        media_role="candidate"
-                    ),
-                }
+            candidate_properties["look_media_payload"] = bearer.adapt_look_media_spec(
+                media_role="candidate"
             )
+            if ctx is not None:
+                candidate_properties["look_description"] = render_text_as(
+                    bearer,
+                    "presence_description",
+                    ctx=ctx,
+                )
 
         candidate = PieceFragment(
             uid=_piece_uid(game.uid, idx, "candidate"),

--- a/engine/src/tangl/mechanics/games/handler.py
+++ b/engine/src/tangl/mechanics/games/handler.py
@@ -20,6 +20,7 @@ from .strategies import opponent_strategies, scoring_strategies
 if TYPE_CHECKING:
     from tangl.core import BaseFragment
     from tangl.journal.intent import Accepts
+    from tangl.vm.ctx import VmPhaseCtx
 
 GameT = TypeVar("GameT", bound=Game)
 
@@ -146,12 +147,18 @@ class GameHandler(ABC, Generic[GameT]):
         """
         return None
 
-    def get_journal_fragments(self, game: GameT) -> list[BaseFragment] | None:
+    def get_journal_fragments(
+        self,
+        game: GameT,
+        *,
+        ctx: VmPhaseCtx | None = None,
+    ) -> list[BaseFragment] | None:
         """
         Return tailored journal fragments for the latest round.
 
-        Returning ``None`` tells the package JOURNAL handler to fall back to the
-        generic round summary.
+        ``ctx`` is the live JOURNAL context when called by the VM; direct
+        library callers may omit it. Returning ``None`` tells the package
+        JOURNAL handler to fall back to the generic round summary.
         """
         return None
     

--- a/engine/src/tangl/mechanics/games/handlers.py
+++ b/engine/src/tangl/mechanics/games/handlers.py
@@ -339,7 +339,7 @@ def generate_game_journal(
     if not isinstance(cursor, HasGame):
         return []
 
-    custom_fragments = cursor.game_handler.get_journal_fragments(cursor.game)
+    custom_fragments = cursor.game_handler.get_journal_fragments(cursor.game, ctx=ctx)
     if custom_fragments is not None:
         logger.debug(
             "Generated %s tailored journal fragments for %s",

--- a/engine/src/tangl/mechanics/games/incremental_game.py
+++ b/engine/src/tangl/mechanics/games/incremental_game.py
@@ -13,6 +13,7 @@ from pydantic import Field
 
 from tangl.core.bases import BaseModelPlus
 from tangl.journal.fragments import ContentFragment
+from tangl.vm.ctx import VmPhaseCtx
 
 from .enums import GameResult, RoundResult
 from .game import Game
@@ -249,7 +250,13 @@ class IncrementalGameHandler(GameHandler[IncrementalGame]):
         detail["cycle"] = game.cycle
         return detail
 
-    def get_journal_fragments(self, game: IncrementalGame) -> list[ContentFragment] | None:
+    def get_journal_fragments(
+        self,
+        game: IncrementalGame,
+        *,
+        ctx: VmPhaseCtx | None = None,
+    ) -> list[ContentFragment] | None:
+        _ = ctx
         last_round = game.last_round
         if last_round is None:
             return []

--- a/engine/src/tangl/mechanics/games/kim_game.py
+++ b/engine/src/tangl/mechanics/games/kim_game.py
@@ -12,6 +12,7 @@ from typing import ClassVar
 from pydantic import Field
 
 from tangl.journal.fragments import ContentFragment
+from tangl.vm.ctx import VmPhaseCtx
 
 from .enums import RoundResult
 from .game import Game
@@ -171,7 +172,13 @@ class KimGameHandler(PickingGameHandler[KimGame]):
             detail["missing_item"] = game.missing_item
         return detail
 
-    def get_journal_fragments(self, game: KimGame) -> list[ContentFragment] | None:
+    def get_journal_fragments(
+        self,
+        game: KimGame,
+        *,
+        ctx: VmPhaseCtx | None = None,
+    ) -> list[ContentFragment] | None:
+        _ = ctx
         last_round = game.last_round
         if last_round is None:
             return []

--- a/engine/src/tangl/mechanics/games/nim_game.py
+++ b/engine/src/tangl/mechanics/games/nim_game.py
@@ -13,6 +13,7 @@ from pydantic import Field
 
 from tangl.journal.intent import QuantityAccepts
 from tangl.journal.fragments import ContentFragment
+from tangl.vm.ctx import VmPhaseCtx
 
 from .enums import RoundResult
 from .game import Game
@@ -166,7 +167,13 @@ class NimGameHandler(GameHandler[NimGame]):
         detail["opponent_next_take"] = game.opponent_next_move
         return detail
 
-    def get_journal_fragments(self, game: NimGame) -> list[ContentFragment] | None:
+    def get_journal_fragments(
+        self,
+        game: NimGame,
+        *,
+        ctx: VmPhaseCtx | None = None,
+    ) -> list[ContentFragment] | None:
+        _ = ctx
         last_round = game.last_round
         if last_round is None:
             return []

--- a/engine/src/tangl/mechanics/games/picking_game.py
+++ b/engine/src/tangl/mechanics/games/picking_game.py
@@ -14,6 +14,7 @@ from typing import Any, ClassVar, TypeVar
 from pydantic import Field
 
 from tangl.journal.fragments import ContentFragment
+from tangl.vm.ctx import VmPhaseCtx
 
 from .enums import RoundResult
 from .game import Game
@@ -234,7 +235,13 @@ class PickingGameHandler(GameHandler[PickingGameT]):
         detail["committed_decision"] = game.committed_decision
         return detail
 
-    def get_journal_fragments(self, game: PickingGameT) -> list[ContentFragment] | None:
+    def get_journal_fragments(
+        self,
+        game: PickingGameT,
+        *,
+        ctx: VmPhaseCtx | None = None,
+    ) -> list[ContentFragment] | None:
+        _ = ctx
         last_round = game.last_round
         if last_round is None:
             return []

--- a/engine/src/tangl/mechanics/games/rps_game.py
+++ b/engine/src/tangl/mechanics/games/rps_game.py
@@ -14,6 +14,7 @@ import random
 from pydantic import Field
 
 from tangl.journal.fragments import ContentFragment
+from tangl.vm.ctx import VmPhaseCtx
 from tangl.vm.dispatch import dispatch
 
 from .enums import GamePhase, GameResult, RoundResult
@@ -89,7 +90,13 @@ class RpsGameHandler(SimpleGameHandler[RpsGame]):
             game.score["opponent"] += 1
             return RoundResult.LOSE
 
-    def get_journal_fragments(self, game: RpsGame) -> list[ContentFragment] | None:
+    def get_journal_fragments(
+        self,
+        game: RpsGame,
+        *,
+        ctx: VmPhaseCtx | None = None,
+    ) -> list[ContentFragment] | None:
+        _ = ctx
         return _round_journal_fragments(game, verb_templates=RPS_VERB_TEMPLATES)
 
 
@@ -235,7 +242,13 @@ class RpslsGameHandler(SimpleGameHandler[RpslsGame]):
             game.score["opponent"] += 1
             return RoundResult.LOSE
 
-    def get_journal_fragments(self, game: RpslsGame) -> list[ContentFragment] | None:
+    def get_journal_fragments(
+        self,
+        game: RpslsGame,
+        *,
+        ctx: VmPhaseCtx | None = None,
+    ) -> list[ContentFragment] | None:
+        _ = ctx
         return _round_journal_fragments(game, verb_templates=RPSLS_VERB_TEMPLATES)
 
 

--- a/engine/src/tangl/mechanics/games/siege_rps_game.py
+++ b/engine/src/tangl/mechanics/games/siege_rps_game.py
@@ -12,6 +12,7 @@ from typing import ClassVar
 from pydantic import Field
 
 from tangl.journal.fragments import ContentFragment
+from tangl.vm.ctx import VmPhaseCtx
 
 from .aggregate_force_game import AggregateForceGame, AggregateForceGameHandler, ForceCommitMove
 from .enums import GameResult, RoundResult
@@ -185,7 +186,13 @@ class SiegeRpsGameHandler(AggregateForceGameHandler[SiegeRpsGame]):
         game.round_detail = detail
         return RoundResult.LOSE
 
-    def get_journal_fragments(self, game: SiegeRpsGame) -> list[ContentFragment] | None:
+    def get_journal_fragments(
+        self,
+        game: SiegeRpsGame,
+        *,
+        ctx: VmPhaseCtx | None = None,
+    ) -> list[ContentFragment] | None:
+        _ = ctx
         last_round = game.last_round
         if last_round is None:
             return []

--- a/engine/src/tangl/mechanics/simulation/queueing.py
+++ b/engine/src/tangl/mechanics/simulation/queueing.py
@@ -13,6 +13,7 @@ from tangl.journal.fragments import ContentFragment
 from tangl.mechanics.games import Game, GameHandler
 from tangl.mechanics.games.enums import GameResult, RoundResult
 from tangl.mechanics.sandbox.time import advance_world_turn_to
+from tangl.vm.ctx import VmPhaseCtx
 
 from .calendar import EventCalendar, SimulationEvent
 
@@ -275,7 +276,13 @@ class QueueSimulationHandler(GameHandler[QueueSimulation]):
             "metrics": game.metrics.model_dump() if game.metrics is not None else None,
         }
 
-    def get_journal_fragments(self, game: QueueSimulation) -> list[ContentFragment] | None:
+    def get_journal_fragments(
+        self,
+        game: QueueSimulation,
+        *,
+        ctx: VmPhaseCtx | None = None,
+    ) -> list[ContentFragment] | None:
+        _ = ctx
         return [
             ContentFragment(content=self.render_trace_event(game, event))
             for event in game.latest_trace

--- a/engine/tests/mechanics/games/test_credentials_fragments.py
+++ b/engine/tests/mechanics/games/test_credentials_fragments.py
@@ -7,17 +7,22 @@ update across rounds.
 
 from __future__ import annotations
 
+from tangl.core import Graph
 from tangl.journal.fragments import (
     ContentFragment,
     GroupFragment,
     KvFragment,
     PieceFragment,
 )
+from tangl.mechanics.credentials import CredentialToken, Indication
 from tangl.mechanics.games import (
     CredentialDisposition,
     CredentialsGame,
     CredentialsGameHandler,
+    HasGame,
 )
+from tangl.story import Block
+from tangl.vm import Frame, VmPhaseCtx
 from engine.tests.mechanics.games.credentials_helpers import make_credential_case as CredentialCase
 
 
@@ -33,6 +38,14 @@ def _case() -> CredentialCase:
     )
 
 
+def _renderable_case() -> CredentialCase:
+    return CredentialCase(
+        candidate_name="Edda Marrow",
+        presented_documents={"passport": "A worn passport."},
+        id_card=CredentialToken(indication=Indication.TRAVEL),
+    )
+
+
 def _game(*cases: CredentialCase) -> tuple[CredentialsGame, CredentialsGameHandler]:
     game = CredentialsGame(roster=list(cases) or [_case()])
     handler = CredentialsGameHandler()
@@ -40,11 +53,103 @@ def _game(*cases: CredentialCase) -> tuple[CredentialsGame, CredentialsGameHandl
     return game, handler
 
 
+class _CredentialsBlock(HasGame, Block):
+    _game_class = CredentialsGame
+    _game_handler_class = CredentialsGameHandler
+
+
+def _live_game(
+    *cases: CredentialCase,
+) -> tuple[_CredentialsBlock, CredentialsGameHandler, VmPhaseCtx]:
+    graph = Graph(label="credential-journal")
+    block = graph.add_node(
+        kind=_CredentialsBlock,
+        label="checkpoint",
+        game_state=CredentialsGame(roster=list(cases) or [_case()]),
+    )
+    handler = block.game_handler
+    handler.setup(block.game)
+    return block, handler, Frame(graph=graph, cursor=block)._make_ctx()
+
+
 def _by_type(fragments, kind):
     return [f for f in fragments if isinstance(f, kind)]
 
 
 class TestStructuredEmission:
+    def test_initial_arrival_precedes_the_structured_packet_surface(self) -> None:
+        block, handler, ctx = _live_game(_renderable_case())
+
+        fragments = handler.get_journal_fragments(block.game, ctx=ctx)
+        content = _by_type(fragments, ContentFragment)
+        candidate = next(
+            fragment
+            for fragment in fragments
+            if isinstance(fragment, PieceFragment) and fragment.piece_kind == "candidate"
+        )
+
+        assert len(content) == 2
+        assert "Edda Marrow" in content[0].content
+        assert "identity document" in content[1].content
+        assert content[0].source_id == block.game.active_case.packet_manager.bearer_id
+        assert content[1].source_id == block.uid
+        assert fragments.index(content[0]) < fragments.index(content[1]) < fragments.index(candidate)
+        assert not any(
+            leaked in " ".join(fragment.content for fragment in content).lower()
+            for leaked in ("mismatch", "invalid", "arrest", "deny", "forged")
+        )
+
+    def test_same_candidate_moves_do_not_repeat_arrival_narration(self) -> None:
+        block, handler, ctx = _live_game(_renderable_case())
+        handler.receive_move(block.game, ("inspect", "passport"))
+
+        content = _by_type(handler.get_journal_fragments(block.game, ctx=ctx), ContentFragment)
+
+        assert all("steps forward" not in fragment.content for fragment in content)
+        assert all("present their documents" not in fragment.content for fragment in content)
+
+    def test_decision_introduces_exactly_one_next_candidate_after_its_outcome(self) -> None:
+        block, handler, ctx = _live_game(_case(), CredentialCase(candidate_name="Tomas Vey"))
+        handler.receive_move(block.game, ("decide", "deny"))
+
+        fragments = handler.get_journal_fragments(block.game, ctx=ctx)
+        content = _by_type(fragments, ContentFragment)
+        candidate = next(
+            fragment
+            for fragment in fragments
+            if isinstance(fragment, PieceFragment) and fragment.piece_kind == "candidate"
+        )
+
+        assert "You choose" in content[0].content
+        assert sum("steps forward" in fragment.content for fragment in content) == 1
+        assert sum("present their documents" in fragment.content for fragment in content) == 1
+        assert "Tomas Vey" in content[2].content
+        assert fragments.index(content[2]) < fragments.index(candidate)
+
+    def test_final_decision_does_not_introduce_a_new_candidate(self) -> None:
+        block, handler, ctx = _live_game()
+        handler.receive_move(block.game, ("decide", "deny"))
+
+        content = _by_type(handler.get_journal_fragments(block.game, ctx=ctx), ContentFragment)
+
+        assert all("steps forward" not in fragment.content for fragment in content)
+        assert all("present their documents" not in fragment.content for fragment in content)
+
+    def test_profile_can_replace_arrival_wording_with_the_same_bindings(self) -> None:
+        block, handler, ctx = _live_game(_renderable_case())
+        block.game.presentation.candidate_arrival_template = (
+            "Hall monitor meets {{ candidate_name }}: "
+            "{{ render_as(candidate, 'presence_description') }}"
+        )
+        block.game.presentation.packet_presentation_template = (
+            "Student papers: {{ render_as(packet, 'inspection_description') }}"
+        )
+
+        content = _by_type(handler.get_journal_fragments(block.game, ctx=ctx), ContentFragment)
+
+        assert content[0].content.startswith("Hall monitor meets Edda Marrow")
+        assert content[1].content.startswith("Student papers: identity document")
+
     def test_initial_projection_emits_candidate_packet_and_documents(self) -> None:
         game, handler = _game()
 

--- a/engine/tests/mechanics/games/test_credentials_game.py
+++ b/engine/tests/mechanics/games/test_credentials_game.py
@@ -24,7 +24,7 @@ from tangl.mechanics.games.credentials_game import (
 from engine.tests.mechanics.games.credentials_helpers import make_credential_case as CredentialCase
 from tangl.mechanics.games.handlers import inject_game_context
 from tangl.story import Action, Block
-from tangl.vm import Ledger, TraversableEdge as ChoiceEdge
+from tangl.vm import Frame, Ledger, TraversableEdge as ChoiceEdge
 
 
 def _two_case_roster() -> list[CredentialCase]:
@@ -454,15 +454,16 @@ def test_graph_bound_packet_projects_neutral_bearer_and_id_photo_looks() -> None
     ]
     block.game_handler.setup(block.game)
 
+    ctx = Frame(graph=graph, cursor=block)._make_ctx()
     pieces = [
         fragment
-        for fragment in block.game_handler.get_journal_fragments(block.game)
+        for fragment in block.game_handler.get_journal_fragments(block.game, ctx=ctx)
         if isinstance(fragment, PieceFragment)
     ]
     candidate = next(piece for piece in pieces if piece.piece_kind == "candidate")
     passport = next(piece for piece in pieces if piece.piece_kind == "id_card")
 
-    assert candidate.properties["look_description"] == "Mara"
+    assert candidate.properties["look_description"] == ""
     assert candidate.properties["look_media_payload"].media_role == "candidate"
     assert passport.properties["look_description"] == ""
     assert passport.properties["look_media_payload"].media_role == "id_photo"

--- a/engine/tests/mechanics/games/test_credentials_game.py
+++ b/engine/tests/mechanics/games/test_credentials_game.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from tangl.core import Graph
-from tangl.journal.fragments import PieceFragment
+from tangl.journal.fragments import ContentFragment, PieceFragment
 from tangl.mechanics.credentials import CREDENTIAL_ID_SLOT, materialize_packet
 from tangl.mechanics.games import (
     CredentialStatus,
@@ -468,3 +468,24 @@ def test_graph_bound_packet_projects_neutral_bearer_and_id_photo_looks() -> None
     assert passport.properties["look_description"] == ""
     assert passport.properties["look_media_payload"].media_role == "id_photo"
     assert "mismatch" not in str([candidate.content, passport.content]).lower()
+
+
+def test_default_roster_packet_matches_its_visible_document_surface() -> None:
+    graph = Graph(label="default_credential_journal")
+    block = graph.add_node(kind=CredentialsBlock, label="checkpoint")
+    block.game_handler.setup(block.game)
+    ctx = Frame(graph=graph, cursor=block)._make_ctx()
+
+    fragments = block.game_handler.get_journal_fragments(block.game, ctx=ctx)
+    prose = [fragment.content for fragment in fragments if isinstance(fragment, ContentFragment)]
+    documents = [
+        fragment
+        for fragment in fragments
+        if isinstance(fragment, PieceFragment) and fragment.piece_kind != "candidate"
+    ]
+
+    assert "No documents" not in " ".join(prose)
+    assert {fragment.content for fragment in documents} == {
+        "A worn passport with a blurred seal.",
+        "A permit stamped for this week.",
+    }

--- a/engine/tests/mechanics/games/test_game_handlers.py
+++ b/engine/tests/mechanics/games/test_game_handlers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from tangl.core import Graph
+from tangl.journal.fragments import ContentFragment
 from tangl.journal.intent import PieceConstraints, PiecesAccepts
 from tangl.mechanics.games import Game, GameHandler, GamePhase, GameResult, RoundResult, HasGame
 from tangl.story import Action, Block
@@ -15,7 +16,7 @@ from tangl.mechanics.games.handlers import (
     provision_game_moves,
     setup_game_on_first_visit,
 )
-from tangl.vm import Frame
+from tangl.vm import Frame, VmPhaseCtx
 
 
 class SampleGame(Game):
@@ -48,6 +49,21 @@ class TestGameHandler(GameHandler[SampleGame]):
         if game.last_round is None:
             return GameResult.IN_PROCESS
         return game.last_round.result.to_game_result()
+
+
+class ContextJournalHandler(TestGameHandler):
+    """Confirms the generic JOURNAL chokepoint forwards its live context."""
+
+    received_ctx: VmPhaseCtx | None = None
+
+    def get_journal_fragments(
+        self,
+        game: SampleGame,
+        *,
+        ctx: VmPhaseCtx | None = None,
+    ) -> list[ContentFragment]:
+        self.received_ctx = ctx
+        return [ContentFragment(content="Context-aware journal.")]
 
 
 class GameBlock(HasGame, Block):
@@ -231,6 +247,20 @@ class TestUpdateHandler:
 
 
 class TestJournalHandler:
+    def test_journal_projection_receives_the_live_phase_context(
+        self,
+        game_graph: Graph,
+        game_block: GameBlock,
+    ) -> None:
+        ctx = make_ctx(make_frame(game_graph, game_block.uid))
+        handler = ContextJournalHandler()
+        game_block._game_handler = handler
+
+        fragments = generate_game_journal(game_block, ctx=ctx)
+
+        assert handler.received_ctx is ctx
+        assert [fragment.content for fragment in fragments] == ["Context-aware journal."]
+
     def test_journal_generation_from_last_round(self, game_graph: Graph, game_block: GameBlock):
         frame = make_frame(game_graph, game_block.uid)
         ctx = make_ctx(frame)


### PR DESCRIPTION
## Summary

- thread the live typed JOURNAL context through game journal projections
- render each arriving credential candidate and packet through the Phase 11–13 text adapters
- preserve existing structured packet, document, choice, finding, and media surfaces

## Behavior

Arrival narration is emitted on initial presentation and after a non-final decision only. It is attributed to the bearer and hosting block, remains neutral about validity and disposition, and precedes the structured packet surface.

## Validation

- `poetry run pytest engine/tests -q` — 2813 passed, 69 skipped, 9 xfailed
- focused rendering, credentials, game-handler, widget, and combined-world tests — 72 passed, 4 skipped
- `poetry run sphinx-build -W --keep-going -b html docs/src /tmp/storytangl-docs-phase14`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Credential episodes now present arrival details, candidate information, and visible document content in the journal.
  * Journal content can use configurable presentation templates while preserving relevant descriptions and media.
  * Credential updates appear at the appropriate points as candidates change, without repeating or adding content after final decisions.

* **Bug Fixes**
  * Improved journal rendering so contextual information is included consistently during live episode playback.

* **Documentation**
  * Updated design references to document the new credential presentation behavior and journal integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->