### PR TITLE
Implement canonical credential document projection

### DIFF
--- a/docs/src/design/story/EPISODE_SYUZHET_RENDERING.md
+++ b/docs/src/design/story/EPISODE_SYUZHET_RENDERING.md
@@ -24,7 +24,12 @@ arrival and packet templates invoke those text adapters through the live phase
 context, then emit attributed ``ContentFragment`` values before the existing
 candidate, packet-zone, and document-piece surfaces. The templates disclose
 only ordinary appearance and visible documents; findings and disposition remain
-on their committed interaction paths.
+on their committed interaction paths. Phase 15 converges packet prose and
+targetable credential pieces on the packet manager's ordered components and
+the same ``document_description`` adapter. Scenario-authored complete document
+text remains an explicit replacement, while compatibility-only visible items
+such as baggage remain separate pieces; document-part degradation and media
+composition remain deferred.
 
 ## Purpose
 

--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
@@ -10,7 +10,11 @@ that composes the packet's assigned document components through the same chain,
 without findings, JOURNAL, or game-owned presentation labels. Phase 14 invokes
 those projections from the credentials game's JOURNAL path through scenario
 arrival and packet templates, while preserving the existing typed candidate,
-packet, document, choice, and finding surfaces.
+packet, document, choice, and finding surfaces. Phase 15 makes the packet
+manager's ordered components the shared inventory for recursive packet prose
+and targetable document pieces, with scenario-authored document text supplied
+as an explicit replacement. Compatibility-only visible items remain separate,
+and visible document-part degradation is still deferred.
 **Scope:** the *global* credential mechanic — `Credential → Document → Media`,
 with carrier/bearer binding — that the credentials checkpoint **game**
 (`tangl.mechanics.games.credentials_game`) becomes one consumer of.

--- a/engine/src/tangl/mechanics/credentials/assembly.py
+++ b/engine/src/tangl/mechanics/credentials/assembly.py
@@ -204,6 +204,14 @@ class CredentialPacketManager(ComponentManager[CredentialComponent]):
             for credential in self.get_slot(CREDENTIAL_PACKET_SLOT)
         ]
 
+    def document_components(self) -> list[CredentialComponent]:
+        """Return the packet's visible documents in presentation order."""
+
+        return [
+            *self.get_slot(CREDENTIAL_ID_SLOT),
+            *self.get_slot(CREDENTIAL_PACKET_SLOT),
+        ]
+
     def get_contraband(self) -> list[ContrabandItem]:
         return list(self.possessions)
 

--- a/engine/src/tangl/mechanics/credentials/presentation.py
+++ b/engine/src/tangl/mechanics/credentials/presentation.py
@@ -5,12 +5,7 @@ from __future__ import annotations
 from tangl.story.dispatch import on_render_text
 from tangl.vm.ctx import VmPhaseCtx
 
-from .assembly import (
-    CREDENTIAL_ID_SLOT,
-    CREDENTIAL_PACKET_SLOT,
-    CredentialComponent,
-    CredentialPacketManager,
-)
+from .assembly import CredentialComponent, CredentialPacketManager
 
 
 @on_render_text(wants_caller_kind=CredentialPacketManager, wants_exact_kind=False)
@@ -25,12 +20,12 @@ def render_packet_text(
     if aspect != "inspection_description":
         return None
     return (
-        f"{{% set identity = subject.get_slot('{CREDENTIAL_ID_SLOT}') %}}"
-        f"{{% set documents = subject.get_slot('{CREDENTIAL_PACKET_SLOT}') %}}"
-        "{% set presented = identity + documents %}"
+        "{% set presented = subject.document_components() %}"
+        "{% set replacements = document_replacements | default({}) %}"
         "{% if presented %}"
         "{% for document in presented %}"
-        "{{ render_as(document, 'document_description', bindings={'packet': subject}) }}"
+        "{{ render_as(document, 'document_description', "
+        "content=replacements.get(document.uid), bindings={'packet': subject}) }}"
         "{% if not loop.last %}; {% endif %}"
         "{% endfor %}"
         "{% else %}No documents.{% endif %}"

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -1919,6 +1919,25 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             return game.presentation.identity_label
         return game.presentation.document_label(component.indication, component)
 
+    @staticmethod
+    def _authored_document_description(
+        game: CredentialsGame,
+        component: CredentialComponent,
+        label: str,
+    ) -> str | None:
+        """Return a replacement when the scenario supplies more than boilerplate."""
+
+        description = game.active_case.presented_documents.get(label)
+        default_identity_description = CredentialPresentationProfile.model_fields[
+            "identity_description"
+        ].default
+        if (
+            component.document_kind == "id"
+            and description == default_identity_description
+        ):
+            return None
+        return description
+
     def _document_components(
         self,
         game: CredentialsGame,
@@ -1929,7 +1948,13 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         documents = []
         for component in case.packet_manager.document_components():
             label = self._component_label(game, component)
-            documents.append((component, label, case.presented_documents.get(label)))
+            documents.append(
+                (
+                    component,
+                    label,
+                    self._authored_document_description(game, component, label),
+                )
+            )
         return documents
 
     def _document_replacements(self, game: CredentialsGame) -> dict[uuid.UUID, str]:
@@ -2010,7 +2035,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                 else authored_description
                 or self._fallback_document_description(component)
             )
-            doc_uid = _piece_uid(game.uid, idx, f"doc:{label}")
+            doc_uid = _piece_uid(game.uid, idx, f"doc:{component.uid}")
             doc_uids.append(doc_uid)
             properties: dict[str, object] = {"component_id": component.uid}
             if (

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -13,6 +13,7 @@ next candidate after every disposition until the game reports terminal.
 from __future__ import annotations
 
 import uuid
+from collections import Counter
 from enum import Enum
 from typing import TYPE_CHECKING, ClassVar, Literal, Self
 
@@ -80,6 +81,10 @@ def _piece_uid(game_uid: uuid.UUID, case_index: int, key: str) -> uuid.UUID:
 
 def _document_piece_id(case_index: int, label: str) -> str:
     return f"{case_index}:{label}"
+
+
+def _component_piece_id(case_index: int, component_id: uuid.UUID) -> str:
+    return f"{case_index}:component:{component_id}"
 
 
 def _document_kind(label: str) -> str:
@@ -1355,11 +1360,22 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         selected_piece_id = piece_ids[0]
         if not isinstance(selected_piece_id, str):
             raise ValueError("Document piece_id must be a string")
-        target_by_piece_id = {
-            _document_piece_id(game.case_index, target): target
+        inspect_targets = {
+            target
             for target in self.get_available_inspect_targets(game)
             if target in game.presented_documents
         }
+        target_by_piece_id = {
+            _document_piece_id(game.case_index, target): target
+            for target in inspect_targets
+        }
+        component_documents = self._document_components(game)
+        label_counts = Counter(label for _component, label, _description in component_documents)
+        for component, label, _description in component_documents:
+            if label_counts[label] <= 1 or label not in inspect_targets:
+                continue
+            target_by_piece_id.pop(_document_piece_id(game.case_index, label), None)
+            target_by_piece_id[_component_piece_id(game.case_index, component.uid)] = label
         target = target_by_piece_id.get(selected_piece_id)
         if target is None:
             raise ValueError(f"Document piece is not inspectable: {selected_piece_id}")
@@ -2021,7 +2037,11 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         doc_uids: list[uuid.UUID] = []
         doc_pieces: list[BaseFragment] = []
         component_labels: set[str] = set()
-        for component, label, authored_description in self._document_components(game):
+        component_documents = self._document_components(game)
+        label_counts = Counter(
+            label for _component, label, _description in component_documents
+        )
+        for component, label, authored_description in component_documents:
             component_labels.add(label)
             description = (
                 render_text_as(
@@ -2055,7 +2075,11 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             doc_pieces.append(
                 PieceFragment(
                     uid=doc_uid,
-                    piece_id=_document_piece_id(idx, label),
+                    piece_id=(
+                        _component_piece_id(idx, component.uid)
+                        if label_counts[label] > 1
+                        else _document_piece_id(idx, label)
+                    ),
                     piece_kind=_document_kind(label),
                     content=description,
                     zone_ref=packet_uid,

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -669,7 +669,9 @@ class CredentialPresentationProfile(BaseModelPlus):
         "{% if description %}, {{ description }}{% endif %} steps forward."
     )
     packet_presentation_template: str = (
-        "They present their documents: {{ render_as(packet, 'inspection_description') }}"
+        "They present their documents: "
+        "{{ render_as(packet, 'inspection_description', "
+        "bindings={'document_replacements': document_replacements}) }}"
     )
     status_text: dict[CredentialStatus, str] = Field(
         default_factory=lambda: {
@@ -1879,6 +1881,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             "candidate_name": case.candidate_name,
             "candidate": candidate,
             "packet": packet,
+            "document_replacements": self._document_replacements(game),
         }
         return [
             ContentFragment(
@@ -1904,6 +1907,51 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                 source_id=ctx.cursor.uid,
             ),
         ]
+
+    def _component_label(
+        self,
+        game: CredentialsGame,
+        component: CredentialComponent,
+    ) -> str:
+        """Return the scenario-facing label for one packet component."""
+
+        if component.document_kind == "id":
+            return game.presentation.identity_label
+        return game.presentation.document_label(component.indication, component)
+
+    def _document_components(
+        self,
+        game: CredentialsGame,
+    ) -> list[tuple[CredentialComponent, str, str | None]]:
+        """Pair canonical packet components with optional authored text."""
+
+        case = game.active_case
+        documents = []
+        for component in case.packet_manager.document_components():
+            label = self._component_label(game, component)
+            documents.append((component, label, case.presented_documents.get(label)))
+        return documents
+
+    def _document_replacements(self, game: CredentialsGame) -> dict[uuid.UUID, str]:
+        """Return authored document replacements keyed by live component id."""
+
+        return {
+            component.uid: description
+            for component, _label, description in self._document_components(game)
+            if description is not None
+        }
+
+    @staticmethod
+    def _fallback_document_description(
+        component: CredentialComponent,
+    ) -> str:
+        """Keep direct callers useful when no live rendering context exists."""
+
+        if component.reference_singleton.name is not None:
+            return component.reference_singleton.name
+        if component.document_kind == "id":
+            return "identity document"
+        return f"{component.indication} document"
 
     def _candidate_fragments(
         self,
@@ -1945,27 +1993,40 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             hints=PresentationHints(label_text=case.candidate_name),
         )
 
-        id_card = _id_component(case.packet_manager)
         doc_uids: list[uuid.UUID] = []
         doc_pieces: list[BaseFragment] = []
-        for label, description in case.presented_documents.items():
+        component_labels: set[str] = set()
+        for component, label, authored_description in self._document_components(game):
+            component_labels.add(label)
+            description = (
+                render_text_as(
+                    component,
+                    "document_description",
+                    ctx=ctx,
+                    content=authored_description,
+                    bindings={"packet": case.packet_manager},
+                )
+                if ctx is not None
+                else authored_description
+                or self._fallback_document_description(component)
+            )
             doc_uid = _piece_uid(game.uid, idx, f"doc:{label}")
             doc_uids.append(doc_uid)
-            properties: dict[str, object] = {}
+            properties: dict[str, object] = {"component_id": component.uid}
             if (
-                id_card is not None
-                and label == game.presentation.identity_label
-                and case.packet_manager.has_resolved_subject(id_card.subject_id)
+                component.document_kind == "id"
+                and case.packet_manager.has_resolved_subject(component.subject_id)
             ):
-                subject = case.packet_manager.resolve_subject(id_card.subject_id)
-                properties.update(
-                    {
-                        "look_description": subject.describe_look(),
-                        "look_media_payload": subject.adapt_look_media_spec(
-                            media_role="id_photo"
-                        ),
-                    }
+                subject = case.packet_manager.resolve_subject(component.subject_id)
+                properties["look_media_payload"] = subject.adapt_look_media_spec(
+                    media_role="id_photo"
                 )
+                if ctx is not None:
+                    properties["look_description"] = render_text_as(
+                        subject,
+                        "presence_description",
+                        ctx=ctx,
+                    )
             doc_pieces.append(
                 PieceFragment(
                     uid=doc_uid,
@@ -1974,6 +2035,22 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                     content=description,
                     zone_ref=packet_uid,
                     properties=properties,
+                    hints=PresentationHints(label_text=label),
+                )
+            )
+
+        for label, description in case.presented_documents.items():
+            if label in component_labels:
+                continue
+            doc_uid = _piece_uid(game.uid, idx, f"doc:{label}")
+            doc_uids.append(doc_uid)
+            doc_pieces.append(
+                PieceFragment(
+                    uid=doc_uid,
+                    piece_id=_document_piece_id(idx, label),
+                    piece_kind=_document_kind(label),
+                    content=description,
+                    zone_ref=packet_uid,
                     hints=PresentationHints(label_text=label),
                 )
             )

--- a/engine/tests/mechanics/credentials/test_credential_text_presentation.py
+++ b/engine/tests/mechanics/credentials/test_credential_text_presentation.py
@@ -195,6 +195,11 @@ def test_packet_renders_identity_before_ordered_ordinary_documents() -> None:
         first.uid,
         second.uid,
     ]
+    assert [component.uid for component in owner.packet_manager.document_components()] == [
+        identity.uid,
+        first.uid,
+        second.uid,
+    ]
     assert rendered.index("travel passport") < rendered.index("Work Permit")
     assert rendered.index("Work Permit") < rendered.index("Travel Visa")
     assert identity.subject_id == owner.packet_manager.bearer_id

--- a/engine/tests/mechanics/games/test_credentials_fragments.py
+++ b/engine/tests/mechanics/games/test_credentials_fragments.py
@@ -7,20 +7,21 @@ update across rounds.
 
 from __future__ import annotations
 
-from tangl.core import Graph
+from tangl.core import Graph, Selector
 from tangl.journal.fragments import (
     ContentFragment,
     GroupFragment,
     KvFragment,
     PieceFragment,
 )
-from tangl.mechanics.credentials import CredentialToken, Indication
+from tangl.mechanics.credentials import CredentialStatus, CredentialToken, Indication
 from tangl.mechanics.games import (
     CredentialDisposition,
     CredentialsGame,
     CredentialsGameHandler,
     HasGame,
 )
+from tangl.mechanics.presence.look import HairColor, HairStyle, Look, SkinTone
 from tangl.story import Block
 from tangl.vm import Frame, VmPhaseCtx
 from engine.tests.mechanics.games.credentials_helpers import make_credential_case as CredentialCase
@@ -90,7 +91,7 @@ class TestStructuredEmission:
 
         assert len(content) == 2
         assert "Edda Marrow" in content[0].content
-        assert "identity document" in content[1].content
+        assert "A worn passport." in content[1].content
         assert content[0].source_id == block.game.active_case.packet_manager.bearer_id
         assert content[1].source_id == block.uid
         assert fragments.index(content[0]) < fragments.index(content[1]) < fragments.index(candidate)
@@ -260,3 +261,168 @@ class TestStructuredEmission:
             p for p in _by_type(frags, PieceFragment) if p.piece_kind == "candidate"
         ]
         assert candidate and candidate[0].content == "Tomas Vey"
+
+    def test_component_documents_share_ordered_content_with_packet_prose(self) -> None:
+        case = CredentialCase(
+            candidate_name="Edda Marrow",
+            presented_documents={
+                "passport": "A blue passport.",
+                "travel permit": "A blue travel permit.",
+                "work permit": "A blue work permit.",
+                "baggage": "A blue suitcase.",
+            },
+            id_card=CredentialToken(indication=Indication.TRAVEL),
+            packet=[
+                CredentialToken(indication=Indication.TRAVEL),
+                CredentialToken(indication=Indication.WORK),
+            ],
+        )
+        block, handler, ctx = _live_game(case)
+
+        fragments = handler.get_journal_fragments(block.game, ctx=ctx)
+        packet_prose = _by_type(fragments, ContentFragment)[1].content
+        documents = [
+            fragment
+            for fragment in _by_type(fragments, PieceFragment)
+            if fragment.piece_kind != "candidate"
+        ]
+        component_pieces = [
+            fragment for fragment in documents if "component_id" in fragment.properties
+        ]
+        packet_components = block.game.active_case.packet_manager.document_components()
+
+        assert [piece.properties["component_id"] for piece in component_pieces] == [
+            component.uid for component in packet_components
+        ]
+        assert [piece.content for piece in component_pieces] == [
+            "A blue passport.",
+            "A blue travel permit.",
+            "A blue work permit.",
+        ]
+        assert [packet_prose.index(piece.content) for piece in component_pieces] == sorted(
+            packet_prose.index(piece.content) for piece in component_pieces
+        )
+        baggage = next(piece for piece in documents if piece.content == "A blue suitcase.")
+        assert "component_id" not in baggage.properties
+
+    def test_default_identity_projection_uses_the_same_recursive_portrait_text(self) -> None:
+        case = CredentialCase(
+            candidate_name="Edda Marrow",
+            presented_documents={"baggage": "A lacquered case."},
+            id_card=CredentialToken(indication=Indication.TRAVEL),
+        )
+        block, handler, ctx = _live_game(case)
+        packet = block.game.active_case.packet_manager
+        packet.resolve_subject(packet.bearer_id).look = Look(
+            hair_color=HairColor.RED,
+            hair_style=HairStyle.LONG,
+            skin_tone=SkinTone.OLIVE,
+        )
+
+        fragments = handler.get_journal_fragments(block.game, ctx=ctx)
+        packet_prose = _by_type(fragments, ContentFragment)[1].content
+        identity_piece = next(
+            piece
+            for piece in _by_type(fragments, PieceFragment)
+            if piece.properties.get("component_id")
+            == packet.document_components()[0].uid
+        )
+
+        assert "red long hair" in identity_piece.content
+        assert identity_piece.content in packet_prose
+        assert identity_piece.properties["look_description"] in identity_piece.content
+
+    def test_invalid_components_do_not_change_the_visible_piece_shape(self) -> None:
+        valid = CredentialCase(
+            presented_documents={"passport": "A passport."},
+            id_card=CredentialToken(indication=Indication.TRAVEL),
+        )
+        invalid = CredentialCase(
+            presented_documents={"passport": "A passport."},
+            id_card=CredentialToken(
+                indication=Indication.TRAVEL,
+                status=CredentialStatus.FORGED,
+            ),
+        )
+        valid_block, valid_handler, valid_ctx = _live_game(valid)
+        invalid_block, invalid_handler, invalid_ctx = _live_game(invalid)
+
+        def visible_shape(handler, game, ctx):
+            fragments = handler.get_journal_fragments(game, ctx=ctx)
+            pieces = [
+                piece
+                for piece in _by_type(fragments, PieceFragment)
+                if piece.piece_kind != "candidate"
+            ]
+            return [
+                (
+                    piece.piece_kind,
+                    piece.presentation_hints.label_text,
+                    set(piece.properties),
+                )
+                for piece in pieces
+            ], " ".join(
+                fragment.content for fragment in _by_type(fragments, ContentFragment)
+            ).lower()
+
+        valid_shape, valid_text = visible_shape(valid_handler, valid_block.game, valid_ctx)
+        invalid_shape, invalid_text = visible_shape(
+            invalid_handler,
+            invalid_block.game,
+            invalid_ctx,
+        )
+
+        assert invalid_shape == valid_shape
+        assert not any(
+            term in valid_text + invalid_text
+            for term in ("forged", "invalid", "deny")
+        )
+
+    def test_unbound_projection_keeps_authored_document_text(self) -> None:
+        case = CredentialCase(
+            presented_documents={"passport": "A stamped passport."},
+            id_card=CredentialToken(indication=Indication.TRAVEL),
+        )
+        game, handler = _game(case)
+
+        pieces = [
+            piece
+            for piece in _by_type(handler.get_journal_fragments(game), PieceFragment)
+            if piece.piece_kind != "candidate"
+        ]
+
+        assert len(pieces) == 1
+        assert pieces[0].content == "A stamped passport."
+        assert (
+            pieces[0].properties["component_id"]
+            == game.active_case.packet_manager.document_components()[0].uid
+        )
+
+    def test_component_piece_projection_survives_graph_roundtrip(self) -> None:
+        case = CredentialCase(
+            presented_documents={
+                "passport": "A stamped passport.",
+                "travel permit": "A stamped travel permit.",
+            },
+            id_card=CredentialToken(indication=Indication.TRAVEL),
+            packet=[CredentialToken(indication=Indication.TRAVEL)],
+        )
+        block, handler, ctx = _live_game(case)
+
+        def component_projection(active_handler, game, active_ctx):
+            return [
+                (piece.content, piece.properties["component_id"])
+                for piece in _by_type(
+                    active_handler.get_journal_fragments(game, ctx=active_ctx),
+                    PieceFragment,
+                )
+                if "component_id" in piece.properties
+            ]
+
+        before = component_projection(handler, block.game, ctx)
+        restored_graph = Graph.structure(ctx.graph.unstructure())
+        restored_block = restored_graph.find_one(Selector(label="checkpoint"))
+        restored_handler = restored_block.game_handler
+        restored_ctx = Frame(graph=restored_graph, cursor=restored_block)._make_ctx()
+
+        assert component_projection(restored_handler, restored_block.game, restored_ctx) == before

--- a/engine/tests/mechanics/games/test_credentials_fragments.py
+++ b/engine/tests/mechanics/games/test_credentials_fragments.py
@@ -17,6 +17,7 @@ from tangl.journal.fragments import (
 from tangl.mechanics.credentials import CredentialStatus, CredentialToken, Indication
 from tangl.mechanics.games import (
     CredentialDisposition,
+    CredentialPresentationProfile,
     CredentialsGame,
     CredentialsGameHandler,
     HasGame,
@@ -331,6 +332,61 @@ class TestStructuredEmission:
         assert "red long hair" in identity_piece.content
         assert identity_piece.content in packet_prose
         assert identity_piece.properties["look_description"] in identity_piece.content
+
+    def test_procedural_default_identity_description_falls_through_to_portrait(self) -> None:
+        case = CredentialCase(
+            candidate_name="Edda Marrow",
+            id_card=CredentialToken(indication=Indication.TRAVEL),
+        )
+        profile = CredentialPresentationProfile()
+        profile.render_case(case, [])
+        assert case.presented_documents[profile.identity_label] == profile.identity_description
+
+        block, handler, ctx = _live_game(case)
+        packet = block.game.active_case.packet_manager
+        packet.resolve_subject(packet.bearer_id).look = Look(
+            hair_color=HairColor.RED,
+            hair_style=HairStyle.LONG,
+            skin_tone=SkinTone.OLIVE,
+        )
+
+        fragments = handler.get_journal_fragments(block.game, ctx=ctx)
+        packet_prose = _by_type(fragments, ContentFragment)[1].content
+        identity_piece = next(
+            piece
+            for piece in _by_type(fragments, PieceFragment)
+            if piece.presentation_hints.label_text == profile.identity_label
+        )
+
+        assert "red long hair" in identity_piece.content
+        assert identity_piece.content in packet_prose
+
+    def test_duplicate_component_labels_have_distinct_fragment_uids(self) -> None:
+        case = CredentialCase(
+            presented_documents={"travel permit": "A stamped travel permit."},
+            packet=[
+                CredentialToken(indication=Indication.TRAVEL),
+                CredentialToken(indication=Indication.TRAVEL),
+            ],
+        )
+        block, handler, ctx = _live_game(case)
+
+        fragments = handler.get_journal_fragments(block.game, ctx=ctx)
+        packet = next(
+            fragment
+            for fragment in fragments
+            if isinstance(fragment, GroupFragment) and fragment.zone_role == "packet"
+        )
+        permits = [
+            piece
+            for piece in _by_type(fragments, PieceFragment)
+            if piece.presentation_hints.label_text == "travel permit"
+        ]
+
+        assert len(permits) == 2
+        assert len({piece.uid for piece in permits}) == 2
+        assert len(set(packet.member_ids)) == 2
+        assert {piece.piece_id for piece in permits} == {"0:travel permit"}
 
     def test_invalid_components_do_not_change_the_visible_piece_shape(self) -> None:
         valid = CredentialCase(

--- a/engine/tests/mechanics/games/test_credentials_fragments.py
+++ b/engine/tests/mechanics/games/test_credentials_fragments.py
@@ -20,6 +20,7 @@ from tangl.mechanics.games import (
     CredentialPresentationProfile,
     CredentialsGame,
     CredentialsGameHandler,
+    CredentialsMove,
     HasGame,
 )
 from tangl.mechanics.presence.look import HairColor, HairStyle, Look, SkinTone
@@ -385,8 +386,17 @@ class TestStructuredEmission:
 
         assert len(permits) == 2
         assert len({piece.uid for piece in permits}) == 2
+        assert len({piece.piece_id for piece in permits}) == 2
         assert len(set(packet.member_ids)) == 2
-        assert {piece.piece_id for piece in permits} == {"0:travel permit"}
+        assert all(piece.piece_id.startswith("0:component:") for piece in permits)
+        assert {
+            handler.resolve_move_payload(
+                block.game,
+                CredentialsMove(kind="inspect", target="__document_piece__"),
+                {"piece_ids": [piece.piece_id]},
+            ).target
+            for piece in permits
+        } == {"travel permit"}
 
     def test_invalid_components_do_not_change_the_visible_piece_shape(self) -> None:
         valid = CredentialCase(


### PR DESCRIPTION
## Summary

- make the packet manager's identity-first component order the canonical visible-document inventory
- render packet prose and component-backed document pieces through the same document adapter and authored replacements
- attach each credential piece's live `component_id` while retaining existing inspect-piece identifiers; keep baggage and other compatibility-only items separate
- project identity portrait text through the presence renderer and document the Phase 15 boundary

## Validation

- `poetry run pytest engine/tests/mechanics/credentials/test_credential_text_presentation.py engine/tests/mechanics/games/test_credentials_fragments.py engine/tests/mechanics/games/test_credentials_game.py -q`
- `poetry run pytest engine/tests/integration/test_credentials_widget_flow.py engine/tests/mechanics/credentials/test_credential_text_presentation.py engine/tests/mechanics/games/test_credentials_fragments.py engine/tests/mechanics/games/test_credentials_game.py -q`
- `poetry run pytest engine/tests -q` — 2819 passed, 69 skipped, 9 xfailed
- `poetry run sphinx-build -W --keep-going -b html docs/src /tmp/storytangl-docs-phase15`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Credential packet documents now render in a consistent order (identity first).
  * Scenario-authored document text can replace default wording during packet rendering.
  * Packet document rendering supports component-aligned substitutions and uses subject appearance for identity descriptions.

* **Bug Fixes**
  * Invalid/forged credential components no longer leak disallowed text into visible prose.
  * Authored document content and component associations are preserved through graph restore/roundtrips.

* **Documentation**
  * Updated episode-to-syuzhet and credential mechanic docs to clarify later-phase credential consumption and rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->