### PR TITLE
Add credential attestation observations

### DIFF
--- a/docs/src/design/story/EPISODE_SYUZHET_RENDERING.md
+++ b/docs/src/design/story/EPISODE_SYUZHET_RENDERING.md
@@ -28,8 +28,12 @@ on their committed interaction paths. Phase 15 converges packet prose and
 targetable credential pieces on the packet manager's ordered components and
 the same ``document_description`` adapter. Scenario-authored complete document
 text remains an explicit replacement, while compatibility-only visible items
-such as baggage remain separate pieces; document-part degradation and media
-composition remain deferred.
+such as baggage remain separate pieces. Phase 16 adds one immutable, typed
+issuer-attestation observation to the same recursive projection: profile-owned
+neutral wording becomes both document prose and a structured ``visible_parts``
+entry on the corresponding piece. A complete authored document replacement owns
+its content and does not append generated parts; media composition remains
+deferred.
 
 ## Purpose
 

--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
@@ -14,7 +14,13 @@ packet, document, choice, and finding surfaces. Phase 15 makes the packet
 manager's ordered components the shared inventory for recursive packet prose
 and targetable document pieces, with scenario-authored document text supplied
 as an explicit replacement. Compatibility-only visible items remain separate,
-and visible document-part degradation is still deferred.
+and further visible document-part degradation is still deferred. Phase 16 adds the
+first concrete visible document part: a profile-owned, immutable issuer
+attestation observation. The ordinary, missing, and alternate visible forms
+project neutrally into the recursive text description and the matching piece's
+``visible_parts`` payload, without exposing a credential finding or disposition.
+A scenario-authored complete document replacement remains self-contained and
+does not append generated parts.
 **Scope:** the *global* credential mechanic — `Credential → Document → Media`,
 with carrier/bearer binding — that the credentials checkpoint **game**
 (`tangl.mechanics.games.credentials_game`) becomes one consumer of.

--- a/engine/src/tangl/mechanics/credentials/__init__.py
+++ b/engine/src/tangl/mechanics/credentials/__init__.py
@@ -36,7 +36,7 @@ from .domain import (
 )
 
 # Register the credential-owned default text presentation handlers.
-from . import presentation as _presentation  # noqa: F401
+from .presentation import CredentialAttestationObservation
 
 __all__ = [
     "COMMON_ALLIED_RESTRICTIONS",
@@ -47,6 +47,7 @@ __all__ = [
     "CREDENTIAL_PACKET_SLOT",
     "CredentialComponent",
     "CredentialComponentToken",
+    "CredentialAttestationObservation",
     "CredentialDefinition",
     "CredentialPacketManager",
     "default_credential_catalog",

--- a/engine/src/tangl/mechanics/credentials/presentation.py
+++ b/engine/src/tangl/mechanics/credentials/presentation.py
@@ -2,10 +2,24 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
+from pydantic import ConfigDict
+
+from tangl.core.bases import BaseModelPlus
 from tangl.story.dispatch import on_render_text
 from tangl.vm.ctx import VmPhaseCtx
 
 from .assembly import CredentialComponent, CredentialPacketManager
+
+
+class CredentialAttestationObservation(BaseModelPlus):
+    """One neutral, visible issuer-attestation observation on a document."""
+
+    model_config = ConfigDict(frozen=True)
+
+    part_id: Literal["issuer_attestation"] = "issuer_attestation"
+    content: str
 
 
 @on_render_text(wants_caller_kind=CredentialPacketManager, wants_exact_kind=False)
@@ -22,10 +36,14 @@ def render_packet_text(
     return (
         "{% set presented = subject.document_components() %}"
         "{% set replacements = document_replacements | default({}) %}"
+        "{% set bases = document_bases | default({}) %}"
+        "{% set observations = document_observations | default({}) %}"
         "{% if presented %}"
         "{% for document in presented %}"
         "{{ render_as(document, 'document_description', "
-        "content=replacements.get(document.uid), bindings={'packet': subject}) }}"
+        "content=replacements.get(document.uid), bindings={'packet': subject, "
+        "'base_description': bases.get(document.uid), "
+        "'visible_observations': observations.get(document.uid, ())}) }}"
         "{% if not loop.last %}; {% endif %}"
         "{% endfor %}"
         "{% else %}No documents.{% endif %}"
@@ -45,11 +63,37 @@ def render_document_text(
         return None
     if caller.document_kind == "id":
         return (
-            "{{ subject.name or 'identity document' }}, bearing a portrait of "
+            "{% set base = base_description | default(subject.name or 'identity document', true) %}"
+            "{{ base }}, bearing a portrait of "
             "{{ render_as(packet.resolve_subject(subject.subject_id), "
             "'presence_description') }}"
+            "{% for observation in visible_observations | default(()) %}; "
+            "{{ render_as(observation, 'part_description') }}{% endfor %}"
         )
-    return "{{ subject.name or (subject.indication | replace('_', ' ') ~ ' document') }}"
+    return (
+        "{% set base = base_description | default(subject.name or "
+        "(subject.indication | replace('_', ' ') ~ ' document'), true) %}"
+        "{{ base }}{% for observation in visible_observations | default(()) %}; "
+        "{{ render_as(observation, 'part_description') }}{% endfor %}"
+    )
 
 
-__all__ = ["render_document_text", "render_packet_text"]
+@on_render_text(wants_caller_kind=CredentialAttestationObservation, wants_exact_kind=False)
+def render_attestation_text(
+    *,
+    caller: CredentialAttestationObservation,
+    aspect: str,
+    ctx: VmPhaseCtx,
+) -> str | None:
+    """Render the authored visible wording for one issuer attestation."""
+
+    _ = ctx
+    return caller.content if aspect == "part_description" else None
+
+
+__all__ = [
+    "CredentialAttestationObservation",
+    "render_attestation_text",
+    "render_document_text",
+    "render_packet_text",
+]

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -766,13 +766,15 @@ class CredentialPresentationProfile(BaseModelPlus):
     def attestation_observations(
         self,
         component: CredentialComponent,
+        *,
+        reissued: bool = False,
     ) -> tuple[CredentialAttestationObservation, ...]:
         """Project the visible issuer attestation without interpreting it."""
 
         if component.issuer_group is None:
             return ()
         template = self.ordinary_attestation_template
-        if component.status is CredentialStatus.MISSING_SEAL:
+        if component.status is CredentialStatus.MISSING_SEAL and not reissued:
             template = self.missing_attestation_template
         elif component.status is CredentialStatus.FORGED:
             template = self.alternate_attestation_template
@@ -2014,7 +2016,10 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                         else None
                     ),
                     visible_observations=game.presentation.attestation_observations(
-                        component
+                        component,
+                        reissued=(
+                            game.finding_status.get(component.indication) == Finding.CLEARED
+                        ),
                     ),
                 )
             )
@@ -2117,7 +2122,13 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                 )
                 if ctx is not None
                 else document.complete_replacement
-                or self._fallback_document_description(component)
+                or "; ".join(
+                    [self._fallback_document_description(component)]
+                    + [
+                        observation.content
+                        for observation in document.visible_observations
+                    ]
+                )
             )
             doc_uid = _piece_uid(game.uid, idx, f"doc:{component.uid}")
             doc_uids.append(doc_uid)

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -1992,7 +1992,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         """Pair canonical components with their profile base and visible parts."""
 
         case = game.active_case
-        documents = []
+        documents: list[_CredentialDocumentRender] = []
         for component in case.packet_manager.document_components():
             label = self._component_label(game, component)
             base_description = (
@@ -2005,21 +2005,27 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                 )
             )
             presented_description = case.presented_documents.get(label)
+            complete_replacement = (
+                presented_description
+                if presented_description != base_description
+                else None
+            )
             documents.append(
                 _CredentialDocumentRender(
                     component=component,
                     label=label,
                     base_description=base_description,
-                    complete_replacement=(
-                        presented_description
-                        if presented_description != base_description
-                        else None
-                    ),
-                    visible_observations=game.presentation.attestation_observations(
-                        component,
-                        reissued=(
-                            game.finding_status.get(component.indication) == Finding.CLEARED
-                        ),
+                    complete_replacement=complete_replacement,
+                    visible_observations=(
+                        ()
+                        if complete_replacement is not None
+                        else game.presentation.attestation_observations(
+                            component,
+                            reissued=(
+                                game.finding_status.get(component.indication)
+                                == Finding.CLEARED
+                            ),
+                        )
                     ),
                 )
             )

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import uuid
 from collections import Counter
+from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, ClassVar, Literal, Self
 
@@ -46,6 +47,7 @@ from tangl.mechanics.credentials.assembly import (
 from tangl.mechanics.credentials import (
     DEFAULT_RESTRICTIONS,
     ContrabandItem,
+    CredentialAttestationObservation,
     CredentialDefect,
     CredentialDefectKind,
     CredentialStatus,
@@ -103,6 +105,17 @@ def _document_kind(label: str) -> str:
     if "passport" in low or "identity" in low or {"id", "ids"} & words:
         return "id_card"
     return "document"
+
+
+@dataclass(frozen=True)
+class _CredentialDocumentRender:
+    """Local render input for one canonical credential component."""
+
+    component: CredentialComponent
+    label: str
+    base_description: str
+    complete_replacement: str | None
+    visible_observations: tuple[CredentialAttestationObservation, ...]
 
 
 class CredentialDisposition(Enum):
@@ -668,6 +681,13 @@ class CredentialPresentationProfile(BaseModelPlus):
     identity_label: str = "passport"
     identity_description: str = "An identity document."
     document_description: str = "A {document}."
+    ordinary_attestation_template: str = (
+        "A round blue {issuer_group} seal is impressed beside the bearer line."
+    )
+    missing_attestation_template: str = "The {issuer_group} seal space is blank."
+    alternate_attestation_template: str = (
+        "An over-bright {issuer_group} seal sits beside the bearer line."
+    )
     possession_description: str = "Openly declared {indication}."
     candidate_arrival_template: str = (
         "{{ candidate_name }}{% set description = render_as(candidate, 'presence_description') %}"
@@ -676,7 +696,9 @@ class CredentialPresentationProfile(BaseModelPlus):
     packet_presentation_template: str = (
         "They present their documents: "
         "{{ render_as(packet, 'inspection_description', "
-        "bindings={'document_replacements': document_replacements}) }}"
+        "bindings={'document_replacements': document_replacements, "
+        "'document_bases': document_bases, "
+        "'document_observations': document_observations}) }}"
     )
     status_text: dict[CredentialStatus, str] = Field(
         default_factory=lambda: {
@@ -739,6 +761,27 @@ class CredentialPresentationProfile(BaseModelPlus):
         return template.format(
             document=document,
             indication=self.indication_labels.get(indication, indication),
+        )
+
+    def attestation_observations(
+        self,
+        component: CredentialComponent,
+    ) -> tuple[CredentialAttestationObservation, ...]:
+        """Project the visible issuer attestation without interpreting it."""
+
+        if component.issuer_group is None:
+            return ()
+        template = self.ordinary_attestation_template
+        if component.status is CredentialStatus.MISSING_SEAL:
+            template = self.missing_attestation_template
+        elif component.status is CredentialStatus.FORGED:
+            template = self.alternate_attestation_template
+        return (
+            CredentialAttestationObservation(
+                content=template.format(
+                    issuer_group=component.issuer_group.replace("_", " "),
+                )
+            ),
         )
 
     def render_case(
@@ -1370,12 +1413,17 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             for target in inspect_targets
         }
         component_documents = self._document_components(game)
-        label_counts = Counter(label for _component, label, _description in component_documents)
-        for component, label, _description in component_documents:
-            if label_counts[label] <= 1 or label not in inspect_targets:
+        label_counts = Counter(document.label for document in component_documents)
+        for document in component_documents:
+            if (
+                label_counts[document.label] <= 1
+                or document.label not in inspect_targets
+            ):
                 continue
-            target_by_piece_id.pop(_document_piece_id(game.case_index, label), None)
-            target_by_piece_id[_component_piece_id(game.case_index, component.uid)] = label
+            target_by_piece_id.pop(_document_piece_id(game.case_index, document.label), None)
+            target_by_piece_id[
+                _component_piece_id(game.case_index, document.component.uid)
+            ] = document.label
         target = target_by_piece_id.get(selected_piece_id)
         if target is None:
             raise ValueError(f"Document piece is not inspectable: {selected_piece_id}")
@@ -1897,7 +1945,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             "candidate_name": case.candidate_name,
             "candidate": candidate,
             "packet": packet,
-            "document_replacements": self._document_replacements(game),
+            **self._document_bindings(game),
         }
         return [
             ContentFragment(
@@ -1935,51 +1983,61 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             return game.presentation.identity_label
         return game.presentation.document_label(component.indication, component)
 
-    @staticmethod
-    def _authored_document_description(
-        game: CredentialsGame,
-        component: CredentialComponent,
-        label: str,
-    ) -> str | None:
-        """Return a replacement when the scenario supplies more than boilerplate."""
-
-        description = game.active_case.presented_documents.get(label)
-        default_identity_description = CredentialPresentationProfile.model_fields[
-            "identity_description"
-        ].default
-        if (
-            component.document_kind == "id"
-            and description == default_identity_description
-        ):
-            return None
-        return description
-
     def _document_components(
         self,
         game: CredentialsGame,
-    ) -> list[tuple[CredentialComponent, str, str | None]]:
-        """Pair canonical packet components with optional authored text."""
+    ) -> list[_CredentialDocumentRender]:
+        """Pair canonical components with their profile base and visible parts."""
 
         case = game.active_case
         documents = []
         for component in case.packet_manager.document_components():
             label = self._component_label(game, component)
+            base_description = (
+                game.presentation.identity_description
+                if component.document_kind == "id"
+                else game.presentation.format(
+                    game.presentation.document_description,
+                    document=label,
+                    indication=component.indication,
+                )
+            )
+            presented_description = case.presented_documents.get(label)
             documents.append(
-                (
-                    component,
-                    label,
-                    self._authored_document_description(game, component, label),
+                _CredentialDocumentRender(
+                    component=component,
+                    label=label,
+                    base_description=base_description,
+                    complete_replacement=(
+                        presented_description
+                        if presented_description != base_description
+                        else None
+                    ),
+                    visible_observations=game.presentation.attestation_observations(
+                        component
+                    ),
                 )
             )
         return documents
 
-    def _document_replacements(self, game: CredentialsGame) -> dict[uuid.UUID, str]:
-        """Return authored document replacements keyed by live component id."""
+    def _document_bindings(self, game: CredentialsGame) -> dict[str, object]:
+        """Return the explicit per-component bindings for recursive packet text."""
 
+        documents = self._document_components(game)
         return {
-            component.uid: description
-            for component, _label, description in self._document_components(game)
-            if description is not None
+            "document_replacements": {
+                document.component.uid: document.complete_replacement
+                for document in documents
+                if document.complete_replacement is not None
+            },
+            "document_bases": {
+                document.component.uid: document.base_description
+                for document in documents
+            },
+            "document_observations": {
+                document.component.uid: document.visible_observations
+                for document in documents
+            },
         }
 
     @staticmethod
@@ -2039,25 +2097,36 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         component_labels: set[str] = set()
         component_documents = self._document_components(game)
         label_counts = Counter(
-            label for _component, label, _description in component_documents
+            document.label for document in component_documents
         )
-        for component, label, authored_description in component_documents:
+        for document in component_documents:
+            component = document.component
+            label = document.label
             component_labels.add(label)
             description = (
                 render_text_as(
                     component,
                     "document_description",
                     ctx=ctx,
-                    content=authored_description,
-                    bindings={"packet": case.packet_manager},
+                    content=document.complete_replacement,
+                    bindings={
+                        "packet": case.packet_manager,
+                        "base_description": document.base_description,
+                        "visible_observations": document.visible_observations,
+                    },
                 )
                 if ctx is not None
-                else authored_description
+                else document.complete_replacement
                 or self._fallback_document_description(component)
             )
             doc_uid = _piece_uid(game.uid, idx, f"doc:{component.uid}")
             doc_uids.append(doc_uid)
-            properties: dict[str, object] = {"component_id": component.uid}
+            properties: dict[str, object] = {
+                "component_id": component.uid,
+                "visible_parts": [
+                    observation.model_dump() for observation in document.visible_observations
+                ],
+            }
             if (
                 component.document_kind == "id"
                 and case.packet_manager.has_resolved_subject(component.subject_id)

--- a/engine/tests/loaders/test_combined_credentials_world.py
+++ b/engine/tests/loaders/test_combined_credentials_world.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from tangl.core import Graph, Selector
 from tangl.loaders import WorldBundle
 from tangl.loaders.compiler import WorldCompiler
+from tangl.journal.fragments import PieceFragment
 from tangl.mechanics.credentials import (
     CREDENTIAL_ID_SLOT,
     CREDENTIAL_PACKET_SLOT,
@@ -95,6 +96,13 @@ BORDER_PRESENTATION = CredentialPresentationProfile(
     identity_label="passport",
     identity_description="A border identity document.",
     document_description="A {document}.",
+    ordinary_attestation_template=(
+        "A round blue {issuer_group} seal is impressed beside the bearer line."
+    ),
+    missing_attestation_template="The {issuer_group} seal space is blank.",
+    alternate_attestation_template=(
+        "An over-bright {issuer_group} seal sits beside the bearer line."
+    ),
     status_text={
         CredentialStatus.MISSING_SEAL: "The issuing stamp is missing.",
         CredentialStatus.BAD_DATE: "The issue date is wrong.",
@@ -113,6 +121,11 @@ SCHOOL_PRESENTATION = CredentialPresentationProfile(
     identity_label="student ID",
     identity_description="A laminated student identification card.",
     document_description="A {document}.",
+    ordinary_attestation_template="The {issuer_group} signature appears in blue ink.",
+    missing_attestation_template="The {issuer_group} signature line is blank.",
+    alternate_attestation_template=(
+        "The {issuer_group} signature is written in a heavy, unfamiliar hand."
+    ),
     status_text={
         CredentialStatus.MISSING_SEAL: "The required teacher signature is missing.",
         CredentialStatus.BAD_DATE: "The date on the pass is wrong.",
@@ -212,6 +225,7 @@ activity_pass:
   name: Work Permit
   origin_ids: [border]
   indication: work
+  issuer_group: immigration
   document_kind: document
   requires_id: true
   facets:
@@ -232,6 +246,7 @@ activity_pass:
   name: Activity Pass
   origin_ids: [school]
   indication: activity
+  issuer_group: classroom
   document_kind: document
   requires_id: true
   facets:
@@ -308,6 +323,7 @@ def test_compiled_story_selects_its_local_credentials_scenarios(tmp_path: Path) 
         decision,
         expected_names,
         excluded_names,
+        expected_attestation,
     ) in (
         (
             "Work the border checkpoint",
@@ -319,6 +335,7 @@ def test_compiled_story_selects_its_local_credentials_scenarios(tmp_path: Path) 
             "Turn away",
             ("Border Identity Card", "Work Permit"),
             ("Student ID", "Activity Pass"),
+            "The immigration seal space is blank.",
         ),
         (
             "Monitor the school halls",
@@ -330,6 +347,7 @@ def test_compiled_story_selects_its_local_credentials_scenarios(tmp_path: Path) 
             "Send back to class",
             ("Student ID", "Activity Pass"),
             ("Border Identity Card", "Work Permit"),
+            "The classroom signature line is blank.",
         ),
     ):
         result = combined_world.create_story("combined_credentials", init_mode=InitMode.EAGER)
@@ -377,6 +395,21 @@ def test_compiled_story_selects_its_local_credentials_scenarios(tmp_path: Path) 
         )
         assert all(name in packet_description for name in expected_names)
         assert not any(name in packet_description for name in excluded_names)
+
+        fragments = ledger.cursor.game_handler.get_journal_fragments(
+            game,
+            ctx=PhaseCtx(graph=result.graph, cursor_id=block.uid),
+        )
+        permit_piece = next(
+            fragment
+            for fragment in fragments
+            if isinstance(fragment, PieceFragment)
+            and fragment.properties.get("component_id") == packet_components[0].uid
+        )
+        assert permit_piece.properties["visible_parts"] == [
+            {"part_id": "issuer_attestation", "content": expected_attestation}
+        ]
+        assert expected_attestation in permit_piece.content
 
         restored = Graph.structure(result.graph.unstructure())
         restored_block = restored.find_one(Selector(label=block_label))

--- a/engine/tests/mechanics/credentials/test_credential_text_presentation.py
+++ b/engine/tests/mechanics/credentials/test_credential_text_presentation.py
@@ -12,6 +12,7 @@ from tangl.core import BehaviorRegistry, DispatchLayer, Graph, Node, Selector
 from tangl.mechanics.credentials import (
     CREDENTIAL_ID_SLOT,
     CREDENTIAL_PACKET_SLOT,
+    CredentialAttestationObservation,
     CredentialComponent,
     CredentialDefinition,
     CredentialPacketManager,
@@ -229,6 +230,14 @@ def test_non_id_document_uses_authored_name_or_neutral_indication_fallback() -> 
 
     assert _render_document(named, owner.packet_manager) == "Work Permit"
     assert _render_document(fallback, owner.packet_manager) == "travel document"
+
+
+def test_attestation_observation_renders_through_its_own_text_aspect() -> None:
+    observation = CredentialAttestationObservation(
+        content="A round blue immigration seal is impressed beside the bearer line."
+    )
+
+    assert render_text_as(observation, "part_description", ctx=_TextCtx()) == observation.content
 
 
 def test_packet_bindings_are_explicit_and_status_does_not_change_output() -> None:

--- a/engine/tests/mechanics/games/test_credentials_fragments.py
+++ b/engine/tests/mechanics/games/test_credentials_fragments.py
@@ -510,7 +510,7 @@ class TestStructuredEmission:
         ).properties["visible_parts"] == []
         replacement = permit_piece(replacement_handler, replacement_block, replacement_ctx)
         assert replacement.content == "A hand-written work permit."
-        assert replacement.properties["visible_parts"]
+        assert replacement.properties["visible_parts"] == []
 
     def test_default_identity_projection_uses_the_same_recursive_portrait_text(self) -> None:
         case = CredentialCase(

--- a/engine/tests/mechanics/games/test_credentials_fragments.py
+++ b/engine/tests/mechanics/games/test_credentials_fragments.py
@@ -7,14 +7,21 @@ update across rounds.
 
 from __future__ import annotations
 
-from tangl.core import Graph, Selector
+from tangl.core import Graph, Selector, TokenCatalog
 from tangl.journal.fragments import (
     ContentFragment,
     GroupFragment,
     KvFragment,
     PieceFragment,
 )
-from tangl.mechanics.credentials import CredentialStatus, CredentialToken, Indication
+from tangl.mechanics.credentials import (
+    CredentialDefinition,
+    CredentialStatus,
+    CredentialToken,
+    Indication,
+    Region,
+    materialize_packet,
+)
 from tangl.mechanics.games import (
     CredentialDisposition,
     CredentialPresentationProfile,
@@ -46,6 +53,58 @@ def _renderable_case() -> CredentialCase:
         candidate_name="Edda Marrow",
         presented_documents={"passport": "A worn passport."},
         id_card=CredentialToken(indication=Indication.TRAVEL),
+    )
+
+
+def _attested_case(
+    *,
+    status: CredentialStatus = CredentialStatus.VALID,
+    issuer_group: str | None = "immigration",
+    presented_documents: dict[str, str] | None = None,
+) -> CredentialCase:
+    permit_label = (
+        "phase16_permit_with_issuer"
+        if issuer_group is not None
+        else "phase16_permit_without_issuer"
+    )
+    id_definition = CredentialDefinition.get_instance("phase16_identity") or CredentialDefinition(
+        label="phase16_identity",
+        name="Passport",
+        indication=Indication.WORK,
+        document_kind="id",
+    )
+    permit_definition = CredentialDefinition.get_instance(permit_label) or CredentialDefinition(
+        label=permit_label,
+        name="Work Permit",
+        indication=Indication.WORK,
+        issuer_group=issuer_group,
+        document_kind="document",
+        requires_id=True,
+    )
+    catalog = TokenCatalog(
+        wst=CredentialDefinition,
+        members=(id_definition, permit_definition),
+        label="phase16",
+    )
+    return CredentialCase(
+        candidate_name="Edda Marrow",
+        presented_documents=presented_documents or {},
+        packet_manager=materialize_packet(
+            owner=object(),
+            region=Region.LOCAL,
+            purpose=Indication.WORK,
+            id_card=CredentialToken(indication=Indication.WORK),
+            credentials=[
+                CredentialToken(
+                    indication=Indication.WORK,
+                    status=status,
+                    requires_id=True,
+                )
+            ],
+            possessions=[],
+            label_prefix="Edda Marrow",
+            catalog=catalog,
+        ),
     )
 
 
@@ -307,6 +366,98 @@ class TestStructuredEmission:
         baggage = next(piece for piece in documents if piece.content == "A blue suitcase.")
         assert "component_id" not in baggage.properties
 
+    def test_visible_attestation_is_shared_by_packet_prose_and_document_piece(self) -> None:
+        block, handler, ctx = _live_game(_attested_case())
+
+        fragments = handler.get_journal_fragments(block.game, ctx=ctx)
+        packet_prose = _by_type(fragments, ContentFragment)[1].content
+        permit = next(
+            piece
+            for piece in _by_type(fragments, PieceFragment)
+            if piece.presentation_hints.label_text == "Work Permit"
+        )
+        attestation = "A round blue immigration seal is impressed beside the bearer line."
+
+        assert permit.properties["visible_parts"] == [
+            {"part_id": "issuer_attestation", "content": attestation}
+        ]
+        assert attestation in permit.content
+        assert permit.content in packet_prose
+        assert permit.model_dump(mode="json", by_alias=True)["properties"][
+            "visible_parts"
+        ] == permit.properties["visible_parts"]
+
+    def test_missing_and_alternate_attestations_remain_neutral_observations(self) -> None:
+        for status, expected in (
+            (CredentialStatus.MISSING_SEAL, "The immigration seal space is blank."),
+            (
+                CredentialStatus.FORGED,
+                "An over-bright immigration seal sits beside the bearer line.",
+            ),
+        ):
+            block, handler, ctx = _live_game(_attested_case(status=status))
+            fragments = handler.get_journal_fragments(block.game, ctx=ctx)
+            permit = next(
+                piece
+                for piece in _by_type(fragments, PieceFragment)
+                if piece.presentation_hints.label_text == "Work Permit"
+            )
+
+            assert permit.properties["visible_parts"][0]["content"] == expected
+            assert expected in permit.content
+            assert not any(
+                word in permit.content.lower()
+                for word in ("forged", "fake", "wrong", "invalid", "deny", "arrest")
+            )
+
+        for status in (
+            CredentialStatus.BAD_DATE,
+            CredentialStatus.EXPIRED,
+            CredentialStatus.WRONG_HOLDER,
+        ):
+            block, handler, ctx = _live_game(_attested_case(status=status))
+            permit = next(
+                piece
+                for piece in _by_type(
+                    handler.get_journal_fragments(block.game, ctx=ctx),
+                    PieceFragment,
+                )
+                if piece.presentation_hints.label_text == "Work Permit"
+            )
+
+            assert permit.properties["visible_parts"][0]["content"] == (
+                "A round blue immigration seal is impressed beside the bearer line."
+            )
+
+    def test_non_attested_and_complete_replacement_documents_do_not_append_parts(self) -> None:
+        no_attestation_block, no_attestation_handler, no_attestation_ctx = _live_game(
+            _attested_case(issuer_group=None)
+        )
+        replacement_block, replacement_handler, replacement_ctx = _live_game(
+            _attested_case(
+                presented_documents={"Work Permit": "A hand-written work permit."}
+            )
+        )
+
+        def permit_piece(handler, block, ctx):
+            return next(
+                piece
+                for piece in _by_type(
+                    handler.get_journal_fragments(block.game, ctx=ctx),
+                    PieceFragment,
+                )
+                if piece.presentation_hints.label_text == "Work Permit"
+            )
+
+        assert permit_piece(
+            no_attestation_handler,
+            no_attestation_block,
+            no_attestation_ctx,
+        ).properties["visible_parts"] == []
+        replacement = permit_piece(replacement_handler, replacement_block, replacement_ctx)
+        assert replacement.content == "A hand-written work permit."
+        assert replacement.properties["visible_parts"]
+
     def test_default_identity_projection_uses_the_same_recursive_portrait_text(self) -> None:
         case = CredentialCase(
             candidate_name="Edda Marrow",
@@ -465,19 +616,15 @@ class TestStructuredEmission:
         )
 
     def test_component_piece_projection_survives_graph_roundtrip(self) -> None:
-        case = CredentialCase(
-            presented_documents={
-                "passport": "A stamped passport.",
-                "travel permit": "A stamped travel permit.",
-            },
-            id_card=CredentialToken(indication=Indication.TRAVEL),
-            packet=[CredentialToken(indication=Indication.TRAVEL)],
-        )
-        block, handler, ctx = _live_game(case)
+        block, handler, ctx = _live_game(_attested_case())
 
         def component_projection(active_handler, game, active_ctx):
             return [
-                (piece.content, piece.properties["component_id"])
+                (
+                    piece.content,
+                    piece.properties["component_id"],
+                    piece.properties["visible_parts"],
+                )
                 for piece in _by_type(
                     active_handler.get_journal_fragments(game, ctx=active_ctx),
                     PieceFragment,

--- a/engine/tests/mechanics/games/test_credentials_fragments.py
+++ b/engine/tests/mechanics/games/test_credentials_fragments.py
@@ -14,6 +14,7 @@ from tangl.journal.fragments import (
     KvFragment,
     PieceFragment,
 )
+from tangl.mechanics.assembly import ComponentFacet
 from tangl.mechanics.credentials import (
     CredentialDefinition,
     CredentialStatus,
@@ -61,12 +62,15 @@ def _attested_case(
     status: CredentialStatus = CredentialStatus.VALID,
     issuer_group: str | None = "immigration",
     presented_documents: dict[str, str] | None = None,
+    requestable: bool = False,
 ) -> CredentialCase:
     permit_label = (
         "phase16_permit_with_issuer"
         if issuer_group is not None
         else "phase16_permit_without_issuer"
     )
+    if requestable:
+        permit_label += "_requestable"
     id_definition = CredentialDefinition.get_instance("phase16_identity") or CredentialDefinition(
         label="phase16_identity",
         name="Passport",
@@ -80,6 +84,15 @@ def _attested_case(
         issuer_group=issuer_group,
         document_kind="document",
         requires_id=True,
+        facets=(
+            ComponentFacet(
+                channel="choice",
+                facet_type="giver",
+                payload="request_document",
+            ),
+        )
+        if requestable
+        else (),
     )
     catalog = TokenCatalog(
         wst=CredentialDefinition,
@@ -386,6 +399,47 @@ class TestStructuredEmission:
         assert permit.model_dump(mode="json", by_alias=True)["properties"][
             "visible_parts"
         ] == permit.properties["visible_parts"]
+
+    def test_context_free_document_piece_includes_its_visible_attestation(self) -> None:
+        game, handler = _game(_attested_case())
+
+        permit = next(
+            piece
+            for piece in _by_type(handler.get_journal_fragments(game), PieceFragment)
+            if piece.presentation_hints.label_text == "Work Permit"
+        )
+        attestation = "A round blue immigration seal is impressed beside the bearer line."
+
+        assert attestation in permit.content
+        assert permit.properties["visible_parts"] == [
+            {"part_id": "issuer_attestation", "content": attestation}
+        ]
+
+    def test_reissued_missing_seal_projects_an_ordinary_attestation(self) -> None:
+        block, handler, ctx = _live_game(
+            _attested_case(
+                status=CredentialStatus.MISSING_SEAL,
+                requestable=True,
+            )
+        )
+        handler.receive_move(block.game, ("request_document", "work"))
+
+        permit = next(
+            piece
+            for piece in _by_type(
+                handler.get_journal_fragments(block.game, ctx=ctx),
+                PieceFragment,
+            )
+            if piece.presentation_hints.label_text == "Work Permit"
+        )
+        attestation = "A round blue immigration seal is impressed beside the bearer line."
+
+        assert block.game.finding_status[Indication.WORK.value] == "cleared"
+        assert attestation in permit.content
+        assert "seal space is blank" not in permit.content
+        assert permit.properties["visible_parts"] == [
+            {"part_id": "issuer_attestation", "content": attestation}
+        ]
 
     def test_missing_and_alternate_attestations_remain_neutral_observations(self) -> None:
         for status, expected in (

--- a/worlds/credential_gate/credential_gate/domain.py
+++ b/worlds/credential_gate/credential_gate/domain.py
@@ -126,7 +126,14 @@ class GateCredentialsGame(CredentialsGame):
                 Indication.WEAPON: "weapon permit",
                 Indication.DRUGS: "drugs permit",
                 Indication.SECRETS: "secrets permit",
-            }
+            },
+            ordinary_attestation_template=(
+                "A round blue {issuer_group} seal is impressed beside the bearer line."
+            ),
+            missing_attestation_template="The {issuer_group} seal space is blank.",
+            alternate_attestation_template=(
+                "An over-bright {issuer_group} seal sits beside the bearer line."
+            ),
         )
     )
 
@@ -185,7 +192,14 @@ class SampledGateGame(CredentialsGame):
                 Indication.WEAPON: "weapon permit",
                 Indication.DRUGS: "drugs permit",
                 Indication.SECRETS: "secrets permit",
-            }
+            },
+            ordinary_attestation_template=(
+                "A round blue {issuer_group} seal is impressed beside the bearer line."
+            ),
+            missing_attestation_template="The {issuer_group} seal space is blank.",
+            alternate_attestation_template=(
+                "An over-bright {issuer_group} seal sits beside the bearer line."
+            ),
         )
     )
 

--- a/worlds/hall_monitor/hall_monitor/domain.py
+++ b/worlds/hall_monitor/hall_monitor/domain.py
@@ -72,7 +72,14 @@ HALL_PRESENTATION = CredentialPresentationProfile(
     },
     identity_label="student ID",
     identity_description="A laminated student identification card.",
-    document_description="{document}. Signed for this period.",
+    document_description="{document}.",
+    ordinary_attestation_template=(
+        "The {issuer_group} signature appears in blue ink."
+    ),
+    missing_attestation_template="The {issuer_group} signature line is blank.",
+    alternate_attestation_template=(
+        "The {issuer_group} signature is written in a heavy, unfamiliar hand."
+    ),
     possession_description="A student openly declares {indication}.",
     status_text={
         CredentialStatus.MISSING_SEAL: "The required teacher signature is missing.",


### PR DESCRIPTION
## Summary
- add immutable issuer-attestation observations to the credentials text presentation seam
- project the same neutral visible part into recursive packet prose and document-piece `visible_parts`
- distinguish generated base descriptions from complete scenario-authored replacements
- give the border and Hall Monitor profiles distinct seal/signature wording

## Validation
- `poetry run pytest engine/tests -q`
- `poetry run pytest engine/tests/mechanics/credentials/test_credential_text_presentation.py engine/tests/mechanics/games/test_credentials_fragments.py engine/tests/loaders/test_combined_credentials_world.py engine/tests/loaders/test_hall_monitor_world.py engine/tests/loaders/test_credential_gate_world.py -q`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Credential documents now include issuer-attestation details both in document text and as structured “visible parts.”
  * Attestation content adapts to ordinary, missing-seal, and alternate/forged conditions, using neutral wording where appropriate.
  * When a complete authored document is provided, it remains self-contained and is not automatically augmented.
  * Visible attestation data is retained through fragment serialization and round-trips.
* **Documentation**
  * Updated the credential rendering design references to reflect the new phase progression and attestation projection behavior.
* **Tests**
  * Expanded credential fragment and projection coverage for visible attestation behavior and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->