### PR TITLE
Add credential validity observations

### DIFF
--- a/docs/src/design/story/EPISODE_SYUZHET_RENDERING.md
+++ b/docs/src/design/story/EPISODE_SYUZHET_RENDERING.md
@@ -33,7 +33,10 @@ issuer-attestation observation to the same recursive projection: profile-owned
 neutral wording becomes both document prose and a structured ``visible_parts``
 entry on the corresponding piece. A complete authored document replacement owns
 its content and does not append generated parts; media composition remains
-deferred.
+deferred. Phase 17 adds a second concrete validity observation and a narrow
+union of those two heterogeneous leaves. The packet/document projection now
+proves ordered text and structured interactive evidence are the same transient
+presentation product; media integration remains a separate next discussion.
 
 ## Purpose
 

--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
@@ -14,13 +14,18 @@ packet, document, choice, and finding surfaces. Phase 15 makes the packet
 manager's ordered components the shared inventory for recursive packet prose
 and targetable document pieces, with scenario-authored document text supplied
 as an explicit replacement. Compatibility-only visible items remain separate,
-and further visible document-part degradation is still deferred. Phase 16 adds the
-first concrete visible document part: a profile-owned, immutable issuer
-attestation observation. The ordinary, missing, and alternate visible forms
+and Phase 16 adds the first concrete visible document part: a profile-owned,
+immutable issuer attestation observation. The ordinary, missing, and alternate visible forms
 project neutrally into the recursive text description and the matching piece's
 ``visible_parts`` payload, without exposing a credential finding or disposition.
 A scenario-authored complete document replacement remains self-contained and
-does not append generated parts.
+does not append generated parts. Phase 17 adds a second concrete visible part:
+validity wording selected from the definition's existing ``valid_period`` and
+the component status. The narrow two-value union preserves ordered, neutral
+attestation-plus-validity prose and ``visible_parts`` without evaluating a
+credential from presentation output. This text/JOURNAL/interactive floor is
+sufficient to discuss a separate media-compositor integration plan; credentials
+will not create placeholder cards or a private forge.
 **Scope:** the *global* credential mechanic — `Credential → Document → Media`,
 with carrier/bearer binding — that the credentials checkpoint **game**
 (`tangl.mechanics.games.credentials_game`) becomes one consumer of.
@@ -333,7 +338,7 @@ worth naming, not worth gating the media work on.
 
 ## 7 · Staged plan (media spec is the forcing function)
 
-### Assembly packet authority landed
+### Assembly and presentation floor landed
 
 The shared credentials package now owns the credential domain vocabulary and the
 canonical assembly-backed packet path. `CredentialCase` now requires
@@ -342,34 +347,16 @@ graph credential components; disposition derivation reads that concrete manager.
 Offer arrival materializes the manager from the selected catalog before gameplay,
 so the roster/game/demo paths share graph-backed packet identity.
 
-This is still not the full credential mechanic described above: document/media
-projection has not landed, presence-snapshot holder binding is not implemented,
-contraband remains value-shaped, and `credential_gate` remains the reference
-consumer rather than a retrofit target. It does establish the retirement path for
-the current game-local implementation: future canonical packets should store
-graph-token credentials by id through the same owner-bound manager pattern used by
-outfits, vehicles, and connector groups.
+Phases 7–17 now cover graph-token packet authority, bearer/subject binding,
+transient defect mediation, recursive text projection, JOURNAL delivery,
+component-backed pieces, and two ordered visible document observations. This is
+the complete text/JOURNAL/interactive floor. It deliberately does not compose a
+card or generate media.
 
-0. **(Media-layer prerequisite, separate track.)** A minimal **RIT registry +
-   composition-strategy** surface, replacing the legacy `svg_forge`/`raster_forge`
-   shape (§3a). Owned by media, not credentials; Phase D consumes it.
-1. **`CredentialCardSpec`** as a `MediaSpec`, built *on the media framework*
-   (`MediaSpec` → `MediaSpecProvisioner` → `MediaRIT` → `MediaFragment`) and the
-   composition surface from (0) — **not** a hand-rolled composition or journal
-   path. It reads a credential's status + carrier binding to render discrepancies,
-   and calls presence's `adapt_look_media_spec(media_role="id_photo")` for the
-   bearer portrait. The genuine *second consumer* of the credential primitives and
-   the *simplest consumer* of the composition framework.
-2. **Extract primitives** (`Credential`, `Document`, carrier binding) into
-   `tangl.mechanics.credentials` — partially landed for the current enum/value
-   vocabulary, assembly packet proof, and graph-owned presence binding.
-3. **Re-point the game** at the promoted primitives; the game adds its overrides
-   (regions, seals, permits).
-4. **Default assets** land alongside (1) so the projection is provable from day
-   one.
-
-Steps 1–4 keep the merged game working; nothing is a big-bang refactor. Step 0 is
-the one genuine dependency, and it is a media-subsystem concern in its own right.
+The next step is a separate requirements and integration-plan discussion with the
+media compositor refactor. Credentials should consume the resulting
+``MediaSpec → MediaSpecProvisioner → MediaRIT → MediaFragment`` path; it must not
+invent placeholder cards, a private forge, or a parallel journal channel.
 
 ---
 

--- a/engine/src/tangl/mechanics/credentials/__init__.py
+++ b/engine/src/tangl/mechanics/credentials/__init__.py
@@ -36,7 +36,11 @@ from .domain import (
 )
 
 # Register the credential-owned default text presentation handlers.
-from .presentation import CredentialAttestationObservation
+from .presentation import (
+    CredentialAttestationObservation,
+    CredentialValidityObservation,
+    CredentialVisibleObservation,
+)
 
 __all__ = [
     "COMMON_ALLIED_RESTRICTIONS",
@@ -48,6 +52,8 @@ __all__ = [
     "CredentialComponent",
     "CredentialComponentToken",
     "CredentialAttestationObservation",
+    "CredentialValidityObservation",
+    "CredentialVisibleObservation",
     "CredentialDefinition",
     "CredentialPacketManager",
     "default_credential_catalog",

--- a/engine/src/tangl/mechanics/credentials/presentation.py
+++ b/engine/src/tangl/mechanics/credentials/presentation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, TypeAlias
 
 from pydantic import ConfigDict
 
@@ -20,6 +20,20 @@ class CredentialAttestationObservation(BaseModelPlus):
 
     part_id: Literal["issuer_attestation"] = "issuer_attestation"
     content: str
+
+
+class CredentialValidityObservation(BaseModelPlus):
+    """One neutral, visible validity observation on a document."""
+
+    model_config = ConfigDict(frozen=True)
+
+    part_id: Literal["validity"] = "validity"
+    content: str
+
+
+CredentialVisibleObservation: TypeAlias = (
+    CredentialAttestationObservation | CredentialValidityObservation
+)
 
 
 @on_render_text(wants_caller_kind=CredentialPacketManager, wants_exact_kind=False)
@@ -91,9 +105,25 @@ def render_attestation_text(
     return caller.content if aspect == "part_description" else None
 
 
+@on_render_text(wants_caller_kind=CredentialValidityObservation, wants_exact_kind=False)
+def render_validity_text(
+    *,
+    caller: CredentialValidityObservation,
+    aspect: str,
+    ctx: VmPhaseCtx,
+) -> str | None:
+    """Render the authored visible wording for one document validity line."""
+
+    _ = ctx
+    return caller.content if aspect == "part_description" else None
+
+
 __all__ = [
     "CredentialAttestationObservation",
+    "CredentialValidityObservation",
+    "CredentialVisibleObservation",
     "render_attestation_text",
     "render_document_text",
     "render_packet_text",
+    "render_validity_text",
 ]

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -2043,7 +2043,15 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                 if presented_description != base_description
                 else None
             )
-            reissued = game.finding_status.get(component.indication) == Finding.CLEARED
+            reissued_component = self._request_document_component(
+                case,
+                component.indication,
+            )
+            reissued = (
+                reissued_component is not None
+                and component.uid == reissued_component.uid
+                and game.finding_status.get(component.indication) == Finding.CLEARED
+            )
             documents.append(
                 _CredentialDocumentRender(
                     component=component,

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -52,6 +52,8 @@ from tangl.mechanics.credentials import (
     CredentialDefectKind,
     CredentialStatus,
     CredentialToken,
+    CredentialValidityObservation,
+    CredentialVisibleObservation,
     FailureClass,
     IndicationId,
     OriginId,
@@ -115,7 +117,7 @@ class _CredentialDocumentRender:
     label: str
     base_description: str
     complete_replacement: str | None
-    visible_observations: tuple[CredentialAttestationObservation, ...]
+    visible_observations: tuple[CredentialVisibleObservation, ...]
 
 
 class CredentialDisposition(Enum):
@@ -688,6 +690,13 @@ class CredentialPresentationProfile(BaseModelPlus):
     alternate_attestation_template: str = (
         "An over-bright {issuer_group} seal sits beside the bearer line."
     )
+    ordinary_validity_template: str = (
+        "The validity line reads “Valid through the current entry period.”"
+    )
+    unusual_date_validity_template: str = "The issue line reads “32 September.”"
+    past_validity_template: str = (
+        "The validity line reads “Valid through the previous entry period.”"
+    )
     possession_description: str = "Openly declared {indication}."
     candidate_arrival_template: str = (
         "{{ candidate_name }}{% set description = render_as(candidate, 'presence_description') %}"
@@ -782,6 +791,30 @@ class CredentialPresentationProfile(BaseModelPlus):
             CredentialAttestationObservation(
                 content=template.format(
                     issuer_group=component.issuer_group.replace("_", " "),
+                )
+            ),
+        )
+
+    def validity_observations(
+        self,
+        component: CredentialComponent,
+        *,
+        reissued: bool = False,
+    ) -> tuple[CredentialValidityObservation, ...]:
+        """Project visible date wording without evaluating the credential."""
+
+        if component.valid_period is None:
+            return ()
+        template = self.ordinary_validity_template
+        if component.status is CredentialStatus.BAD_DATE and not reissued:
+            template = self.unusual_date_validity_template
+        elif component.status is CredentialStatus.EXPIRED and not reissued:
+            template = self.past_validity_template
+        return (
+            CredentialValidityObservation(
+                content=template.format(
+                    valid_period=component.valid_period,
+                    issuer_group=(component.issuer_group or "").replace("_", " "),
                 )
             ),
         )
@@ -2010,6 +2043,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                 if presented_description != base_description
                 else None
             )
+            reissued = game.finding_status.get(component.indication) == Finding.CLEARED
             documents.append(
                 _CredentialDocumentRender(
                     component=component,
@@ -2019,12 +2053,15 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                     visible_observations=(
                         ()
                         if complete_replacement is not None
-                        else game.presentation.attestation_observations(
-                            component,
-                            reissued=(
-                                game.finding_status.get(component.indication)
-                                == Finding.CLEARED
-                            ),
+                        else (
+                            game.presentation.attestation_observations(
+                                component,
+                                reissued=reissued,
+                            )
+                            + game.presentation.validity_observations(
+                                component,
+                                reissued=reissued,
+                            )
                         )
                     ),
                 )

--- a/engine/tests/loaders/test_combined_credentials_world.py
+++ b/engine/tests/loaders/test_combined_credentials_world.py
@@ -103,6 +103,13 @@ BORDER_PRESENTATION = CredentialPresentationProfile(
     alternate_attestation_template=(
         "An over-bright {issuer_group} seal sits beside the bearer line."
     ),
+    ordinary_validity_template=(
+        "The validity line reads “Valid through the current entry period.”"
+    ),
+    unusual_date_validity_template="The issue line reads “32 September.”",
+    past_validity_template=(
+        "The validity line reads “Valid through the previous entry period.”"
+    ),
     status_text={
         CredentialStatus.MISSING_SEAL: "The issuing stamp is missing.",
         CredentialStatus.BAD_DATE: "The issue date is wrong.",
@@ -126,6 +133,9 @@ SCHOOL_PRESENTATION = CredentialPresentationProfile(
     alternate_attestation_template=(
         "The {issuer_group} signature is written in a heavy, unfamiliar hand."
     ),
+    ordinary_validity_template="The pass is marked “Valid for this period.”",
+    unusual_date_validity_template="The period box is marked “Period 9.”",
+    past_validity_template="The pass is marked “Valid for last period.”",
     status_text={
         CredentialStatus.MISSING_SEAL: "The required teacher signature is missing.",
         CredentialStatus.BAD_DATE: "The date on the pass is wrong.",
@@ -224,6 +234,7 @@ assets:
 activity_pass:
   name: Work Permit
   origin_ids: [border]
+  valid_period: 0
   indication: work
   issuer_group: immigration
   document_kind: document
@@ -245,6 +256,7 @@ activity_pass:
 activity_pass:
   name: Activity Pass
   origin_ids: [school]
+  valid_period: 0
   indication: activity
   issuer_group: classroom
   document_kind: document
@@ -324,6 +336,7 @@ def test_compiled_story_selects_its_local_credentials_scenarios(tmp_path: Path) 
         expected_names,
         excluded_names,
         expected_attestation,
+        expected_validity,
     ) in (
         (
             "Work the border checkpoint",
@@ -336,6 +349,7 @@ def test_compiled_story_selects_its_local_credentials_scenarios(tmp_path: Path) 
             ("Border Identity Card", "Work Permit"),
             ("Student ID", "Activity Pass"),
             "The immigration seal space is blank.",
+            "The validity line reads “Valid through the current entry period.”",
         ),
         (
             "Monitor the school halls",
@@ -348,6 +362,7 @@ def test_compiled_story_selects_its_local_credentials_scenarios(tmp_path: Path) 
             ("Student ID", "Activity Pass"),
             ("Border Identity Card", "Work Permit"),
             "The classroom signature line is blank.",
+            "The pass is marked “Valid for this period.”",
         ),
     ):
         result = combined_world.create_story("combined_credentials", init_mode=InitMode.EAGER)
@@ -407,9 +422,18 @@ def test_compiled_story_selects_its_local_credentials_scenarios(tmp_path: Path) 
             and fragment.properties.get("component_id") == packet_components[0].uid
         )
         assert permit_piece.properties["visible_parts"] == [
-            {"part_id": "issuer_attestation", "content": expected_attestation}
+            {"part_id": "issuer_attestation", "content": expected_attestation},
+            {"part_id": "validity", "content": expected_validity},
         ]
+        journal_packet = next(
+            fragment.content
+            for fragment in fragments
+            if fragment.fragment_type == "content"
+            and "They present their documents:" in fragment.content
+        )
         assert expected_attestation in permit_piece.content
+        assert expected_validity in permit_piece.content
+        assert permit_piece.content in journal_packet
 
         restored = Graph.structure(result.graph.unstructure())
         restored_block = restored.find_one(Selector(label=block_label))

--- a/engine/tests/mechanics/credentials/test_credential_text_presentation.py
+++ b/engine/tests/mechanics/credentials/test_credential_text_presentation.py
@@ -17,6 +17,7 @@ from tangl.mechanics.credentials import (
     CredentialDefinition,
     CredentialPacketManager,
     CredentialStatus,
+    CredentialValidityObservation,
     Indication,
 )
 from tangl.mechanics.games import CredentialsGame, HasGame
@@ -235,6 +236,14 @@ def test_non_id_document_uses_authored_name_or_neutral_indication_fallback() -> 
 def test_attestation_observation_renders_through_its_own_text_aspect() -> None:
     observation = CredentialAttestationObservation(
         content="A round blue immigration seal is impressed beside the bearer line."
+    )
+
+    assert render_text_as(observation, "part_description", ctx=_TextCtx()) == observation.content
+
+
+def test_validity_observation_renders_through_its_own_text_aspect() -> None:
+    observation = CredentialValidityObservation(
+        content="The validity line reads “Valid through the current entry period.”"
     )
 
     assert render_text_as(observation, "part_description", ctx=_TextCtx()) == observation.content

--- a/engine/tests/mechanics/games/test_credentials_fragments.py
+++ b/engine/tests/mechanics/games/test_credentials_fragments.py
@@ -61,6 +61,7 @@ def _attested_case(
     *,
     status: CredentialStatus = CredentialStatus.VALID,
     issuer_group: str | None = "immigration",
+    valid_period: int | None = None,
     presented_documents: dict[str, str] | None = None,
     requestable: bool = False,
 ) -> CredentialCase:
@@ -71,6 +72,8 @@ def _attested_case(
     )
     if requestable:
         permit_label += "_requestable"
+    if valid_period is not None:
+        permit_label += f"_period_{valid_period}"
     id_definition = CredentialDefinition.get_instance("phase16_identity") or CredentialDefinition(
         label="phase16_identity",
         name="Passport",
@@ -82,6 +85,7 @@ def _attested_case(
         name="Work Permit",
         indication=Indication.WORK,
         issuer_group=issuer_group,
+        valid_period=valid_period,
         document_kind="document",
         requires_id=True,
         facets=(
@@ -400,8 +404,31 @@ class TestStructuredEmission:
             "visible_parts"
         ] == permit.properties["visible_parts"]
 
+    def test_visible_observations_are_ordered_and_shared_by_packet_and_piece(self) -> None:
+        block, handler, ctx = _live_game(_attested_case(valid_period=0))
+
+        fragments = handler.get_journal_fragments(block.game, ctx=ctx)
+        packet_prose = _by_type(fragments, ContentFragment)[1].content
+        permit = next(
+            piece
+            for piece in _by_type(fragments, PieceFragment)
+            if piece.presentation_hints.label_text == "Work Permit"
+        )
+        attestation = "A round blue immigration seal is impressed beside the bearer line."
+        validity = "The validity line reads “Valid through the current entry period.”"
+
+        assert permit.properties["visible_parts"] == [
+            {"part_id": "issuer_attestation", "content": attestation},
+            {"part_id": "validity", "content": validity},
+        ]
+        assert permit.content.index(attestation) < permit.content.index(validity)
+        assert permit.content in packet_prose
+        assert permit.model_dump(mode="json", by_alias=True)["properties"][
+            "visible_parts"
+        ] == permit.properties["visible_parts"]
+
     def test_context_free_document_piece_includes_its_visible_attestation(self) -> None:
-        game, handler = _game(_attested_case())
+        game, handler = _game(_attested_case(valid_period=0))
 
         permit = next(
             piece
@@ -409,16 +436,19 @@ class TestStructuredEmission:
             if piece.presentation_hints.label_text == "Work Permit"
         )
         attestation = "A round blue immigration seal is impressed beside the bearer line."
+        validity = "The validity line reads “Valid through the current entry period.”"
 
         assert attestation in permit.content
         assert permit.properties["visible_parts"] == [
-            {"part_id": "issuer_attestation", "content": attestation}
+            {"part_id": "issuer_attestation", "content": attestation},
+            {"part_id": "validity", "content": validity},
         ]
 
     def test_reissued_missing_seal_projects_an_ordinary_attestation(self) -> None:
         block, handler, ctx = _live_game(
             _attested_case(
                 status=CredentialStatus.MISSING_SEAL,
+                valid_period=0,
                 requestable=True,
             )
         )
@@ -433,13 +463,87 @@ class TestStructuredEmission:
             if piece.presentation_hints.label_text == "Work Permit"
         )
         attestation = "A round blue immigration seal is impressed beside the bearer line."
+        validity = "The validity line reads “Valid through the current entry period.”"
 
         assert block.game.finding_status[Indication.WORK.value] == "cleared"
         assert attestation in permit.content
         assert "seal space is blank" not in permit.content
         assert permit.properties["visible_parts"] == [
-            {"part_id": "issuer_attestation", "content": attestation}
+            {"part_id": "issuer_attestation", "content": attestation},
+            {"part_id": "validity", "content": validity},
         ]
+
+    def test_reissued_bad_date_projects_an_ordinary_validity_line(self) -> None:
+        block, handler, ctx = _live_game(
+            _attested_case(
+                status=CredentialStatus.BAD_DATE,
+                valid_period=0,
+                requestable=True,
+            )
+        )
+        handler.receive_move(block.game, ("request_document", "work"))
+
+        permit = next(
+            piece
+            for piece in _by_type(
+                handler.get_journal_fragments(block.game, ctx=ctx),
+                PieceFragment,
+            )
+            if piece.presentation_hints.label_text == "Work Permit"
+        )
+
+        assert block.game.finding_status[Indication.WORK.value] == "cleared"
+        assert "The issue line reads “32 September.”" not in permit.content
+        assert permit.properties["visible_parts"][1] == {
+            "part_id": "validity",
+            "content": "The validity line reads “Valid through the current entry period.”",
+        }
+
+    def test_statuses_change_only_their_visible_observation(self) -> None:
+        ordinary_attestation = "A round blue immigration seal is impressed beside the bearer line."
+        ordinary_validity = "The validity line reads “Valid through the current entry period.”"
+        expected = {
+            CredentialStatus.BAD_DATE: (
+                ordinary_attestation,
+                "The issue line reads “32 September.”",
+            ),
+            CredentialStatus.EXPIRED: (
+                ordinary_attestation,
+                "The validity line reads “Valid through the previous entry period.”",
+            ),
+            CredentialStatus.MISSING_SEAL: (
+                "The immigration seal space is blank.",
+                ordinary_validity,
+            ),
+            CredentialStatus.FORGED: (
+                "An over-bright immigration seal sits beside the bearer line.",
+                ordinary_validity,
+            ),
+            CredentialStatus.WRONG_HOLDER: (
+                ordinary_attestation,
+                ordinary_validity,
+            ),
+        }
+
+        for status, (attestation, validity) in expected.items():
+            block, handler, ctx = _live_game(_attested_case(status=status, valid_period=0))
+            permit = next(
+                piece
+                for piece in _by_type(
+                    handler.get_journal_fragments(block.game, ctx=ctx),
+                    PieceFragment,
+                )
+                if piece.presentation_hints.label_text == "Work Permit"
+            )
+
+            assert permit.properties["visible_parts"] == [
+                {"part_id": "issuer_attestation", "content": attestation},
+                {"part_id": "validity", "content": validity},
+            ]
+            assert not any(
+                word in permit.content.lower()
+                for word in ("forged", "invalid", "expired", "wrong", "deny", "arrest")
+            )
 
     def test_missing_and_alternate_attestations_remain_neutral_observations(self) -> None:
         for status, expected in (
@@ -489,6 +593,7 @@ class TestStructuredEmission:
         )
         replacement_block, replacement_handler, replacement_ctx = _live_game(
             _attested_case(
+                valid_period=0,
                 presented_documents={"Work Permit": "A hand-written work permit."}
             )
         )
@@ -670,7 +775,7 @@ class TestStructuredEmission:
         )
 
     def test_component_piece_projection_survives_graph_roundtrip(self) -> None:
-        block, handler, ctx = _live_game(_attested_case())
+        block, handler, ctx = _live_game(_attested_case(valid_period=0))
 
         def component_projection(active_handler, game, active_ctx):
             return [

--- a/engine/tests/mechanics/games/test_credentials_fragments.py
+++ b/engine/tests/mechanics/games/test_credentials_fragments.py
@@ -62,6 +62,8 @@ def _attested_case(
     status: CredentialStatus = CredentialStatus.VALID,
     issuer_group: str | None = "immigration",
     valid_period: int | None = None,
+    id_status: CredentialStatus = CredentialStatus.VALID,
+    id_valid_period: int | None = None,
     presented_documents: dict[str, str] | None = None,
     requestable: bool = False,
 ) -> CredentialCase:
@@ -74,10 +76,14 @@ def _attested_case(
         permit_label += "_requestable"
     if valid_period is not None:
         permit_label += f"_period_{valid_period}"
-    id_definition = CredentialDefinition.get_instance("phase16_identity") or CredentialDefinition(
-        label="phase16_identity",
+    id_label = "phase16_identity"
+    if id_valid_period is not None:
+        id_label += f"_period_{id_valid_period}"
+    id_definition = CredentialDefinition.get_instance(id_label) or CredentialDefinition(
+        label=id_label,
         name="Passport",
         indication=Indication.WORK,
+        valid_period=id_valid_period,
         document_kind="id",
     )
     permit_definition = CredentialDefinition.get_instance(permit_label) or CredentialDefinition(
@@ -110,7 +116,10 @@ def _attested_case(
             owner=object(),
             region=Region.LOCAL,
             purpose=Indication.WORK,
-            id_card=CredentialToken(indication=Indication.WORK),
+            id_card=CredentialToken(
+                indication=Indication.WORK,
+                status=id_status,
+            ),
             credentials=[
                 CredentialToken(
                     indication=Indication.WORK,
@@ -498,6 +507,35 @@ class TestStructuredEmission:
             "part_id": "validity",
             "content": "The validity line reads “Valid through the current entry period.”",
         }
+
+    def test_reissuing_a_permit_does_not_refresh_an_expired_id(self) -> None:
+        block, handler, ctx = _live_game(
+            _attested_case(
+                status=CredentialStatus.MISSING_SEAL,
+                valid_period=0,
+                id_status=CredentialStatus.EXPIRED,
+                id_valid_period=0,
+                requestable=True,
+            )
+        )
+        handler.receive_move(block.game, ("request_document", "work"))
+
+        identity = next(
+            piece
+            for piece in _by_type(
+                handler.get_journal_fragments(block.game, ctx=ctx),
+                PieceFragment,
+            )
+            if piece.presentation_hints.label_text == "passport"
+        )
+
+        assert block.game.finding_status[Indication.WORK.value] == "cleared"
+        assert identity.properties["visible_parts"] == [
+            {
+                "part_id": "validity",
+                "content": "The validity line reads “Valid through the previous entry period.”",
+            }
+        ]
 
     def test_statuses_change_only_their_visible_observation(self) -> None:
         ordinary_attestation = "A round blue immigration seal is impressed beside the bearer line."

--- a/worlds/credential_gate/credential_gate/domain.py
+++ b/worlds/credential_gate/credential_gate/domain.py
@@ -134,6 +134,13 @@ class GateCredentialsGame(CredentialsGame):
             alternate_attestation_template=(
                 "An over-bright {issuer_group} seal sits beside the bearer line."
             ),
+            ordinary_validity_template=(
+                "The validity line reads “Valid through the current entry period.”"
+            ),
+            unusual_date_validity_template="The issue line reads “32 September.”",
+            past_validity_template=(
+                "The validity line reads “Valid through the previous entry period.”"
+            ),
         )
     )
 
@@ -199,6 +206,13 @@ class SampledGateGame(CredentialsGame):
             missing_attestation_template="The {issuer_group} seal space is blank.",
             alternate_attestation_template=(
                 "An over-bright {issuer_group} seal sits beside the bearer line."
+            ),
+            ordinary_validity_template=(
+                "The validity line reads “Valid through the current entry period.”"
+            ),
+            unusual_date_validity_template="The issue line reads “32 September.”",
+            past_validity_template=(
+                "The validity line reads “Valid through the previous entry period.”"
             ),
         )
     )

--- a/worlds/hall_monitor/credential_types.yaml
+++ b/worlds/hall_monitor/credential_types.yaml
@@ -46,6 +46,7 @@ student_id_records:
 hall_pass:
   name: Hall Pass
   origin_ids: [upper, lower, exchange]
+  valid_period: 0
   indication: academic
   issuer_group: classroom
   document_kind: document
@@ -58,6 +59,7 @@ hall_pass:
 activity_pass:
   name: Activity Pass
   origin_ids: [upper, lower, exchange]
+  valid_period: 0
   indication: activity
   issuer_group: activities_office
   document_kind: document
@@ -70,6 +72,7 @@ activity_pass:
 off_campus_pass:
   name: Off-Campus Pass
   origin_ids: [upper, lower, exchange]
+  valid_period: 0
   indication: off_campus
   issuer_group: attendance_office
   document_kind: document
@@ -82,6 +85,7 @@ off_campus_pass:
 uniform_waiver:
   name: Uniform Waiver
   origin_ids: [upper, lower, exchange]
+  valid_period: 0
   indication: uniform
   issuer_group: dean
   document_kind: document
@@ -94,6 +98,7 @@ uniform_waiver:
 doctors_note:
   name: Doctor's Note
   origin_ids: [upper, lower, exchange]
+  valid_period: 0
   indication: medicine
   issuer_group: nurses_office
   document_kind: document
@@ -106,6 +111,7 @@ doctors_note:
 office_pass:
   name: Office Pass
   origin_ids: [upper, lower, exchange]
+  valid_period: 0
   indication: records
   issuer_group: front_office
   document_kind: document

--- a/worlds/hall_monitor/hall_monitor/domain.py
+++ b/worlds/hall_monitor/hall_monitor/domain.py
@@ -80,6 +80,9 @@ HALL_PRESENTATION = CredentialPresentationProfile(
     alternate_attestation_template=(
         "The {issuer_group} signature is written in a heavy, unfamiliar hand."
     ),
+    ordinary_validity_template="The pass is marked “Valid for this period.”",
+    unusual_date_validity_template="The period box is marked “Period 9.”",
+    past_validity_template="The pass is marked “Valid for last period.”",
     possession_description="A student openly declares {indication}.",
     status_text={
         CredentialStatus.MISSING_SEAL: "The required teacher signature is missing.",


### PR DESCRIPTION
## Summary
- add immutable validity observations alongside issuer attestations
- preserve ordered visible evidence in document prose, packet JOURNAL prose, and `PieceFragment.properties["visible_parts"]`
- provide distinct border and Hall Monitor validity wording through existing `valid_period` definitions
- retain complete authored replacement and transient-rendering boundaries

## Validation
- `poetry run pytest engine/tests -q`
- `poetry run pytest engine/tests/mechanics/credentials/test_credential_text_presentation.py engine/tests/mechanics/games/test_credentials_fragments.py engine/tests/mechanics/games/test_credentials_game.py engine/tests/loaders/test_combined_credentials_world.py engine/tests/loaders/test_credential_gate_world.py engine/tests/loaders/test_hall_monitor_world.py engine/tests/integration/test_credentials_widget_flow.py -q`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Credential documents now display validity-period information alongside issuer details.
  * Validity wording adapts to current, unusual, past, reissued, and cleared credential scenarios.
  * Validity information appears consistently in rendered document text, packets, and journal content.
  * Added validity presentation support across credential types in supported story worlds.

* **Documentation**
  * Updated design and credential documentation to clarify visible validity information and presentation boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->