### PR TITLE
Add presentation-safe credential card projection

### DIFF
--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
@@ -25,7 +25,9 @@ the component status. The narrow two-value union preserves ordered, neutral
 attestation-plus-validity prose and ``visible_parts`` without evaluating a
 credential from presentation output. This text/JOURNAL/interactive floor is
 sufficient to discuss a separate media-compositor integration plan; credentials
-will not create placeholder cards or a private forge.
+will not create placeholder cards or a private forge. Media Slices A–C landed
+through PR #326, and D1 adds the presentation-safe ``CredentialCardProjection``
+for canonical ID documents without provisioning or emitting media.
 **Scope:** the *global* credential mechanic — `Credential → Document → Media`,
 with carrier/bearer binding — that the credentials checkpoint **game**
 (`tangl.mechanics.games.credentials_game`) becomes one consumer of.
@@ -353,10 +355,15 @@ component-backed pieces, and two ordered visible document observations. This is
 the complete text/JOURNAL/interactive floor. It deliberately does not compose a
 card or generate media.
 
-The next step is a separate requirements and integration-plan discussion with the
-media compositor refactor. Credentials should consume the resulting
-``MediaSpec → MediaSpecProvisioner → MediaRIT → MediaFragment`` path; it must not
-invent placeholder cards, a private forge, or a parallel journal channel.
+Media Slices A–C landed through PR #326, including the minimal one-level
+compositor. D1 adds the credentials-owned, presentation-safe
+``CredentialCardProjection`` from the canonical document-render calculation;
+it still does not provision or emit media. The next slice needs a generic
+printable text/vector child before a credential card can compose meaningful
+content. Credentials must consume the resulting ``MediaSpec →
+MediaSpecProvisioner → MediaRIT → MediaFragment`` path; it must not invent a
+packet sheet, recursive DAG, credential forge, catalog abstraction, or parallel
+JOURNAL media channel.
 
 ---
 
@@ -365,13 +372,13 @@ invent placeholder cards, a private forge, or a parallel journal channel.
 - **Portrait pool keying.** Phase 9 materializes a minimal `HasSimpleLook` subject
   per procedural candidate. The remaining question is how a world later maps
   those stable subject ids to reusable portrait-pool entries.
-- **RIT registry + composition-strategy surface (media-layer, §3a step 0).** The
-  one genuine dependency. Unifies the legacy `svg_forge` catalog-assembler and the
-  `raster_forge`/file-forge stub into registries of mini-RITs + interchangeable
-  composition strategies producing a composite RIT. Recipe/spec format (layer list
-  + transforms + strategy + content-addressing) is the open piece. Paperdoll-
-  driven; credentials is the degenerate validating consumer, not the driver.
-  Deserves its own media-subsystem design note / issue.
+- **Broader RIT catalog + composition-strategy surface (media-layer, §3a step
+  0).** The minimal one-level ``CompositionSpec`` compositor landed in PR #326.
+  What remains open is generalizing the legacy `svg_forge` catalog-assembler and
+  the `raster_forge`/file-forge stub into registries of mini-RITs plus
+  interchangeable composition strategies. Recipe/spec format (layer list +
+  transforms + strategy + content-addressing) remains a media concern;
+  paperdolls, not credentials, are the likely forcing consumer.
 - **Journal integration of composed media.** The single-RIT path exists
   (`MediaFragment(content=rit)` → service deref). Confirm a composite RIT rides
   the same path unchanged (it should — a composite is just a RIT), so neither

--- a/engine/src/tangl/mechanics/credentials/__init__.py
+++ b/engine/src/tangl/mechanics/credentials/__init__.py
@@ -38,6 +38,7 @@ from .domain import (
 # Register the credential-owned default text presentation handlers.
 from .presentation import (
     CredentialAttestationObservation,
+    CredentialCardProjection,
     CredentialValidityObservation,
     CredentialVisibleObservation,
 )
@@ -52,6 +53,7 @@ __all__ = [
     "CredentialComponent",
     "CredentialComponentToken",
     "CredentialAttestationObservation",
+    "CredentialCardProjection",
     "CredentialValidityObservation",
     "CredentialVisibleObservation",
     "CredentialDefinition",

--- a/engine/src/tangl/mechanics/credentials/presentation.py
+++ b/engine/src/tangl/mechanics/credentials/presentation.py
@@ -38,7 +38,24 @@ CredentialVisibleObservation: TypeAlias = (
 
 
 class CredentialCardProjection(BaseModelPlus):
-    """Presentation-safe semantic input for one future credential-card renderer."""
+    """Projection data for future credential-card renderers.
+
+    Why:
+        Keep presentation data separate from credential evaluation and mutation.
+
+    Key Features:
+        Preserve canonical IDs, scenario labels, and ordered visible observations.
+
+    API:
+        ``CredentialsGameHandler.credential_card_projections()`` produces this
+        value from the canonical ID document render.
+
+    Notes:
+        This model excludes validity, defect, policy, and outcome state.
+
+    See also:
+        ``CredentialVisibleObservation`` for the ordered visible document parts.
+    """
 
     model_config = ConfigDict(frozen=True)
 

--- a/engine/src/tangl/mechanics/credentials/presentation.py
+++ b/engine/src/tangl/mechanics/credentials/presentation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Literal, TypeAlias
+from uuid import UUID
 
 from pydantic import ConfigDict
 
@@ -34,6 +35,19 @@ class CredentialValidityObservation(BaseModelPlus):
 CredentialVisibleObservation: TypeAlias = (
     CredentialAttestationObservation | CredentialValidityObservation
 )
+
+
+class CredentialCardProjection(BaseModelPlus):
+    """Presentation-safe semantic input for one future credential-card renderer."""
+
+    model_config = ConfigDict(frozen=True)
+
+    component_id: UUID
+    subject_id: UUID
+    document_kind: str
+    document_label: str
+    bearer_label: str
+    visible_parts: tuple[CredentialVisibleObservation, ...]
 
 
 @on_render_text(wants_caller_kind=CredentialPacketManager, wants_exact_kind=False)
@@ -120,6 +134,7 @@ def render_validity_text(
 
 __all__ = [
     "CredentialAttestationObservation",
+    "CredentialCardProjection",
     "CredentialValidityObservation",
     "CredentialVisibleObservation",
     "render_attestation_text",

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -48,6 +48,7 @@ from tangl.mechanics.credentials import (
     DEFAULT_RESTRICTIONS,
     ContrabandItem,
     CredentialAttestationObservation,
+    CredentialCardProjection,
     CredentialDefect,
     CredentialDefectKind,
     CredentialStatus,
@@ -2075,6 +2076,28 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                 )
             )
         return documents
+
+    def credential_card_projections(
+        self,
+        game: CredentialsGame,
+    ) -> list[CredentialCardProjection]:
+        """Project the active case's canonical ID documents for future card media."""
+        case = game.active_case
+        return [
+            CredentialCardProjection(
+                component_id=document.component.uid,
+                subject_id=document.component.subject_id,
+                document_kind=document.component.document_kind,
+                document_label=document.label,
+                bearer_label=case.candidate_name,
+                visible_parts=document.visible_observations,
+            )
+            for document in self._document_components(game)
+            if (
+                document.component.document_kind == "id"
+                and document.complete_replacement is None
+            )
+        ]
 
     def _document_bindings(self, game: CredentialsGame) -> dict[str, object]:
         """Return the explicit per-component bindings for recursive packet text."""

--- a/engine/tests/mechanics/credentials/test_credential_card_projection.py
+++ b/engine/tests/mechanics/credentials/test_credential_card_projection.py
@@ -105,7 +105,10 @@ def _game(
     *,
     presentation: CredentialPresentationProfile | None = None,
 ) -> tuple[CredentialsGame, CredentialsGameHandler]:
-    game = CredentialsGame(roster=[case], presentation=presentation or CredentialPresentationProfile())
+    game = CredentialsGame(
+        roster=[case],
+        presentation=presentation or CredentialPresentationProfile(),
+    )
     handler = CredentialsGameHandler()
     handler.setup(game)
     return game, handler

--- a/engine/tests/mechanics/credentials/test_credential_card_projection.py
+++ b/engine/tests/mechanics/credentials/test_credential_card_projection.py
@@ -1,0 +1,233 @@
+"""Presentation-safe credential-card projection tests."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tangl.core import TokenCatalog
+from tangl.mechanics.assembly import ComponentFacet
+from tangl.mechanics.credentials import (
+    CredentialCardProjection,
+    CredentialDefinition,
+    CredentialStatus,
+    CredentialToken,
+    Indication,
+    Region,
+    materialize_packet,
+)
+from tangl.mechanics.games import (
+    CredentialPresentationProfile,
+    CredentialsGame,
+    CredentialsGameHandler,
+)
+from tangl.mechanics.games.credentials_game import CredentialCase
+
+
+@pytest.fixture(autouse=True)
+def clear_credential_definitions():
+    CredentialDefinition.clear_instances()
+    yield
+    CredentialDefinition.clear_instances()
+
+
+def _case(
+    *,
+    id_status: CredentialStatus = CredentialStatus.VALID,
+    presented_documents: dict[str, str] | None = None,
+    include_id: bool = True,
+    include_requestable_permit: bool = False,
+) -> CredentialCase:
+    id_definition = CredentialDefinition(
+        label="projection-id",
+        name="Border Pass",
+        indication=Indication.TRAVEL,
+        document_kind="id",
+        issuer_group="border_control",
+        valid_period=0,
+    )
+    definitions = [id_definition] if include_id else []
+    credentials: list[CredentialToken] = []
+    if include_requestable_permit:
+        definitions.append(
+            CredentialDefinition(
+                label="projection-permit",
+                name="Travel Permit",
+                indication=Indication.WORK,
+                document_kind="document",
+                issuer_group="border_control",
+                valid_period=0,
+                requires_id=True,
+                facets=(
+                    ComponentFacet(
+                        channel="choice",
+                        facet_type="giver",
+                        payload="request_document",
+                    ),
+                ),
+            )
+        )
+        credentials.append(
+            CredentialToken(
+                indication=Indication.WORK,
+                status=CredentialStatus.MISSING_SEAL,
+                requires_id=True,
+            )
+        )
+    catalog = TokenCatalog(
+        wst=CredentialDefinition,
+        label="projection",
+        members=tuple(definitions),
+    )
+    return CredentialCase(
+        candidate_name="Ada Venn",
+        presented_documents=presented_documents or {},
+        packet_manager=materialize_packet(
+            owner=object(),
+            region=Region.LOCAL,
+            purpose=Indication.TRAVEL,
+            id_card=(
+                CredentialToken(indication=Indication.TRAVEL, status=id_status)
+                if include_id
+                else None
+            ),
+            credentials=credentials,
+            possessions=[],
+            label_prefix="Ada Venn",
+            catalog=catalog,
+        ),
+    )
+
+
+def _game(
+    case: CredentialCase,
+    *,
+    presentation: CredentialPresentationProfile | None = None,
+) -> tuple[CredentialsGame, CredentialsGameHandler]:
+    game = CredentialsGame(roster=[case], presentation=presentation or CredentialPresentationProfile())
+    handler = CredentialsGameHandler()
+    handler.setup(game)
+    return game, handler
+
+
+def test_id_projection_uses_canonical_component_case_labels_and_visible_order() -> None:
+    game, handler = _game(_case())
+    component = game.active_case.packet_manager.document_components()[0]
+
+    projections = handler.credential_card_projections(game)
+
+    assert len(projections) == 1
+    assert projections[0].component_id == component.uid
+    assert projections[0].subject_id == component.subject_id
+    assert projections[0].document_kind == "id"
+    assert projections[0].document_label == "passport"
+    assert projections[0].bearer_label == "Ada Venn"
+    assert [part.part_id for part in projections[0].visible_parts] == [
+        "issuer_attestation",
+        "validity",
+    ]
+    assert [part.content for part in projections[0].visible_parts] == [
+        "A round blue border control seal is impressed beside the bearer line.",
+        "The validity line reads “Valid through the current entry period.”",
+    ]
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        CredentialStatus.BAD_DATE,
+        CredentialStatus.EXPIRED,
+        CredentialStatus.MISSING_SEAL,
+        CredentialStatus.FORGED,
+        CredentialStatus.WRONG_HOLDER,
+    ],
+)
+def test_projection_never_serializes_raw_evaluation_status(status: CredentialStatus) -> None:
+    game, handler = _game(_case(id_status=status))
+
+    payload = handler.credential_card_projections(game)[0].model_dump(mode="json")
+
+    assert set(payload) == {
+        "component_id",
+        "subject_id",
+        "document_kind",
+        "document_label",
+        "bearer_label",
+        "visible_parts",
+    }
+    assert status.value not in json.dumps(payload)
+
+
+def test_complete_authored_replacement_suppresses_card_projection() -> None:
+    game, handler = _game(
+        _case(presented_documents={"passport": "A hand-drawn credential."})
+    )
+
+    assert handler.credential_card_projections(game) == []
+
+
+def test_unrelated_cleared_reissue_does_not_change_the_id_card_projection() -> None:
+    game, handler = _game(_case(include_requestable_permit=True))
+    before = handler.credential_card_projections(game)
+
+    handler.receive_move(game, ("request_document", Indication.WORK.value))
+    documents = handler._document_components(game)
+    permit = next(document for document in documents if document.component.document_kind != "id")
+
+    assert game.finding_status[Indication.WORK.value] == "cleared"
+    assert [part.content for part in permit.visible_observations] == [
+        "A round blue border control seal is impressed beside the bearer line.",
+        "The validity line reads “Valid through the current entry period.”",
+    ]
+    assert handler.credential_card_projections(game) == before
+
+
+def test_non_id_documents_do_not_produce_card_projections() -> None:
+    game, handler = _game(_case(include_id=False, include_requestable_permit=True))
+
+    assert handler.credential_card_projections(game) == []
+
+
+def test_profiles_change_card_wording_without_changing_the_component() -> None:
+    case = _case()
+    first_game, first_handler = _game(case)
+    first = first_handler.credential_card_projections(first_game)[0]
+    second_game, second_handler = _game(
+        case,
+        presentation=CredentialPresentationProfile(
+            identity_label="student ID",
+            ordinary_attestation_template="A campus {issuer_group} stamp appears.",
+            ordinary_validity_template="The date line is current.",
+        ),
+    )
+    second = second_handler.credential_card_projections(second_game)[0]
+
+    assert first.component_id == second.component_id
+    assert first.document_label != second.document_label
+    assert first.visible_parts != second.visible_parts
+
+
+def test_projection_json_is_stable_and_presentation_safe() -> None:
+    game, handler = _game(_case())
+    projection = handler.credential_card_projections(game)[0]
+    payload = {
+        "component_id": str(projection.component_id),
+        "subject_id": str(projection.subject_id),
+        "document_kind": "id",
+        "document_label": "passport",
+        "bearer_label": "Ada Venn",
+        "visible_parts": [
+            {
+                "part_id": "issuer_attestation",
+                "content": "A round blue border control seal is impressed beside the bearer line.",
+            },
+            {
+                "part_id": "validity",
+                "content": "The validity line reads “Valid through the current entry period.”",
+            },
+        ],
+    }
+
+    assert projection.model_dump(mode="json") == payload
+    assert CredentialCardProjection.model_validate(payload) == projection


### PR DESCRIPTION
## Summary

Adds one immutable credentials-owned `CredentialCardProjection` for future ID-card rendering.

## Scope

- Derives projections only from `CredentialsGameHandler._document_components()`.
- Preserves canonical ID component/subject UUID provenance, scenario-facing document and bearer labels, and ordered neutral visible observations.
- Suppresses generation for complete authored replacements and excludes non-ID documents.
- Keeps all validity, defect, policy, and outcome logic outside the projection.

No media lifecycle, SVG, RIT, provisioning, JOURNAL emission, or card rendering is introduced.

## Validation

`poetry run pytest engine/tests/mechanics/credentials/test_credential_card_projection.py engine/tests/mechanics/credentials/test_credential_text_presentation.py engine/tests/mechanics/games/test_credentials_fragments.py -q`

- `59 passed`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added presentation-safe credential card projections with document details, bearer information, and visible observations.
  * Credential cards now provide stable identifiers and consistent ordering for active identity documents.
  * Complete replacement text and non-identity content are excluded from projections.
  * Presentation wording can change without modifying the underlying credential information.

* **Documentation**
  * Updated credential presentation guidance to reflect shared media and composition practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->