### PR TITLE
Add printable credential ID card composition

### DIFF
--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
@@ -360,7 +360,8 @@ compositor. D1 adds the credentials-owned, presentation-safe
 ``CredentialCardProjection`` from the canonical document-render calculation;
 it still does not provision or emit media. The next slice needs a generic
 printable text/vector child before a credential card can compose meaningful
-content. Credentials must consume the resulting ``MediaSpec →
+content. D2 supplies that media-owned generic child but does not consume a
+credential projection. Credentials must consume the resulting ``MediaSpec →
 MediaSpecProvisioner → MediaRIT → MediaFragment`` path; it must not invent a
 packet sheet, recursive DAG, credential forge, catalog abstraction, or parallel
 JOURNAL media channel.

--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
@@ -361,10 +361,14 @@ compositor. D1 adds the credentials-owned, presentation-safe
 it still does not provision or emit media. The next slice needs a generic
 printable text/vector child before a credential card can compose meaningful
 content. D2 supplies that media-owned generic child but does not consume a
-credential projection. Credentials must consume the resulting ``MediaSpec →
-MediaSpecProvisioner → MediaRIT → MediaFragment`` path; it must not invent a
-packet sheet, recursive DAG, credential forge, catalog abstraction, or parallel
-JOURNAL media channel.
+credential projection. D3 proves that one projection can request a recorded
+subject portrait and printable text, then compose their resolved RITs into one
+presentation-safe ID card. That card is not yet emitted into JOURNAL. Slice E
+remains responsible for lifecycle timing, ``PieceFragment`` association, text
+fallback, authored alternatives/replacements, and media selection. Credentials
+must consume the resulting ``MediaSpec → MediaSpecProvisioner → MediaRIT →
+MediaFragment`` path; it must not invent a packet sheet, recursive DAG,
+credential forge, catalog abstraction, or parallel JOURNAL media channel.
 
 ---
 

--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
@@ -364,13 +364,14 @@ content. D2 supplies that media-owned generic child but does not consume a
 credential projection. D3 proves that one projection can request a recorded
 subject portrait and printable text, then compose their resolved RITs into one
 presentation-safe ID card. Its media-owned ``credential_card`` text profile
-wraps the safe observation wording into the fixed card-text layout. That card
-is not yet emitted into JOURNAL. Slice E remains responsible for lifecycle
-timing, ``PieceFragment`` association, text fallback, authored
-alternatives/replacements, and media selection. Credentials must consume the
-resulting ``MediaSpec → MediaSpecProvisioner → MediaRIT → MediaFragment`` path;
-it must not invent a packet sheet, recursive DAG, credential forge, catalog
-abstraction, or parallel JOURNAL media channel.
+wraps the safe observation wording into the fixed card-text layout and elides
+only overflowing execution lines; the complete projection remains in the
+derivation payload. That card is not yet emitted into JOURNAL. Slice E remains
+responsible for lifecycle timing, ``PieceFragment`` association, text fallback,
+authored alternatives/replacements, and media selection. Credentials must
+consume the resulting ``MediaSpec → MediaSpecProvisioner → MediaRIT →
+MediaFragment`` path; it must not invent a packet sheet, recursive DAG,
+credential forge, catalog abstraction, or parallel JOURNAL media channel.
 
 ---
 

--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
@@ -363,12 +363,14 @@ printable text/vector child before a credential card can compose meaningful
 content. D2 supplies that media-owned generic child but does not consume a
 credential projection. D3 proves that one projection can request a recorded
 subject portrait and printable text, then compose their resolved RITs into one
-presentation-safe ID card. That card is not yet emitted into JOURNAL. Slice E
-remains responsible for lifecycle timing, ``PieceFragment`` association, text
-fallback, authored alternatives/replacements, and media selection. Credentials
-must consume the resulting ``MediaSpec → MediaSpecProvisioner → MediaRIT →
-MediaFragment`` path; it must not invent a packet sheet, recursive DAG,
-credential forge, catalog abstraction, or parallel JOURNAL media channel.
+presentation-safe ID card. Its media-owned ``credential_card`` text profile
+wraps the safe observation wording into the fixed card-text layout. That card
+is not yet emitted into JOURNAL. Slice E remains responsible for lifecycle
+timing, ``PieceFragment`` association, text fallback, authored
+alternatives/replacements, and media selection. Credentials must consume the
+resulting ``MediaSpec → MediaSpecProvisioner → MediaRIT → MediaFragment`` path;
+it must not invent a packet sheet, recursive DAG, credential forge, catalog
+abstraction, or parallel JOURNAL media channel.
 
 ---
 

--- a/engine/src/tangl/mechanics/credentials/__init__.py
+++ b/engine/src/tangl/mechanics/credentials/__init__.py
@@ -42,6 +42,11 @@ from .presentation import (
     CredentialValidityObservation,
     CredentialVisibleObservation,
 )
+from .card_media import (
+    credential_card_composition_spec,
+    credential_card_portrait_spec,
+    credential_card_text_spec,
+)
 
 __all__ = [
     "COMMON_ALLIED_RESTRICTIONS",
@@ -56,6 +61,9 @@ __all__ = [
     "CredentialCardProjection",
     "CredentialValidityObservation",
     "CredentialVisibleObservation",
+    "credential_card_composition_spec",
+    "credential_card_portrait_spec",
+    "credential_card_text_spec",
     "CredentialDefinition",
     "CredentialPacketManager",
     "default_credential_catalog",

--- a/engine/src/tangl/mechanics/credentials/card_media.py
+++ b/engine/src/tangl/mechanics/credentials/card_media.py
@@ -25,6 +25,7 @@ def credential_card_text_spec(projection: CredentialCardProjection) -> Printable
     """Build the card's ordered, presentation-safe printed wording."""
     return PrintableTextSpec(
         label="credential_card_text",
+        style_profile="credential_card",
         lines=(
             projection.document_label,
             projection.bearer_label,

--- a/engine/src/tangl/mechanics/credentials/card_media.py
+++ b/engine/src/tangl/mechanics/credentials/card_media.py
@@ -1,0 +1,65 @@
+"""Presentation-safe media requests for one credential ID card."""
+
+from __future__ import annotations
+
+from tangl.media import CompositionInputRef, CompositionSpec, PrintableTextSpec
+from tangl.media.media_creators.portrait_spec import PortraitSpec
+from tangl.media.media_resource import MediaResourceInventoryTag as MediaRIT
+from tangl.mechanics.presence.look import HasSimpleLook, portrait_spec_from_look
+
+from .presentation import CredentialCardProjection
+
+
+def credential_card_portrait_spec(
+    projection: CredentialCardProjection,
+    subject: HasSimpleLook,
+) -> PortraitSpec:
+    """Build the recorded document subject's renderer-neutral portrait request."""
+    payload = subject.adapt_look_media_spec(media_role="id_photo")
+    return portrait_spec_from_look(payload, identity_key=str(projection.subject_id))
+
+
+def credential_card_text_spec(projection: CredentialCardProjection) -> PrintableTextSpec:
+    """Build the card's ordered, presentation-safe printed wording."""
+    return PrintableTextSpec(
+        label="credential_card_text",
+        lines=(
+            projection.document_label,
+            projection.bearer_label,
+            *(part.content for part in projection.visible_parts),
+        ),
+    )
+
+
+def credential_card_composition_spec(
+    projection: CredentialCardProjection,
+    *,
+    portrait_rit: MediaRIT,
+    text_rit: MediaRIT,
+) -> CompositionSpec:
+    """Compose resolved portrait and printable-text resources into one ID card."""
+    _ = projection
+    portrait_hash = portrait_rit.get_content_hash()
+    text_hash = text_rit.get_content_hash()
+    if portrait_hash is None or text_hash is None:
+        raise ValueError("Credential-card composition requires resolved child content")
+    return CompositionSpec(
+        label="credential_card",
+        inputs=[
+            CompositionInputRef(
+                role="portrait",
+                rit_id=portrait_rit.uid,
+                content_hash=portrait_hash,
+                offset=(16, 32),
+            ),
+            CompositionInputRef(
+                role="printable_text",
+                rit_id=text_rit.uid,
+                content_hash=text_hash,
+                offset=(176, 16),
+            ),
+        ],
+        canvas_size=(512, 192),
+        background="white",
+        treatment="credential_id_card",
+    )

--- a/engine/src/tangl/mechanics/credentials/card_media.py
+++ b/engine/src/tangl/mechanics/credentials/card_media.py
@@ -15,6 +15,8 @@ def credential_card_portrait_spec(
     subject: HasSimpleLook,
 ) -> PortraitSpec:
     """Build the recorded document subject's renderer-neutral portrait request."""
+    if subject.uid != projection.subject_id:
+        raise ValueError("Credential-card portrait subject does not match projection")
     payload = subject.adapt_look_media_spec(media_role="id_photo")
     return portrait_spec_from_look(payload, identity_key=str(projection.subject_id))
 
@@ -32,13 +34,11 @@ def credential_card_text_spec(projection: CredentialCardProjection) -> Printable
 
 
 def credential_card_composition_spec(
-    projection: CredentialCardProjection,
     *,
     portrait_rit: MediaRIT,
     text_rit: MediaRIT,
 ) -> CompositionSpec:
     """Compose resolved portrait and printable-text resources into one ID card."""
-    _ = projection
     portrait_hash = portrait_rit.get_content_hash()
     text_hash = text_rit.get_content_hash()
     if portrait_hash is None or text_hash is None:

--- a/engine/src/tangl/media/MEDIA_DESIGN.md
+++ b/engine/src/tangl/media/MEDIA_DESIGN.md
@@ -352,11 +352,12 @@ There is no HTTP renderer path or style-selection catalog at this layer.
 
 `PrintableTextSpec` is the corresponding generic text leaf: an ordered sequence
 of printable lines with one semantic default profile. Its adapter produces a
-fully resolved `SvgTextSpec` (fixed panel dimensions, padding, font, colors,
-and adapter version), and `SvgTextForge` emits XML-safe standalone SVG. It is
-not a text-layout system: wrapping, font measurement, rich text, and template
-rendering remain outside this contract. The semantic request and resolved SVG
-request retain the normal derivation/adapted/execution RIT provenance split.
+fully resolved `SvgTextSpec` with deterministic dimensions derived from the
+line count, plus padding, font, colors, and adapter version; `SvgTextForge`
+emits XML-safe standalone SVG. It is not a text-layout system: wrapping, font
+measurement, rich text, and template rendering remain outside this contract.
+The semantic request and resolved SVG request retain the normal
+derivation/adapted/execution RIT provenance split.
 
 `composition_forge` is the first one-level consumer of this distinction. A
 `CompositionSpec` persists ordered `CompositionInputRef` values with each child

--- a/engine/src/tangl/media/MEDIA_DESIGN.md
+++ b/engine/src/tangl/media/MEDIA_DESIGN.md
@@ -351,13 +351,15 @@ the adapted-spec fingerprint because they cannot change the rendered output.
 There is no HTTP renderer path or style-selection catalog at this layer.
 
 `PrintableTextSpec` is the corresponding generic text leaf: an ordered sequence
-of printable lines with one semantic default profile. Its adapter produces a
-fully resolved `SvgTextSpec` with deterministic dimensions derived from the
-line count, plus padding, font, colors, and adapter version; `SvgTextForge`
-emits XML-safe standalone SVG. It is not a text-layout system: wrapping, font
-measurement, rich text, and template rendering remain outside this contract.
-The semantic request and resolved SVG request retain the normal
-derivation/adapted/execution RIT provenance split.
+of printable lines with a semantic default profile that preserves exact source
+lines. Its adapter produces a fully resolved `SvgTextSpec` with deterministic
+dimensions derived from the resolved line count, plus padding, font, colors,
+and adapter version; `SvgTextForge` emits XML-safe standalone SVG. The first
+consumer-specific `credential_card` profile deterministically wraps into a
+fixed-width, monospaced card-text layout. This remains deliberately narrower
+than a general text-layout system: font measurement, rich text, and template
+rendering remain outside the contract. The semantic request and resolved SVG
+request retain the normal derivation/adapted/execution RIT provenance split.
 
 `composition_forge` is the first one-level consumer of this distinction. A
 `CompositionSpec` persists ordered `CompositionInputRef` values with each child

--- a/engine/src/tangl/media/MEDIA_DESIGN.md
+++ b/engine/src/tangl/media/MEDIA_DESIGN.md
@@ -336,6 +336,7 @@ carry different non-rendering request provenance. That is normal cache behavior.
 | `checker_forge` | IMAGE | Active deterministic harness used to prove sync/async pipeline slices |
 | `comfy_forge` | IMAGE | Active ComfyUI backend with workflow-backed specs, async dispatch, and optional `FAST_SYNC` creation |
 | `dicebear_forge` | VECTOR | Active local deterministic portrait example; one CC0 Lorelei style, not a general style catalog |
+| `svg_text_forge` | VECTOR | Active local deterministic printable-text leaf with one fixed profile |
 | `svg_forge` | VECTOR | Partial — group/transform/viewbox infrastructure exists |
 | `stable_forge` | IMAGE | Partial — API client and spec model exist |
 | `tts_forge` | AUDIO | Partial/stub — API clients exist, worker-backed flow deferred |
@@ -348,6 +349,14 @@ options; the exact definition content hash and package version are part of the
 backend request. Unsupported traits remain provenance, but are excluded from
 the adapted-spec fingerprint because they cannot change the rendered output.
 There is no HTTP renderer path or style-selection catalog at this layer.
+
+`PrintableTextSpec` is the corresponding generic text leaf: an ordered sequence
+of printable lines with one semantic default profile. Its adapter produces a
+fully resolved `SvgTextSpec` (fixed panel dimensions, padding, font, colors,
+and adapter version), and `SvgTextForge` emits XML-safe standalone SVG. It is
+not a text-layout system: wrapping, font measurement, rich text, and template
+rendering remain outside this contract. The semantic request and resolved SVG
+request retain the normal derivation/adapted/execution RIT provenance split.
 
 `composition_forge` is the first one-level consumer of this distinction. A
 `CompositionSpec` persists ordered `CompositionInputRef` values with each child

--- a/engine/src/tangl/media/MEDIA_DESIGN.md
+++ b/engine/src/tangl/media/MEDIA_DESIGN.md
@@ -356,10 +356,13 @@ lines. Its adapter produces a fully resolved `SvgTextSpec` with deterministic
 dimensions derived from the resolved line count, plus padding, font, colors,
 and adapter version; `SvgTextForge` emits XML-safe standalone SVG. The first
 consumer-specific `credential_card` profile deterministically wraps into a
-fixed-width, monospaced card-text layout. This remains deliberately narrower
-than a general text-layout system: font measurement, rich text, and template
-rendering remain outside the contract. The semantic request and resolved SVG
-request retain the normal derivation/adapted/execution RIT provenance split.
+fixed-width, monospaced card-text layout. Its execution layout is capped at
+the available card height with a final ellipsis, while the semantic request
+retains the complete source wording as derivation provenance. This remains
+deliberately narrower than a general text-layout system: font measurement, rich
+text, and template rendering remain outside the contract. The semantic request
+and resolved SVG request retain the normal derivation/adapted/execution RIT
+provenance split.
 
 `composition_forge` is the first one-level consumer of this distinction. A
 `CompositionSpec` persists ordered `CompositionInputRef` values with each child

--- a/engine/src/tangl/media/__init__.py
+++ b/engine/src/tangl/media/__init__.py
@@ -6,8 +6,10 @@ from .media_resource.media_resource_inv_tag import MediaPersistencePolicy, Media
 
 from .media_creators.media_spec import MediaResolutionClass, MediaSpec, on_adapt_media_spec
 from .media_creators.portrait_spec import PortraitSpec
+from .media_creators.printable_text_spec import PrintableTextSpec
 from .media_creators.dicebear_forge import DiceBearForge, DiceBearSpec
 from .media_creators.composition_forge import CompositionInputRef, CompositionSpec
+from .media_creators import svg_text_forge as _svg_text_forge  # noqa: F401
 from .dispatch import MediaTask, media_dispatch
 from .system_media import get_system_resource_manager
 from .worker_dispatcher import WorkerDispatcher, WorkerResult

--- a/engine/src/tangl/media/media_creators/media_spec.py
+++ b/engine/src/tangl/media/media_creators/media_spec.py
@@ -28,6 +28,7 @@ _SPEC_ALIAS_MAP = {
     "composition": "tangl.media.media_creators.composition_forge.composition_spec.CompositionSpec",
     "dicebear": "tangl.media.media_creators.dicebear_forge.dicebear_spec.DiceBearSpec",
     "portrait": "tangl.media.media_creators.portrait_spec.PortraitSpec",
+    "printable_text": "tangl.media.media_creators.printable_text_spec.PrintableTextSpec",
     "stable": "tangl.media.media_creators.stable_forge.stable_spec.StableSpec",
     "vector": "tangl.media.media_creators.svg_forge.vector_spec.VectorSpec",
     "tts": "tangl.media.media_creators.tts_forge.tts_spec.TtsSpec",

--- a/engine/src/tangl/media/media_creators/printable_text_spec.py
+++ b/engine/src/tangl/media/media_creators/printable_text_spec.py
@@ -1,0 +1,12 @@
+"""Renderer-neutral request for ordered printable text."""
+
+from __future__ import annotations
+
+from tangl.media.media_creators.media_spec import MediaSpec
+
+
+class PrintableTextSpec(MediaSpec):
+    """Semantic request for a fixed ordered sequence of printed text lines."""
+
+    lines: tuple[str, ...]
+    style_profile: str = "default"

--- a/engine/src/tangl/media/media_creators/printable_text_spec.py
+++ b/engine/src/tangl/media/media_creators/printable_text_spec.py
@@ -6,7 +6,26 @@ from tangl.media.media_creators.media_spec import MediaSpec
 
 
 class PrintableTextSpec(MediaSpec):
-    """Semantic request for a fixed ordered sequence of printed text lines."""
+    """Semantic request for an ordered sequence of printable text.
+
+    Why:
+        Preserve authored text and its presentation intent independently from a
+        concrete vector renderer.
+
+    Key Features:
+        Carries ordered source lines and a named style profile without making
+        layout or backend choices.
+
+    API:
+        ``adapt_spec()`` resolves this request into an ``SvgTextSpec``.
+
+    Notes:
+        The default profile preserves one source line per SVG text element;
+        other named profiles may define their own deterministic layout rules.
+
+    See also:
+        ``SvgTextSpec`` for resolved SVG instructions.
+    """
 
     lines: tuple[str, ...]
     style_profile: str = "default"

--- a/engine/src/tangl/media/media_creators/svg_text_forge/__init__.py
+++ b/engine/src/tangl/media/media_creators/svg_text_forge/__init__.py
@@ -1,0 +1,7 @@
+"""Deterministic SVG backend for printable text."""
+
+from . import svg_text_adapter as _svg_text_adapter  # noqa: F401
+from .svg_text_forge import SvgTextForge
+from .svg_text_spec import SvgTextSpec
+
+__all__ = ["SvgTextForge", "SvgTextSpec"]

--- a/engine/src/tangl/media/media_creators/svg_text_forge/svg_text_adapter.py
+++ b/engine/src/tangl/media/media_creators/svg_text_forge/svg_text_adapter.py
@@ -1,0 +1,48 @@
+"""Compile semantic printable text into fixed SVG layout instructions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tangl.core import Priority
+from tangl.media.media_creators.media_spec import on_adapt_media_spec
+from tangl.media.media_creators.printable_text_spec import PrintableTextSpec
+
+from .svg_text_spec import SvgTextSpec
+
+_DEFAULT_STYLE_PROFILE = "default"
+_CANVAS_WIDTH = 320
+_PADDING = 16
+_FONT_FAMILY = "sans-serif"
+_FONT_SIZE = 16
+_LINE_HEIGHT = 24
+_FOREGROUND = "#111111"
+_BACKGROUND = "#ffffff"
+_ADAPTER_VERSION = "1"
+
+
+@on_adapt_media_spec.register(priority=Priority.NORMAL)
+def adapt_printable_text_spec(
+    spec: PrintableTextSpec,
+    ctx: dict[str, Any] | None = None,
+) -> SvgTextSpec:
+    """Resolve the single supported printable-text profile into fixed SVG layout."""
+    _ = ctx
+    if spec.style_profile != _DEFAULT_STYLE_PROFILE:
+        raise ValueError(f"Unsupported printable text style profile {spec.style_profile!r}")
+    return SvgTextSpec(
+        label=spec.label,
+        lines=spec.lines,
+        canvas_width=_CANVAS_WIDTH,
+        canvas_height=_PADDING * 2 + _LINE_HEIGHT * max(1, len(spec.lines)),
+        padding=_PADDING,
+        font_family=_FONT_FAMILY,
+        font_size=_FONT_SIZE,
+        line_height=_LINE_HEIGHT,
+        foreground=_FOREGROUND,
+        background=_BACKGROUND,
+        adapter_version=_ADAPTER_VERSION,
+    )
+
+
+adapt_printable_text_spec._behavior.wants_caller_kind = PrintableTextSpec

--- a/engine/src/tangl/media/media_creators/svg_text_forge/svg_text_adapter.py
+++ b/engine/src/tangl/media/media_creators/svg_text_forge/svg_text_adapter.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from textwrap import TextWrapper
-from typing import Any
 
 from tangl.core import Priority
 from tangl.media.media_creators.media_spec import on_adapt_media_spec
 from tangl.media.media_creators.printable_text_spec import PrintableTextSpec
+from tangl.type_hints import StringMap
 
 from .svg_text_spec import SvgTextSpec
 
@@ -25,6 +25,7 @@ _CREDENTIAL_CARD_FONT_FAMILY = "monospace"
 _CREDENTIAL_CARD_FONT_SIZE = 14
 _CREDENTIAL_CARD_LINE_HEIGHT = 20
 _CREDENTIAL_CARD_LINE_WIDTH = 34
+_CREDENTIAL_CARD_MAX_LINES = 7
 
 
 def _credential_card_lines(lines: tuple[str, ...]) -> tuple[str, ...]:
@@ -34,17 +35,20 @@ def _credential_card_lines(lines: tuple[str, ...]) -> tuple[str, ...]:
         break_long_words=True,
         break_on_hyphens=False,
     )
-    return tuple(
+    wrapped_lines = tuple(
         wrapped
         for line in lines
         for wrapped in (wrapper.wrap(line) or [""])
     )
+    if len(wrapped_lines) <= _CREDENTIAL_CARD_MAX_LINES:
+        return wrapped_lines
+    return (*wrapped_lines[: _CREDENTIAL_CARD_MAX_LINES - 1], "…")
 
 
 @on_adapt_media_spec.register(priority=Priority.NORMAL)
 def adapt_printable_text_spec(
     spec: PrintableTextSpec,
-    ctx: dict[str, Any] | None = None,
+    ctx: StringMap | None = None,
 ) -> SvgTextSpec:
     """Resolve a named printable-text profile into deterministic SVG layout."""
     _ = ctx

--- a/engine/src/tangl/media/media_creators/svg_text_forge/svg_text_adapter.py
+++ b/engine/src/tangl/media/media_creators/svg_text_forge/svg_text_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from textwrap import TextWrapper
 from typing import Any
 
 from tangl.core import Priority
@@ -11,6 +12,7 @@ from tangl.media.media_creators.printable_text_spec import PrintableTextSpec
 from .svg_text_spec import SvgTextSpec
 
 _DEFAULT_STYLE_PROFILE = "default"
+_CREDENTIAL_CARD_STYLE_PROFILE = "credential_card"
 _CANVAS_WIDTH = 320
 _PADDING = 16
 _FONT_FAMILY = "sans-serif"
@@ -19,6 +21,24 @@ _LINE_HEIGHT = 24
 _FOREGROUND = "#111111"
 _BACKGROUND = "#ffffff"
 _ADAPTER_VERSION = "1"
+_CREDENTIAL_CARD_FONT_FAMILY = "monospace"
+_CREDENTIAL_CARD_FONT_SIZE = 14
+_CREDENTIAL_CARD_LINE_HEIGHT = 20
+_CREDENTIAL_CARD_LINE_WIDTH = 34
+
+
+def _credential_card_lines(lines: tuple[str, ...]) -> tuple[str, ...]:
+    """Wrap source lines to the fixed-width credential-card text contract."""
+    wrapper = TextWrapper(
+        width=_CREDENTIAL_CARD_LINE_WIDTH,
+        break_long_words=True,
+        break_on_hyphens=False,
+    )
+    return tuple(
+        wrapped
+        for line in lines
+        for wrapped in (wrapper.wrap(line) or [""])
+    )
 
 
 @on_adapt_media_spec.register(priority=Priority.NORMAL)
@@ -26,19 +46,30 @@ def adapt_printable_text_spec(
     spec: PrintableTextSpec,
     ctx: dict[str, Any] | None = None,
 ) -> SvgTextSpec:
-    """Resolve the single supported printable-text profile into fixed SVG layout."""
+    """Resolve a named printable-text profile into deterministic SVG layout."""
     _ = ctx
-    if spec.style_profile != _DEFAULT_STYLE_PROFILE:
+    if spec.style_profile == _DEFAULT_STYLE_PROFILE:
+        lines = spec.lines
+        font_family = _FONT_FAMILY
+        font_size = _FONT_SIZE
+        line_height = _LINE_HEIGHT
+    elif spec.style_profile == _CREDENTIAL_CARD_STYLE_PROFILE:
+        lines = _credential_card_lines(spec.lines)
+        font_family = _CREDENTIAL_CARD_FONT_FAMILY
+        font_size = _CREDENTIAL_CARD_FONT_SIZE
+        line_height = _CREDENTIAL_CARD_LINE_HEIGHT
+    else:
         raise ValueError(f"Unsupported printable text style profile {spec.style_profile!r}")
     return SvgTextSpec(
         label=spec.label,
-        lines=spec.lines,
+        lines=lines,
+        style_profile=spec.style_profile,
         canvas_width=_CANVAS_WIDTH,
-        canvas_height=_PADDING * 2 + _LINE_HEIGHT * max(1, len(spec.lines)),
+        canvas_height=_PADDING * 2 + line_height * max(1, len(lines)),
         padding=_PADDING,
-        font_family=_FONT_FAMILY,
-        font_size=_FONT_SIZE,
-        line_height=_LINE_HEIGHT,
+        font_family=font_family,
+        font_size=font_size,
+        line_height=line_height,
         foreground=_FOREGROUND,
         background=_BACKGROUND,
         adapter_version=_ADAPTER_VERSION,

--- a/engine/src/tangl/media/media_creators/svg_text_forge/svg_text_forge.py
+++ b/engine/src/tangl/media/media_creators/svg_text_forge/svg_text_forge.py
@@ -1,0 +1,50 @@
+"""Deterministic local SVG creation for fixed printable text."""
+
+from __future__ import annotations
+
+from lxml import etree
+
+from .svg_text_spec import SvgTextSpec
+
+
+class SvgTextForge:
+    """Render resolved printable text layout into a standalone SVG document."""
+
+    def create_media(self, spec: SvgTextSpec) -> tuple[str, SvgTextSpec]:
+        """Return XML-safe SVG text and the realized backend spec."""
+        root = etree.Element(
+            "{http://www.w3.org/2000/svg}svg",
+            nsmap={None: "http://www.w3.org/2000/svg"},
+            width=str(spec.canvas_width),
+            height=str(spec.canvas_height),
+            viewBox=f"0 0 {spec.canvas_width} {spec.canvas_height}",
+        )
+        etree.SubElement(
+            root,
+            "{http://www.w3.org/2000/svg}rect",
+            x="0",
+            y="0",
+            width=str(spec.canvas_width),
+            height=str(spec.canvas_height),
+            fill=spec.background,
+        )
+        for index, line in enumerate(spec.lines):
+            text = etree.SubElement(
+                root,
+                "{http://www.w3.org/2000/svg}text",
+                x=str(spec.padding),
+                y=str(spec.padding + spec.font_size + index * spec.line_height),
+                fill=spec.foreground,
+                **{
+                    "font-family": spec.font_family,
+                    "font-size": str(spec.font_size),
+                    "{http://www.w3.org/XML/1998/namespace}space": "preserve",
+                },
+            )
+            text.text = line
+        return etree.tostring(root, encoding="unicode"), spec.model_copy(
+            update={
+                "renderer_name": "svg-text-forge",
+                "renderer_version": spec.adapter_version,
+            }
+        )

--- a/engine/src/tangl/media/media_creators/svg_text_forge/svg_text_forge.py
+++ b/engine/src/tangl/media/media_creators/svg_text_forge/svg_text_forge.py
@@ -8,7 +8,26 @@ from .svg_text_spec import SvgTextSpec
 
 
 class SvgTextForge:
-    """Render resolved printable text layout into a standalone SVG document."""
+    """Render resolved printable-text layout into standalone SVG.
+
+    Why:
+        Provide a deterministic local vector backend without a remote text
+        rendering service.
+
+    Key Features:
+        Emits namespace-qualified SVG with XML-safe, whitespace-preserving text
+        nodes from resolved layout instructions.
+
+    API:
+        ``create_media()`` returns SVG data and the realized ``SvgTextSpec``.
+
+    Notes:
+        The forge performs no wrapping or measurement; those decisions belong
+        to the profile adapter that produced the spec.
+
+    See also:
+        ``SvgTextSpec`` for the resolved input contract.
+    """
 
     def create_media(self, spec: SvgTextSpec) -> tuple[str, SvgTextSpec]:
         """Return XML-safe SVG text and the realized backend spec."""

--- a/engine/src/tangl/media/media_creators/svg_text_forge/svg_text_spec.py
+++ b/engine/src/tangl/media/media_creators/svg_text_forge/svg_text_spec.py
@@ -1,0 +1,37 @@
+"""Concrete SVG layout for one printable-text request."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tangl.media.media_creators.media_spec import MediaResolutionClass, MediaSpec
+from tangl.media.media_data_type import MediaDataType
+
+if TYPE_CHECKING:
+    from .svg_text_forge import SvgTextForge
+
+
+class SvgTextSpec(MediaSpec):
+    """Resolved fixed-layout SVG instructions for ordered text lines."""
+
+    resolution_class: MediaResolutionClass = MediaResolutionClass.FAST_SYNC
+    data_type: MediaDataType = MediaDataType.VECTOR
+
+    lines: tuple[str, ...]
+    canvas_width: int
+    canvas_height: int
+    padding: int
+    font_family: str
+    font_size: int
+    line_height: int
+    foreground: str
+    background: str
+    adapter_version: str = "1"
+    renderer_name: str | None = None
+    renderer_version: str | None = None
+
+    @classmethod
+    def get_creation_service(cls) -> SvgTextForge:
+        from .svg_text_forge import SvgTextForge
+
+        return SvgTextForge()

--- a/engine/src/tangl/media/media_creators/svg_text_forge/svg_text_spec.py
+++ b/engine/src/tangl/media/media_creators/svg_text_forge/svg_text_spec.py
@@ -12,12 +12,32 @@ if TYPE_CHECKING:
 
 
 class SvgTextSpec(MediaSpec):
-    """Resolved fixed-layout SVG instructions for ordered text lines."""
+    """Resolved SVG layout instructions for printable text.
+
+    Why:
+        Make a printable-text request's concrete dimensions, typography, and
+        ordered rendered lines explicit before SVG creation.
+
+    Key Features:
+        Captures deterministic canvas geometry and the selected profile's
+        resolved lines, including wrapped credential-card text.
+
+    API:
+        ``get_creation_service()`` supplies ``SvgTextForge`` for local SVG
+        materialization.
+
+    Notes:
+        This is backend-specific execution input, not an authored text model.
+
+    See also:
+        ``PrintableTextSpec`` for the semantic request contract.
+    """
 
     resolution_class: MediaResolutionClass = MediaResolutionClass.FAST_SYNC
     data_type: MediaDataType = MediaDataType.VECTOR
 
     lines: tuple[str, ...]
+    style_profile: str
     canvas_width: int
     canvas_height: int
     padding: int

--- a/engine/tests/mechanics/credentials/test_credential_card_media.py
+++ b/engine/tests/mechanics/credentials/test_credential_card_media.py
@@ -1,0 +1,270 @@
+"""One presentation-safe credential card through ordinary media provisioning."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+from lxml import etree
+import pytest
+
+from tangl.core import TokenCatalog
+from tangl.media import MediaDataType
+from tangl.media.media_creators.composition_forge.composition_spec import CompositionSpec
+from tangl.media.media_resource import MediaDep, MediaResourceInventoryTag as MediaRIT
+from tangl.media.media_resource.media_provisioning import MediaSpecProvisioner
+from tangl.mechanics.credentials import (
+    CredentialDefinition,
+    CredentialStatus,
+    CredentialToken,
+    Indication,
+    Region,
+    credential_card_composition_spec,
+    credential_card_portrait_spec,
+    credential_card_text_spec,
+    materialize_packet,
+)
+from tangl.mechanics.games import CredentialsGame, CredentialsGameHandler, HasGame
+from tangl.mechanics.games.credentials_game import CredentialCase
+from tangl.mechanics.presence.look import HairColor, Look
+from tangl.story import Block
+from tangl.story.fabula import World
+
+
+@pytest.fixture(autouse=True)
+def clear_credential_definitions():
+    CredentialDefinition.clear_instances()
+    yield
+    CredentialDefinition.clear_instances()
+
+
+class _CredentialsBlock(HasGame, Block):
+    _game_class = CredentialsGame
+    _game_handler_class = CredentialsGameHandler
+
+
+def _story_media_root(tmp_path: Path):
+    root = tmp_path / "story_media"
+
+    def _resolve(story_id=None):
+        return root if story_id is None else root / str(story_id)
+
+    return _resolve
+
+
+def _case(*, status: CredentialStatus = CredentialStatus.VALID) -> CredentialCase:
+    definition = CredentialDefinition(
+        label="card-id",
+        name="Border Pass",
+        indication=Indication.TRAVEL,
+        document_kind="id",
+        issuer_group="border_control",
+        valid_period=0,
+    )
+    return CredentialCase(
+        candidate_name="Ada Venn",
+        presented_documents={"passport": "An identity document."},
+        packet_manager=materialize_packet(
+            owner=object(),
+            region=Region.LOCAL,
+            purpose=Indication.TRAVEL,
+            id_card=CredentialToken(indication=Indication.TRAVEL, status=status),
+            credentials=[],
+            possessions=[],
+            label_prefix="Ada Venn",
+            catalog=TokenCatalog(wst=CredentialDefinition, label="card", members=(definition,)),
+        ),
+    )
+
+
+def _live_card_case(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    status: CredentialStatus = CredentialStatus.VALID,
+):
+    monkeypatch.setattr(
+        "tangl.media.story_media.get_story_media_dir",
+        _story_media_root(tmp_path),
+    )
+    world = World.from_script_data(
+        script_data={
+            "label": "credential-card-world",
+            "scenes": {"intro": {"blocks": {"start": {"content": "Checkpoint"}}}},
+        }
+    )
+    story = world.create_story("credential-card-story").graph
+    block = story.add_node(
+        kind=_CredentialsBlock,
+        label="checkpoint",
+        game_state=CredentialsGame(roster=[_case(status=status)]),
+    )
+    handler = block.game_handler
+    handler.setup(block.game)
+    projection = handler.credential_card_projections(block.game)[0]
+    return story, block, block.game.active_case.packet_manager, projection
+
+
+def _context(story, block):
+    return SimpleNamespace(
+        graph=story,
+        cursor=block,
+        cursor_id=block.uid,
+        get_ns=lambda _parent: {},
+    )
+
+
+def _provision(story, block, spec):
+    dependency = MediaDep(registry=story, predecessor_id=block.uid, media_spec=spec)
+    story.add(dependency)
+    offers = list(
+        MediaSpecProvisioner(graph=story).get_dependency_offers(
+            dependency.requirement,
+            _ctx=_context(story, block),
+        )
+    )
+    assert len(offers) == 1
+    rit = offers[0].callback(_ctx=_context(story, block))
+    story.add(rit)
+    return rit
+
+
+def test_card_specs_use_document_subject_and_safe_ordered_text(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    story, block, packet, projection = _live_card_case(
+        monkeypatch,
+        tmp_path,
+        status=CredentialStatus.WRONG_HOLDER,
+    )
+    bearer = packet.resolve_subject(packet.bearer_id)
+    subject = packet.resolve_subject(projection.subject_id)
+    bearer.look = Look(hair_color=HairColor.RED)
+    subject.look = Look(hair_color=HairColor.DARK)
+
+    portrait = credential_card_portrait_spec(projection, subject)
+    text = credential_card_text_spec(projection)
+
+    assert story.get(block.uid) is block
+    assert projection.subject_id != packet.bearer_id
+    assert portrait.identity_key == str(projection.subject_id)
+    assert portrait.media_role == "id_photo"
+    assert portrait.traits != bearer.adapt_look_media_spec().traits
+    assert text.lines == (
+        projection.document_label,
+        projection.bearer_label,
+        *(part.content for part in projection.visible_parts),
+    )
+    payload = json.dumps(
+        {"portrait": portrait.normalized_spec_payload(), "text": text.normalized_spec_payload()},
+        default=str,
+    )
+    assert CredentialStatus.WRONG_HOLDER.value not in payload
+    assert "DiceBear" not in Path(__file__).parents[3].joinpath(
+        "src/tangl/mechanics/credentials/card_media.py"
+    ).read_text()
+
+
+def test_card_composition_provisions_and_reuses_children_and_parent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    story, block, packet, projection = _live_card_case(monkeypatch, tmp_path)
+    subject = packet.resolve_subject(projection.subject_id)
+    portrait_spec = credential_card_portrait_spec(projection, subject)
+    text_spec = credential_card_text_spec(projection)
+    portrait_rit = _provision(story, block, portrait_spec)
+    text_rit = _provision(story, block, text_spec)
+    composition = credential_card_composition_spec(
+        projection,
+        portrait_rit=portrait_rit,
+        text_rit=text_rit,
+    )
+    card_rit = _provision(story, block, composition)
+    reused = _provision(
+        story,
+        block,
+        credential_card_composition_spec(
+            projection,
+            portrait_rit=portrait_rit,
+            text_rit=text_rit,
+        ),
+    )
+
+    assert card_rit.uid == reused.uid
+    assert card_rit.status.value == "resolved"
+    assert card_rit.data_type is MediaDataType.VECTOR
+    assert card_rit.path is not None
+    root = etree.fromstring(card_rit.path.read_bytes())
+    lines = root.xpath(".//svg:text", namespaces={"svg": "http://www.w3.org/2000/svg"})
+    assert [line.text for line in lines] == list(text_spec.lines)
+    assert [item.role for item in composition.inputs] == ["portrait", "printable_text"]
+    assert [item.offset for item in composition.inputs] == [(16, 32), (176, 16)]
+    assert composition.canvas_size == (512, 192)
+    assert composition.background == "white"
+    assert composition.treatment == "credential_id_card"
+    assert card_rit.derivation_spec == composition.normalized_spec_payload()
+    assert card_rit.adapted_spec is not None
+    assert card_rit.execution_spec is not None
+
+
+def test_card_identity_uses_visible_children_not_component_or_rit_ids(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _, _, packet, projection = _live_card_case(monkeypatch, tmp_path)
+    subject = packet.resolve_subject(projection.subject_id)
+    portrait = credential_card_portrait_spec(projection, subject)
+    text = credential_card_text_spec(projection)
+    equivalent_projection = projection.model_copy(update={"component_id": uuid4()})
+    first_portrait = MediaRIT(label="portrait-one", data="<svg/>", data_type=MediaDataType.VECTOR)
+    first_text = MediaRIT(label="text-one", data="<svg>text</svg>", data_type=MediaDataType.VECTOR)
+    second_portrait = MediaRIT(label="portrait-two", data="<svg/>", data_type=MediaDataType.VECTOR)
+    second_text = MediaRIT(label="text-two", data="<svg>text</svg>", data_type=MediaDataType.VECTOR)
+    first = credential_card_composition_spec(
+        projection,
+        portrait_rit=first_portrait,
+        text_rit=first_text,
+    )
+    equivalent = credential_card_composition_spec(
+        equivalent_projection,
+        portrait_rit=second_portrait,
+        text_rit=second_text,
+    )
+    changed = credential_card_text_spec(
+        projection.model_copy(update={"document_label": "student ID"})
+    )
+    changed_text_rit = MediaRIT(
+        label="text-changed",
+        data="<svg>student ID</svg>",
+        data_type=MediaDataType.VECTOR,
+    )
+    changed_parent = credential_card_composition_spec(
+        projection.model_copy(update={"document_label": "student ID"}),
+        portrait_rit=first_portrait,
+        text_rit=changed_text_rit,
+    )
+
+    assert portrait.spec_fingerprint() == credential_card_portrait_spec(
+        equivalent_projection,
+        subject,
+    ).spec_fingerprint()
+    assert text.spec_fingerprint() == credential_card_text_spec(equivalent_projection).spec_fingerprint()
+    assert first.spec_fingerprint() == equivalent.spec_fingerprint()
+    assert text.spec_fingerprint() != changed.spec_fingerprint()
+    assert first.spec_fingerprint() != changed_parent.spec_fingerprint()
+    assert first.normalized_spec_payload()["inputs"][0]["rit_id"] == first_portrait.uid
+
+
+def test_complete_replacement_has_no_card_media_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    story, block, _, _ = _live_card_case(monkeypatch, tmp_path)
+    block.game.active_case.presented_documents = {"passport": "An authored replacement."}
+
+    assert block.game_handler.credential_card_projections(block.game) == []
+    assert story.get(block.uid) is block

--- a/engine/tests/mechanics/credentials/test_credential_card_media.py
+++ b/engine/tests/mechanics/credentials/test_credential_card_media.py
@@ -14,6 +14,8 @@ from tangl.core import TokenCatalog
 from tangl.media import MediaDataType
 from tangl.media.media_resource import MediaDep, MediaResourceInventoryTag as MediaRIT
 from tangl.media.media_resource.media_provisioning import MediaSpecProvisioner
+from tangl.media.media_resource.media_resource_inv_tag import MediaRITStatus
+from tangl.media.media_creators.svg_text_forge import SvgTextSpec
 from tangl.mechanics.credentials import (
     CredentialDefinition,
     CredentialStatus,
@@ -207,7 +209,10 @@ def test_card_composition_provisions_and_reuses_children_and_parent(
     assert card_rit.path is not None
     root = etree.fromstring(card_rit.path.read_bytes())
     lines = root.xpath(".//svg:text", namespaces={"svg": "http://www.w3.org/2000/svg"})
-    assert [line.text for line in lines] == list(text_spec.lines)
+    adapted_text = text_spec.adapt_spec(ctx={})
+    assert isinstance(adapted_text, SvgTextSpec)
+    assert [line.text for line in lines] == list(adapted_text.lines)
+    assert adapted_text.canvas_height <= 176
     assert [item.role for item in composition.inputs] == ["portrait", "printable_text"]
     assert [item.offset for item in composition.inputs] == [(16, 32), (176, 16)]
     assert composition.canvas_size == (512, 192)
@@ -216,6 +221,22 @@ def test_card_composition_provisions_and_reuses_children_and_parent(
     assert card_rit.derivation_spec == composition.normalized_spec_payload()
     assert card_rit.adapted_spec is not None
     assert card_rit.execution_spec is not None
+
+
+def test_card_composition_requires_resolved_child_content(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _, _, _, projection = _live_card_case(monkeypatch, tmp_path)
+    pending = MediaRIT(
+        label="pending-portrait",
+        status=MediaRITStatus.PENDING,
+        data_type=MediaDataType.VECTOR,
+    )
+    text = MediaRIT(label="text", data="<svg/>", data_type=MediaDataType.VECTOR)
+
+    with pytest.raises(ValueError, match="requires resolved child content"):
+        credential_card_composition_spec(portrait_rit=pending, text_rit=text)
 
 
 def test_card_identity_uses_visible_children_not_component_or_rit_ids(

--- a/engine/tests/mechanics/credentials/test_credential_card_media.py
+++ b/engine/tests/mechanics/credentials/test_credential_card_media.py
@@ -227,7 +227,7 @@ def test_card_composition_requires_resolved_child_content(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    _, _, _, projection = _live_card_case(monkeypatch, tmp_path)
+    _live_card_case(monkeypatch, tmp_path)
     pending = MediaRIT(
         label="pending-portrait",
         status=MediaRITStatus.PENDING,

--- a/engine/tests/mechanics/credentials/test_credential_card_media.py
+++ b/engine/tests/mechanics/credentials/test_credential_card_media.py
@@ -12,7 +12,6 @@ import pytest
 
 from tangl.core import TokenCatalog
 from tangl.media import MediaDataType
-from tangl.media.media_creators.composition_forge.composition_spec import CompositionSpec
 from tangl.media.media_resource import MediaDep, MediaResourceInventoryTag as MediaRIT
 from tangl.media.media_resource.media_provisioning import MediaSpecProvisioner
 from tangl.mechanics.credentials import (
@@ -74,7 +73,11 @@ def _case(*, status: CredentialStatus = CredentialStatus.VALID) -> CredentialCas
             credentials=[],
             possessions=[],
             label_prefix="Ada Venn",
-            catalog=TokenCatalog(wst=CredentialDefinition, label="card", members=(definition,)),
+            catalog=TokenCatalog(
+                wst=CredentialDefinition,
+                label="card",
+                members=(definition,),
+            ),
         ),
     )
 
@@ -166,6 +169,8 @@ def test_card_specs_use_document_subject_and_safe_ordered_text(
     assert "DiceBear" not in Path(__file__).parents[3].joinpath(
         "src/tangl/mechanics/credentials/card_media.py"
     ).read_text()
+    with pytest.raises(ValueError, match="does not match projection"):
+        credential_card_portrait_spec(projection, bearer)
 
 
 def test_card_composition_provisions_and_reuses_children_and_parent(
@@ -178,8 +183,9 @@ def test_card_composition_provisions_and_reuses_children_and_parent(
     text_spec = credential_card_text_spec(projection)
     portrait_rit = _provision(story, block, portrait_spec)
     text_rit = _provision(story, block, text_spec)
+    reused_portrait = _provision(story, block, portrait_spec)
+    reused_text = _provision(story, block, text_spec)
     composition = credential_card_composition_spec(
-        projection,
         portrait_rit=portrait_rit,
         text_rit=text_rit,
     )
@@ -188,12 +194,13 @@ def test_card_composition_provisions_and_reuses_children_and_parent(
         story,
         block,
         credential_card_composition_spec(
-            projection,
             portrait_rit=portrait_rit,
             text_rit=text_rit,
         ),
     )
 
+    assert portrait_rit.uid == reused_portrait.uid
+    assert text_rit.uid == reused_text.uid
     assert card_rit.uid == reused.uid
     assert card_rit.status.value == "resolved"
     assert card_rit.data_type is MediaDataType.VECTOR
@@ -225,12 +232,10 @@ def test_card_identity_uses_visible_children_not_component_or_rit_ids(
     second_portrait = MediaRIT(label="portrait-two", data="<svg/>", data_type=MediaDataType.VECTOR)
     second_text = MediaRIT(label="text-two", data="<svg>text</svg>", data_type=MediaDataType.VECTOR)
     first = credential_card_composition_spec(
-        projection,
         portrait_rit=first_portrait,
         text_rit=first_text,
     )
     equivalent = credential_card_composition_spec(
-        equivalent_projection,
         portrait_rit=second_portrait,
         text_rit=second_text,
     )
@@ -243,7 +248,6 @@ def test_card_identity_uses_visible_children_not_component_or_rit_ids(
         data_type=MediaDataType.VECTOR,
     )
     changed_parent = credential_card_composition_spec(
-        projection.model_copy(update={"document_label": "student ID"}),
         portrait_rit=first_portrait,
         text_rit=changed_text_rit,
     )

--- a/engine/tests/media/test_printable_text_media.py
+++ b/engine/tests/media/test_printable_text_media.py
@@ -55,6 +55,7 @@ def test_printable_text_adapts_to_concrete_svg_layout() -> None:
 
     assert isinstance(adapted, SvgTextSpec)
     assert adapted.lines == request.lines
+    assert adapted.style_profile == "default"
     assert adapted.canvas_width == 320
     assert adapted.canvas_height == 80
     assert adapted.font_family == "sans-serif"
@@ -92,6 +93,28 @@ def test_printable_text_identity_includes_order_and_resolved_layout() -> None:
     assert adapted.spec_fingerprint() != adapted.model_copy(
         update={"font_size": adapted.font_size + 1}
     ).spec_fingerprint()
+
+
+def test_credential_card_profile_wraps_into_its_resolved_layout() -> None:
+    request = PrintableTextSpec(
+        style_profile="credential_card",
+        lines=(
+            "passport",
+            "Ada Venn",
+            "A round blue border control seal is impressed beside the bearer line.",
+            "The validity line reads “Valid through the current entry period.”",
+        ),
+    )
+
+    adapted = request.adapt_spec(ctx={})
+
+    assert isinstance(adapted, SvgTextSpec)
+    assert adapted.style_profile == "credential_card"
+    assert adapted.canvas_width == 320
+    assert adapted.font_family == "monospace"
+    assert all(len(line) <= 34 for line in adapted.lines)
+    assert adapted.canvas_height == 32 + 20 * len(adapted.lines)
+    assert adapted.canvas_height <= 176
 
 
 def test_printable_text_provisions_and_reuses_story_svg(

--- a/engine/tests/media/test_printable_text_media.py
+++ b/engine/tests/media/test_printable_text_media.py
@@ -1,0 +1,137 @@
+"""Generic printable text through the deterministic SVG media lifecycle."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lxml import etree
+import pytest
+
+from tangl.core import Graph
+from tangl.media import MediaDataType, PrintableTextSpec
+from tangl.media.media_creators.svg_text_forge import SvgTextSpec
+from tangl.media.media_resource import MediaDep, MediaResourceInventoryTag as MediaRIT
+from tangl.story.fabula import World
+
+
+def _story_media_root(tmp_path: Path):
+    root = tmp_path / "story_media"
+
+    def _resolve(story_id=None):
+        return root if story_id is None else root / str(story_id)
+
+    return _resolve
+
+
+def _story(*requests: PrintableTextSpec) -> dict[str, object]:
+    return {
+        "label": "printable_text_world",
+        "scenes": {
+            "intro": {
+                "blocks": {
+                    "start": {
+                        "content": "Generated text",
+                        "media": [
+                            {
+                                "spec": {
+                                    "kind": "printable_text",
+                                    **request.normalized_spec_payload(),
+                                },
+                                "media_role": "narrative_im",
+                            }
+                            for request in requests
+                        ],
+                    }
+                }
+            }
+        },
+    }
+
+
+def test_printable_text_adapts_to_concrete_svg_layout() -> None:
+    request = PrintableTextSpec(lines=("NAME: Ada", "CLASS: visitor"))
+
+    adapted = request.adapt_spec(ctx={})
+
+    assert isinstance(adapted, SvgTextSpec)
+    assert adapted.lines == request.lines
+    assert adapted.canvas_width == 320
+    assert adapted.canvas_height == 80
+    assert adapted.font_family == "sans-serif"
+    assert adapted.line_height == 24
+    assert adapted.adapter_version == "1"
+
+
+def test_svg_text_uses_literal_xml_safe_ordered_lines() -> None:
+    request = PrintableTextSpec(lines=(" first ", "<&> \"quoted\""))
+
+    svg, realized = request.create_media(ctx={})
+    root = etree.fromstring(svg.encode("utf-8"))
+    lines = root.xpath("./svg:text", namespaces={"svg": "http://www.w3.org/2000/svg"})
+
+    assert [line.text for line in lines] == [" first ", "<&> \"quoted\""]
+    assert all(
+        line.get("{http://www.w3.org/XML/1998/namespace}space") == "preserve"
+        for line in lines
+    )
+    assert realized.renderer_name == "svg-text-forge"
+    assert "&lt;&amp;&gt;" in svg
+
+
+def test_printable_text_identity_includes_order_and_resolved_layout() -> None:
+    request = PrintableTextSpec(lines=("one", "two"))
+    equivalent = PrintableTextSpec(lines=("one", "two"))
+    changed_text = PrintableTextSpec(lines=("one", "three"))
+    changed_order = PrintableTextSpec(lines=("two", "one"))
+    adapted = request.adapt_spec(ctx={})
+    assert isinstance(adapted, SvgTextSpec)
+
+    assert adapted.spec_fingerprint() == equivalent.adapt_spec(ctx={}).spec_fingerprint()
+    assert adapted.spec_fingerprint() != changed_text.adapt_spec(ctx={}).spec_fingerprint()
+    assert adapted.spec_fingerprint() != changed_order.adapt_spec(ctx={}).spec_fingerprint()
+    assert adapted.spec_fingerprint() != adapted.model_copy(
+        update={"font_size": adapted.font_size + 1}
+    ).spec_fingerprint()
+
+
+def test_printable_text_provisions_and_reuses_story_svg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        "tangl.media.story_media.get_story_media_dir",
+        _story_media_root(tmp_path),
+    )
+    request = PrintableTextSpec(label="badge_text", lines=("ADA VENN", "VISITOR"))
+    world = World.from_script_data(script_data=_story(request, request.model_copy(deep=True)))
+    story = world.create_story("printable-text-story").graph
+    block = next(node for node in story.values() if getattr(node, "label", None) == "start")
+    deps = [edge for edge in block.edges_out() if isinstance(edge, MediaDep)]
+
+    assert len(deps) == 2
+    assert deps[0].provider is not None
+    assert deps[0].provider.uid == deps[1].provider.uid
+    provider = deps[0].provider
+    assert isinstance(provider, MediaRIT)
+    assert provider.status.value == "resolved"
+    assert provider.data_type is MediaDataType.VECTOR
+    assert provider.path is not None
+    assert etree.fromstring(provider.path.read_bytes()).tag.endswith("svg")
+    assert provider.derivation_spec == request.normalized_spec_payload()
+    assert provider.adapted_spec is not None
+    assert provider.adapted_spec["canvas_width"] == 320
+    assert provider.execution_spec is not None
+    assert provider.execution_spec["renderer_name"] == "svg-text-forge"
+
+
+def test_graph_constructor_round_trip_restores_typed_printable_text_spec() -> None:
+    graph = Graph(label="printable-text")
+    request = PrintableTextSpec(lines=("Ada",))
+    dep = MediaDep(registry=graph, media_spec=request)
+    graph.add(dep)
+
+    restored = Graph.structure(graph.unstructure())
+    restored_dep = next(value for value in restored.values() if isinstance(value, MediaDep))
+
+    assert isinstance(restored_dep.requirement.media_spec, PrintableTextSpec)
+    assert restored_dep.requirement.media_spec.lines == ("Ada",)

--- a/engine/tests/media/test_printable_text_media.py
+++ b/engine/tests/media/test_printable_text_media.py
@@ -117,6 +117,19 @@ def test_credential_card_profile_wraps_into_its_resolved_layout() -> None:
     assert adapted.canvas_height <= 176
 
 
+def test_credential_card_profile_caps_overflow_without_losing_source_text() -> None:
+    source = "An unusually long credential observation requires more than seven lines. " * 8
+    request = PrintableTextSpec(style_profile="credential_card", lines=(source,))
+
+    adapted = request.adapt_spec(ctx={})
+
+    assert isinstance(adapted, SvgTextSpec)
+    assert len(adapted.lines) == 7
+    assert adapted.lines[-1] == "…"
+    assert adapted.canvas_height <= 176
+    assert request.lines == (source,)
+
+
 def test_printable_text_provisions_and_reuses_story_svg(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary

- add a generic printable-text SVG leaf and its deterministic adapter/forge
- compose one presentation-safe credential ID card from document-subject portrait and safe printed observations
- prove ordinary child and parent provisioning, reuse, provenance, and subject binding without JOURNAL integration

## Validation

- poetry run pytest engine/tests/mechanics/credentials/test_credential_card_projection.py engine/tests/mechanics/credentials/test_credential_card_media.py engine/tests/media/test_printable_text_media.py engine/tests/media/test_dicebear_portraits.py engine/tests/media/test_svg_composition.py -q
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added presentation-safe credential cards combining subject portraits with printable credential text.
  - Added deterministic SVG rendering for ordered, XML-safe printable text.
  - Added reusable portrait, text, and composition support for credential cards.
  - Added fixed-width formatting for consistent card presentation.

- **Bug Fixes**
  - Prevented mismatched identities from producing credential media.
  - Excluded sensitive status values and fallback renderer details.
  - Ensured authored document replacements suppress generated credential-card media.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->