### PR TITLE
Provision credential cards through the game lifecycle

### DIFF
--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
@@ -26,8 +26,9 @@ attestation-plus-validity prose and ``visible_parts`` without evaluating a
 credential from presentation output. This text/JOURNAL/interactive floor is
 sufficient to discuss a separate media-compositor integration plan; credentials
 will not create placeholder cards or a private forge. Media Slices A–C landed
-through PR #326, and D1 adds the presentation-safe ``CredentialCardProjection``
-for canonical ID documents without provisioning or emitting media.
+through PR #326, D1–D3 landed the presentation-safe
+``CredentialCardProjection`` and its one-level card-media requests, and Slice E
+adds lifecycle-safe provisioning plus JOURNAL association for eligible ID cards.
 **Scope:** the *global* credential mechanic — `Credential → Document → Media`,
 with carrier/bearer binding — that the credentials checkpoint **game**
 (`tangl.mechanics.games.credentials_game`) becomes one consumer of.
@@ -366,12 +367,15 @@ subject portrait and printable text, then compose their resolved RITs into one
 presentation-safe ID card. Its media-owned ``credential_card`` text profile
 wraps the safe observation wording into the fixed card-text layout and elides
 only overflowing execution lines; the complete projection remains in the
-derivation payload. That card is not yet emitted into JOURNAL. Slice E remains
-responsible for lifecycle timing, ``PieceFragment`` association, text fallback,
-authored alternatives/replacements, and media selection. Credentials must
-consume the resulting ``MediaSpec → MediaSpecProvisioner → MediaRIT →
-MediaFragment`` path; it must not invent a packet sheet, recursive DAG,
-credential forge, catalog abstraction, or parallel JOURNAL media channel.
+derivation payload. Slice E provisions its portrait and printable-text children
+before the one-level parent, keeps the text ``PieceFragment`` unconditional,
+and emits an ordinary associated ``MediaFragment`` only when the complete card
+is resolved. Complete authored replacements suppress that generated card.
+Authored alternatives/replacements and world-scoped media selection remain the
+next slice. Credentials must consume the resulting ``MediaSpec →
+MediaSpecProvisioner → MediaRIT → MediaFragment`` path; it must not invent a
+packet sheet, recursive DAG, credential forge, catalog abstraction, or parallel
+JOURNAL media channel.
 
 ---
 

--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
@@ -368,9 +368,12 @@ presentation-safe ID card. Its media-owned ``credential_card`` text profile
 wraps the safe observation wording into the fixed card-text layout and elides
 only overflowing execution lines; the complete projection remains in the
 derivation payload. Slice E provisions its portrait and printable-text children
-before the one-level parent, keeps the text ``PieceFragment`` unconditional,
-and emits an ordinary associated ``MediaFragment`` only when the complete card
-is resolved. Complete authored replacements suppress that generated card.
+before the one-level parent, including the sequential successor frontier during
+PLANNING without changing the active case. UPDATE then selects the already
+prepared successor; it does not JIT-provision presentation. The text
+``PieceFragment`` remains unconditional, and an ordinary associated
+``MediaFragment`` appears only when the complete card is resolved. Complete
+authored replacements suppress that generated card.
 Authored alternatives/replacements and world-scoped media selection remain the
 next slice. Credentials must consume the resulting ``MediaSpec →
 MediaSpecProvisioner → MediaRIT → MediaFragment`` path; it must not invent a

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -31,9 +31,17 @@ from tangl.journal.fragments import (
     GroupFragment,
     KvFragment,
     KvRow,
+    MediaFragment,
     PieceFragment,
     PresentationHints,
 )
+from tangl.media.media_creators.composition_forge.composition_inputs import (
+    CompositionInputUnavailable,
+    resolve_composition_inputs,
+)
+from tangl.media.media_creators.composition_forge.composition_spec import CompositionSpec
+from tangl.media.media_creators.media_spec import MediaSpec
+from tangl.media.media_resource import MediaDep, MediaResourceInventoryTag as MediaRIT
 from tangl.mechanics.credentials.assembly import (
     CREDENTIAL_ID_SLOT,
     CREDENTIAL_PACKET_SLOT,
@@ -62,10 +70,14 @@ from tangl.mechanics.credentials import (
     Region,
     Restrictions,
     RestrictionLevel,
+    credential_card_composition_spec,
+    credential_card_portrait_spec,
+    credential_card_text_spec,
 )
 from tangl.prose import TextRenderSession
 from tangl.story.presentation import render_text_as
 from tangl.vm.ctx import VmPhaseCtx
+from tangl.vm.provision.resolver import Resolver
 from .enums import GamePhase, GameResult, RoundResult
 from .game import Game
 from .picking_game import PickingGame, PickingGameHandler, PickingMove
@@ -82,6 +94,16 @@ _DOCUMENT_SELECTOR_TARGET = "__document_piece__"
 
 def _piece_uid(game_uid: uuid.UUID, case_index: int, key: str) -> uuid.UUID:
     return uuid.uuid5(_PIECE_NS, f"credentials:{game_uid}:{case_index}:{key}")
+
+
+def _card_media_dep_uid(
+    game_uid: uuid.UUID,
+    case_index: int,
+    component_id: uuid.UUID,
+    role: str,
+) -> uuid.UUID:
+    """Return the stable dependency ID for one credential-card media role."""
+    return _piece_uid(game_uid, case_index, f"card-dependency:{component_id}:{role}")
 
 
 def _document_piece_id(case_index: int, label: str) -> str:
@@ -1231,6 +1253,91 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         if game.has_component_manager_owner and game.offers:
             game.prepare_active_case()
 
+    def provision_presentation(self, game: CredentialsGame, *, ctx: VmPhaseCtx) -> None:
+        """Provision one eligible ID card through ordinary media dependencies."""
+        if game.shift_complete or ctx.cursor is None:
+            return
+
+        case = game.active_case
+        for projection in self.credential_card_projections(game):
+            component = next(
+                component
+                for component in case.packet_manager.document_components()
+                if component.uid == projection.component_id
+            )
+            subject = case.packet_manager.resolve_subject(projection.subject_id)
+            portrait = self._card_media_dependency(
+                game,
+                component=component,
+                role="portrait",
+                spec=credential_card_portrait_spec(projection, subject),
+                ctx=ctx,
+            )
+            text = self._card_media_dependency(
+                game,
+                component=component,
+                role="printable_text",
+                spec=credential_card_text_spec(projection),
+                ctx=ctx,
+            )
+            resolver = Resolver.from_ctx(ctx)
+            for dependency in (portrait, text):
+                if not dependency.render_ready:
+                    resolver.resolve_dependency(dependency, _ctx=ctx)
+            if not portrait.render_ready or not text.render_ready:
+                continue
+
+            portrait_rit = portrait.provider
+            text_rit = text.provider
+            if not isinstance(portrait_rit, MediaRIT) or not isinstance(text_rit, MediaRIT):
+                continue
+            if portrait_rit.get_content_hash() is None or text_rit.get_content_hash() is None:
+                continue
+
+            card = self._card_media_dependency(
+                game,
+                component=component,
+                role="card",
+                spec=credential_card_composition_spec(
+                    portrait_rit=portrait_rit,
+                    text_rit=text_rit,
+                ),
+                ctx=ctx,
+            )
+            if not card.render_ready:
+                resolver.resolve_dependency(card, _ctx=ctx)
+
+    @staticmethod
+    def _card_media_dependency(
+        game: CredentialsGame,
+        *,
+        component: CredentialComponent,
+        role: str,
+        spec: MediaSpec,
+        ctx: VmPhaseCtx,
+    ) -> MediaDep:
+        """Return one stable, graph-owned media dependency for a card role."""
+        dependency_id = _card_media_dep_uid(
+            game.uid,
+            game.case_index,
+            component.uid,
+            role,
+        )
+        existing = ctx.graph.get(dependency_id)
+        if existing is not None:
+            assert isinstance(existing, MediaDep)
+            return existing
+        dependency = MediaDep(
+            uid=dependency_id,
+            registry=ctx.graph,
+            predecessor_id=ctx.cursor_id,
+            media_spec=spec,
+            media_role="credential_card",
+            label=f"credential-card-{role}",
+        )
+        ctx.graph.add(dependency, _ctx=ctx)
+        return dependency
+
     def resolve_round(self, game, player_move, opponent_move):
         # Charge the move's time cost to the shift budget before resolving it.
         # Soft budget: actions are never blocked; overtime converts to penalty.
@@ -2175,6 +2282,10 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         doc_pieces: list[BaseFragment] = []
         component_labels: set[str] = set()
         component_documents = self._document_components(game)
+        card_projections = {
+            projection.component_id: projection
+            for projection in self.credential_card_projections(game)
+        }
         label_counts = Counter(
             document.label for document in component_documents
         )
@@ -2241,6 +2352,16 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                     hints=PresentationHints(label_text=label),
                 )
             )
+            projection = card_projections.get(component.uid)
+            if projection is not None:
+                doc_pieces.extend(
+                    self._card_media_fragments(
+                        game,
+                        projection=projection,
+                        document_piece_id=doc_uid,
+                        ctx=ctx,
+                    )
+                )
 
         for label, description in case.presented_documents.items():
             if label in component_labels:
@@ -2266,6 +2387,62 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             hints=PresentationHints(label_text="Credentials packet"),
         )
         return [candidate, packet, *doc_pieces]
+
+    @staticmethod
+    def _card_media_fragments(
+        game: CredentialsGame,
+        *,
+        projection: CredentialCardProjection,
+        document_piece_id: uuid.UUID,
+        ctx: VmPhaseCtx | None,
+    ) -> list[BaseFragment]:
+        """Project one resolved card RIT beside its canonical document piece."""
+        if ctx is None:
+            return []
+        dependency = ctx.graph.get(
+            _card_media_dep_uid(
+                game.uid,
+                game.case_index,
+                projection.component_id,
+                "card",
+            )
+        )
+        if not isinstance(dependency, MediaDep) or not dependency.render_ready:
+            return []
+        card = dependency.provider
+        spec = dependency.requirement.media_spec
+        if not isinstance(card, MediaRIT) or not isinstance(spec, CompositionSpec):
+            return []
+        try:
+            resolve_composition_inputs(spec, graph=ctx.graph)
+        except CompositionInputUnavailable:
+            return []
+
+        media_uid = _piece_uid(
+            game.uid,
+            game.case_index,
+            f"card-media:{projection.component_id}",
+        )
+        return [
+            MediaFragment(
+                uid=media_uid,
+                source_id=projection.component_id,
+                media_role="credential_card",
+                content=card,
+                content_format="rit",
+                content_type=card.data_type,
+                scope="story",
+            ),
+            GroupFragment(
+                uid=_piece_uid(
+                    game.uid,
+                    game.case_index,
+                    f"piece-media:{projection.component_id}",
+                ),
+                group_type="piece_media",
+                member_ids=[document_piece_id, media_uid],
+            ),
+        ]
 
     def _findings_fragment(self, game: CredentialsGame) -> KvFragment | None:
         """Project revealed document/packet findings as a KvFragment.

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -1025,14 +1025,14 @@ class CredentialsGame(PickingGame):
 
         return self._component_manager_owner is not None
 
-    def prepare_active_case(self) -> CredentialCase:
-        """Materialize the arriving sampled case at setup or UPDATE time."""
+    def prepare_case(self, case_index: int) -> CredentialCase:
+        """Materialize one sequential case without making it active."""
 
         if not self.offers:
-            return self.roster[self.case_index]
+            return self.roster[case_index]
         from .credentials_roster import materialize
 
-        while len(self.materialized) <= self.case_index:
+        while len(self.materialized) <= case_index:
             offer = self.offers[len(self.materialized)]
             self.materialized.append(
                 materialize(
@@ -1047,7 +1047,7 @@ class CredentialsGame(PickingGame):
                     narrative_renderer=self.presentation.render_case,
                 )
             )
-        return self.materialized[self.case_index]
+        return self.materialized[case_index]
 
     # ----- active case access ----------------------------------------------
     def _total_cases(self) -> int:
@@ -1065,7 +1065,7 @@ class CredentialsGame(PickingGame):
                 and self.phase is GamePhase.READY
             ):
                 raise RuntimeError("Sampled credential cases must be prepared before PLANNING")
-            return self.prepare_active_case()
+            return self.prepare_case(self.case_index)
         return self.materialized[self.case_index]
 
     @property
@@ -1201,8 +1201,6 @@ class CredentialsGame(PickingGame):
         self.packet_findings = {}
         self.committed_decision = None
         self.finding_status = {}
-        if self.has_component_manager_owner and not self.shift_complete:
-            self.prepare_active_case()
 
     def to_namespace(self) -> dict[str, object]:
         namespace = super().to_namespace()
@@ -1251,15 +1249,35 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         """Prepare the first sampled packet before move provisioning begins."""
 
         if game.has_component_manager_owner and game.offers:
-            game.prepare_active_case()
+            game.prepare_case(game.case_index)
 
     def provision_presentation(self, game: CredentialsGame, *, ctx: VmPhaseCtx) -> None:
-        """Provision one eligible ID card through ordinary media dependencies."""
+        """Prepare the current and sequential successor card frontiers."""
         if game.shift_complete or ctx.cursor is None:
             return
 
-        case = game.active_case
-        for projection in self.credential_card_projections(game):
+        indices = [game.case_index]
+        if game.case_index + 1 < game._total_cases():
+            indices.append(game.case_index + 1)
+        for case_index in indices:
+            case = game.prepare_case(case_index)
+            self._provision_case_presentation(
+                game,
+                case=case,
+                case_index=case_index,
+                ctx=ctx,
+            )
+
+    def _provision_case_presentation(
+        self,
+        game: CredentialsGame,
+        *,
+        case: CredentialCase,
+        case_index: int,
+        ctx: VmPhaseCtx,
+    ) -> None:
+        """Provision one already-prepared case without changing active state."""
+        for projection in self.credential_card_projections(game, case=case):
             component = next(
                 component
                 for component in case.packet_manager.document_components()
@@ -1269,6 +1287,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             portrait = self._card_media_dependency(
                 game,
                 component=component,
+                case_index=case_index,
                 role="portrait",
                 spec=credential_card_portrait_spec(projection, subject),
                 ctx=ctx,
@@ -1276,6 +1295,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             text = self._card_media_dependency(
                 game,
                 component=component,
+                case_index=case_index,
                 role="printable_text",
                 spec=credential_card_text_spec(projection),
                 ctx=ctx,
@@ -1297,6 +1317,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             card = self._card_media_dependency(
                 game,
                 component=component,
+                case_index=case_index,
                 role="card",
                 spec=credential_card_composition_spec(
                     portrait_rit=portrait_rit,
@@ -1312,6 +1333,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         game: CredentialsGame,
         *,
         component: CredentialComponent,
+        case_index: int,
         role: str,
         spec: MediaSpec,
         ctx: VmPhaseCtx,
@@ -1319,7 +1341,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         """Return one stable, graph-owned media dependency for a card role."""
         dependency_id = _card_media_dep_uid(
             game.uid,
-            game.case_index,
+            case_index,
             component.uid,
             role,
         )
@@ -2129,10 +2151,13 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
     def _document_components(
         self,
         game: CredentialsGame,
+        *,
+        case: CredentialCase | None = None,
     ) -> list[_CredentialDocumentRender]:
         """Pair canonical components with their profile base and visible parts."""
 
-        case = game.active_case
+        case = case or game.active_case
+        is_active_case = case is game.active_case
         documents: list[_CredentialDocumentRender] = []
         for component in case.packet_manager.document_components():
             label = self._component_label(game, component)
@@ -2156,7 +2181,8 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                 component.indication,
             )
             reissued = (
-                reissued_component is not None
+                is_active_case
+                and reissued_component is not None
                 and component.uid == reissued_component.uid
                 and game.finding_status.get(component.indication) == Finding.CLEARED
             )
@@ -2187,9 +2213,11 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
     def credential_card_projections(
         self,
         game: CredentialsGame,
+        *,
+        case: CredentialCase | None = None,
     ) -> list[CredentialCardProjection]:
-        """Project the active case's canonical ID documents for future card media."""
-        case = game.active_case
+        """Project one case's canonical ID documents for future card media."""
+        case = case or game.active_case
         return [
             CredentialCardProjection(
                 component_id=document.component.uid,
@@ -2199,7 +2227,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                 bearer_label=case.candidate_name,
                 visible_parts=document.visible_observations,
             )
-            for document in self._document_components(game)
+            for document in self._document_components(game, case=case)
             if (
                 document.component.document_kind == "id"
                 and document.complete_replacement is None

--- a/engine/src/tangl/mechanics/games/handler.py
+++ b/engine/src/tangl/mechanics/games/handler.py
@@ -161,6 +161,10 @@ class GameHandler(ABC, Generic[GameT]):
         JOURNAL handler to fall back to the generic round summary.
         """
         return None
+
+    def provision_presentation(self, game: GameT, *, ctx: VmPhaseCtx) -> None:
+        """Provision optional game presentation resources during PLANNING."""
+        _ = game, ctx
     
     # ─────────────────────────────────────────────────────────────────────
     # Lifecycle methods

--- a/engine/src/tangl/mechanics/games/handlers.py
+++ b/engine/src/tangl/mechanics/games/handlers.py
@@ -300,6 +300,9 @@ def process_game_move(
     if isinstance(ns_inflight, set):
         ns_inflight.clear()
 
+    if cursor.game.phase == GamePhase.READY and not cursor.game.result.is_terminal:
+        cursor.game_handler.provision_presentation(cursor.game, ctx=ctx)
+
     _clear_dynamic_game_actions(cursor, ctx=ctx)
     if cursor.game.phase == GamePhase.READY and not cursor.game.result.is_terminal:
         actions = _build_game_actions(cursor)

--- a/engine/src/tangl/mechanics/games/handlers.py
+++ b/engine/src/tangl/mechanics/games/handlers.py
@@ -300,9 +300,6 @@ def process_game_move(
     if isinstance(ns_inflight, set):
         ns_inflight.clear()
 
-    if cursor.game.phase == GamePhase.READY and not cursor.game.result.is_terminal:
-        cursor.game_handler.provision_presentation(cursor.game, ctx=ctx)
-
     _clear_dynamic_game_actions(cursor, ctx=ctx)
     if cursor.game.phase == GamePhase.READY and not cursor.game.result.is_terminal:
         actions = _build_game_actions(cursor)

--- a/engine/src/tangl/mechanics/games/handlers.py
+++ b/engine/src/tangl/mechanics/games/handlers.py
@@ -207,6 +207,9 @@ def provision_game_moves(
     if cursor.game.phase != GamePhase.READY:
         return None if runtime_planning else []
 
+    if runtime_planning:
+        cursor.game_handler.provision_presentation(cursor.game, ctx=ctx)
+
     moves = cursor.game_handler.get_provisioned_moves(cursor.game)
 
     if not moves:

--- a/engine/src/tangl/vm/VM_DESIGN.md
+++ b/engine/src/tangl/vm/VM_DESIGN.md
@@ -119,6 +119,51 @@ JOURNAL — the player's next choice is recorded at the start of the *next*
 `resolve_choice` call, not at the end of the current pipeline. This keeps the pipeline
 atomic and simplifies replay: every step is a complete VALIDATE→POSTREQS sequence.
 
+### Turn atomicity and frontier timing
+
+User interaction begins a turn; presentation of the next live frontier ends it. The
+pipeline never blocks midway for more external instruction. A question that needs a
+player answer is itself an end-of-turn choice surface; the answer begins another
+complete cycle.
+
+PLANNING establishes the topology of the next frontier. From the current node it
+provisions the successor nodes, providers, dependencies, and actions that may be
+selected next. Those successors must exist before they are presented: a disclosed
+“note on the door” is either a fact on an already-provisioned provider or a durable
+constraint that any remaining lazy realization must satisfy.
+
+UPDATE changes committed state after the frontier's shape is mostly settled. It may
+lock or unlock already-provisioned doors, transfer custody, apply injury, change
+relationships, or activate the selected successor. Availability and presentation then
+interpret the provisioned frontier under that updated state.
+
+UPDATE may create an entity when creation is itself a consequence, but the new entity
+does not retroactively participate in a namespace/frontier assembled earlier in the
+same turn. Ordinary interaction with it begins during the following turn's PLANNING.
+If same-turn use appears necessary, the design has usually hidden another turn;
+represent that as an automatic setup/continuation step instead.
+
+A pre-materialized world does not waive this rule. Adding “one temporary sword”
+directly during UPDATE because it is convenient bypasses the dependency/affordance and
+provenance contracts just as surely as lazy story generation does. If the sword must
+be a selectable or inspectable possibility this turn, provision it into the frontier.
+If receiving the sword is the consequence of the selected action, create/transfer it
+during UPDATE and expose its uses next turn.
+
+JIT provisioning of the current node is an exceptional recovery path for startup,
+out-of-order/debug traversal, stale derived frontier state, or explicit on-demand
+projections such as a map. It is not the ordinary choice lifecycle.
+
+```
+user input
+  → validate selected choice
+  → provision next frontier
+  → settle prerequisites
+  → update committed state
+  → journal and project live choices
+  → return control to user
+```
+
 **Phases are recursively refinable symbols.** A phase is atomic at the contract
 boundary but may be decomposed at the implementation boundary. At the VM level,
 `UPDATE` is one causal symbol in the pipeline. Internally it may be refined into

--- a/engine/src/tangl/vm/provision/requirement.py
+++ b/engine/src/tangl/vm/provision/requirement.py
@@ -103,7 +103,13 @@ class Requirement(Selector, Generic[PT]):
             return False
 
         criteria = dict(self.__pydantic_extra__ or {})
-        for key in ("has_identifier", "authored_path", "is_qualified", "is_absolute"):
+        for key in (
+            "has_identifier",
+            "authored_path",
+            "is_qualified",
+            "is_absolute",
+            "adapted_spec",
+        ):
             criteria.pop(key, None)
         return Selector(predicate=self.predicate, **criteria).matches(entity)
 

--- a/engine/src/tangl/vm/provision/resolver.py
+++ b/engine/src/tangl/vm/provision/resolver.py
@@ -254,8 +254,6 @@ class Resolver:
         *,
         _ctx: VmPhaseCtx | None = None,
     ) -> list[ProvisionOffer]:
-        if requirement.media_spec is not None:
-            return []
         if _ctx is None:
             return []
 
@@ -342,11 +340,11 @@ class Resolver:
         _ctx: VmPhaseCtx | None = None,
     ) -> list[ProvisionOffer]:
         offers: list[ProvisionOffer] = list(preferred_offers or [])
+        offers.extend(self._media_spec_offers_for_requirement(requirement, _ctx=_ctx))
         offers.extend(self._existing_offers_for_requirement(requirement))
         offers.extend(self._template_offers_for_requirement(requirement, _ctx=_ctx))
         offers.extend(self._token_offers_for_requirement(requirement, _ctx=_ctx))
         offers.extend(self._media_inventory_offers_for_requirement(requirement, _ctx=_ctx))
-        offers.extend(self._media_spec_offers_for_requirement(requirement, _ctx=_ctx))
         offers.extend(self._inline_template_offers_for_requirement(requirement, _ctx=_ctx))
         offers.extend(UpdateCloneProvisioner.get_dependency_offers(requirement=requirement, offers=offers))
         return offers

--- a/engine/src/tangl/vm/provision/resolver.py
+++ b/engine/src/tangl/vm/provision/resolver.py
@@ -254,6 +254,8 @@ class Resolver:
         *,
         _ctx: VmPhaseCtx | None = None,
     ) -> list[ProvisionOffer]:
+        if requirement.media_spec is not None:
+            return []
         if _ctx is None:
             return []
 

--- a/engine/tests/loaders/test_credential_gate_world.py
+++ b/engine/tests/loaders/test_credential_gate_world.py
@@ -367,9 +367,8 @@ activity_pass:
         )
         assert "shift complete" in content.lower()
 
-    def test_randomized_shift_materializes_lazily_and_routes_to_victory(self) -> None:
-        """The sampled path materializes each candidate on arrival and, played
-        correctly, routes to the same victory ending."""
+    def test_randomized_shift_prepares_one_successor_and_routes_to_victory(self) -> None:
+        """The sampled path prepares one successor frontier and reaches victory."""
 
         bundle = WorldBundle.load(_credential_gate_root())
         world = WorldCompiler().compile(bundle)
@@ -385,8 +384,10 @@ activity_pass:
         game = ledger.cursor.game
         total = game._total_cases()
         assert total > 1
-        # Lazy: only the active arrival has materialized; the rest still pending.
-        assert len(game.materialized) == 1
+        # PLANNING prepares the active case and its one sequential successor;
+        # later offers remain unmaterialized until they become the frontier.
+        assert len(game.materialized) == min(2, total)
+        assert game.case_index == 0
 
         for _ in range(total):
             target = game.expected_disposition(game.active_case).value

--- a/engine/tests/loaders/test_hall_monitor_world.py
+++ b/engine/tests/loaders/test_hall_monitor_world.py
@@ -143,13 +143,16 @@ class TestHallMonitorWorld:
             for component in restored_manager.get_slot(CREDENTIAL_PACKET_SLOT)
         )
 
-    def test_repeated_provisioning_does_not_materialize_another_case(self) -> None:
+    def test_repeated_move_reads_do_not_expand_the_prepared_frontier(self) -> None:
         _, ledger = _started_shift()
         game = ledger.cursor.game
         handler = ledger.cursor.game_handler
+        prepared = tuple(game.materialized)
 
         first = handler.get_provisioned_moves(game)
         second = handler.get_provisioned_moves(game)
 
         assert first == second
-        assert len(game.materialized) == 1
+        assert game.materialized == list(prepared)
+        assert len(prepared) == 2
+        assert game.active_case is prepared[0]

--- a/engine/tests/mechanics/credentials/test_credential_card_media.py
+++ b/engine/tests/mechanics/credentials/test_credential_card_media.py
@@ -29,10 +29,14 @@ from tangl.mechanics.credentials import (
     materialize_packet,
 )
 from tangl.mechanics.games import CredentialsGame, CredentialsGameHandler, HasGame
-from tangl.mechanics.games.handlers import provision_game_moves
-from tangl.mechanics.games.credentials_game import CredentialCase
+from tangl.mechanics.games.handlers import process_game_move, provision_game_moves
+from tangl.mechanics.games.credentials_game import (
+    CredentialCase,
+    CredentialDisposition,
+    CredentialsMove,
+)
 from tangl.mechanics.presence.look import HairColor, Look
-from tangl.story import Block
+from tangl.story import Action, Block
 from tangl.story.fabula import World
 from tangl.vm import Frame, ResolutionPhase
 
@@ -58,9 +62,14 @@ def _story_media_root(tmp_path: Path):
     return _resolve
 
 
-def _case(*, status: CredentialStatus = CredentialStatus.VALID) -> CredentialCase:
+def _case(
+    *,
+    status: CredentialStatus = CredentialStatus.VALID,
+    candidate_name: str = "Ada Venn",
+    definition_label: str = "card-id",
+) -> CredentialCase:
     definition = CredentialDefinition(
-        label="card-id",
+        label=definition_label,
         name="Border Pass",
         indication=Indication.TRAVEL,
         document_kind="id",
@@ -68,7 +77,7 @@ def _case(*, status: CredentialStatus = CredentialStatus.VALID) -> CredentialCas
         valid_period=0,
     )
     return CredentialCase(
-        candidate_name="Ada Venn",
+        candidate_name=candidate_name,
         presented_documents={"passport": "An identity document."},
         packet_manager=materialize_packet(
             owner=object(),
@@ -92,6 +101,7 @@ def _live_card_case(
     tmp_path: Path,
     *,
     status: CredentialStatus = CredentialStatus.VALID,
+    roster: list[CredentialCase] | None = None,
 ):
     monkeypatch.setattr(
         "tangl.media.story_media.get_story_media_dir",
@@ -107,7 +117,7 @@ def _live_card_case(
     block = story.add_node(
         kind=_CredentialsBlock,
         label="checkpoint",
-        game_state=CredentialsGame(roster=[_case(status=status)]),
+        game_state=CredentialsGame(roster=roster or [_case(status=status)]),
     )
     handler = block.game_handler
     handler.setup(block.game)
@@ -391,6 +401,69 @@ def test_lifecycle_uses_document_subject_and_keeps_text_when_card_inputs_fail(
     stale = block.game_handler.get_journal_fragments(block.game, ctx=ctx)
     assert any(isinstance(fragment, PieceFragment) for fragment in stale)
     assert not any(isinstance(fragment, MediaFragment) for fragment in stale)
+
+
+def test_lifecycle_keeps_text_when_parent_card_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    story, block, _, _ = _live_card_case(monkeypatch, tmp_path)
+    ctx = Frame(graph=story, cursor=block)._make_ctx()
+    block.game_handler.provision_presentation(block.game, ctx=ctx)
+    card = next(
+        dependency
+        for dependency in story.values()
+        if isinstance(dependency, MediaDep) and dependency.label == "credential-card-card"
+    )
+
+    card.provider.status = MediaRITStatus.PENDING
+    pending = block.game_handler.get_journal_fragments(block.game, ctx=ctx)
+    assert any(isinstance(fragment, PieceFragment) for fragment in pending)
+    assert not any(isinstance(fragment, MediaFragment) for fragment in pending)
+    assert not any(
+        isinstance(fragment, GroupFragment) and fragment.group_type == "piece_media"
+        for fragment in pending
+    )
+
+    card.provider.status = MediaRITStatus.FAILED
+    failed = block.game_handler.get_journal_fragments(block.game, ctx=ctx)
+    assert any(isinstance(fragment, PieceFragment) for fragment in failed)
+    assert not any(isinstance(fragment, MediaFragment) for fragment in failed)
+
+
+def test_lifecycle_provisions_the_next_candidate_during_update(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    first_case = _case(candidate_name="Ada Venn", definition_label="card-id-one")
+    second_case = _case(candidate_name="Bea Moss", definition_label="card-id-two")
+    story, block, _, _ = _live_card_case(
+        monkeypatch,
+        tmp_path,
+        roster=[first_case, second_case],
+    )
+    frame = Frame(graph=story, cursor=block)
+    action = Action(
+        graph=story,
+        predecessor_id=block.uid,
+        successor_id=block.uid,
+        payload={"move": CredentialsMove(kind="decide", target=CredentialDisposition.PASS.value)},
+    )
+    frame.selected_edge = action
+    ctx = frame._make_ctx(incoming_edge=action, incoming_payload=action.payload)
+
+    ctx.current_phase = ResolutionPhase.PLANNING
+    provision_game_moves(cursor=block, ctx=ctx)
+    ctx.current_phase = ResolutionPhase.UPDATE
+    process_game_move(block, ctx=ctx)
+
+    assert block.game.case_index == 1
+    next_projection = block.game_handler.credential_card_projections(block.game)[0]
+    journal = block.game_handler.get_journal_fragments(block.game, ctx=ctx)
+    assert any(
+        isinstance(fragment, MediaFragment) and fragment.source_id == next_projection.component_id
+        for fragment in journal
+    )
 
 
 def test_lifecycle_replacement_suppresses_previously_provisioned_card_media(

--- a/engine/tests/mechanics/credentials/test_credential_card_media.py
+++ b/engine/tests/mechanics/credentials/test_credential_card_media.py
@@ -454,12 +454,30 @@ def test_lifecycle_provisions_the_next_candidate_during_update(
 
     ctx.current_phase = ResolutionPhase.PLANNING
     provision_game_moves(cursor=block, ctx=ctx)
+    next_projection = block.game_handler.credential_card_projections(block.game, case=second_case)[0]
+    prepared_dependency_ids = {
+        dependency.uid for dependency in story.values() if isinstance(dependency, MediaDep)
+    }
+    active_journal = block.game_handler.get_journal_fragments(block.game, ctx=ctx)
+
+    assert block.game.case_index == 0
+    assert block.game.active_case is first_case
+    assert block.game.to_namespace()["credential_candidate_name"] == "Ada Venn"
+    assert len(prepared_dependency_ids) == 6
+    assert not any(
+        isinstance(fragment, MediaFragment) and fragment.source_id == next_projection.component_id
+        for fragment in active_journal
+    )
+    assert all("Bea Moss" not in str(fragment.content) for fragment in active_journal)
+
     ctx.current_phase = ResolutionPhase.UPDATE
     process_game_move(block, ctx=ctx)
 
     assert block.game.case_index == 1
-    next_projection = block.game_handler.credential_card_projections(block.game)[0]
     journal = block.game_handler.get_journal_fragments(block.game, ctx=ctx)
+    assert {
+        dependency.uid for dependency in story.values() if isinstance(dependency, MediaDep)
+    } == prepared_dependency_ids
     assert any(
         isinstance(fragment, MediaFragment) and fragment.source_id == next_projection.component_id
         for fragment in journal

--- a/engine/tests/mechanics/credentials/test_credential_card_media.py
+++ b/engine/tests/mechanics/credentials/test_credential_card_media.py
@@ -10,7 +10,8 @@ from uuid import uuid4
 from lxml import etree
 import pytest
 
-from tangl.core import TokenCatalog
+from tangl.core import Graph, Selector, TokenCatalog
+from tangl.journal.fragments import GroupFragment, MediaFragment, PieceFragment
 from tangl.media import MediaDataType
 from tangl.media.media_resource import MediaDep, MediaResourceInventoryTag as MediaRIT
 from tangl.media.media_resource.media_provisioning import MediaSpecProvisioner
@@ -28,10 +29,12 @@ from tangl.mechanics.credentials import (
     materialize_packet,
 )
 from tangl.mechanics.games import CredentialsGame, CredentialsGameHandler, HasGame
+from tangl.mechanics.games.handlers import provision_game_moves
 from tangl.mechanics.games.credentials_game import CredentialCase
 from tangl.mechanics.presence.look import HairColor, Look
 from tangl.story import Block
 from tangl.story.fabula import World
+from tangl.vm import Frame, ResolutionPhase
 
 
 @pytest.fixture(autouse=True)
@@ -293,3 +296,146 @@ def test_complete_replacement_has_no_card_media_path(
 
     assert block.game_handler.credential_card_projections(block.game) == []
     assert story.get(block.uid) is block
+
+
+def test_lifecycle_provisions_one_card_and_emits_stable_piece_media_relation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    story, block, _, projection = _live_card_case(monkeypatch, tmp_path)
+    ctx = Frame(graph=story, cursor=block)._make_ctx()
+
+    assert not any(
+        isinstance(fragment, MediaFragment)
+        for fragment in block.game_handler.get_journal_fragments(block.game, ctx=ctx)
+    )
+    ctx.current_phase = ResolutionPhase.PLANNING
+    assert provision_game_moves(cursor=block, ctx=ctx) is None
+    first = block.game_handler.get_journal_fragments(block.game, ctx=ctx)
+    block.game_handler.provision_presentation(block.game, ctx=ctx)
+    second = block.game_handler.get_journal_fragments(block.game, ctx=ctx)
+
+    dependencies = [value for value in story.values() if isinstance(value, MediaDep)]
+    rits = [value for value in story.values() if isinstance(value, MediaRIT)]
+    assert [dependency.label for dependency in dependencies] == [
+        "credential-card-portrait",
+        "credential-card-printable_text",
+        "credential-card-card",
+    ]
+    assert len(rits) == 3
+
+    document = next(
+        fragment
+        for fragment in first
+        if isinstance(fragment, PieceFragment)
+        and fragment.properties.get("component_id") == projection.component_id
+    )
+    media = [fragment for fragment in first if isinstance(fragment, MediaFragment)]
+    relation = [
+        fragment
+        for fragment in first
+        if isinstance(fragment, GroupFragment) and fragment.group_type == "piece_media"
+    ]
+    assert len(media) == 1
+    assert media[0].source_id == projection.component_id
+    assert media[0].content_format == "rit"
+    assert len(relation) == 1
+    assert relation[0].member_ids == [document.uid, media[0].uid]
+    assert [fragment.uid for fragment in second if isinstance(fragment, MediaFragment)] == [
+        media[0].uid
+    ]
+    assert [
+        fragment.uid
+        for fragment in second
+        if isinstance(fragment, GroupFragment) and fragment.group_type == "piece_media"
+    ] == [relation[0].uid]
+
+
+def test_lifecycle_uses_document_subject_and_keeps_text_when_card_inputs_fail(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    story, block, packet, projection = _live_card_case(
+        monkeypatch,
+        tmp_path,
+        status=CredentialStatus.WRONG_HOLDER,
+    )
+    ctx = Frame(graph=story, cursor=block)._make_ctx()
+    block.game_handler.provision_presentation(block.game, ctx=ctx)
+    portrait = next(
+        dependency
+        for dependency in story.values()
+        if isinstance(dependency, MediaDep) and dependency.label == "credential-card-portrait"
+    )
+    text = next(
+        dependency
+        for dependency in story.values()
+        if isinstance(dependency, MediaDep) and dependency.label == "credential-card-printable_text"
+    )
+
+    assert portrait.provider.derivation_spec["identity_key"] == str(projection.subject_id)
+    assert projection.subject_id != packet.bearer_id
+    text.provider.status = MediaRITStatus.PENDING
+    pending = block.game_handler.get_journal_fragments(block.game, ctx=ctx)
+    assert any(isinstance(fragment, PieceFragment) for fragment in pending)
+    assert not any(isinstance(fragment, MediaFragment) for fragment in pending)
+
+    text.provider.status = MediaRITStatus.FAILED
+    failed = block.game_handler.get_journal_fragments(block.game, ctx=ctx)
+    assert any(isinstance(fragment, PieceFragment) for fragment in failed)
+    assert not any(isinstance(fragment, MediaFragment) for fragment in failed)
+
+    text.provider.status = MediaRITStatus.RESOLVED
+    text.provider.data = "<svg/>"
+    text.provider.path = None
+    stale = block.game_handler.get_journal_fragments(block.game, ctx=ctx)
+    assert any(isinstance(fragment, PieceFragment) for fragment in stale)
+    assert not any(isinstance(fragment, MediaFragment) for fragment in stale)
+
+
+def test_lifecycle_replacement_suppresses_previously_provisioned_card_media(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    story, block, _, _ = _live_card_case(monkeypatch, tmp_path)
+    ctx = Frame(graph=story, cursor=block)._make_ctx()
+    block.game_handler.provision_presentation(block.game, ctx=ctx)
+    block.game.active_case.presented_documents = {"passport": "An authored replacement."}
+
+    fragments = block.game_handler.get_journal_fragments(block.game, ctx=ctx)
+
+    assert not any(isinstance(fragment, MediaFragment) for fragment in fragments)
+    assert any(
+        isinstance(fragment, PieceFragment) and fragment.content == "An authored replacement."
+        for fragment in fragments
+    )
+
+
+def test_lifecycle_round_trip_preserves_card_dependencies_and_fragment_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    story, block, _, _ = _live_card_case(monkeypatch, tmp_path)
+    ctx = Frame(graph=story, cursor=block)._make_ctx()
+    block.game_handler.provision_presentation(block.game, ctx=ctx)
+    original = next(
+        fragment
+        for fragment in block.game_handler.get_journal_fragments(block.game, ctx=ctx)
+        if isinstance(fragment, MediaFragment)
+    )
+
+    restored = Graph.structure(story.unstructure())
+    restored_block = restored.find_one(Selector(label="checkpoint"))
+    restored_ctx = Frame(graph=restored, cursor=restored_block)._make_ctx()
+    restored_block.game_handler.provision_presentation(restored_block.game, ctx=restored_ctx)
+    restored_media = [
+        fragment
+        for fragment in restored_block.game_handler.get_journal_fragments(
+            restored_block.game,
+            ctx=restored_ctx,
+        )
+        if isinstance(fragment, MediaFragment)
+    ]
+
+    assert len([value for value in restored.values() if isinstance(value, MediaDep)]) == 3
+    assert [fragment.uid for fragment in restored_media] == [original.uid]

--- a/engine/tests/mechanics/credentials/test_credential_packet_manager.py
+++ b/engine/tests/mechanics/credentials/test_credential_packet_manager.py
@@ -769,7 +769,7 @@ def test_has_game_materializes_offer_packet_manager_on_arrival() -> None:
     assert restored_manager.get_slot(CREDENTIAL_ID_SLOT)
 
 
-def test_sampled_offers_materialize_once_at_game_lifecycle_boundaries() -> None:
+def test_sampled_offers_prepare_successor_before_update_selects_it() -> None:
     graph = Graph()
     block = graph.add_node(kind=CredentialsBlock, label="checkpoint")
     block.game_state = CredentialsGame(
@@ -800,21 +800,28 @@ def test_sampled_offers_materialize_once_at_game_lifecycle_boundaries() -> None:
         for item in graph.members.values()
     )
 
+    second_case = block.game.prepare_case(1)
+    prepared_component_count = sum(
+        isinstance(item, CredentialComponent)
+        for item in graph.members.values()
+    )
+    assert second_case.candidate_name == "Tomas"
+    assert prepared_component_count > component_count
+
     assert handler.get_available_moves(block.game)
     assert (
         sum(isinstance(item, CredentialComponent) for item in graph.members.values())
-        == component_count
+        == prepared_component_count
     )
 
     handler.receive_move(block.game, ("inspect", "passport"))
     handler.receive_move(block.game, ("decide", "pass"))
 
-    second_case = block.game.active_case
-    assert second_case.candidate_name == "Tomas"
+    assert block.game.active_case is second_case
     assert second_case.packet_manager.owner is block
     assert (
         sum(isinstance(item, CredentialComponent) for item in graph.members.values())
-        > component_count
+        == prepared_component_count
     )
 
 

--- a/engine/tests/vm/test_resolver.py
+++ b/engine/tests/vm/test_resolver.py
@@ -30,6 +30,7 @@ from tangl.core import (
     TokenCatalog,
 )
 from tangl.core.runtime_op import Predicate
+from tangl.media import MediaDataType
 from tangl.media.media_creators.svg_forge.vector_spec import VectorSpec
 from tangl.media.media_resource import (
     MediaInventory,
@@ -676,6 +677,54 @@ class TestResolverOfferGathering:
 
         assert len(offers) == 1
         assert offers[0].policy == ProvisionPolicy.CREATE
+
+    def test_inline_media_spec_inventory_matching_uses_adapted_fingerprint(self) -> None:
+        spec = VectorSpec(label="checkpoint-card")
+        fingerprint = spec.adapt_spec(ctx={}).spec_fingerprint()
+        exact = MediaRIT(
+            label="exact.svg",
+            data="<svg/>",
+            data_type=MediaDataType.VECTOR,
+            adapted_spec_hash=fingerprint,
+        )
+        unrelated = MediaRIT(label="other.svg", data="<svg/>", data_type=MediaDataType.VECTOR)
+        inventory = _media_inventory("world", unrelated, exact)
+        requirement = Requirement(
+            has_kind=MediaRIT,
+            media_spec=spec,
+            provision_policy=ProvisionPolicy.ANY,
+        )
+
+        ctx = _ctx_with_media_inventories(inventory)
+        resolver = Resolver()
+        offers = resolver.gather_offers(requirement, _ctx=ctx)
+
+        assert requirement.has_identifier == fingerprint
+        assert [offer.policy for offer in offers] == [ProvisionPolicy.EXISTING, ProvisionPolicy.CREATE]
+        assert offers[0].candidate is exact
+        provider = resolver.resolve_requirement(requirement, _ctx=ctx)
+        assert provider.uid == exact.uid
+        assert requirement.selected_offer_policy is ProvisionPolicy.EXISTING
+
+    def test_inline_media_spec_without_inventory_match_creates(self) -> None:
+        spec = VectorSpec(label="checkpoint-card")
+        inventory = _media_inventory(
+            "world",
+            MediaRIT(label="other.svg", data="<svg/>", data_type=MediaDataType.VECTOR),
+        )
+        requirement = Requirement(
+            has_kind=MediaRIT,
+            media_spec=spec,
+            provision_policy=ProvisionPolicy.ANY,
+        )
+
+        offers = Resolver().gather_offers(
+            requirement,
+            _ctx=_ctx_with_media_inventories(inventory),
+        )
+
+        assert len(offers) == 1
+        assert offers[0].policy is ProvisionPolicy.CREATE
 
     def test_clone_offer_uses_selected_reference_and_template(self) -> None:
         source = Entity(label="source")


### PR DESCRIPTION
## Summary

- provision credential card portrait, printable text, and one-level composition dependencies during the existing game PLANNING lifecycle
- emit a resolved card as an ordinary MediaFragment associated with its canonical document PieceFragment
- retain the unconditional text floor for absent, pending, failed, stale, and authored-replacement cases
- prevent inventory candidates from preempting inline MediaSpec provisioning before its adapted identity is resolved

## Validation

- poetry run pytest engine/tests/mechanics/credentials/test_credential_card_projection.py engine/tests/mechanics/credentials/test_credential_card_media.py engine/tests/mechanics/games/test_credentials_fragments.py engine/tests/mechanics/games/test_game_handlers.py engine/tests/media/test_inline_spec_generation.py engine/tests/media/test_printable_text_media.py engine/tests/media/test_dicebear_portraits.py engine/tests/media/test_svg_composition.py engine/tests/vm/test_resolver.py -q
- git diff --check

Closes #329

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic credential-card media generation, including portraits, printable text, and composed card images.
  - Credential documents now include rendered card media when all required content is available.
  - Media resources are provisioned earlier, including for upcoming credential candidates during updates.

- **Bug Fixes**
  - Prevented generated cards when authored replacements exist.
  - Suppressed incomplete card media when required content is pending, failed, or outdated.
  - Preserved stable media relationships across graph reloads and reused matching prepared media when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->