### PR TITLE
Credentials: return Hall Monitor consequences from case results

### DIFF
--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -1168,8 +1168,8 @@ fact to the frontier or namespace already assembled for the disposition turn.
 
 Hall Monitor is the worked proof: its authored medical-note encounter records a
 school-specific inhaler outcome, then an attendance-note action projects that
-outcome with the receipt's recorded candidate label on a later turn. Credentials
-itself still owns only evaluation and scoring.
+outcome with the bearer's current graph-owned presentation on a later turn.
+Credentials itself still owns only evaluation and scoring.
 
 A procedural candidate today is generated for one shift and disappears at
 terminal. A *real* checkpoint story wants candidates to return: the

--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -250,7 +250,8 @@ What shipped:
   reserved seams for Phase A (`region`/`purpose`/`contraband`) and Phase C
   (`whitelist`/`blacklist`/`bribe_offer`).
 - **`CredentialCaseResult`** -- an auditable record per disposition (chosen vs.
-  expected, correct, findings).
+  expected, correct, findings), including the completed case index and canonical
+  packet bearer UUID for world-owned attribution.
 - **`shift_complete` + `evaluate()`** own shift terminality; `advance_case()`
   resets only per-case working state; `pass_threshold` defaults to strict
   all-correct.
@@ -1157,6 +1158,18 @@ gatekeeping kernel**.
 
 ## Beyond the phased roadmap: cross-shift continuity and recurring candidates
 
+### World-authored consequence return (landed 2026-08-04)
+
+`CredentialCaseResult` is a mechanical receipt, not a moral or narrative
+judgment. A world authority may inspect one newly committed receipt during
+UPDATE, record an idempotent world fact attributed to its `case_index` and
+`bearer_id`, and reveal that fact on a genuinely later beat. It must not add the
+fact to the frontier or namespace already assembled for the disposition turn.
+
+Hall Monitor is the worked proof: Mira Quill's medical-note decision records a
+school-specific inhaler outcome, then an attendance-note action reveals it on a
+later turn. Credentials itself still owns only evaluation and scoring.
+
 A procedural candidate today is generated for one shift and disappears at
 terminal. A *real* checkpoint story wants candidates to return: the
 procedurally-sampled traveler you wrongly admitted on day 1 walks back through
@@ -1167,9 +1180,10 @@ today.
 
 The seams already exist; persistence is the missing piece:
 
-- **Identity persistence.** A `CredentialCaseResult` already captures one
-  decided candidate. Continuity needs a stable *candidate id* (and the option
-  to persist a materialized `CredentialCase` snapshot keyed to that id).
+- **Identity persistence.** A `CredentialCaseResult` already carries the
+  graph-bound packet bearer UUID for its decided case. Cross-shift continuity
+  still needs a stable *candidate id* that outlives that materialized packet
+  (and the option to persist a `CredentialCase` snapshot keyed to that id).
 - **Recurrence as an authored offer.** A recurring candidate is a normal
   `ScenarioOffer` whose payload carries prior `CredentialCaseResult`s alongside
   the current packet and any narrative overrides.

--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -1166,9 +1166,10 @@ UPDATE, record an idempotent world fact attributed to its `case_index` and
 `bearer_id`, and reveal that fact on a genuinely later beat. It must not add the
 fact to the frontier or namespace already assembled for the disposition turn.
 
-Hall Monitor is the worked proof: Mira Quill's medical-note decision records a
-school-specific inhaler outcome, then an attendance-note action reveals it on a
-later turn. Credentials itself still owns only evaluation and scoring.
+Hall Monitor is the worked proof: its authored medical-note encounter records a
+school-specific inhaler outcome, then an attendance-note action projects that
+outcome with the receipt's recorded candidate label on a later turn. Credentials
+itself still owns only evaluation and scoring.
 
 A procedural candidate today is generated for one shift and disappears at
 terminal. A *real* checkpoint story wants candidates to return: the

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -250,6 +250,8 @@ class CredentialCase(Unstructurable):
 class CredentialCaseResult(BaseModelPlus):
     """Auditable record of one dispositioned candidate."""
 
+    case_index: int
+    bearer_id: uuid.UUID
     candidate_name: str
     chosen_disposition: CredentialDisposition
     expected_disposition: CredentialDisposition
@@ -1722,6 +1724,8 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
 
         game.case_results.append(
             CredentialCaseResult(
+                case_index=game.case_index,
+                bearer_id=case.packet_manager.bearer_id,
                 candidate_name=case.candidate_name,
                 chosen_disposition=chosen,
                 expected_disposition=expected,

--- a/engine/tests/loaders/test_hall_monitor_world.py
+++ b/engine/tests/loaders/test_hall_monitor_world.py
@@ -12,6 +12,7 @@ from tangl.mechanics.credentials import (
     CredentialDefinition,
     FailureMode,
 )
+from tangl.mechanics.presence.look import HairColor, HasSimpleLook
 from tangl.mechanics.games.credentials_game import CredentialDisposition, derive_disposition
 from tangl.mechanics.games.credentials_roster import materialize
 from tangl.service.world_registry import WorldRegistry
@@ -45,14 +46,10 @@ def _inspect(ledger: Ledger, target: str) -> None:
     )
 
 
-def _started_shift(*, pinned_candidate_name: str | None = None) -> tuple[StoryGraph, Ledger]:
+def _started_shift() -> tuple[StoryGraph, Ledger]:
     world = WorldCompiler().compile(WorldBundle.load(_hall_monitor_root()))
     result = world.create_story("hall_monitor", init_mode=InitMode.EAGER)
     ledger = Ledger.from_graph(result.graph, entry_id=result.graph.initial_cursor_id)
-    if pinned_candidate_name is not None:
-        block = result.graph.find_one(Selector(label="morning_shift"))
-        assert block is not None
-        block.game.offers[0].candidate_name = pinned_candidate_name
     _choose(ledger, "Monitor the morning halls")
     return result.graph, ledger
 
@@ -179,7 +176,7 @@ class TestHallMonitorWorld:
         assert game.active_case is prepared[0]
 
     def test_hall_monitor_records_and_later_reveals_harsh_inhaler_outcome(self) -> None:
-        graph, ledger = _started_shift(pinned_candidate_name="Ren Ito")
+        graph, ledger = _started_shift()
         block = ledger.cursor
         game = block.game
         bearer_id = game.active_case.packet_manager.bearer_id
@@ -193,9 +190,13 @@ class TestHallMonitorWorld:
         assert len(block.consequences) == 1
         consequence = block.consequences[0]
         assert consequence.bearer_id == bearer_id
-        assert consequence.candidate_name == "Ren Ito"
         assert consequence.outcome == "inhaler_withheld"
         assert "remained at the hall desk" not in _journal_text(ledger)
+
+        bearer = graph.get(bearer_id)
+        assert isinstance(bearer, HasSimpleLook)
+        bearer.label = "Zapp"
+        bearer.look.hair_color = HairColor.BLUE
 
         _finish_shift_correctly(ledger)
         assert ledger.cursor.label == "victory"
@@ -203,7 +204,7 @@ class TestHallMonitorWorld:
         _choose(ledger, "Read the attendance note")
 
         assert ledger.cursor.label == "attendance_note"
-        assert "Ren Ito was sent back to class" in _journal_text(ledger)
+        assert "Zapp, with blue hair, was sent back to class" in _journal_text(ledger)
 
         restored = Graph.structure(graph.unstructure())
         restored_block = restored.find_one(Selector(label="morning_shift"))
@@ -233,7 +234,7 @@ class TestHallMonitorWorld:
         _finish_shift_correctly(ledger)
         assert ledger.cursor.label == "defeat"
         _choose(ledger, "Read the attendance note")
-        assert "Mira Quill reached the nurse's office" in _journal_text(ledger)
+        assert "reached the nurse's office with their inhaler" in _journal_text(ledger)
 
         ledger.get_journal()
         ledger.get_journal()

--- a/engine/tests/loaders/test_hall_monitor_world.py
+++ b/engine/tests/loaders/test_hall_monitor_world.py
@@ -53,6 +53,22 @@ def _started_shift() -> tuple[StoryGraph, Ledger]:
     return result.graph, ledger
 
 
+def _journal_text(ledger: Ledger) -> str:
+    return " ".join(
+        fragment.content
+        for fragment in ledger.get_journal()
+        if isinstance(fragment.content, str)
+    )
+
+
+def _finish_shift_correctly(ledger: Ledger) -> None:
+    while ledger.cursor.label == "morning_shift":
+        game = ledger.cursor.game
+        _inspect(ledger, next(iter(game.presented_documents)))
+        decision = game.expected_disposition(game.active_case).value
+        _choose(ledger, game.presentation.decision_labels[decision])
+
+
 class TestHallMonitorWorld:
     """The school skin exercises the shared credentials lifecycle."""
 
@@ -114,7 +130,7 @@ class TestHallMonitorWorld:
         first_case = ledger.cursor.game.active_case
 
         assert "student ID" in first_case.presented_documents
-        assert "activity pass" in first_case.presented_documents
+        assert "doctor's note" in first_case.presented_documents
         assert "passport" not in first_case.presented_documents
 
         while ledger.cursor.label == "morning_shift":
@@ -156,3 +172,58 @@ class TestHallMonitorWorld:
         assert game.materialized == list(prepared)
         assert len(prepared) == 2
         assert game.active_case is prepared[0]
+
+    def test_hall_monitor_records_and_later_reveals_harsh_inhaler_outcome(self) -> None:
+        graph, ledger = _started_shift()
+        block = ledger.cursor
+        game = block.game
+        bearer_id = game.active_case.packet_manager.bearer_id
+
+        _inspect(ledger, "doctor's note")
+        _choose(ledger, "Send back to class")
+
+        assert game.case_results[0].correct is True
+        assert game.score["player"] == 1
+        assert game.score["opponent"] == 0
+        assert len(block.consequences) == 1
+        consequence = block.consequences[0]
+        assert consequence.bearer_id == bearer_id
+        assert consequence.candidate_name == "Mira Quill"
+        assert consequence.outcome == "inhaler_withheld"
+        assert "remained at the hall desk" not in _journal_text(ledger)
+
+        _finish_shift_correctly(ledger)
+        assert ledger.cursor.label == "victory"
+        assert block.consequences == [consequence]
+        _choose(ledger, "Read the attendance note")
+
+        assert ledger.cursor.label == "attendance_note"
+        assert "Mira Quill was sent back to class" in _journal_text(ledger)
+
+        restored = Graph.structure(graph.unstructure())
+        restored_block = restored.find_one(Selector(label="morning_shift"))
+        assert restored_block is not None
+        assert restored_block.consequences == [consequence]
+
+    def test_hall_monitor_records_compassionate_inhaler_outcome_without_changing_score(self) -> None:
+        _, ledger = _started_shift()
+        block = ledger.cursor
+        game = block.game
+
+        _inspect(ledger, "doctor's note")
+        _choose(ledger, "Allow onward")
+
+        assert game.case_results[0].correct is False
+        assert game.score["opponent"] == 1
+        assert game.score["player"] == 0
+        assert [fact.outcome for fact in block.consequences] == ["inhaler_allowed"]
+        assert "reached the nurse's office" not in _journal_text(ledger)
+
+        _finish_shift_correctly(ledger)
+        assert ledger.cursor.label == "defeat"
+        _choose(ledger, "Read the attendance note")
+        assert "Mira Quill reached the nurse's office" in _journal_text(ledger)
+
+        ledger.get_journal()
+        ledger.get_journal()
+        assert len(block.consequences) == 1

--- a/engine/tests/loaders/test_hall_monitor_world.py
+++ b/engine/tests/loaders/test_hall_monitor_world.py
@@ -45,10 +45,14 @@ def _inspect(ledger: Ledger, target: str) -> None:
     )
 
 
-def _started_shift() -> tuple[StoryGraph, Ledger]:
+def _started_shift(*, pinned_candidate_name: str | None = None) -> tuple[StoryGraph, Ledger]:
     world = WorldCompiler().compile(WorldBundle.load(_hall_monitor_root()))
     result = world.create_story("hall_monitor", init_mode=InitMode.EAGER)
     ledger = Ledger.from_graph(result.graph, entry_id=result.graph.initial_cursor_id)
+    if pinned_candidate_name is not None:
+        block = result.graph.find_one(Selector(label="morning_shift"))
+        assert block is not None
+        block.game.offers[0].candidate_name = pinned_candidate_name
     _choose(ledger, "Monitor the morning halls")
     return result.graph, ledger
 
@@ -101,6 +105,7 @@ class TestHallMonitorWorld:
         assert block is ledger.cursor
         assert block.encounters == 5
         assert block.seed == 20260719
+        assert block.inhaler_case_index == 0
         assert block.disposition_distribution == {
             CredentialDisposition.PASS: 0.5,
             CredentialDisposition.DENY: 0.3,
@@ -174,7 +179,7 @@ class TestHallMonitorWorld:
         assert game.active_case is prepared[0]
 
     def test_hall_monitor_records_and_later_reveals_harsh_inhaler_outcome(self) -> None:
-        graph, ledger = _started_shift()
+        graph, ledger = _started_shift(pinned_candidate_name="Ren Ito")
         block = ledger.cursor
         game = block.game
         bearer_id = game.active_case.packet_manager.bearer_id
@@ -188,7 +193,7 @@ class TestHallMonitorWorld:
         assert len(block.consequences) == 1
         consequence = block.consequences[0]
         assert consequence.bearer_id == bearer_id
-        assert consequence.candidate_name == "Mira Quill"
+        assert consequence.candidate_name == "Ren Ito"
         assert consequence.outcome == "inhaler_withheld"
         assert "remained at the hall desk" not in _journal_text(ledger)
 
@@ -198,14 +203,20 @@ class TestHallMonitorWorld:
         _choose(ledger, "Read the attendance note")
 
         assert ledger.cursor.label == "attendance_note"
-        assert "Mira Quill was sent back to class" in _journal_text(ledger)
+        assert "Ren Ito was sent back to class" in _journal_text(ledger)
 
         restored = Graph.structure(graph.unstructure())
         restored_block = restored.find_one(Selector(label="morning_shift"))
         assert restored_block is not None
         assert restored_block.consequences == [consequence]
+        restored_result = restored_block.game.case_results[0]
+        assert restored_result.case_index == consequence.source_case_index
+        assert restored_result.bearer_id == consequence.bearer_id
+        assert restored.get(restored_result.bearer_id) is not None
 
-    def test_hall_monitor_records_compassionate_inhaler_outcome_without_changing_score(self) -> None:
+    def test_hall_monitor_records_compassionate_inhaler_outcome_without_changing_score(
+        self,
+    ) -> None:
         _, ledger = _started_shift()
         block = ledger.cursor
         game = block.game

--- a/worlds/hall_monitor/README.md
+++ b/worlds/hall_monitor/README.md
@@ -13,6 +13,6 @@ mediation, disposition resolution, scoring, and persistence.
 
 Hall Monitor also demonstrates world-authored consequence return. Its recurring
 Mira Quill medical-note case records a durable, bearer-attributed inhaler outcome
-after UPDATE, but reveals it only from the later attendance-note beat. The
-credentials mechanic supplies the case receipt; it does not decide the school
-meaning or change scoring.
+after UPDATE, but reveals it only from the later attendance-note beat using the
+bearer's then-current graph presentation. The credentials mechanic supplies the
+case receipt; it does not decide the school meaning or change scoring.

--- a/worlds/hall_monitor/README.md
+++ b/worlds/hall_monitor/README.md
@@ -6,7 +6,13 @@ Hall Monitor scenario type, and lets the script configure one sampled morning
 shift with a deterministic seed, disposition distribution, and recurring
 student encounter.
 
-The world keeps school vocabulary—student IDs, teacher signatures, activity
-passes, and office referrals—in its catalog and presentation profile. The shared
+The world keeps school vocabulary—student IDs, teacher signatures, doctor's
+notes, and office referrals—in its catalog and presentation profile. The shared
 credentials game still owns packet materialization, availability, inspection,
 mediation, disposition resolution, scoring, and persistence.
+
+Hall Monitor also demonstrates world-authored consequence return. Its recurring
+Mira Quill medical-note case records a durable, bearer-attributed inhaler outcome
+after UPDATE, but reveals it only from the later attendance-note beat. The
+credentials mechanic supplies the case receipt; it does not decide the school
+meaning or change scoring.

--- a/worlds/hall_monitor/hall_monitor/domain.py
+++ b/worlds/hall_monitor/hall_monitor/domain.py
@@ -194,7 +194,6 @@ class HallMonitorConsequence(BaseModelPlus):
     bearer_id: UUID
     candidate_name: str
     outcome: Literal["inhaler_withheld", "inhaler_allowed"]
-    later_text: str
 
 
 class HallMonitorBlock(HasGame, Block):
@@ -209,6 +208,7 @@ class HallMonitorBlock(HasGame, Block):
         }
     )
     seed: int = 20260719
+    inhaler_case_index: int = 0
     consequences: list[HallMonitorConsequence] = Field(
         default_factory=list,
         json_schema_extra={"include": True},
@@ -256,20 +256,15 @@ def record_hall_monitor_consequence(
     if not game.case_results:
         return None
     result = game.case_results[-1]
-    if result.candidate_name != "Mira Quill":
+    if result.case_index != caller.inhaler_case_index:
         return None
     if any(fact.source_case_index == result.case_index for fact in caller.consequences):
         return None
 
     if result.chosen_disposition is CredentialDisposition.DENY:
         outcome: Literal["inhaler_withheld", "inhaler_allowed"] = "inhaler_withheld"
-        later_text = (
-            "Mira Quill was sent back to class. Her inhaler remained at the hall desk "
-            "while the nurse's unsigned note was checked."
-        )
     elif result.chosen_disposition is CredentialDisposition.PASS:
         outcome = "inhaler_allowed"
-        later_text = "Mira Quill reached the nurse's office with her inhaler."
     else:
         return None
 
@@ -279,7 +274,6 @@ def record_hall_monitor_consequence(
             bearer_id=result.bearer_id,
             candidate_name=result.candidate_name,
             outcome=outcome,
-            later_text=later_text,
         )
     )
     return None
@@ -298,8 +292,15 @@ def render_hall_monitor_consequence(
     if not isinstance(source, HallMonitorBlock) or not source.consequences:
         return None
     consequence = source.consequences[-1]
+    if consequence.outcome == "inhaler_withheld":
+        content = (
+            f"{consequence.candidate_name} was sent back to class. Their inhaler remained "
+            "at the hall desk while the nurse's unsigned note was checked."
+        )
+    else:
+        content = f"{consequence.candidate_name} reached the nurse's office with their inhaler."
     return ContentFragment(
-        content=consequence.later_text,
+        content=content,
         source_id=consequence.bearer_id,
         tags={"hall_monitor_consequence"},
     )

--- a/worlds/hall_monitor/hall_monitor/domain.py
+++ b/worlds/hall_monitor/hall_monitor/domain.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from typing import Literal
 from uuid import UUID
 
 from pydantic import Field, model_validator
 
+from tangl.core import Selector
+from tangl.core.bases import BaseModelPlus
+from tangl.journal.fragments import ContentFragment
 from tangl.mechanics.credentials import (
     CredentialDefinition,
     CredentialStatus,
@@ -23,7 +27,9 @@ from tangl.mechanics.games.credentials_roster import (
     ShiftSpec,
     generate_roster,
 )
-from tangl.story import Block
+from tangl.story import Block, on_journal
+from tangl.vm import on_update
+from tangl.vm.ctx import VmPhaseCtx
 
 
 HALL_RULES = {
@@ -120,20 +126,20 @@ _HALL_FAILURES = (
 
 
 def _special_student() -> ScenarioOffer:
-    """Return the recurring lower-school activity-pass case for every shift."""
+    """Return the recurring lower-school medical-pass case for every shift."""
 
     return ScenarioOffer(
         target_disposition=CredentialDisposition.DENY,
         candidate_name="Mira Quill",
         region="lower",
-        purpose="activity",
+        purpose="medicine",
         failure_modes=[FailureMode.UNSEALED_PERMIT],
         presented_documents_override={
             "student ID": "A laminated lower-school student identification card.",
-            "activity pass": "An activity pass lacking the teacher's signature.",
+            "doctor's note": "A doctor's note for an inhaler, lacking the nurse's signature.",
         },
         hidden_facts_override={
-            "activity pass": "The required teacher signature is missing.",
+            "doctor's note": "The required nurse signature is missing.",
         },
         packet_hidden_facts_override={
             "packet consistency": "The student's papers do not satisfy the hall rules.",
@@ -175,6 +181,22 @@ class HallMonitorCredentialsGame(CredentialsGame):
     )
 
 
+class HallMonitorConsequence(BaseModelPlus):
+    """World-authored later fate for one completed Hall Monitor case.
+
+    Why
+    ---
+    Credentials records the mechanical receipt. Hall Monitor owns the meaning
+    and the later narration of that receipt.
+    """
+
+    source_case_index: int
+    bearer_id: UUID
+    candidate_name: str
+    outcome: Literal["inhaler_withheld", "inhaler_allowed"]
+    later_text: str
+
+
 class HallMonitorBlock(HasGame, Block):
     """Script-configured Hall Monitor scenario instance."""
 
@@ -187,6 +209,10 @@ class HallMonitorBlock(HasGame, Block):
         }
     )
     seed: int = 20260719
+    consequences: list[HallMonitorConsequence] = Field(
+        default_factory=list,
+        json_schema_extra={"include": True},
+    )
 
     _game_class = HallMonitorCredentialsGame
     _game_handler_class = CredentialsGameHandler
@@ -202,6 +228,81 @@ class HallMonitorBlock(HasGame, Block):
                 )
             )
         return self
+
+
+class HallMonitorConsequenceBlock(Block):
+    """Later attendance-note beat that reveals a recorded Hall Monitor fate.
+
+    Why
+    ---
+    A completed credential disposition is a mechanical receipt. This ordinary
+    later block makes any Hall Monitor interpretation visible without granting
+    it same-turn frontier or namespace visibility.
+    """
+
+    source_block_label: str = "morning_shift"
+
+
+@on_update(wants_caller_kind=HallMonitorBlock, wants_exact_kind=False)
+def record_hall_monitor_consequence(
+    *,
+    caller: HallMonitorBlock,
+    ctx: VmPhaseCtx,
+    **_kw: object,
+) -> None:
+    """Record Mira's later outcome after the credentials disposition commits."""
+
+    game = caller.game
+    if not game.case_results:
+        return None
+    result = game.case_results[-1]
+    if result.candidate_name != "Mira Quill":
+        return None
+    if any(fact.source_case_index == result.case_index for fact in caller.consequences):
+        return None
+
+    if result.chosen_disposition is CredentialDisposition.DENY:
+        outcome: Literal["inhaler_withheld", "inhaler_allowed"] = "inhaler_withheld"
+        later_text = (
+            "Mira Quill was sent back to class. Her inhaler remained at the hall desk "
+            "while the nurse's unsigned note was checked."
+        )
+    elif result.chosen_disposition is CredentialDisposition.PASS:
+        outcome = "inhaler_allowed"
+        later_text = "Mira Quill reached the nurse's office with her inhaler."
+    else:
+        return None
+
+    caller.consequences.append(
+        HallMonitorConsequence(
+            source_case_index=result.case_index,
+            bearer_id=result.bearer_id,
+            candidate_name=result.candidate_name,
+            outcome=outcome,
+            later_text=later_text,
+        )
+    )
+    return None
+
+
+@on_journal(wants_caller_kind=HallMonitorConsequenceBlock, wants_exact_kind=False)
+def render_hall_monitor_consequence(
+    *,
+    caller: HallMonitorConsequenceBlock,
+    ctx: VmPhaseCtx,
+    **_kw: object,
+) -> ContentFragment | None:
+    """Reveal recorded Hall Monitor consequences only at the later note beat."""
+
+    source = caller.graph.find_one(Selector(label=caller.source_block_label))
+    if not isinstance(source, HallMonitorBlock) or not source.consequences:
+        return None
+    consequence = source.consequences[-1]
+    return ContentFragment(
+        content=consequence.later_text,
+        source_id=consequence.bearer_id,
+        tags={"hall_monitor_consequence"},
+    )
 
 
 HallMonitorBlock.model_rebuild(_types_namespace={"UUID": UUID})

--- a/worlds/hall_monitor/hall_monitor/domain.py
+++ b/worlds/hall_monitor/hall_monitor/domain.py
@@ -15,6 +15,7 @@ from tangl.mechanics.credentials import (
     Restrictions,
     RestrictionLevel,
 )
+from tangl.mechanics.presence.look import HasSimpleLook
 from tangl.mechanics.games import HasGame
 from tangl.mechanics.games.credentials_game import (
     CredentialDisposition,
@@ -28,6 +29,7 @@ from tangl.mechanics.games.credentials_roster import (
     generate_roster,
 )
 from tangl.story import Block, on_journal
+from tangl.story.presentation import render_text_as
 from tangl.vm import on_update
 from tangl.vm.ctx import VmPhaseCtx
 
@@ -192,7 +194,6 @@ class HallMonitorConsequence(BaseModelPlus):
 
     source_case_index: int
     bearer_id: UUID
-    candidate_name: str
     outcome: Literal["inhaler_withheld", "inhaler_allowed"]
 
 
@@ -272,7 +273,6 @@ def record_hall_monitor_consequence(
         HallMonitorConsequence(
             source_case_index=result.case_index,
             bearer_id=result.bearer_id,
-            candidate_name=result.candidate_name,
             outcome=outcome,
         )
     )
@@ -292,13 +292,19 @@ def render_hall_monitor_consequence(
     if not isinstance(source, HallMonitorBlock) or not source.consequences:
         return None
     consequence = source.consequences[-1]
+    bearer = caller.graph.get(consequence.bearer_id)
+    if not isinstance(bearer, HasSimpleLook):
+        raise LookupError(f"Hall Monitor bearer {consequence.bearer_id} is not present")
+    name = bearer.get_label()
+    presence = render_text_as(bearer, "presence_description", ctx=ctx)
+    subject = f"{name}, {presence}," if presence else name
     if consequence.outcome == "inhaler_withheld":
         content = (
-            f"{consequence.candidate_name} was sent back to class. Their inhaler remained "
-            "at the hall desk while the nurse's unsigned note was checked."
+            f"{subject} was sent back to class. Their inhaler remained at the "
+            "hall desk while the nurse's unsigned note was checked."
         )
     else:
-        content = f"{consequence.candidate_name} reached the nurse's office with their inhaler."
+        content = f"{subject} reached the nurse's office with their inhaler."
     return ContentFragment(
         content=content,
         source_id=consequence.bearer_id,

--- a/worlds/hall_monitor/script.yaml
+++ b/worlds/hall_monitor/script.yaml
@@ -25,6 +25,7 @@ scenes:
           deny: 0.30
           arrest: 0.20
         seed: 20260719
+        inhaler_case_index: 0
         content: |
           Check each student’s identification and pass before deciding whether
           to allow them onward, send them back to class, or refer them to office.

--- a/worlds/hall_monitor/script.yaml
+++ b/worlds/hall_monitor/script.yaml
@@ -39,7 +39,18 @@ scenes:
       victory:
         content: |
           The morning bell settles the halls. Every student was handled correctly.
+        actions:
+          - text: "Read the attendance note"
+            successor: attendance_note
 
       defeat:
         content: |
           The passing period ends with an unresolved mistake on the attendance sheet.
+        actions:
+          - text: "Read the attendance note"
+            successor: attendance_note
+
+      attendance_note:
+        kind: "hall_monitor.domain.HallMonitorConsequenceBlock"
+        content: |
+          The attendance office has filed one note from the morning shift.


### PR DESCRIPTION
Closes #334\n\nSummary:\n- add canonical case and bearer provenance to each credential case receipt\n- let Hall Monitor record Mira Quill's medical-note outcome during UPDATE without affecting credential scoring\n- reveal that fact only through a later attendance-note beat\n- cover harsh and compassionate outcomes, attribution, delayed disclosure, idempotency, and graph round-trip\n\nValidation:\n- poetry run pytest engine/tests/loaders engine/tests/mechanics/games/test_credentials_game.py engine/tests/mechanics/games/test_credentials_scoring.py engine/tests/mechanics/games/test_credentials_scoring_config.py engine/tests/mechanics/games/test_game_handlers.py engine/tests/service/test_credentials_story_info.py engine/tests/mechanics/credentials/test_credential_packet_manager.py -q (232 passed, 2 skipped)\n- poetry run pytest engine/tests/persistence/test_serialization.py engine/tests/persistence/test_component_manager_persistence.py engine/tests/persistence/test_ledger_persistence.py engine/tests/vm/test_ledger_persistence.py -q (28 passed, 13 skipped)\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced activity-pass cases with recurring doctor’s-note scenarios.
  * Added compassionate and harsh inhaler outcomes that can be recorded during a shift and revealed in a later attendance note.
  * Added attendance-note details to both victory and defeat outcomes.
* **Bug Fixes**
  * Corrected the initial document shown in the Hall Monitor scenario.
* **Documentation**
  * Updated the Hall Monitor guidance to describe medical-note scenarios and delayed consequence reveals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->