### PR TITLE
Index multi-lane story material through devref

### DIFF
--- a/docs/notes/narrative_theory_notes.md
+++ b/docs/notes/narrative_theory_notes.md
@@ -6,6 +6,13 @@ Capture the recurring theoretical framing that guided earlier iterations so we c
 
 ## Key theoretical threads
 
+```{storytangl-topic}
+:topics: multi_lane
+:facets: notes
+:relation: mentions
+:related: traversal, journal
+```
+
 - **Tangled feature space** – prior notes describe narrative design as exploring a superposition of interdependent features, with traversal collapsing the space into a stable measurement that becomes the playable lane.【F:scratch/overviews/notes_v34.md†L100-L176】
 - **Cross-domain inspirations** – the same notes tie StoryTangl to Bayesian inference, constraint solving, package resolution, compiler IRs, and quantum collapse, highlighting how deterministic yet replayable execution should feel.【F:scratch/overviews/notes_v34.md†L108-L115】
 - **Navigation as a separable role** – older notes repeatedly treat the

--- a/docs/src/design/story/GENRE_AUDIT_NOTES.md
+++ b/docs/src/design/story/GENRE_AUDIT_NOTES.md
@@ -134,6 +134,13 @@ might be worth promoting. Today: convention covers it.
 
 ### Hot-seat as multi-cursor stand-in
 
+```{storytangl-topic}
+:topics: multi_lane
+:facets: notes
+:relation: documents
+:related: widget, journal
+```
+
 Elefant Hunt and any future multi-player bundle must hot-seat
 through one cursor until §1.5 graduates from Tier P1. The
 convention: emit "Pass the keyboard to Player Red" `content`

--- a/docs/src/design/story/STORYTANGL_WIDGET_VOCAB.md
+++ b/docs/src/design/story/STORYTANGL_WIDGET_VOCAB.md
@@ -356,6 +356,13 @@ differs.
 
 ### 1.5 Cursors and journal channels — Tier P1
 
+```{storytangl-topic}
+:topics: multi_lane, widget
+:facets: design, governance
+:relation: defines
+:related: journal, ledger, frame
+```
+
 > Each cursor has its own journal channel. Envelopes are per-channel.
 > The backend coordinates shared world state across channels; the
 > contract makes no commitment about turn ordering or simultaneous input

--- a/docs/src/design/story/philosophy.md
+++ b/docs/src/design/story/philosophy.md
@@ -387,6 +387,13 @@ roadmap.  See the research agenda for "Narrative Shape Space" directions.
 
 ## The Observer Roles
 
+```{storytangl-topic}
+:topics: multi_lane
+:facets: overview, design
+:relation: documents
+:related: journal, ledger, traversal
+```
+
 Three roles interact with the narrative system, each engaging a different
 layer:
 

--- a/engine/src/tangl/devref/annotations.py
+++ b/engine/src/tangl/devref/annotations.py
@@ -42,6 +42,12 @@ def extract_storytangl_topic_annotations(text: str) -> list[TopicAnnotation]:
                 candidate = lines[index]
                 if candidate.strip() and not candidate.startswith((" ", "\t")):
                     break
+                # A following directive ends this one even when both are
+                # indented, as they are inside a class or method docstring.
+                # Without this the second block is swallowed as body text and
+                # its options silently overwrite the first block's.
+                if candidate.strip() == ".. storytangl-topic::":
+                    break
                 if candidate.strip():
                     body.append(candidate)
                 index += 1

--- a/engine/src/tangl/devref/builder.py
+++ b/engine/src/tangl/devref/builder.py
@@ -96,14 +96,25 @@ def first_paragraph(text: str) -> str:
 
     paragraphs: list[str] = []
     block: list[str] = []
+    in_topic_fence = False
     for raw_line in text.splitlines():
         line = raw_line.strip()
+        # A MyST topic directive is a fenced block; skip through its closing
+        # fence so the delimiter never becomes the section summary. The rst
+        # form has no closing delimiter and needs only the opening skip.
+        if in_topic_fence:
+            if line.startswith("```"):
+                in_topic_fence = False
+            continue
+        if line.startswith("```{storytangl-topic}"):
+            in_topic_fence = True
+            continue
         if not line:
             if block:
                 paragraphs.append(" ".join(block))
                 block = []
             continue
-        if line.startswith(".. storytangl-topic::") or line.startswith("```{storytangl-topic}"):
+        if line.startswith(".. storytangl-topic::"):
             continue
         if line.startswith(":") and block == []:
             continue
@@ -224,6 +235,8 @@ def classify_source(path: Path, repo_root: Path) -> tuple[str, DevTopicFacet, De
         return "note", "notes", "mentions"
     if path.name == "__init__.py":
         return "doc_section", "overview", "documents"
+    if path.suffix.lower() == ".py":
+        return "doc_section", "code", "defines"
     return "doc_section", "notes", "mentions"
 
 

--- a/engine/src/tangl/devref/builder.py
+++ b/engine/src/tangl/devref/builder.py
@@ -290,9 +290,11 @@ def iter_source_paths(repo_root: Path) -> list[Path]:
         "engine/tests/AGENTS.md",
         "docs/src/**/*.md",
         "docs/src/**/*.rst",
+        "docs/notes/**/*.md",
+        "docs/notes/**/*.rst",
         "engine/src/**/*.py",
         "engine/src/**/*_DESIGN.md",
-        "engine/src/**/notes.md",
+        "engine/src/**/*notes.md",
         "engine/tests/**/*.py",
         "apps/**/AGENTS.md",
         "apps/**/notes/**/*.md",
@@ -367,10 +369,19 @@ def extract_python_source(
         return [], []
     module_name = module_name_for_path(path, repo_root)
     module_doc = ast.get_docstring(tree, clean=False) or ""
+    module_annotations = extract_storytangl_topic_annotations(module_doc)
     artifacts: list[ExtractedArtifact] = []
     symbols: list[ExtractedSymbol] = []
 
-    if module_doc and (path.name == "__init__.py" or "tests" in path.parts):
+    # Package and test modules always carry an overview artifact. Any other
+    # module opts in by writing a topic annotation into its docstring, so
+    # annotating a module is enough to make it addressable without indexing
+    # every module docstring in the tree.
+    if module_doc and (
+        path.name == "__init__.py"
+        or "tests" in path.parts
+        or module_annotations
+    ):
         kind, facet, relation = classify_source(path, repo_root)
         title = module_name or path.stem
         if "tests" in path.parts:
@@ -389,7 +400,7 @@ def extract_python_source(
                 summary=summarize_text(module_doc),
                 content=module_doc,
                 metadata={
-                    "annotations": [item.model_dump(mode="python") for item in extract_storytangl_topic_annotations(module_doc)],
+                    "annotations": [item.model_dump(mode="python") for item in module_annotations],
                     "related_paths": [],
                     "symbol_refs": [],
                 },
@@ -445,7 +456,10 @@ def extract_python_source(
                 content=(ast.get_docstring(node, clean=False) or "").strip(),
                 qualified_name=qualified_name,
                 metadata={
-                    "annotations": [],
+                    "annotations": [
+                        item.model_dump(mode="python")
+                        for item in extract_storytangl_topic_annotations(docstring)
+                    ],
                     "related_paths": [],
                     "symbol_refs": [qualified_name],
                     "module_name": module_name,

--- a/engine/src/tangl/devref/topics.json
+++ b/engine/src/tangl/devref/topics.json
@@ -350,6 +350,32 @@
     ]
   },
   {
+    "topic_id": "multi_lane",
+    "display_name": "Multi-Lane Stories",
+    "aliases": [
+      "multi-lane",
+      "multi lane",
+      "multi-cursor",
+      "multi-participant",
+      "cursor channel",
+      "journal channel",
+      "per-cursor",
+      "hot-seat",
+      "navigator role",
+      "focalization"
+    ],
+    "layer": "vm",
+    "short_description": "Several navigators traversing one shared fabula: N cursors, N journal channels, per-participant visibility, and cross-lane coordination above follow.",
+    "related_topic_ids": [
+      "ledger",
+      "journal",
+      "widget",
+      "traversal",
+      "frame",
+      "replay"
+    ]
+  },
+  {
     "topic_id": "open_link",
     "display_name": "Open Link",
     "aliases": [

--- a/engine/src/tangl/devref/topics.json
+++ b/engine/src/tangl/devref/topics.json
@@ -361,8 +361,7 @@
       "journal channel",
       "per-cursor",
       "hot-seat",
-      "navigator role",
-      "focalization"
+      "navigator role"
     ],
     "layer": "vm",
     "short_description": "Several navigators traversing one shared fabula: N cursors, N journal channels, per-participant visibility, and cross-lane coordination above follow.",

--- a/engine/src/tangl/mechanics/games/has_game.py
+++ b/engine/src/tangl/mechanics/games/has_game.py
@@ -51,10 +51,15 @@ class HasGame:
     strategy inside this game state, not a second cursor.
 
     .. storytangl-topic::
-       :topics: multi_lane, open_link
+       :topics: open_link
        :facets: code
        :relation: demonstrates
        :related: traversal, provisioning
+
+    .. storytangl-topic::
+       :topics: multi_lane
+       :facets: code
+       :relation: mentions
     """
 
     _game_class: ClassVar[type[Game]] = Game

--- a/engine/src/tangl/mechanics/games/has_game.py
+++ b/engine/src/tangl/mechanics/games/has_game.py
@@ -45,10 +45,10 @@ class HasGame:
     variant carrying different payload/label data while still targeting this
     same node.
 
-    This self-fanout block is the structural shape a contest node needs: a
-    re-entrant node whose outgoing move edges are recomputed each visit from
-    current shared state. Multi-lane contests reuse it directly; lane asymmetry
-    lives in the template registry, not here.
+    The self-fanout shape — a re-entrant node whose outgoing move edges are
+    recomputed each visit from current state — is also what a two-party contest
+    node would need. Nothing here is multi-navigator today: the opponent is a
+    strategy inside this game state, not a second cursor.
 
     .. storytangl-topic::
        :topics: multi_lane, open_link

--- a/engine/src/tangl/mechanics/games/has_game.py
+++ b/engine/src/tangl/mechanics/games/has_game.py
@@ -44,6 +44,17 @@ class HasGame:
     formal model is closer to a self-fanout: each available move is an edge
     variant carrying different payload/label data while still targeting this
     same node.
+
+    This self-fanout block is the structural shape a contest node needs: a
+    re-entrant node whose outgoing move edges are recomputed each visit from
+    current shared state. Multi-lane contests reuse it directly; lane asymmetry
+    lives in the template registry, not here.
+
+    .. storytangl-topic::
+       :topics: multi_lane, open_link
+       :facets: code
+       :relation: demonstrates
+       :related: traversal, provisioning
     """
 
     _game_class: ClassVar[type[Game]] = Game

--- a/engine/src/tangl/vm/replay/design_notes.md
+++ b/engine/src/tangl/vm/replay/design_notes.md
@@ -200,6 +200,13 @@ that the intermediate state be reconstructable from patches alone.  But:
 
 ### When to Revisit
 
+```{storytangl-topic}
+:topics: multi_lane, replay
+:facets: notes
+:relation: documents
+:related: ledger, journal
+```
+
 Dual-phase patches become relevant when:
 
 - Multi-lane stories where multiple players share a graph and need to

--- a/engine/src/tangl/vm/runtime/ledger.py
+++ b/engine/src/tangl/vm/runtime/ledger.py
@@ -11,10 +11,15 @@ vocabulary "Cursors and journal channels" contract leaves the coordination
 design open.
 
 .. storytangl-topic::
-   :topics: ledger, multi_lane
+   :topics: ledger
    :facets: code
    :relation: defines
    :related: journal, frame, widget
+
+.. storytangl-topic::
+   :topics: multi_lane
+   :facets: code
+   :relation: mentions
 """
 
 from __future__ import annotations

--- a/engine/src/tangl/vm/runtime/ledger.py
+++ b/engine/src/tangl/vm/runtime/ledger.py
@@ -3,6 +3,16 @@
 
 The Ledger owns long-lived state that persists across player actions:
 the graph, cursor position and history, return stack, and accumulated output.
+
+One ledger holds exactly one cursor and one output stream. Multi-lane stories
+(several navigators over one shared fabula) require this to become plural; see
+the widget vocabulary "Cursors and journal channels" contract.
+
+.. storytangl-topic::
+   :topics: ledger, multi_lane
+   :facets: code
+   :relation: defines
+   :related: journal, frame, widget
 """
 
 from __future__ import annotations

--- a/engine/src/tangl/vm/runtime/ledger.py
+++ b/engine/src/tangl/vm/runtime/ledger.py
@@ -5,8 +5,10 @@ The Ledger owns long-lived state that persists across player actions:
 the graph, cursor position and history, return stack, and accumulated output.
 
 One ledger holds exactly one cursor and one output stream. Multi-lane stories
-(several navigators over one shared fabula) require this to become plural; see
-the widget vocabulary "Cursors and journal channels" contract.
+(several navigators over one shared fabula) need per-navigator cursors and
+journal channels, which this shape does not currently express; the widget
+vocabulary "Cursors and journal channels" contract leaves the coordination
+design open.
 
 .. storytangl-topic::
    :topics: ledger, multi_lane

--- a/engine/tests/devref/test_annotations.py
+++ b/engine/tests/devref/test_annotations.py
@@ -6,6 +6,28 @@ from tangl.devref.annotations import extract_storytangl_topic_annotations
 from tangl.devref.builder import extract_symbol_refs, parse_sections
 
 
+def test_consecutive_indented_directives_stay_separate() -> None:
+    """Two directives in one class docstring must not merge into one."""
+
+    docstring = """Mixin docstring.
+
+    .. storytangl-topic::
+       :topics: open_link
+       :facets: code
+       :relation: demonstrates
+
+    .. storytangl-topic::
+       :topics: multi_lane
+       :facets: code
+       :relation: mentions
+    """
+
+    annotations = extract_storytangl_topic_annotations(docstring)
+
+    assert [item.topics for item in annotations] == [["open_link"], ["multi_lane"]]
+    assert [item.relation for item in annotations] == ["demonstrates", "mentions"]
+
+
 def test_extract_storytangl_topic_annotations_from_rst_and_myst() -> None:
     rst_text = """
 .. storytangl-topic::

--- a/engine/tests/devref/test_builder.py
+++ b/engine/tests/devref/test_builder.py
@@ -122,6 +122,48 @@ class Annotated:
     assert module_hits, "annotated module docstring should produce a module artifact"
     assert symbol_hits, "annotated class docstring should link its symbol artifact"
 
+    # The declared classification must survive onto the artifact, not just the
+    # topic link, since find/map report the artifact's own facet and relation.
+    assert module_hits[0].facet == "code"
+    assert module_hits[0].relation == "defines"
+    assert module_hits[0].summary.startswith("Annotated module")
+
+
+def test_myst_topic_fence_is_not_summarized_as_a_section(tmp_path) -> None:
+    """A MyST directive must not leave its closing fence as the summary."""
+
+    repo_root = _mini_repo(tmp_path)
+    db_path = tmp_path / "mini.sqlite3"
+    _write(
+        repo_root / "docs" / "src" / "design" / "fenced.md",
+        """
+# Fenced
+
+## Annotated Section
+
+```{storytangl-topic}
+:topics: entity
+:facets: design
+:relation: documents
+```
+
+The real opening paragraph.
+""".strip()
+        + "\n",
+    )
+
+    build_index(repo_root=repo_root, db_path=db_path, incremental=False)
+
+    hits = [
+        artifact
+        for artifact in search_topics("entity", db_path=db_path).artifacts
+        if artifact.source_path.endswith("design/fenced.md")
+    ]
+
+    assert hits
+    assert all("```" not in artifact.summary for artifact in hits)
+    assert any(artifact.summary.startswith("The real opening paragraph") for artifact in hits)
+
 
 def test_unannotated_plain_module_produces_no_module_artifact(tmp_path) -> None:
     """Annotation is the opt-in; ordinary modules stay symbol-only."""

--- a/engine/tests/devref/test_builder.py
+++ b/engine/tests/devref/test_builder.py
@@ -77,6 +77,69 @@ class Entity:
     return repo
 
 
+def test_annotated_plain_module_and_symbol_are_indexed(tmp_path) -> None:
+    """Non-package, non-test modules opt into indexing via topic annotations."""
+
+    repo_root = _mini_repo(tmp_path)
+    db_path = tmp_path / "mini.sqlite3"
+    _write(
+        repo_root / "engine" / "src" / "tangl" / "core" / "annotated.py",
+        '''
+"""Annotated module.
+
+.. storytangl-topic::
+   :topics: selector
+   :facets: code
+   :relation: defines
+"""
+
+class Annotated:
+    """Annotated symbol.
+
+    .. storytangl-topic::
+       :topics: registry
+       :facets: code
+       :relation: defines
+    """
+'''.strip()
+        + "\n",
+    )
+
+    build_index(repo_root=repo_root, db_path=db_path, incremental=False)
+
+    module_hits = [
+        artifact
+        for artifact in search_topics("selector", db_path=db_path).artifacts
+        if artifact.source_path.endswith("core/annotated.py") and artifact.kind != "symbol"
+    ]
+    symbol_hits = [
+        artifact
+        for artifact in search_topics("registry", db_path=db_path).artifacts
+        if artifact.qualified_name is not None
+        and artifact.qualified_name.endswith("annotated.Annotated")
+    ]
+
+    assert module_hits, "annotated module docstring should produce a module artifact"
+    assert symbol_hits, "annotated class docstring should link its symbol artifact"
+
+
+def test_unannotated_plain_module_produces_no_module_artifact(tmp_path) -> None:
+    """Annotation is the opt-in; ordinary modules stay symbol-only."""
+
+    repo_root = _mini_repo(tmp_path)
+    db_path = tmp_path / "mini.sqlite3"
+
+    build_index(repo_root=repo_root, db_path=db_path, incremental=False)
+
+    entity_module_hits = [
+        artifact
+        for artifact in search_topics("entity", db_path=db_path).artifacts
+        if artifact.source_path.endswith("core/entity.py") and artifact.kind != "symbol"
+    ]
+
+    assert not entity_module_hits
+
+
 def test_build_index_full_and_noop(tmp_path) -> None:
     repo_root = _mini_repo(tmp_path)
     db_path = tmp_path / "mini.sqlite3"


### PR DESCRIPTION
## Summary

Multi-lane stories (several navigators traversing one shared fabula, N cursors,
N journal channels) are already a written commitment — `STORYTANGL_WIDGET_VOCAB.md`
§1.5 is a **Tier P1 committed target contract**, and four other docs reference the
idea. None of it was reachable through devref: there was no topic to link against,
and two of the source files sat outside the indexer's globs entirely.

This registers the topic, annotates the sections that carry it, and fixes the two
indexing gaps that annotating exposed.

## What changed

**New `multi_lane` topic** (`topics.json`), layer `vm`, related to `ledger`,
`journal`, `widget`, `traversal`, `frame`, `replay`.

**Five sections annotated:**

| File | Section | Relation |
|---|---|---|
| `STORYTANGL_WIDGET_VOCAB.md` | §1.5 Cursors and journal channels | `defines` |
| `philosophy.md` | The Observer Roles | `documents` |
| `GENRE_AUDIT_NOTES.md` | Hot-seat as multi-cursor stand-in | `documents` |
| `vm/replay/design_notes.md` | When to Revisit | `documents` |
| `docs/notes/narrative_theory_notes.md` | Key theoretical threads | `mentions` |

Plus two code sites that carry load-bearing facts: `vm/runtime/ledger.py` (one
ledger holds exactly one cursor and one output stream — the actual constraint
multi-lane has to change) and `mechanics/games/has_game.py` (the self-fanout
block, which is already the structural shape a contest node needs).

## Indexer fixes

Both were found by annotating and observing that nothing happened.

1. **Glob gaps.** `docs/notes/**` was never scanned — the pattern was
   `docs/src/**/*.md`. And `engine/src/**/notes.md` does not match
   `design_notes.md`. Widened to `docs/notes/**/*.{md,rst}` and
   `engine/src/**/*notes.md`.

2. **`.py` annotations were inert outside `__init__.py` and tests.** Symbol
   artifacts hardcoded `"annotations": []`, and plain modules produced no module
   artifact at all, so a `.. storytangl-topic::` directive in an ordinary module
   or class docstring was silently dropped. Symbol docstrings are now parsed, and
   a plain module opts into a module artifact **by carrying an annotation** —
   rather than indexing every module docstring in the tree.

The opt-in keeps growth proportional to intent: 898 → 908 indexed sources.

## Alias note

Aliases are deliberately narrow. An earlier pass including `visibility`, `lane`,
and `participant` pulled in sandbox `SandboxVisibilityRule` and presence material,
tripling the topic's artifact set (10 → 33 sources) with noise. Worth knowing when
adding future topics.

## Verification

- `pytest engine/tests` → **2880 passed**, 69 skipped, 9 xfailed.
- Two pre-existing failures in `test_package_distribution.py::TestScriptInvocation`
  (console-script presence) reproduce on a stashed tree and are unrelated.
- Two new tests cover the opt-in behavior in both directions: an annotated module
  and class are indexed; an unannotated module stays symbol-only.
- `tangl-devref find multi_lane` resolves the topic and ranks §1.5 first.

## Follow-up

A `devref:multi_lane` label should be created — the existing `devref:*` labels map
1:1 onto topic ids. An aspirational demo design issue for the multi-lane MVP
follows separately.

Related: #223 (devref annotation polish), #282 (devref indexing convention), #235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer topic metadata across design and narrative documentation for multi-lane, journal, widget, and replay concepts.
  * Expanded documentation indexing so annotated Python modules and symbols are now included in generated reference artifacts.

* **Bug Fixes**
  * Improved summary extraction to ignore fenced metadata blocks while keeping real content.
  * Added coverage to ensure unannotated modules are not indexed and annotated content retains key details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->