### PR TITLE
Credentials: return a stable bearer with a fresh packet

### DIFF
--- a/engine/src/tangl/mechanics/credentials/assembly.py
+++ b/engine/src/tangl/mechanics/credentials/assembly.py
@@ -347,17 +347,24 @@ def materialize_packet(
     possessions: list[ContrabandItem],
     label_prefix: str,
     catalog: TokenCatalog[CredentialDefinition] | None = None,
+    bearer_id: UUID | None = None,
 ) -> CredentialPacketManager:
     """Create an owner-bound graph packet from a factory's value-shaped output."""
 
+    resolved_bearer_id = bearer_id or uuid4()
     manager = CredentialPacketManager(
         region=region,
         purpose=purpose,
         possessions=list(possessions),
+        bearer_id=resolved_bearer_id,
     )
-    bearer = manager.materialize_subject(f"{label_prefix}:bearer")
-    manager.bearer_id = bearer.uid
     manager.bind_owner(owner)
+    if bearer_id is None and manager._owner_registry() is None:
+        bearer = HasSimpleLook(uid=resolved_bearer_id, label=f"{label_prefix}:bearer")
+    else:
+        bearer = manager.resolve_subject(resolved_bearer_id)
+        if bearer_id is None:
+            bearer.label = f"{label_prefix}:bearer"
     id_subject = bearer
     if id_card is not None and id_card.status is CredentialStatus.WRONG_HOLDER:
         id_subject = manager.materialize_subject(f"{label_prefix}:id-subject")

--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -1171,6 +1171,19 @@ school-specific inhaler outcome, then an attendance-note action projects that
 outcome with the bearer's current graph-owned presentation on a later turn.
 Credentials itself still owns only evaluation and scoring.
 
+### Same-story returning bearer (landed 2026-08-04)
+
+A world may author one return node and configure its ordinary `ScenarioOffer`
+during the predecessor's PLANNING pass after a prior receipt exists. The offer
+may carry the earlier `CredentialCaseResult` as semantic context plus its
+canonical `bearer_id`; normal packet materialization then creates a fresh packet
+whose ID-bound documents point at that existing graph subject. The return node
+is already prepared before selection, and its JOURNAL narration resolves the
+bearer's current graph presentation at use time.
+
+This is deliberately one-story, one-authored-return proof. It is not a
+candidate dossier, recurrence scheduler, or cross-session identity system.
+
 A procedural candidate today is generated for one shift and disappears at
 terminal. A *real* checkpoint story wants candidates to return: the
 procedurally-sampled traveler you wrongly admitted on day 1 walks back through

--- a/engine/src/tangl/mechanics/games/credentials_factory.py
+++ b/engine/src/tangl/mechanics/games/credentials_factory.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import random
 from collections.abc import Iterable, Sequence
+from uuid import UUID
 
 from tangl.core import TokenCatalog
 from tangl.mechanics.credentials import (
@@ -58,6 +59,7 @@ def build_valid(
     contraband: Sequence[IndicationId] = (),
     owner: object | None = None,
     catalog: TokenCatalog[CredentialDefinition] | None = None,
+    bearer_id: UUID | None = None,
 ) -> CredentialCase:
     """Assemble a fully valid packet for ``purpose`` (+ declared contraband).
 
@@ -112,6 +114,7 @@ def build_valid(
             possessions=possessions,
             label_prefix=candidate_name,
             catalog=catalog,
+            bearer_id=bearer_id,
         ),
     )
 

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -195,6 +195,10 @@ class CredentialCase(Unstructurable):
     packet_manager: AssemblyCredentialPacketManager = Field(
         json_schema_extra={"include": True, "unstructurable": True},
     )
+    prior_case_results: list["CredentialCaseResult"] = Field(
+        default_factory=list,
+        json_schema_extra={"include": True},
+    )
 
     # Authored override; None means "derive from the rules".
     correct_disposition: CredentialDisposition | None = None
@@ -262,6 +266,9 @@ class CredentialCaseResult(BaseModelPlus):
     unjustified: bool = False
     discovered_findings: dict[str, str] = Field(default_factory=dict)
     packet_findings: dict[str, str] = Field(default_factory=dict)
+
+
+CredentialCase.model_rebuild(_types_namespace={"CredentialCaseResult": CredentialCaseResult})
 
 
 def _default_roster() -> list[CredentialCase]:

--- a/engine/src/tangl/mechanics/games/credentials_roster.py
+++ b/engine/src/tangl/mechanics/games/credentials_roster.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import random
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
+from uuid import UUID
 
 from pydantic import Field
 
@@ -39,6 +40,7 @@ from tangl.mechanics.credentials import (
 from .credentials_factory import build_valid, degrade, render_narrative
 from .credentials_game import (
     CredentialCase,
+    CredentialCaseResult,
     CredentialDisposition,
     CredentialsGame,
     derive_defects,
@@ -73,6 +75,8 @@ class ScenarioOffer(Unstructurable):
     presented_documents_override: dict[str, str] | None = None
     hidden_facts_override: dict[str, str] | None = None
     packet_hidden_facts_override: dict[str, str] | None = None
+    bearer_id: UUID | None = None
+    prior_case_results: list[CredentialCaseResult] = Field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -335,7 +339,9 @@ def materialize(
         contraband=list(offer.contraband),
         owner=owner or object(),
         catalog=catalog,
+        bearer_id=offer.bearer_id,
     )
+    case.prior_case_results = list(offer.prior_case_results)
     degrade(case, offer.failure_modes)
     defects = derive_defects(case.packet_manager, rules)
     (narrative_renderer or render_narrative)(case, defects)

--- a/engine/tests/loaders/test_hall_monitor_world.py
+++ b/engine/tests/loaders/test_hall_monitor_world.py
@@ -239,3 +239,74 @@ class TestHallMonitorWorld:
         ledger.get_journal()
         ledger.get_journal()
         assert len(block.consequences) == 1
+
+    def test_attendance_note_prepares_a_returning_bearer_with_prior_receipt(self) -> None:
+        graph, ledger = _started_shift()
+        source = ledger.cursor
+        source_game = source.game
+        first_packet = source_game.active_case.packet_manager
+        bearer_id = first_packet.bearer_id
+
+        _inspect(ledger, "doctor's note")
+        _choose(ledger, "Send back to class")
+        first_result = source_game.case_results[0].model_dump(mode="python")
+        _finish_shift_correctly(ledger)
+        assert ledger.cursor.label == "victory"
+
+        subjects_before_return = sum(
+            isinstance(item, HasSimpleLook)
+            for item in graph.members.values()
+        )
+        _choose(ledger, "Read the attendance note")
+        assert ledger.cursor.label == "attendance_note"
+
+        returning = graph.find_one(Selector(label="returning_student"))
+        assert returning is not None
+        returning_game = returning.game
+        returning_case = returning_game.active_case
+        returning_packet = returning_case.packet_manager
+        assert returning_packet is not first_packet
+        assert returning_packet.bearer_id == bearer_id
+        assert returning_case.prior_case_results == source_game.case_results[:1]
+        assert not any(case.prior_case_results for case in source_game.materialized[1:])
+        assert sum(isinstance(item, HasSimpleLook) for item in graph.members.values()) == (
+            subjects_before_return
+        )
+        assert {
+            component.uid for component in returning_packet.document_components()
+        }.isdisjoint(component.uid for component in first_packet.document_components())
+
+        restored = Graph.structure(graph.unstructure())
+        restored_source = restored.find_one(Selector(label="morning_shift"))
+        restored_attendance = restored.find_one(Selector(label="attendance_note"))
+        restored_returning = restored.find_one(Selector(label="returning_student"))
+        assert restored_source is not None
+        assert restored_attendance is not None
+        assert restored_returning is not None
+        restored_case = restored_returning.game.active_case
+        assert restored_case.packet_manager.bearer_id == bearer_id
+        assert restored_case.prior_case_results[0].model_dump(mode="python") == first_result
+
+        restored_subject_count = sum(
+            isinstance(item, HasSimpleLook)
+            for item in restored.members.values()
+        )
+
+        bearer = restored.get(bearer_id)
+        assert isinstance(bearer, HasSimpleLook)
+        bearer.label = "Zapp"
+        bearer.look.hair_color = HairColor.BLUE
+
+        restored_ledger = Ledger.from_graph(restored, entry_id=restored_attendance.uid)
+        assert sum(isinstance(item, HasSimpleLook) for item in restored.members.values()) == (
+            restored_subject_count
+        )
+        _choose(restored_ledger, "Meet the returning student")
+        assert restored_ledger.cursor is restored_returning
+        assert "Zapp, with blue hair, returns" in _journal_text(restored_ledger)
+
+        _inspect(restored_ledger, "doctor's note")
+        _choose(restored_ledger, "Allow onward")
+        assert restored_returning.game.case_results[0].correct is True
+        assert len(restored_returning.game.case_results) == 1
+        assert restored_source.game.case_results[0].model_dump(mode="python") == first_result

--- a/engine/tests/loaders/test_hall_monitor_world.py
+++ b/engine/tests/loaders/test_hall_monitor_world.py
@@ -18,6 +18,9 @@ from tangl.mechanics.games.credentials_roster import materialize
 from tangl.service.world_registry import WorldRegistry
 from tangl.story import Action, InitMode, StoryGraph
 from tangl.vm import Ledger
+from tangl.vm.dispatch import do_provision
+from tangl.vm.resolution_phase import ResolutionPhase
+from tangl.vm.runtime.frame import PhaseCtx
 
 
 def _repo_worlds_dir() -> Path:
@@ -259,6 +262,7 @@ class TestHallMonitorWorld:
         )
         _choose(ledger, "Read the attendance note")
         assert ledger.cursor.label == "attendance_note"
+        assert any(action.text == "Meet the returning student" for action in _actions(ledger))
 
         returning = graph.find_one(Selector(label="returning_student"))
         assert returning is not None
@@ -276,13 +280,14 @@ class TestHallMonitorWorld:
             component.uid for component in returning_packet.document_components()
         }.isdisjoint(component.uid for component in first_packet.document_components())
 
-        restored = Graph.structure(graph.unstructure())
+        restored = StoryGraph.structure(graph.unstructure())
         restored_source = restored.find_one(Selector(label="morning_shift"))
         restored_attendance = restored.find_one(Selector(label="attendance_note"))
         restored_returning = restored.find_one(Selector(label="returning_student"))
         assert restored_source is not None
         assert restored_attendance is not None
         assert restored_returning is not None
+        assert restored_source.consequences
         restored_case = restored_returning.game.active_case
         assert restored_case.packet_manager.bearer_id == bearer_id
         assert restored_case.prior_case_results[0].model_dump(mode="python") == first_result
@@ -298,6 +303,19 @@ class TestHallMonitorWorld:
         bearer.look.hair_color = HairColor.BLUE
 
         restored_ledger = Ledger.from_graph(restored, entry_id=restored_attendance.uid)
+        planning_ctx = PhaseCtx(
+            graph=restored,
+            cursor_id=restored_attendance.uid,
+            current_phase=ResolutionPhase.PLANNING,
+        )
+        do_provision(restored_attendance, ctx=planning_ctx)
+        do_provision(restored_attendance, ctx=planning_ctx)
+        returning_actions = [
+            action
+            for action in _actions(restored_ledger)
+            if action.text == "Meet the returning student"
+        ]
+        assert len(returning_actions) == 1
         assert sum(isinstance(item, HasSimpleLook) for item in restored.members.values()) == (
             restored_subject_count
         )
@@ -310,3 +328,19 @@ class TestHallMonitorWorld:
         assert restored_returning.game.case_results[0].correct is True
         assert len(restored_returning.game.case_results) == 1
         assert restored_source.game.case_results[0].model_dump(mode="python") == first_result
+
+    def test_arrest_does_not_offer_or_prepare_a_returning_student(self) -> None:
+        graph, ledger = _started_shift()
+
+        _inspect(ledger, "doctor's note")
+        _choose(ledger, "Send to the office")
+        _finish_shift_correctly(ledger)
+        assert ledger.cursor.label == "defeat"
+
+        _choose(ledger, "Read the attendance note")
+        assert ledger.cursor.label == "attendance_note"
+        assert all(action.text != "Meet the returning student" for action in _actions(ledger))
+
+        returning = graph.find_one(Selector(label="returning_student"))
+        assert returning is not None
+        assert returning.game_state is None

--- a/worlds/hall_monitor/README.md
+++ b/worlds/hall_monitor/README.md
@@ -16,3 +16,8 @@ Mira Quill medical-note case records a durable, bearer-attributed inhaler outcom
 after UPDATE, but reveals it only from the later attendance-note beat using the
 bearer's then-current graph presentation. The credentials mechanic supplies the
 case receipt; it does not decide the school meaning or change scoring.
+
+The attendance note also prepares one authored return encounter. That encounter
+uses a fresh packet with the same graph-owned bearer UUID and receives the first
+case receipt as semantic prior context. Its recognition prose resolves the
+bearer's current presence only when the return is entered.

--- a/worlds/hall_monitor/hall_monitor/domain.py
+++ b/worlds/hall_monitor/hall_monitor/domain.py
@@ -18,6 +18,7 @@ from tangl.mechanics.credentials import (
 from tangl.mechanics.presence.look import HasSimpleLook
 from tangl.mechanics.games import HasGame
 from tangl.mechanics.games.credentials_game import (
+    CredentialCaseResult,
     CredentialDisposition,
     CredentialPresentationProfile,
     CredentialsGame,
@@ -30,7 +31,7 @@ from tangl.mechanics.games.credentials_roster import (
 )
 from tangl.story import Block, on_journal
 from tangl.story.presentation import render_text_as
-from tangl.vm import on_update
+from tangl.vm import on_provision, on_update
 from tangl.vm.ctx import VmPhaseCtx
 
 
@@ -222,6 +223,7 @@ class HallMonitorBlock(HasGame, Block):
     def _configure_game(self) -> HallMonitorBlock:
         if self.game_state is None:
             self.game_state = HallMonitorCredentialsGame(
+                roster=[],
                 offers=_hall_offers(
                     encounters=self.encounters,
                     disposition_distribution=self.disposition_distribution,
@@ -242,6 +244,20 @@ class HallMonitorConsequenceBlock(Block):
     """
 
     source_block_label: str = "morning_shift"
+    return_block_label: str = "returning_student"
+
+
+class HallMonitorReturnBlock(HasGame, Block):
+    """One pre-authored return encounter prepared from the attendance note.
+
+    Why
+    ---
+    The node is ordinary authored topology. Its game is configured only after
+    the first case receipt exists, during the predecessor's PLANNING pass.
+    """
+
+    _game_class = HallMonitorCredentialsGame
+    _game_handler_class = CredentialsGameHandler
 
 
 @on_update(wants_caller_kind=HallMonitorBlock, wants_exact_kind=False)
@@ -279,6 +295,50 @@ def record_hall_monitor_consequence(
     return None
 
 
+@on_provision(wants_caller_kind=HallMonitorConsequenceBlock, wants_exact_kind=False)
+def prepare_hall_monitor_return(
+    *,
+    caller: HallMonitorConsequenceBlock,
+    ctx: VmPhaseCtx,
+    **_kw: object,
+) -> None:
+    """Configure the authored return before its successor is presented."""
+
+    source = caller.graph.find_one(Selector(label=caller.source_block_label))
+    return_block = caller.graph.find_one(Selector(label=caller.return_block_label))
+    if not isinstance(source, HallMonitorBlock) or not isinstance(
+        return_block,
+        HallMonitorReturnBlock,
+    ):
+        raise LookupError("Hall Monitor return topology is incomplete")
+    if return_block.game_state is not None or not source.consequences:
+        return None
+
+    consequence = source.consequences[-1]
+    prior_result = source.game.case_results[consequence.source_case_index]
+    if prior_result.bearer_id != consequence.bearer_id:
+        raise ValueError("Hall Monitor consequence does not match its source receipt")
+
+    return_block.game_state = HallMonitorCredentialsGame(
+        roster=[],
+        offers=[
+            ScenarioOffer(
+                target_disposition=CredentialDisposition.PASS,
+                region="lower",
+                purpose="medicine",
+                candidate_name="Returning student",
+                bearer_id=consequence.bearer_id,
+                prior_case_results=[prior_result],
+                presented_documents_override={
+                    "student ID": "A current student identification card.",
+                    "doctor's note": "A fresh nurse-signed note for an inhaler.",
+                },
+            )
+        ]
+    )
+    return None
+
+
 @on_journal(wants_caller_kind=HallMonitorConsequenceBlock, wants_exact_kind=False)
 def render_hall_monitor_consequence(
     *,
@@ -309,6 +369,32 @@ def render_hall_monitor_consequence(
         content=content,
         source_id=consequence.bearer_id,
         tags={"hall_monitor_consequence"},
+    )
+
+
+@on_journal(wants_caller_kind=HallMonitorReturnBlock, wants_exact_kind=False)
+def render_hall_monitor_return(
+    *,
+    caller: HallMonitorReturnBlock,
+    ctx: VmPhaseCtx,
+    **_kw: object,
+) -> ContentFragment | None:
+    """Recognize the returning bearer through their live presence projection."""
+
+    game = caller.game
+    if game.history or not game.active_case.prior_case_results:
+        return None
+    prior_result = game.active_case.prior_case_results[0]
+    bearer = game.active_case.packet_manager.resolve_subject(prior_result.bearer_id)
+    name = bearer.get_label()
+    presence = render_text_as(bearer, "presence_description", ctx=ctx)
+    subject = f"{name}, {presence}," if presence else name
+    return ContentFragment(
+        content=(
+            f"{subject} returns after this morning's decision with a fresh nurse-signed note."
+        ),
+        source_id=bearer.uid,
+        tags={"hall_monitor_return"},
     )
 
 

--- a/worlds/hall_monitor/hall_monitor/domain.py
+++ b/worlds/hall_monitor/hall_monitor/domain.py
@@ -29,7 +29,7 @@ from tangl.mechanics.games.credentials_roster import (
     ShiftSpec,
     generate_roster,
 )
-from tangl.story import Block, on_journal
+from tangl.story import Action, Block, on_journal
 from tangl.story.presentation import render_text_as
 from tangl.vm import on_provision, on_update
 from tangl.vm.ctx import VmPhaseCtx
@@ -311,31 +311,41 @@ def prepare_hall_monitor_return(
         HallMonitorReturnBlock,
     ):
         raise LookupError("Hall Monitor return topology is incomplete")
-    if return_block.game_state is not None or not source.consequences:
+    if not source.consequences:
         return None
 
     consequence = source.consequences[-1]
-    prior_result = source.game.case_results[consequence.source_case_index]
-    if prior_result.bearer_id != consequence.bearer_id:
-        raise ValueError("Hall Monitor consequence does not match its source receipt")
-
-    return_block.game_state = HallMonitorCredentialsGame(
-        roster=[],
-        offers=[
-            ScenarioOffer(
-                target_disposition=CredentialDisposition.PASS,
-                region="lower",
-                purpose="medicine",
-                candidate_name="Returning student",
-                bearer_id=consequence.bearer_id,
-                prior_case_results=[prior_result],
-                presented_documents_override={
-                    "student ID": "A current student identification card.",
-                    "doctor's note": "A fresh nurse-signed note for an inhaler.",
-                },
-            )
-        ]
-    )
+    if return_block.game_state is None:
+        prior_result = source.game.case_results[consequence.source_case_index]
+        if prior_result.bearer_id != consequence.bearer_id:
+            raise ValueError("Hall Monitor consequence does not match its source receipt")
+        return_block.game_state = HallMonitorCredentialsGame(
+            roster=[],
+            offers=[
+                ScenarioOffer(
+                    target_disposition=CredentialDisposition.PASS,
+                    region="lower",
+                    purpose="medicine",
+                    candidate_name="Returning student",
+                    bearer_id=consequence.bearer_id,
+                    prior_case_results=[prior_result],
+                    presented_documents_override={
+                        "student ID": "A current student identification card.",
+                        "doctor's note": "A fresh nurse-signed note for an inhaler.",
+                    },
+                )
+            ]
+        )
+    if not any(
+        caller.edges_out(Selector(has_kind=Action, successor_id=return_block.uid)),
+    ):
+        Action(
+            registry=caller.graph,
+            predecessor_id=caller.uid,
+            successor_id=return_block.uid,
+            text="Meet the returning student",
+            tags={"dynamic", "hall_monitor_return"},
+        )
     return None
 
 

--- a/worlds/hall_monitor/script.yaml
+++ b/worlds/hall_monitor/script.yaml
@@ -55,9 +55,6 @@ scenes:
         kind: "hall_monitor.domain.HallMonitorConsequenceBlock"
         content: |
           The attendance office has filed one note from the morning shift.
-        actions:
-          - text: "Meet the returning student"
-            successor: returning_student
 
       returning_student:
         kind: "hall_monitor.domain.HallMonitorReturnBlock"

--- a/worlds/hall_monitor/script.yaml
+++ b/worlds/hall_monitor/script.yaml
@@ -55,3 +55,22 @@ scenes:
         kind: "hall_monitor.domain.HallMonitorConsequenceBlock"
         content: |
           The attendance office has filed one note from the morning shift.
+        actions:
+          - text: "Meet the returning student"
+            successor: returning_student
+
+      returning_student:
+        kind: "hall_monitor.domain.HallMonitorReturnBlock"
+        content: |
+          A student waits at the hall desk with new paperwork.
+        continues:
+          - successor: return_complete
+            trigger: last
+            predicate: game_won
+          - successor: return_complete
+            trigger: last
+            predicate: game_lost
+
+      return_complete:
+        content: |
+          The final bell rings across the now-quiet hall.


### PR DESCRIPTION
Closes #344\n\nSummary:\n- let an authored ScenarioOffer reference an existing bearer UUID and prior case receipts\n- materialize a fresh packet around that existing graph subject without duplicate subjects or components\n- prepare Hall Monitor's authored return during attendance-note PLANNING, before its action is selected\n- render recognition from the bearer's live graph presentation and preserve prior receipts through graph round-trip\n\nValidation:\n- poetry run pytest engine/tests/loaders/test_hall_monitor_world.py engine/tests/mechanics/credentials/test_credential_packet_manager.py engine/tests/mechanics/games/test_credentials_roster.py engine/tests/mechanics/games/test_credentials_game.py engine/tests/mechanics/games/test_credentials_scoring.py engine/tests/mechanics/games/test_credentials_scoring_config.py engine/tests/mechanics/games/test_credentials_fragments.py engine/tests/persistence/test_serialization.py engine/tests/persistence/test_component_manager_persistence.py engine/tests/persistence/test_ledger_persistence.py engine/tests/vm/test_ledger_persistence.py -q (161 passed, 13 skipped)\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a returning-student flow to the Hall Monitor scenario.
  * Returning students receive a fresh attendance note while retaining their established identity and prior case results.
  * Added outcome routing for successful and unsuccessful return inspections, followed by a final-bell conclusion.
  * Updated journal presentation to reflect the student’s current appearance and a newly signed note.

* **Documentation**
  * Documented the returning-student encounter and credential continuity behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->