### PR TITLE
design(story): vantage, observation, and the prose pipeline

### DIFF
--- a/engine/src/tangl/devref/topics.json
+++ b/engine/src/tangl/devref/topics.json
@@ -346,7 +346,8 @@
       "replay",
       "open_link",
       "sandbox",
-      "widget"
+      "widget",
+      "observation"
     ]
   },
   {
@@ -431,7 +432,8 @@
     "related_topic_ids": [
       "assembly",
       "media",
-      "open_link"
+      "open_link",
+      "observation"
     ]
   },
   {
@@ -468,7 +470,8 @@
     "short_description": "Staged picking/inspection game: visible evidence vs hidden truth, mediation moves, disposition/penalty policy.",
     "related_topic_ids": [
       "assembly",
-      "dispatch"
+      "dispatch",
+      "observation"
     ]
   },
   {
@@ -485,7 +488,8 @@
     "short_description": "Media dependency/resource model and media-as-affordance attachment (pre-decided media bound on first sighting).",
     "related_topic_ids": [
       "open_link",
-      "presence"
+      "presence",
+      "observation"
     ]
   },
   {
@@ -522,7 +526,8 @@
     "short_description": "Backend-authored widget vocabulary: fragments, accepts, ui_hints, blockers, and projected state rendered by clients.",
     "related_topic_ids": [
       "journal",
-      "frame"
+      "frame",
+      "observation"
     ]
   },
   {
@@ -557,6 +562,28 @@
     "short_description": "Standalone catalog/sampler for names/regions/cultures built on Singleton catalogs; world-extensible.",
     "related_topic_ids": [
       "singleton"
+    ]
+  },
+  {
+    "topic_id": "observation",
+    "display_name": "Observation & Vantage",
+    "aliases": [
+      "vantage",
+      "observe",
+      "describe",
+      "perceptibility",
+      "referring expression",
+      "prose rendering",
+      "disclosure"
+    ],
+    "layer": "story",
+    "short_description": "Epistemic projection: what is perceptible from a vantage, how it is described at a level of detail, and how referring expressions are realized.",
+    "related_topic_ids": [
+      "journal",
+      "presence",
+      "credentials",
+      "media",
+      "widget"
     ]
   }
 ]

--- a/engine/src/tangl/story/OBSERVATION_DESIGN.md
+++ b/engine/src/tangl/story/OBSERVATION_DESIGN.md
@@ -7,7 +7,7 @@
 :related: journal, presence, credentials, media, widget, open_link
 ```
 
-**Document Version:** 0.6
+**Document Version:** 0.7
 **Status:** DESIGN — proposed coarse-grid nouns (`Vantage`, `Observation`), a
 description protocol over them, and a strawman prose pipeline. Not a migration plan.
 *v0.2: three-stage prose pipeline (self-description / observation / realization),
@@ -25,7 +25,13 @@ review): Observation defined as redacted truth (never belief; distortion is a se
 authored layer); lang/story dependency inverted via a VantageLike protocol; describe()
 and the non-commutative fold anchored to the existing render_text_as / on_render_text /
 BehaviorRegistry dispatch; observation merge key defined; referring-expression rules
-made mutually exclusive; PoV example corrected.*
+made mutually exclusive; PoV example corrected. v0.7 (second review pass): observe()
+is a truth-preserving PROJECTION (soundness + opacity), not set subtraction; call
+direction corrected -- describe() is the leaf, render_text_as the controller; the
+observation fold needs its own on_observe task (do_render_text is typed str|None);
+both journal records preserved (semantic provenance AND experienced syuzhet), with
+re-rendering as replacement+tombstone rather than silent regeneration; unreliability
+separated from omniscience in non-goals.*
 **Relevant layers:** `tangl.lang` (noun protocol), `tangl.story` (vantage, dispatch),
 `tangl.mechanics.presence` / `.credentials` / `.sandbox` (consumers),
 `tangl.journal` (downstream output).
@@ -104,7 +110,23 @@ existing 14 `describe()` sites stay valid.
 **`observe()` is opt-in.** A concept implements it only when its perceptibility is
 genuinely vantage-dependent. `describe()` consults it when present.
 
-Default `describe()` resolution order:
+**Call direction — `describe()` is the leaf, not the controller.** This matches the
+live code (`render_look_text` / `render_outfit_text` are `@on_render_text` handlers that
+call `caller.describe()`), and inverting it would recurse:
+
+```text
+render_text_as(target, aspect, ctx)        story/presentation.py — the controller
+  └─▶ on_render_text handlers              authority chain selects the source
+        └─▶ target.describe(...)           the object's LOCAL default prose leaf
+```
+
+- **`describe()`** is one object's local/default semantic prose contribution. It knows
+  its own content and its components; it does not orchestrate.
+- **`render_text_as`** is the story-aware controller: it applies observation, runs the
+  authority dispatch, and bounds recursion via `TextRenderSession`. Authored overrides
+  and vantage gating attach here, not inside `describe()`.
+
+A `describe()` leaf's default content resolution order:
 
 ```text
 1. self.observe(vantage)              — if implemented, render from the observation
@@ -112,15 +134,9 @@ Default `describe()` resolution order:
 ```
 
 So `assembly.describe()` works unchanged today, and gains vantage-gating the moment
-that assembly grows an `observe()`. Adoption is strictly opt-in per concept.
-
-**`describe()` is not a new controller — it routes through the existing prose
-dispatch.** Text realization goes through `story/presentation.py::render_text_as`
-(which already dispatches `on_render_text` / `do_render_text` over the ordinary
-authority chain) and composes under `prose/rendering.py::TextRenderSession` for bounded
-recursion. Concretely: `observe()` supplies *what* may be said, and the existing
-`on_render_text` chain decides *how it reads*. No parallel rendering path is
-introduced, and no new registration mechanism is required.
+that assembly grows an `observe()`. Adoption is strictly opt-in per concept, and no
+parallel rendering path is introduced: the controller, the authority chain, and the
+recursion bound are all the ones that already exist.
 
 ### Detail levels
 
@@ -161,14 +177,24 @@ A good coarse noun should support uses it was not designed for. Three that fall 
 That the first two are configurations rather than features is the argument that
 `Vantage` is a real noun and not a parameter.
 
-### Observation is redacted truth, not belief
+### Observation is truth-preserving, not belief
 
-An `Observation` is **true content, narrowed** — never false content. `observe(vantage)`
-is a *filter*, and the only operation it may perform is removal:
+An `Observation` carries **true content** — never false content. But `observe(vantage)`
+is a *truth-preserving projection over permitted inputs*, **not** set subtraction.
+Normalizing raw state into typed observations, aggregating components, and reporting
+*"a silhouette"* instead of a person are all transformations, and all legitimate. The
+invariant is about information flow, not about which operations are allowed:
 
 ```text
-observe(vantage) ⊆ the true state.   It may omit. It may not invent or alter.
+soundness    every claim in observe(vantage) is true of the underlying state
+             — it may abstract, aggregate, generalize, or re-type, but never invent
+
+opacity      no fact excluded by the vantage is recoverable from the output
+             — abstraction may lose detail; it may not smuggle it
 ```
+
+Set-subtraction is one way to satisfy both. Abstraction ("a silhouette"), aggregation
+(component union), and re-typing (raw state → `ValidityObservation`) are others.
 
 This is the decision that keeps the disclosure guarantee meaningful. If observations
 could carry vantage-relative falsehood, "nothing downstream of `observe()` consults
@@ -471,12 +497,23 @@ generated text**. Given a model, the ladder shifts:
 fabula-invariance never required identical discourse — replay-as-reskin explicitly wants
 different words for the same events. The constraint that follows is narrow:
 
-> The durable record is the observation / fragment. Generated prose is a projection over
-> it, never the stored artifact.
+> **Two durable records, different jobs.** Observations and referents are the durable
+> *semantic provenance*; `ContentFragment.content` is the durable *syuzhet* — the prose
+> the reader actually experienced.
 
-Store generated text as the journal and replay breaks; store the semantic fragment and
-render at display time, and a model is simply the fifth constraint source, behaving like
-the other four.
+Both persist. The journal contract is unchanged: realized prose is stored as the
+historical projection, and **ordinary retrieval returns what was read, never a silent
+regeneration**. Scrolling back must not quietly reword the past.
+
+Re-rendering is therefore an explicit operation, not a retrieval side effect. Replay,
+reskin, and retcon **produce replacement fragments and tombstone the superseded ones**
+— the same provenance-bearing tombstone discipline used elsewhere — so the record of
+what the reader saw, and the fact that it was later re-realized, both survive.
+
+The failure mode to avoid is narrower than "don't store prose": it is letting generated
+prose become the *only* record of an event — a fact that exists in the text and nowhere
+in the graph. Keep observations authoritative for meaning and fragments authoritative
+for experience, and a model is simply the fifth constraint source.
 
 ### What that fixes about the dependency question
 
@@ -502,11 +539,22 @@ Coverage masking is exactly where union is wrong — a tattoo under a coat must 
 appear — so outfit-aware composition overrides it. This is the posture already settled
 in `../mechanics/assembly/COMPONENT_DESIGN.md`.
 
-**The override is an ordinary dispatch handler, not a new registration path.** There is
-no separate "manager registry": an outfit-aware fold registers on the existing
-`on_render_text` / `BehaviorRegistry` chain at `DispatchLayer.DOMAIN`, and the shipped
-commutative union is the application-level default it supersedes. Same mechanism every
-other handler uses; nothing new to wire.
+**The override is an ordinary dispatch handler — but it cannot ride the text hook.**
+`do_render_text` is typed to `str | None` and raises `TypeError` on anything else, so a
+fold returning `Observation` data must **not** overload `on_render_text`. The correct
+shape reuses the same `BehaviorRegistry` with its own task:
+
+```text
+on_observe / do_observe    a future story-dispatch task returning Observation data
+                           (same registry, same authority layers, distinct task)
+on_render_text             existing, str | None — prose only, unchanged
+```
+
+An outfit-aware fold registers on `on_observe` at `DispatchLayer.DOMAIN`, superseding
+the shipped commutative union at the application layer. No new registration *mechanism*
+— but a new *task*, because the type contracts genuinely differ. Keeping the two tasks
+separate is also what makes the observation/prose type boundary real rather than
+nominal.
 
 ### Merge contract for the union
 
@@ -602,8 +650,10 @@ count.
 
 - Not a migration plan. Existing `describe()` implementations remain valid and
   unchanged; `observe()` is opt-in per concept.
-- Not a narrator subsystem. Unreliable/omniscient narration are vantage
-  configurations, not new machinery.
+- Not a narrator subsystem. **Omniscience** is a vantage configuration (a vantage with
+  no occlusion). **Unreliability is not** — false or distorted narration is the separate
+  authored distortion/revoicing layer downstream of `observe()`, per the
+  truth-preserving rule above.
 - Not a fragment channel. Observations feed descriptions, which feed journal
   fragments, which remain the only narrative output surface.
 - Not a merge of facets and observations (rule vs. result).

--- a/engine/src/tangl/story/OBSERVATION_DESIGN.md
+++ b/engine/src/tangl/story/OBSERVATION_DESIGN.md
@@ -1,0 +1,524 @@
+# Vantage, Observation, and Description
+
+```{storytangl-topic}
+:topics: observation
+:facets: design
+:relation: defines
+:related: journal, presence, credentials, media, widget, open_link
+```
+
+**Document Version:** 0.5
+**Status:** DESIGN — proposed coarse-grid nouns (`Vantage`, `Observation`), a
+description protocol over them, and a strawman prose pipeline. Not a migration plan.
+*v0.2: three-stage prose pipeline (self-description / observation / realization),
+discourse-context-vs-vantage split, strawman referring-expression selection policy.
+v0.3: stage 3 corrected to constrained RE-realization of authored prose (parse →
+un-substitute → adopt → re-substitute); four constraint sources unified (vantage,
+PoV/tense, voice/register, skin) with #241 as a fifth; `scratch/discourse/refrazer/`
+prior art recorded; parser placed in-pipeline. v0.4: authoring principle (authors
+write prose, not template soup) with the worked constraint-escalation example; adoption
+ladder with a rung-0 floor (raw string -> fragment) and graceful degradation; rung 2
+(declared-cast compile-time lift) named as the cheapest next step. v0.5: LLM impact —
+rung 4 collapses, rungs 0-2 and stage 2 sharpen (a model cannot be redacted after the
+fact); durable record is the observation, generated prose is a projection.*
+**Relevant layers:** `tangl.lang` (noun protocol), `tangl.story` (vantage, dispatch),
+`tangl.mechanics.presence` / `.credentials` / `.sandbox` (consumers),
+`tangl.journal` (downstream output).
+
+---
+
+## Problem: three encodings of "what can be seen"
+
+The same question is answered three different ways today, and none of the three
+knows about the others:
+
+| Encoding | Where | Shape | Vantage |
+|---|---|---|---|
+| `describe()` convention | presence (outfit, wardrobe, ornaments), assembly (vehicle) — 14 methods | prose (`str` / `list[str]`) | **implicit** ("the narrator, now") |
+| `Observation` types | `mechanics/credentials/presentation.py` — `CredentialAttestationObservation`, `CredentialValidityObservation`, `CardProjection.visible_parts` | data, `neutral`/`visible` | **explicit** but local |
+| `SandboxVisibilityRule` | `mechanics/sandbox/visibility.py` | booleans (`suppress_location_description`, `suppress_asset_affordances`, `suppress_fixture_affordances`) | implicit, ns-predicate driven |
+
+No `Vantage` or observer concept exists anywhere in the engine (the only "observer"
+symbols are unrelated tick observers). `describe()` therefore hardcodes a single
+implied perspective, which is why multi-reader and knowledge-gated cases have no
+place to attach.
+
+This is one coarse-level gap wearing three costumes. Reconciling the three encodings
+locally would generate the same finding every pass; naming the missing noun dissolves
+all three.
+
+---
+
+## Authoring principle: authors write prose, not template soup
+
+The requirement that motivates the whole stack. An author should write:
+
+```text
+you open the door and find john waiting for you
+```
+
+and **not**:
+
+```text
+{{ person.mc }} opens the door and finds {{ person.john }}
+waiting for {{ person.mc.obj_pronoun }}.
+```
+
+The engine's job is to detangle authored prose and retangle it to match the current
+story. Each step below adds exactly one constraint to the *same* authored source:
+
+| Constraint added | Result |
+|---|---|
+| — (authored) | you open the door and find **john** waiting for you |
+| role binding (john → jane) | you open the door and find **jane** waiting for you |
+| vantage (jane not known) | you open the door and find **a girl wearing a pair of blue pants** waiting for you |
+| tone / register | you open the door **brusquely** and find a girl wearing a pair of **worn** blue pants waiting **anxiously** for you |
+| PoV + tense (2nd present → 3rd past) | **he opened** the door brusquely and **found** a girl wearing worn blue pants waiting for **him** |
+
+Each rung is one more constraint over one authored string, which is why they compose
+rather than multiply. The last two are not qualitatively harder than the first two —
+they are the same substitution with a different constraint source.
+
+---
+
+## The cut
+
+Three layers, each with one job:
+
+```text
+observe(vantage)   -> data    : what is perceptible from here (the redaction boundary)
+describe(vantage,  -> prose   : how that reads, at a requested level of detail
+         detail)
+nominal(vantage)   -> phrase  : how the thing is referred to, given what is known
+```
+
+**`describe()` is the primary and expected surface.** Prose is assembled from
+`describe()` calls; an implementation may be raw text or a Jinja template. The
+existing 14 `describe()` sites stay valid.
+
+**`observe()` is opt-in.** A concept implements it only when its perceptibility is
+genuinely vantage-dependent. `describe()` consults it when present.
+
+Default `describe()` resolution order:
+
+```text
+1. self.observe(vantage)              — if implemented, render from the observation
+2. [c.describe(vantage) for c in self.components]   — else compose children
+```
+
+So `assembly.describe()` works unchanged today, and gains vantage-gating the moment
+that assembly grows an `observe()`. Migration cost is near zero and strictly opt-in.
+
+### Detail levels
+
+`describe(vantage, detail)` where detail ∈ `nominal | short | extended`. Recurring
+mentions need not be exhaustive: first sighting may be `extended`, later references
+`nominal`. Detail is a *rendering* request, not a disclosure control — it may never
+widen what `observe()` permitted.
+
+---
+
+## Vantage
+
+> **Vantage** — the epistemic position a projection is rendered from: what is
+> perceptible, and what is known, at a point in the story.
+
+**Default: third-person limited, pinned at the current cursor position.** Each
+namespace carries its own vantage, which is what makes multi-reader work fall out
+rather than require a mechanism: two readers on one graph are two cursors, therefore
+two namespaces, therefore two vantages over the same state.
+
+Vantage carries **knowledge state**, not only sightlines. Whether a concept's name is
+known is part of the vantage, which is what lets `actor.nominal(vantage)` return
+*"a guy with a backpack"* or *"Dave"* from the same actor.
+
+### Deliberate misuses that validate the shape
+
+A good coarse noun should support uses it was not designed for. Three that fall out:
+
+- **Relayed vantage.** Talking a partner through a bomb defusal: your observations are
+  filtered through what a remote actor reports. Vantage composes — one vantage is the
+  input to another.
+- **Narrative mode switch.** Moving from second-person to third-omniscient reveals
+  everyone's tattoos under their clothes: same graph, same `describe()` calls, a
+  vantage with no occlusion.
+- **Unreliable narration.** A vantage that reports confidently but wrongly is a
+  vantage with a lossy or lying filter, not a special narrator subsystem.
+
+That these are configurations rather than features is the argument that `Vantage` is a
+real noun and not a parameter.
+
+### Vantage vs. PoV — adjacent, not the same
+
+`tangl.lang.pov` already exists: **PoV is grammatical person** (how a subject is
+addressed — I / you / they), consumed by `pronoun(pt, pov, gens)` and
+`conjugate(pov)`. **Vantage is epistemic position** (what may be known). The
+omniscient example moves both at once, which is why they blur; keep them distinct.
+Open question below: whether `Vantage` carries a `PoV` or merely references one.
+
+---
+
+## The noun protocol
+
+The `lang` package already has the pieces but no unified protocol — the subcalls
+exist, the controller does not:
+
+| Call | Purpose | Status today |
+|---|---|---|
+| `proper_noun.name()` | the bare proper name | `PersonalName.name()` ✔ |
+| `noun.nominal(vantage)` | referring phrase, knowledge-gated | `Nominal` + `DeterminativeType`/`DetHandler` exist; no vantage ✘ |
+| `noun.describe(vantage, detail)` | prose rendering | convention exists across mechanics; no vantage/detail ✘ |
+| `noun.observe(vantage)` | perceptible data | credentials-local only ✘ |
+| `noun.pronoun(type)` | pronoun for a slot | `pronoun(pt, pov, gens)` ✔ |
+| `noun.conjugate(verb, tense)` | agreement | `conjugate(pov)` ✔ |
+
+`Observation` is the missing member of a family that was already designed. That is
+evidence for promotion rather than invention: the shape was predicted, the subcalls
+were built, and the connective noun was the piece left out.
+
+---
+
+## The prose pipeline (strawman)
+
+Separating the concerns so they stop being reinvented per mechanic. Four inputs
+produce one prose segment:
+
+```text
+  Observable ──observe(vantage)──▶ Observation ──describe(detail)──▶ Description
+                                                                          │
+   Vantage ─────────────────────────────────────────┐                     │
+   (perception + knowledge)                          │                     │
+                                                     ▼                     ▼
+   DiscourseContext ──────────────────────────▶  realize(role) ──▶ Phrase ──▶ segment
+   (what has already been said)
+```
+
+| Stage | Question | Input → output | Owner | Status |
+|---|---|---|---|---|
+| **1 · Self-description** | what is there to say about this thing, at this detail? | concept + detail → content | world / domain author | ✔ exists (14 `describe()` sites, text or Jinja) |
+| **2 · Observation** | what of that is perceptible and known *from here*? | + vantage → `Observation` | engine (this doc) | ◐ credentials + presence only |
+| **3 · Realization** | how does this thing enter *this* sentence, under current constraints? | + role + discourse + constraints → phrase / rewritten clause | `tangl.lang` + a rephrase layer | ◐ phrase generators exist; selection policy does not; a full rewrite pipeline exists in `scratch/` |
+
+This is the standard natural-language-generation decomposition (content determination
+→ referring-expression generation → surface realization) with **one StoryTangl-specific
+insertion**: stage 2. Ordinary NLG has no epistemic filter as a first-class stage.
+Naming that alignment matters because it tells us which stages are *replaceable with
+existing art* (1 and 3) and which are *ours to own* (2).
+
+### Discourse context is not vantage
+
+The distinction most likely to be conflated, and the one that causes trouble later:
+
+- **Vantage** — *what I can perceive and know.* Persistent, epistemic. Decides
+  `"Dave"` vs `"a guy with a backpack"`.
+- **Discourse context** — *what has already been said in this passage.* Transient,
+  textual. Decides `"a key"` vs `"the key"` vs `"it"`.
+
+Both feed the determiner choice, from different sources. A first mention of a
+well-known person is `"Dave"` (vantage: known) with no determiner; a second mention of
+an unknown one is `"the man"` (vantage: unknown → nominal; discourse: seen → definite).
+Keep them separate or referring expressions will be wrong in ways that are very hard
+to trace.
+
+### What exists, and the one missing piece
+
+`tangl.lang.Nominal` is already substantial — noun synonym lists, adjectives,
+adjective synonym groups, quantifiers, plural inference — with working determiner
+forms:
+
+```text
+Nominal(nouns=['pants','trousers'], plural=True,
+        adjective_groups=[{'blue'}], quantifiers=['pair of'])
+
+  .idet()  -> "a pair of blue pants"      .ddet()  -> "the blue pants"
+  .ppdet(is_xx=True) -> "her pair of blue pants"
+```
+
+Plus `pronoun(pt, pov, gens)`, `conjugate(pov)`, `PersonalName.name()`,
+`DeterminativeType` (indefinite/definite/possessive/demonstrative, with `use_an`
+heuristics), and a thesaurus.
+
+**The phrase generators exist; the selection policy does not.** Nothing decides *which*
+of `idet` / `ddet` / `ppdet` / pronoun / proper name applies at a given mention. That
+policy is the missing controller, and it is exactly where vantage and discourse context
+meet.
+
+### Strawman selection policy
+
+Deliberately naive, obviously improvable, good enough to stop reinvention:
+
+```text
+1. vantage knows the proper name        -> PersonalName.name()        "Dave"
+2. else first mention in this segment   -> Nominal.idet()             "a brass key"
+3. else subsequent mention              -> Nominal.ddet()             "the brass key"
+4. else owned by the discourse subject  -> Nominal.ppdet()            "her coat"
+5. else sole salient referent matching
+   gender/number in the recent window   -> pronoun(...)               "it"
+```
+
+Rule 5 is the classic referring-expression ambiguity trap: pronominalize only when
+exactly one active referent matches, otherwise fall back to rule 3. Naive, but it fails
+safe (a redundant `"the brass key"` is merely clunky; a wrong `"it"` is unreadable).
+
+Detail level modulates *within* a choice — `nominal` picks the shortest form, `extended`
+admits more adjectives and quantifiers — but never overrides vantage.
+
+### Stage 3 is re-realization, not generation
+
+The above understates stage 3, and one earlier framing here was wrong: parsing is *in*
+this pipeline, not banished to authoring tooling.
+
+Most story prose is **authored, then rewritten to fit the current pass** — not generated
+from semantics. The authored line says *"Jane came in."* This pass needs:
+
+- *"a girl with blue pants came in"* — vantage: Jane is not yet known;
+- *"a girl with blue pants comes in"* — and the narration is second-person present.
+
+So the operation is a round trip, not a render:
+
+```text
+authored prose
+  ─ parse ─────────▶ words tagged with POS, dependency head, pov / pronoun-type / gens
+  ─ un-substitute ─▶ resolve surface forms back to referents
+                     ("Jane" → the Jane concept; "she" → most recent feminine referent)
+  ─ adopt ─────────▶ apply current constraints
+  ─ re-substitute ─▶ re-realize each referent + propagate agreement to dependents
+```
+
+**Un-substitute is `detangl` at sentence scale; re-substitute is `tangl`.** The same
+round trip as the compression thesis, one unit smaller — which is why the two efforts
+should share machinery rather than grow separate parsers.
+
+### One mechanism, four constraint sources
+
+The constraint that drives re-substitution is pluggable, and this is the unification
+worth keeping:
+
+| Constraint | Rewrites | Example |
+|---|---|---|
+| **Vantage** | referring expressions by knowledge | "Jane" → "a girl with blue pants" |
+| **PoV / tense** | person and agreement | "came in" → "comes in" |
+| **Voice / register** | word senses within a register | "ate the delicious sandwich" → "nibbled the nasty gruel" |
+| **Skin** | domain diction over identical structure | issue #220 narrative skins |
+
+Same parse, same rewrite, different constraint. That means narrative skins, vantage
+gating, and PoV switching are **not three features** — and **issue #241 (LLM journal
+smoothing) is a fifth constraint source**, not a separate layer. It also stays
+structurally safe: every one of these runs *downstream of* `observe()`, so none can
+widen disclosure.
+
+### Prior art: `scratch/discourse/refrazer/`
+
+A working version of this existed at ~v2.1.1 and should be mined rather than
+reinvented:
+
+- **`rephrase/{document,statement,word}.py`** — a `Document → Statement → Word`
+  hierarchy where each `Word` carries `pov`, `pt` (pronoun type), `gens`, and `head`
+  (its dependency head), with `render(ctx)` at every level. Built from a parse via
+  `from_stanza()` / `from_passage()`. **`Word.head` is the substrate for agreement
+  propagation**, and `Word.gens` is the substrate for the most-recent-referent tracking
+  that resolves a later *"she"* back to Jane.
+- **`Document.adopt_voice()` / `adopt_voices(*voices)`** — constraints are *adopted*
+  onto a parsed document, and plural from the start. That is exactly the
+  multi-constraint composition the table above needs.
+- **`eurynym.py`** — a "broad word": a concept's sense collection across registers,
+  with the full worked pipeline in its docstring (identify lemmas → check referent →
+  select sense → per-POS morphological transform).
+- **`dep_matcher.py`** — a spaCy `DependencyMatcher` sketch for propagating a
+  substitution to dependent words, so swapping a noun carries its modifiers.
+- **`sample_lingo.yaml`** — an authoring surface of `sememes` (sense sets per register)
+  and `paradigms`.
+
+It used **Stanza**; `dep_matcher.py` was a spaCy experiment. Parts already migrated
+into the engine: `lang/pos/treebank_symbols.py`, and `lang/apis/`
+(`language_tool`, `verbix`, `reverso`, `mw`) for morphology and lookup.
+
+**The name carries the decomposition.** *refrazer* contracted "**ref**erence
+dictionaries, conjugation, and expression **razor**s" into a homonym for *rephraser* —
+and those three categories are still legible in the tree:
+
+| Category | Where it lives now |
+|---|---|
+| reference dictionaries | `lang/apis/mw.py`, `apis/reverso.py`, `thesaurus.py`; `eurynym.py` sense sets |
+| conjugation | `conjugates.py`, `apis/verbix.py`, `pronoun.py`, `gens.py`, `pov.py` |
+| **expression razors** | **not built** |
+
+A razor is a rule for choosing among candidates, so *expression razor* is the original
+name for the selection policy identified as missing above: which of `idet` / `ddet` /
+`ppdet` / pronoun / proper name applies at this mention. The strawman policy in this
+document is one. Notably, the two categories that *were* built are the two with
+external services to lean on; the razor is the part that was always going to be ours.
+
+### Adoption ladder — a defined floor, optional rungs
+
+**It starts with converting raw strings into fragments, and is built out from there
+with whatever tooling is wanted.** That floor is the only commitment; every rung above
+it is optional, independently adoptable, and degrades to the rung below.
+
+| Rung | What it does | Needs | Status |
+|---|---|---|---|
+| **0 · Fragments** | raw authored string → `ContentFragment` | nothing | ✔ today |
+| **1 · Templates** | explicit substitution — `{{ role.jane.name() }}` | Jinja (present) | ✔ today |
+| **2 · Compile-time lift** | author writes `Jane`; the compiler rewrites it to `{{ role.jane.name() }}` against the declared cast | name matching, no parser | ← cheapest next step |
+| **3 · Vantage re-realization** | referring expressions gated by knowledge | `observe()` + discourse tracking | this doc |
+| **4 · Deterministic NLP** | tone, register, PoV/tense over parsed prose | parser + `refrazer` machinery | experimental |
+| **5 · LLM refinement** | final polish over already-determined content | model access (#241) | proposal |
+
+**Rung 2 is the high-value cheap one**, and it is *detangl easy mode*: with a declared
+cast you can lift `Jane` → `{{ role.jane.name() }}` by matching names, no parsing
+required. It buys the first two rows of the escalation table (role rebinding) for
+nearly nothing, keeps authored prose readable, and produces exactly the templates rung
+1 already renders.
+
+Graceful degradation is the property that makes this safe to build incrementally: no
+parser available → you still have rung 2; no model available → you still have rung 4.
+Prose quality degrades; nothing breaks. This is the same "additive and soft-failing"
+posture the widget contract takes toward media.
+
+### What LLMs change (and what they sharpen)
+
+Most of the machinery above predates practical LLM rewriting. Stanza is itself a small
+task-specific learned model — the same family, differing in scale and generality — so
+the useful distinction is not neural-vs-rules but **structured reproducible output vs.
+generated text**. Given a model, the ladder shifts:
+
+- **Rung 4 largely collapses.** Parse → un-substitute → re-substitute, sense
+  substitution, and conjugation lookup were mechanical means to an end a model now
+  reaches directly. External conjugation/dictionary services are hard to justify.
+- **Rungs 0–2 matter *more*.** A model cannot know that `john` is bound to jane this
+  playthrough, or that the viewer has not met her. That is story state, not language.
+  Referent binding stays ours; the declared-cast lift (rung 2) is unaffected.
+- **Stage 2 becomes load-bearing rather than optional.** **An LLM cannot be redacted
+  after the fact.** Given full state and asked to describe a scene, it will disclose —
+  helpfully, not maliciously. So `observe()` stops being a correctness nicety and
+  becomes *the constructor of the model's input set*. The disclosure boundary must sit
+  upstream of the model, which is where this document already places it.
+
+**Determinism resolves via the existing thesis.** LLM prose is not reproducible, but
+fabula-invariance never required identical discourse — replay-as-reskin explicitly wants
+different words for the same events. The constraint that follows is narrow:
+
+> The durable record is the observation / fragment. Generated prose is a projection over
+> it, never the stored artifact.
+
+Store generated text as the journal and replay breaks; store the semantic fragment and
+render at display time, and a model is simply the fifth constraint source, behaving like
+the other four.
+
+### What that fixes about the dependency question
+
+- **A parser (spaCy or Stanza) belongs in stage 3**, at un-substitute. It is how
+  referents are recovered from authored text. Not an authoring-only tool.
+- **Stage 2 stays ours.** No parser models "what this observer may know"; vantage is
+  the StoryTangl-specific insertion and cannot be delegated.
+- **Stage 1 stays authored.** The source prose is the input to the round trip, so
+  authoring quality still dominates output quality.
+
+---
+
+## Composition and folds
+
+An observation composes from its parts:
+
+```text
+assembly.observe(v)  ->  default: union of [c.observe(v) for c in components]
+```
+
+**Union is the commutative default; specialized managers own non-commutative folds.**
+Coverage masking is exactly where union is wrong — a tattoo under a coat must not
+appear — so `OutfitManager.observe()` overrides with its coverage fold. This is the
+posture already settled in `../mechanics/assembly/COMPONENT_DESIGN.md`: the general
+layer does the commutative fold and a registered manager owns anything else. No new
+conflict machinery is introduced.
+
+---
+
+## Why this matters: disclosure becomes a type boundary
+
+The load-bearing consequence. If `describe()` consumes only `Observation`s, prose
+**cannot** leak hidden state — a leak has to occur inside `observe()`, which is one
+auditable place per concept.
+
+This converts a rule that people must remember into a structure that holds by
+construction:
+
+- *"no client may receive hidden mechanic state in order to make a choice legible"*
+  (issue #337);
+- no inferring correct/incorrect or new/old from action ids, metadata, or wording;
+- credentials' `neutral, visible` observation docstrings become an enforced property
+  rather than an authoring convention.
+
+---
+
+## Relationship to neighbouring concepts
+
+- **Facets** (`ComponentFacet`) are the *rule*; observations are the *result*. A
+  `hider` facet suppresses; an observation is what survived suppression. Shared
+  subject matter, different intent — do not merge them.
+- **Journal fragments** are downstream: `observe → describe → prose → ContentFragment`.
+  Observation must not become a parallel fragment channel.
+- **The four parity axes** in `docs/src/design/story/STORYTANGL_WIDGET_VOCAB.md` §0.2
+  resolve cleanly against this stack: `observe()` is the **information parity**
+  (decision legibility) boundary; `describe()` and its dispatch spine
+  (`story/presentation.py` `render_text_as`, `prose/rendering.py` `TextRenderSession`)
+  are semantic→text; the **CLI floor** is capability parity downstream of both. This
+  disambiguates "presentation," which currently spans all of these plus display hints.
+
+---
+
+## Promotion assessment (two-key gate)
+
+**(a) Invariants stateable without the originating demo** — yes:
+
+> An observation is a fact about a subject as perceptible from a given vantage.
+> Observations compose, union by default. A description is prose over observations at
+> a requested level of detail. Nothing downstream of `observe()` may consult hidden
+> state. Detail may narrow a description but never widen disclosure.
+
+**(b) Positive reason to predict multiple mechanism-consumers** — yes: presence and
+credentials are consumers *today*; sandbox visibility is the same question in boolean
+form; multi-lane (issue #346) is a *scheduled* consumer that cannot be built without
+an explicit vantage; media (which image is shown is a visibility question) and guides
+/ inner voices (issue #340) follow.
+
+→ **Promote** as a coarse noun, predictively, on spectrum argument — not on consumer
+count.
+
+---
+
+## Open questions
+
+1. **Typed-per-domain or generic `Observation`?** Credentials has domain subtypes. A
+   small base plus subtypes (the `fragment_type` pattern) is the likely answer; the
+   failure modes are dict-soup at one end and type explosion at the other.
+2. **Does `Vantage` carry a `PoV`, or reference one?** The omniscient switch moves
+   both; the bomb-defusal relay moves only vantage.
+3. **Where does vantage come from at a call site** — an explicit argument, or read
+   from `ctx`/namespace? Sandbox darkness is ns-predicate driven today; multi-lane
+   forces an explicit answer.
+4. **Does `nominal()` belong to lang or story?** It needs vantage (a story concept)
+   and determiners (a lang concept).
+5. **Retrofit shape for `SandboxVisibilityRule`** — does it become a vantage filter, or
+   stay a facet-style `hider` whose *result* is an observation?
+
+---
+
+## Non-goals
+
+- Not a migration plan. Existing `describe()` implementations remain valid and
+  unchanged; `observe()` is opt-in per concept.
+- Not a narrator subsystem. Unreliable/omniscient narration are vantage
+  configurations, not new machinery.
+- Not a fragment channel. Observations feed descriptions, which feed journal
+  fragments, which remain the only narrative output surface.
+- Not a merge of facets and observations (rule vs. result).
+- Detail levels are not a disclosure control.
+- Not an NLG system. Stage 3 rewrites authored prose under constraints; it does not
+  generate sentences from semantics. Stages 1 and 3 keep naive implementations until a
+  consumer justifies better ones.
+- Not a commitment to a parser. Stanza and spaCy are both candidates; the pipeline only
+  requires POS + dependency head + referent resolution from whatever is chosen.
+- Not a required stack. Rung 0 (string -> fragment) is the only commitment; rungs 2-5
+  are independently optional and each degrades to the rung below.
+- Generated prose is never the durable record. Whatever renders -- template, parser, or
+  model -- the stored artifact is the observation/fragment it rendered from.

--- a/engine/src/tangl/story/OBSERVATION_DESIGN.md
+++ b/engine/src/tangl/story/OBSERVATION_DESIGN.md
@@ -7,7 +7,7 @@
 :related: journal, presence, credentials, media, widget, open_link
 ```
 
-**Document Version:** 0.5
+**Document Version:** 0.6
 **Status:** DESIGN — proposed coarse-grid nouns (`Vantage`, `Observation`), a
 description protocol over them, and a strawman prose pipeline. Not a migration plan.
 *v0.2: three-stage prose pipeline (self-description / observation / realization),
@@ -20,7 +20,12 @@ write prose, not template soup) with the worked constraint-escalation example; a
 ladder with a rung-0 floor (raw string -> fragment) and graceful degradation; rung 2
 (declared-cast compile-time lift) named as the cheapest next step. v0.5: LLM impact —
 rung 4 collapses, rungs 0-2 and stage 2 sharpen (a model cannot be redacted after the
-fact); durable record is the observation, generated prose is a projection.*
+fact); durable record is the observation, generated prose is a projection. v0.6 (PR #350
+review): Observation defined as redacted truth (never belief; distortion is a separate
+authored layer); lang/story dependency inverted via a VantageLike protocol; describe()
+and the non-commutative fold anchored to the existing render_text_as / on_render_text /
+BehaviorRegistry dispatch; observation merge key defined; referring-expression rules
+made mutually exclusive; PoV example corrected.*
 **Relevant layers:** `tangl.lang` (noun protocol), `tangl.story` (vantage, dispatch),
 `tangl.mechanics.presence` / `.credentials` / `.sandbox` (consumers),
 `tangl.journal` (downstream output).
@@ -107,7 +112,15 @@ Default `describe()` resolution order:
 ```
 
 So `assembly.describe()` works unchanged today, and gains vantage-gating the moment
-that assembly grows an `observe()`. Migration cost is near zero and strictly opt-in.
+that assembly grows an `observe()`. Adoption is strictly opt-in per concept.
+
+**`describe()` is not a new controller — it routes through the existing prose
+dispatch.** Text realization goes through `story/presentation.py::render_text_as`
+(which already dispatches `on_render_text` / `do_render_text` over the ordinary
+authority chain) and composes under `prose/rendering.py::TextRenderSession` for bounded
+recursion. Concretely: `observe()` supplies *what* may be said, and the existing
+`on_render_text` chain decides *how it reads*. No parallel rendering path is
+introduced, and no new registration mechanism is required.
 
 ### Detail levels
 
@@ -142,11 +155,39 @@ A good coarse noun should support uses it was not designed for. Three that fall 
 - **Narrative mode switch.** Moving from second-person to third-omniscient reveals
   everyone's tattoos under their clothes: same graph, same `describe()` calls, a
   vantage with no occlusion.
-- **Unreliable narration.** A vantage that reports confidently but wrongly is a
-  vantage with a lossy or lying filter, not a special narrator subsystem.
+- **Unreliable narration.** A narrator who reports confidently but wrongly. See the
+  truth-vs-belief decision below: this is *not* simply a lossy vantage.
 
-That these are configurations rather than features is the argument that `Vantage` is a
-real noun and not a parameter.
+That the first two are configurations rather than features is the argument that
+`Vantage` is a real noun and not a parameter.
+
+### Observation is redacted truth, not belief
+
+An `Observation` is **true content, narrowed** — never false content. `observe(vantage)`
+is a *filter*, and the only operation it may perform is removal:
+
+```text
+observe(vantage) ⊆ the true state.   It may omit. It may not invent or alter.
+```
+
+This is the decision that keeps the disclosure guarantee meaningful. If observations
+could carry vantage-relative falsehood, "nothing downstream of `observe()` consults
+hidden state" would no longer imply "downstream output is trustworthy," and replay,
+audit, and the type boundary all become murky. It also honours the standing principle
+that the engine guarantees determinism but never invents semantics — a lie is *authored
+content*, not an engine-inferred filter.
+
+Consequences:
+
+- **Redaction and distortion are different layers.** Two observers seeing the same fact
+  at different detail is redaction (this mechanism). A narrator asserting something
+  false is authored, explicitly marked, and sits *downstream* of `observe()` as a
+  distortion pass — never inside it.
+- **Belief, when modelled, is state — not a vantage mode.** "What Jane thinks is in the
+  box" is a fact about Jane's beliefs, observable in the ordinary way. It is not
+  `observe()` returning something untrue.
+- **Durable records stay objective.** A stored observation is a true-but-narrowed view,
+  so replay and audit can rely on it.
 
 ### Vantage vs. PoV — adjacent, not the same
 
@@ -175,6 +216,27 @@ exist, the controller does not:
 `Observation` is the missing member of a family that was already designed. That is
 evidence for promotion rather than invention: the shape was predicted, the subcalls
 were built, and the connective noun was the piece left out.
+
+### Dependency direction: `lang` must not import `story`
+
+`Vantage` is Story state, but the noun protocol lives in `tangl.lang` — so a naive
+`nominal(vantage)` signature would invert the layering. `tangl.lang` currently imports
+nothing from `tangl.story`, and that stays true.
+
+Resolution is ordinary dependency inversion: **`lang` declares a minimal structural
+protocol; `story` owns the concrete type and satisfies it.**
+
+```text
+tangl.lang    VantageLike(Protocol)   — only what realization needs:
+                                        knows_name(subject) -> bool
+                                        pov  -> PoV
+                                        gens(subject) -> Gens
+tangl.story   Vantage                 — full epistemic state; satisfies VantageLike
+```
+
+`lang` therefore never learns about cursors, namespaces, or perception; it learns only
+the three questions a referring expression actually asks. This also answers open
+question 4 below: `nominal()` stays in `lang`, `Vantage` stays in `story`.
 
 ---
 
@@ -247,18 +309,27 @@ meet.
 
 Deliberately naive, obviously improvable, good enough to stop reinvention:
 
+Two *orthogonal* predicates decide this, so a flat ladder gets it wrong — ownership and
+salience are independent of first-vs-subsequent mention. Ordered by precedence:
+
 ```text
-1. vantage knows the proper name        -> PersonalName.name()        "Dave"
-2. else first mention in this segment   -> Nominal.idet()             "a brass key"
-3. else subsequent mention              -> Nominal.ddet()             "the brass key"
-4. else owned by the discourse subject  -> Nominal.ppdet()            "her coat"
-5. else sole salient referent matching
-   gender/number in the recent window   -> pronoun(...)               "it"
+known_name(vantage, x)        vantage knows the proper name
+owned_by_subject(x)           possessed by the current discourse subject
+first_mention(discourse, x)   not yet mentioned in this segment
+sole_salient(discourse, x)    only active referent matching gender/number in window
+
+1. known_name                       -> PersonalName.name()   "Dave"
+2. owned_by_subject                 -> Nominal.ppdet()       "her coat"
+3. not first_mention AND sole_salient -> pronoun(...)        "it"
+4. first_mention                    -> Nominal.idet()        "a brass key"
+5. otherwise (subsequent)           -> Nominal.ddet()        "the brass key"
 ```
 
-Rule 5 is the classic referring-expression ambiguity trap: pronominalize only when
-exactly one active referent matches, otherwise fall back to rule 3. Naive, but it fails
-safe (a redundant `"the brass key"` is merely clunky; a wrong `"it"` is unreadable).
+Rules 4 and 5 are the exhaustive fallback pair, so the discriminating checks must
+precede them. Rule 3 is the classic ambiguity trap and is deliberately conjunctive:
+never pronominalize a first mention, and only when exactly one active referent matches
+— otherwise fall through to rule 5. Naive, but it fails safe (a redundant
+`"the brass key"` is merely clunky; a wrong `"it"` is unreadable).
 
 Detail level modulates *within* a choice — `nominal` picks the shortest form, `extended`
 admits more adjectives and quantifiers — but never overrides vantage.
@@ -272,7 +343,9 @@ Most story prose is **authored, then rewritten to fit the current pass** — not
 from semantics. The authored line says *"Jane came in."* This pass needs:
 
 - *"a girl with blue pants came in"* — vantage: Jane is not yet known;
-- *"a girl with blue pants comes in"* — and the narration is second-person present.
+- *"a girl with blue pants comes in"* — and this pass narrates in the present tense.
+  (The clause subject stays third-person; only the *narration frame* is second-person,
+  which is why tense and person move independently.)
 
 So the operation is a round trip, not a render:
 
@@ -359,15 +432,15 @@ it is optional, independently adoptable, and degrades to the rung below.
 |---|---|---|---|
 | **0 · Fragments** | raw authored string → `ContentFragment` | nothing | ✔ today |
 | **1 · Templates** | explicit substitution — `{{ role.jane.name() }}` | Jinja (present) | ✔ today |
-| **2 · Compile-time lift** | author writes `Jane`; the compiler rewrites it to `{{ role.jane.name() }}` against the declared cast | name matching, no parser | ← cheapest next step |
+| **2 · Compile-time lift** | author writes `Jane`; the compiler rewrites it to `{{ role.jane.name() }}` against the declared cast | name matching, no parser | lowest-cost rung |
 | **3 · Vantage re-realization** | referring expressions gated by knowledge | `observe()` + discourse tracking | this doc |
 | **4 · Deterministic NLP** | tone, register, PoV/tense over parsed prose | parser + `refrazer` machinery | experimental |
 | **5 · LLM refinement** | final polish over already-determined content | model access (#241) | proposal |
 
-**Rung 2 is the high-value cheap one**, and it is *detangl easy mode*: with a declared
+**Rung 2 is the lowest-cost rung**, and it is *detangl easy mode*: with a declared
 cast you can lift `Jane` → `{{ role.jane.name() }}` by matching names, no parsing
 required. It buys the first two rows of the escalation table (role rebinding) for
-nearly nothing, keeps authored prose readable, and produces exactly the templates rung
+nearly nothing (sequencing is an implementation decision, not part of this design), keeps authored prose readable, and produces exactly the templates rung
 1 already renders.
 
 Graceful degradation is the property that makes this safe to build incrementally: no
@@ -424,12 +497,33 @@ An observation composes from its parts:
 assembly.observe(v)  ->  default: union of [c.observe(v) for c in components]
 ```
 
-**Union is the commutative default; specialized managers own non-commutative folds.**
+**Union is the commutative default; a domain handler owns any non-commutative fold.**
 Coverage masking is exactly where union is wrong — a tattoo under a coat must not
-appear — so `OutfitManager.observe()` overrides with its coverage fold. This is the
-posture already settled in `../mechanics/assembly/COMPONENT_DESIGN.md`: the general
-layer does the commutative fold and a registered manager owns anything else. No new
-conflict machinery is introduced.
+appear — so outfit-aware composition overrides it. This is the posture already settled
+in `../mechanics/assembly/COMPONENT_DESIGN.md`.
+
+**The override is an ordinary dispatch handler, not a new registration path.** There is
+no separate "manager registry": an outfit-aware fold registers on the existing
+`on_render_text` / `BehaviorRegistry` chain at `DispatchLayer.DOMAIN`, and the shipped
+commutative union is the application-level default it supersedes. Same mechanism every
+other handler uses; nothing new to wire.
+
+### Merge contract for the union
+
+"Union" needs a key, since composed observations are heterogeneous:
+
+```text
+merge key   : (subject_id, observation_type, aspect)
+duplicates  : same key from multiple children -> keep the nearest-scope contributor
+              (the arbitration order already used for grants), then stable-sort by
+              source_id for determinism
+disjoint    : different keys accumulate; no coercion between Observation subtypes
+```
+
+Subtypes never merge into one another — a `ValidityObservation` and an
+`AttestationObservation` about the same document coexist as separate entries. Only
+identical keys contend, and contention resolves by scope distance rather than by
+arrival order, so composition stays replay-stable.
 
 ---
 
@@ -496,8 +590,9 @@ count.
 3. **Where does vantage come from at a call site** — an explicit argument, or read
    from `ctx`/namespace? Sandbox darkness is ns-predicate driven today; multi-lane
    forces an explicit answer.
-4. **Does `nominal()` belong to lang or story?** It needs vantage (a story concept)
-   and determiners (a lang concept).
+4. *(resolved — see "Dependency direction" above: `nominal()` stays in `lang` against a
+   `VantageLike` protocol; `Vantage` stays in `story`.)* Remaining: what the minimal
+   protocol surface actually is — `knows_name` / `pov` / `gens` is a first guess.
 5. **Retrofit shape for `SandboxVisibilityRule`** — does it become a vantage filter, or
    stay a facet-style `hider` whose *result* is an observation?
 

--- a/engine/src/tangl/story/OBSERVATION_DESIGN.md
+++ b/engine/src/tangl/story/OBSERVATION_DESIGN.md
@@ -7,7 +7,7 @@
 :related: journal, presence, credentials, media, widget, open_link
 ```
 
-**Document Version:** 0.7
+**Document Version:** 0.8
 **Status:** DESIGN — proposed coarse-grid nouns (`Vantage`, `Observation`), a
 description protocol over them, and a strawman prose pipeline. Not a migration plan.
 *v0.2: three-stage prose pipeline (self-description / observation / realization),
@@ -31,7 +31,18 @@ direction corrected -- describe() is the leaf, render_text_as the controller; th
 observation fold needs its own on_observe task (do_render_text is typed str|None);
 both journal records preserved (semantic provenance AND experienced syuzhet), with
 re-rendering as replacement+tombstone rather than silent regeneration; unreliability
-separated from omniscience in non-goals.*
+separated from omniscience in non-goals. v0.8 (third review pass): opacity replaced by
+NONINTERFERENCE (inference from visible evidence is expected; dependence on hidden state
+is the leak); describe() is a local leaf taking only a detail hint while the controller
+owns vantage and child recursion via render_as; Vantage is request-scoped context
+referencing observer/scope/knowledge, not cursor identity or grammatical person;
+referring expressions split into vantage-selects-identity then discourse-selects-form
+(known names no longer suppress pronouns); ladder recast as four independent axes where
+only realization quality soft-fails; composition de-specified to ordered collection with
+arbitration deferred to a second consumer; type boundary downgraded to auditable
+chokepoint with the condition for it to become structural; three-way record split
+(graph = meaning, fragment = experience, observation = optional snapshot); LLM is a
+realization backend, not a constraint; DispatchLayer.DOMAIN (invented) corrected.*
 **Relevant layers:** `tangl.lang` (noun protocol), `tangl.story` (vantage, dispatch),
 `tangl.mechanics.presence` / `.credentials` / `.sandbox` (consumers),
 `tangl.journal` (downstream output).
@@ -86,7 +97,7 @@ story. Each step below adds exactly one constraint to the *same* authored source
 | tone / register | you open the door **brusquely** and find a girl wearing a pair of **worn** blue pants waiting **anxiously** for you |
 | PoV + tense (2nd present → 3rd past) | **he opened** the door brusquely and **found** a girl wearing worn blue pants waiting for **him** |
 
-Each rung is one more constraint over one authored string, which is why they compose
+Each step is one more constraint over one authored string, which is why they compose
 rather than multiply. The last two are not qualitatively harder than the first two —
 they are the same substitution with a different constraint source.
 
@@ -97,18 +108,21 @@ they are the same substitution with a different constraint source.
 Three layers, each with one job:
 
 ```text
-observe(vantage)   -> data    : what is perceptible from here (the redaction boundary)
-describe(vantage,  -> prose   : how that reads, at a requested level of detail
-         detail)
-nominal(vantage)   -> phrase  : how the thing is referred to, given what is known
+observe(subject, vantage) -> data    what is perceptible from here (the disclosure step)
+describe(detail=...)      -> prose   an object's LOCAL default contribution
+nominal(...)              -> phrase  how a thing is referred to in this mention
 ```
 
-**`describe()` is the primary and expected surface.** Prose is assembled from
-`describe()` calls; an implementation may be raw text or a Jinja template. The
-existing 14 `describe()` sites stay valid.
+**Vantage never reaches the leaf.** `describe()` stays the object's local, default
+semantic prose contribution — it may accept a `detail` *hint* (`nominal | short |
+extended`), which is a rendering request, but it does not take a vantage and does not
+consult story state. The existing 14 `describe()` sites stay valid as written.
 
-**`observe()` is opt-in.** A concept implements it only when its perceptibility is
-genuinely vantage-dependent. `describe()` consults it when present.
+**The controller owns perspective and recursion.** `render_text_as` / `render_as`
+applies observation, runs the authority chain, walks children, and bounds recursion via
+`TextRenderSession`. Children are reached **through `render_as`**, not by a leaf calling
+`child.describe()` directly — otherwise per-child authority overrides and the recursion
+bound are silently bypassed.
 
 **Call direction — `describe()` is the leaf, not the controller.** This matches the
 live code (`render_look_text` / `render_outfit_text` are `@on_render_text` handlers that
@@ -120,27 +134,23 @@ render_text_as(target, aspect, ctx)        story/presentation.py — the control
         └─▶ target.describe(...)           the object's LOCAL default prose leaf
 ```
 
-- **`describe()`** is one object's local/default semantic prose contribution. It knows
-  its own content and its components; it does not orchestrate.
-- **`render_text_as`** is the story-aware controller: it applies observation, runs the
-  authority dispatch, and bounds recursion via `TextRenderSession`. Authored overrides
-  and vantage gating attach here, not inside `describe()`.
-
-A `describe()` leaf's default content resolution order:
+The controller's resolution order (not the leaf's):
 
 ```text
-1. self.observe(vantage)              — if implemented, render from the observation
-2. [c.describe(vantage) for c in self.components]   — else compose children
+1. observe(target, vantage)        if the subject participates in disclosure
+2. dispatch on_render_text         authority chain picks the source
+3. target.describe(detail=...)     local default leaf, if no override wins
+4. render_as(child, ...)           recurse per child THROUGH the controller
 ```
 
-So `assembly.describe()` works unchanged today, and gains vantage-gating the moment
-that assembly grows an `observe()`. Adoption is strictly opt-in per concept, and no
-parallel rendering path is introduced: the controller, the authority chain, and the
+So `assembly.describe()` works unchanged today, and gains vantage-gating when the
+controller starts observing it — no signature change to the leaf. Adoption is opt-in per
+concept, and no parallel rendering path appears: controller, authority chain, and
 recursion bound are all the ones that already exist.
 
 ### Detail levels
 
-`describe(vantage, detail)` where detail ∈ `nominal | short | extended`. Recurring
+`describe(detail=...)` where detail ∈ `nominal | short | extended`. Recurring
 mentions need not be exhaustive: first sighting may be `extended`, later references
 `nominal`. Detail is a *rendering* request, not a disclosure control — it may never
 widen what `observe()` permitted.
@@ -152,14 +162,33 @@ widen what `observe()` permitted.
 > **Vantage** — the epistemic position a projection is rendered from: what is
 > perceptible, and what is known, at a point in the story.
 
-**Default: third-person limited, pinned at the current cursor position.** Each
-namespace carries its own vantage, which is what makes multi-reader work fall out
-rather than require a mechanism: two readers on one graph are two cursors, therefore
-two namespaces, therefore two vantages over the same state.
+**Vantage is request-scoped context, not an identity and not a grammatical mode.** It
+*references* three things rather than owning them:
 
-Vantage carries **knowledge state**, not only sightlines. Whether a concept's name is
-known is part of the vantage, which is what lets `actor.nominal(vantage)` return
-*"a guy with a backpack"* or *"Dave"* from the same actor.
+```text
+observer         whose perspective this is (the focalizer)
+spatial scope    what is currently in view / reachable
+knowledge        persistent per-observer knowledge state, held as concept state
+```
+
+**Default binding: limited to what the current observer knows at the cursor's scope.**
+That is where a vantage is normally *derived* from — but it is not identical to a cursor
+and does not own the knowledge store:
+
+- two readers may share one cursor;
+- one reader may change focalizer mid-scene without moving;
+- narrator knowledge is durable concept state keyed by narrator, so it outlives any
+  single request while a vantage does not.
+
+Multi-reader still falls out cheaply — distinct observers yield distinct vantages over
+one graph — it just isn't a one-to-one identity with cursor or namespace.
+
+**"Limited" here is epistemic, not grammatical.** Whether narration says *I / you / they*
+is `PoV` (see below); whether the narration is *restricted to one observer's knowledge*
+is vantage. The two commonly move together and are still separate axes.
+
+Knowledge state is what lets `nominal()` return *"a guy with a backpack"* or *"Dave"* for
+the same actor — the vantage supplies the answer, the knowledge store holds it.
 
 ### Deliberate misuses that validate the shape
 
@@ -186,15 +215,23 @@ Normalizing raw state into typed observations, aggregating components, and repor
 invariant is about information flow, not about which operations are allowed:
 
 ```text
-soundness    every claim in observe(vantage) is true of the underlying state
-             — it may abstract, aggregate, generalize, or re-type, but never invent
+soundness         every claim in observe(...) is true of the underlying state
+                  — it may abstract, aggregate, generalize, or re-type, but never invent
 
-opacity      no fact excluded by the vantage is recoverable from the output
-             — abstraction may lose detail; it may not smuggle it
+noninterference   the projection is computed ONLY from permitted inputs and does not
+                  encode excluded state — vary a hidden fact with permitted inputs
+                  held constant, and the output must not change
 ```
 
-Set-subtraction is one way to satisfy both. Abstraction ("a silhouette"), aggregation
+Set subtraction is one way to satisfy both. Abstraction ("a silhouette"), aggregation
 (component union), and re-typing (raw state → `ValidityObservation`) are others.
+
+**Noninterference, explicitly not non-inference.** A player *is supposed to* infer
+hidden correctness from permitted evidence — in credentials that is the entire game, and
+in correlated data non-inference is unachievable anyway. Inference from legitimately
+visible evidence is expected and desirable. The leak is *dependence*: a projection whose
+content varies with hidden validity or expected disposition, even if no excluded fact is
+stated outright.
 
 This is the decision that keeps the disclosure guarantee meaningful. If observations
 could carry vantage-relative falsehood, "nothing downstream of `observe()` consults
@@ -234,8 +271,8 @@ exist, the controller does not:
 |---|---|---|
 | `proper_noun.name()` | the bare proper name | `PersonalName.name()` ✔ |
 | `noun.nominal(vantage)` | referring phrase, knowledge-gated | `Nominal` + `DeterminativeType`/`DetHandler` exist; no vantage ✘ |
-| `noun.describe(vantage, detail)` | prose rendering | convention exists across mechanics; no vantage/detail ✘ |
-| `noun.observe(vantage)` | perceptible data | credentials-local only ✘ |
+| `noun.describe(detail=...)` | local default prose leaf | convention exists across mechanics; no detail hint ✘ |
+| `observe(subject, vantage)` | perceptible data (controller-invoked) | credentials-local only ✘ |
 | `noun.pronoun(type)` | pronoun for a slot | `pronoun(pt, pov, gens)` ✔ |
 | `noun.conjugate(verb, tense)` | agreement | `conjugate(pov)` ✔ |
 
@@ -284,7 +321,7 @@ produce one prose segment:
 | Stage | Question | Input → output | Owner | Status |
 |---|---|---|---|---|
 | **1 · Self-description** | what is there to say about this thing, at this detail? | concept + detail → content | world / domain author | ✔ exists (14 `describe()` sites, text or Jinja) |
-| **2 · Observation** | what of that is perceptible and known *from here*? | + vantage → `Observation` | engine (this doc) | ◐ credentials + presence only |
+| **2 · Observation** | what of that is perceptible and known *from here*? | + vantage → `Observation` | engine (this doc) | ◐ credentials only (presence has related visibility/description behaviour, no formal `Observation`) |
 | **3 · Realization** | how does this thing enter *this* sentence, under current constraints? | + role + discourse + constraints → phrase / rewritten clause | `tangl.lang` + a rephrase layer | ◐ phrase generators exist; selection policy does not; a full rewrite pipeline exists in `scratch/` |
 
 This is the standard natural-language-generation decomposition (content determination
@@ -335,27 +372,34 @@ meet.
 
 Deliberately naive, obviously improvable, good enough to stop reinvention:
 
-Two *orthogonal* predicates decide this, so a flat ladder gets it wrong — ownership and
-salience are independent of first-vs-subsequent mention. Ordered by precedence:
+This is **two decisions, not one ladder** — which is exactly why vantage and discourse
+context were separated above. Collapsing them is what makes a known name suppress
+pronouns forever (*"Dave … Dave … Dave"*).
+
+**Decision 1 — vantage selects the permitted lexical identity.** What may this observer
+call the subject at all?
 
 ```text
-known_name(vantage, x)        vantage knows the proper name
-owned_by_subject(x)           possessed by the current discourse subject
-first_mention(discourse, x)   not yet mentioned in this segment
-sole_salient(discourse, x)    only active referent matching gender/number in window
-
-1. known_name                       -> PersonalName.name()   "Dave"
-2. owned_by_subject                 -> Nominal.ppdet()       "her coat"
-3. not first_mention AND sole_salient -> pronoun(...)        "it"
-4. first_mention                    -> Nominal.idet()        "a brass key"
-5. otherwise (subsequent)           -> Nominal.ddet()        "the brass key"
+known_name(vantage, x)   ->  identity = PROPER    ("Dave")
+otherwise                ->  identity = ANONYMOUS (a Nominal: "a girl with blue pants")
 ```
 
-Rules 4 and 5 are the exhaustive fallback pair, so the discriminating checks must
-precede them. Rule 3 is the classic ambiguity trap and is deliberately conjunctive:
-never pronominalize a first mention, and only when exactly one active referent matches
-— otherwise fall through to rule 5. Naive, but it fails safe (a redundant
-`"the brass key"` is merely clunky; a wrong `"it"` is unreadable).
+**Decision 2 — discourse context and grammatical role select the realization form**,
+within whatever identity decision 1 permitted:
+
+```text
+not first_mention AND sole_salient  ->  pronoun(...)        "he" / "it"
+owned_by_subject                    ->  Nominal.ppdet()     "her coat"
+first_mention                       ->  PROPER: name()      "Dave"
+                                        ANON:   idet()      "a brass key"
+otherwise (subsequent)              ->  PROPER: name()      "Dave"
+                                        ANON:   ddet()      "the brass key"
+```
+
+So a known person can still pronominalize on an unambiguous subsequent mention, and an
+unknown one still moves indefinite → definite. Pronominalization stays deliberately
+conjunctive — never a first mention, and only when exactly one active referent matches —
+so it fails safe: a redundant *"the brass key"* is clunky, a wrong *"it"* is unreadable.
 
 Detail level modulates *within* a choice — `nominal` picks the shortest form, `extended`
 admits more adjectives and quantifiers — but never overrides vantage.
@@ -401,10 +445,10 @@ worth keeping:
 | **Skin** | domain diction over identical structure | issue #220 narrative skins |
 
 Same parse, same rewrite, different constraint. That means narrative skins, vantage
-gating, and PoV switching are **not three features** — and **issue #241 (LLM journal
-smoothing) is a fifth constraint source**, not a separate layer. It also stays
-structurally safe: every one of these runs *downstream of* `observe()`, so none can
-widen disclosure.
+gating, and PoV switching are **not three features**. Issue #241 (LLM journal smoothing)
+is not a fifth constraint — a model is a realization **backend**; the tone/smoothing
+policy handed to it is the constraint. Every constraint here runs *downstream of*
+`observe()`, so none widens disclosure.
 
 ### Prior art: `scratch/discourse/refrazer/`
 
@@ -448,45 +492,50 @@ name for the selection policy identified as missing above: which of `idet` / `dd
 document is one. Notably, the two categories that *were* built are the two with
 external services to lean on; the razor is the part that was always going to be ours.
 
-### Adoption ladder — a defined floor, optional rungs
+### Four independent axes — not a degradation ladder
 
-**It starts with converting raw strings into fragments, and is built out from there
-with whatever tooling is wanted.** That floor is the only commitment; every rung above
-it is optional, independently adoptable, and degrades to the rung below.
+An earlier draft framed these as rungs where each degrades to the one below. That is
+wrong in a way that matters: **vantage gating does not depend on name lifting, an LLM
+does not depend on deterministic NLP, and a disclosure-sensitive projection must not
+"degrade" to ungated prose.** Calling a safety downgrade graceful degradation is how
+leaks get shipped.
 
-| Rung | What it does | Needs | Status |
-|---|---|---|---|
-| **0 · Fragments** | raw authored string → `ContentFragment` | nothing | ✔ today |
-| **1 · Templates** | explicit substitution — `{{ role.jane.name() }}` | Jinja (present) | ✔ today |
-| **2 · Compile-time lift** | author writes `Jane`; the compiler rewrites it to `{{ role.jane.name() }}` against the declared cast | name matching, no parser | lowest-cost rung |
-| **3 · Vantage re-realization** | referring expressions gated by knowledge | `observe()` + discourse tracking | this doc |
-| **4 · Deterministic NLP** | tone, register, PoV/tense over parsed prose | parser + `refrazer` machinery | experimental |
-| **5 · LLM refinement** | final polish over already-determined content | model access (#241) | proposal |
+They are four independent choices:
 
-**Rung 2 is the lowest-cost rung**, and it is *detangl easy mode*: with a declared
-cast you can lift `Jane` → `{{ role.jane.name() }}` by matching names, no parsing
-required. It buys the first two rows of the escalation table (role rebinding) for
-nearly nothing (sequencing is an implementation decision, not part of this design), keeps authored prose readable, and produces exactly the templates rung
-1 already renders.
+| Axis | Options | Note |
+|---|---|---|
+| **Authored source form** | raw string · explicit template · compile-time lifted | what the author writes |
+| **Disclosure projection** | none · vantage-gated | **safety axis — never soft-fails** |
+| **Realization backend** | template · deterministic NLP · model | quality axis — may soft-fail |
+| **Durable output** | `ContentFragment` (+ optional observation snapshot) | what persists |
 
-Graceful degradation is the property that makes this safe to build incrementally: no
-parser available → you still have rung 2; no model available → you still have rung 4.
-Prose quality degrades; nothing breaks. This is the same "additive and soft-failing"
-posture the widget contract takes toward media.
+**Only realization quality may soft-fail.** No parser or no model available → prose gets
+plainer. That is fine. But a story whose content is disclosure-sensitive may not fall
+back to ungated rendering; if the projection cannot run, the correct behaviour is to
+fail, not to narrate more than the observer knows.
+
+**The floor is still real:** raw string → `ContentFragment` (axis 1 = raw, axis 2 = none,
+axis 3 = template) is the only commitment, and it is what exists today. Everything else
+is opt-in per axis.
+
+**Compile-time lifting is the cheapest single move**, and it is *detangl easy mode*: with
+a declared cast you can lift `Jane` → `{{ role.jane.name() }}` by matching names, no
+parser required. It buys role rebinding for nearly nothing and keeps authored prose
+readable. Note it is independent of vantage gating — either can be adopted first.
 
 ### What LLMs change (and what they sharpen)
 
 Most of the machinery above predates practical LLM rewriting. Stanza is itself a small
 task-specific learned model — the same family, differing in scale and generality — so
 the useful distinction is not neural-vs-rules but **structured reproducible output vs.
-generated text**. Given a model, the ladder shifts:
+generated text**. Given a model, the realization axis shifts:
 
-- **Rung 4 largely collapses.** Parse → un-substitute → re-substitute, sense
+- **The deterministic-NLP option largely collapses.** Parse → un-substitute → re-substitute, sense
   substitution, and conjugation lookup were mechanical means to an end a model now
   reaches directly. External conjugation/dictionary services are hard to justify.
-- **Rungs 0–2 matter *more*.** A model cannot know that `john` is bound to jane this
+- **Source form and disclosure matter *more*.** A model cannot know that `john` is bound to jane this
   playthrough, or that the viewer has not met her. That is story state, not language.
-  Referent binding stays ours; the declared-cast lift (rung 2) is unaffected.
+  Referent binding stays ours; compile-time declared-cast lifting is unaffected.
 - **Stage 2 becomes load-bearing rather than optional.** **An LLM cannot be redacted
   after the fact.** Given full state and asked to describe a scene, it will disclose —
   helpfully, not maliciously. So `observe()` stops being a correctness nicety and
@@ -497,12 +546,19 @@ generated text**. Given a model, the ladder shifts:
 fabula-invariance never required identical discourse — replay-as-reskin explicitly wants
 different words for the same events. The constraint that follows is narrow:
 
-> **Two durable records, different jobs.** Observations and referents are the durable
-> *semantic provenance*; `ContentFragment.content` is the durable *syuzhet* — the prose
-> the reader actually experienced.
+> **Three records, three jobs.** *Authoritative semantics* live in graph state, case
+> receipts, and referenced concepts with their provenance. *Experience* lives in
+> `ContentFragment.content` — the prose the reader actually read. An *`Observation` is a
+> transient projection*, optionally snapshotted when audit or exact replay needs a record
+> of what was disclosed.
 
-Both persist. The journal contract is unchanged: realized prose is stored as the
-historical projection, and **ordinary retrieval returns what was read, never a silent
+An earlier draft called observations "the durable semantic provenance." That
+overreached: an observation is deliberately **narrowed**, so it cannot be the authority
+for meaning. Meaning stays with the graph and its receipts; the observation records only
+what was shown.
+
+The journal contract is unchanged: realized prose is stored as the historical
+projection, and **ordinary retrieval returns what was read, never a silent
 regeneration**. Scrolling back must not quietly reword the past.
 
 Re-rendering is therefore an explicit operation, not a retrieval side effect. Replay,
@@ -512,8 +568,7 @@ what the reader saw, and the fact that it was later re-realized, both survive.
 
 The failure mode to avoid is narrower than "don't store prose": it is letting generated
 prose become the *only* record of an event — a fact that exists in the text and nowhere
-in the graph. Keep observations authoritative for meaning and fragments authoritative
-for experience, and a model is simply the fifth constraint source.
+in the graph. Keep the graph authoritative for meaning and fragments authoritative for experience. A model is then simply one realization backend among several.
 
 ### What that fixes about the dependency question
 
@@ -550,36 +605,51 @@ on_observe / do_observe    a future story-dispatch task returning Observation da
 on_render_text             existing, str | None — prose only, unchanged
 ```
 
-An outfit-aware fold registers on `on_observe` at `DispatchLayer.DOMAIN`, superseding
-the shipped commutative union at the application layer. No new registration *mechanism*
+An outfit-aware fold registers on `on_observe` at a layer above the shipped default —
+`AUTHOR` or `USER` for world-supplied overrides, given the real ladder is
+`GLOBAL < SYSTEM < APPLICATION < AUTHOR < USER < LOCAL` and the shipped fold sits at
+`APPLICATION`. (An earlier draft cited a `DOMAIN` layer, which does not exist.) No new registration *mechanism*
 — but a new *task*, because the type contracts genuinely differ. Keeping the two tasks
 separate is also what makes the observation/prose type boundary real rather than
 nominal.
 
-### Merge contract for the union
+### Composition: start ordered, defer arbitration
 
-"Union" needs a key, since composed observations are heterogeneous:
+An earlier draft specified a full merge scheme — key of
+`(subject_id, observation_type, aspect)`, scope-distance arbitration, stable `source_id`
+sort. That was **over-specified for one consumer**: the base `Observation` shape has not
+been chosen, today's credential observations carry none of those identity fields, and
+they preserve authored order. Writing generic arbitration before a second consumer
+exhibits the same collision is exactly the premature generalization this codebase
+otherwise resists.
+
+Start with the minimum that is actually forced:
 
 ```text
-merge key   : (subject_id, observation_type, aspect)
-duplicates  : same key from multiple children -> keep the nearest-scope contributor
-              (the arbitration order already used for grants), then stable-sort by
-              source_id for determinism
-disjoint    : different keys accumulate; no coercion between Observation subtypes
+boundary     a typed Observable surface: observe(subject, vantage) -> Observation
+collection   deterministic ORDERED collection over children (authored order preserved)
+folding      concrete domains filter or fold via a distinct on_observe task
 ```
 
-Subtypes never merge into one another — a `ValidityObservation` and an
-`AttestationObservation` about the same document coexist as separate entries. Only
-identical keys contend, and contention resolves by scope distance rather than by
-arrival order, so composition stays replay-stable.
+Deterministic ordering is enough for replay stability, and authored order is what the
+existing credential observations already rely on. **Extract generic arbitration only
+when a second consumer demonstrates the same collision** — and let that consumer's real
+collision choose the key, rather than guessing it now.
 
 ---
 
 ## Why this matters: disclosure becomes a type boundary
 
-The load-bearing consequence. If `describe()` consumes only `Observation`s, prose
-**cannot** leak hidden state — a leak has to occur inside `observe()`, which is one
-auditable place per concept.
+The load-bearing consequence — stated at the strength it actually holds. If realization
+consumes only `Observation`s, a leak must occur inside `observe()`: **one auditable
+chokepoint per concept** rather than a property to re-check at every prose site.
+
+**Today that is a chokepoint, not a type-enforced guarantee.** `on_render_text` handlers
+receive the original `caller` and a `PhaseCtx` exposing the graph, so a handler *can*
+re-acquire the raw subject and inspect hidden state after an `Observation` was produced.
+"Cannot leak" becomes structurally true only when realization is handed the
+disclosure-safe `Observation` plus a suitably bounded rendering context, without the raw
+subject in reach. That is the target; until then the honest claim is auditability.
 
 This converts a rule that people must remember into a structure that holds by
 construction:
@@ -663,7 +733,8 @@ count.
   consumer justifies better ones.
 - Not a commitment to a parser. Stanza and spaCy are both candidates; the pipeline only
   requires POS + dependency head + referent resolution from whatever is chosen.
-- Not a required stack. Rung 0 (string -> fragment) is the only commitment; rungs 2-5
-  are independently optional and each degrades to the rung below.
-- Generated prose is never the durable record. Whatever renders -- template, parser, or
-  model -- the stored artifact is the observation/fragment it rendered from.
+- Not a degradation ladder. The four axes are independent; only realization *quality*
+  soft-fails. Disclosure gating never degrades -- if the projection cannot run, fail
+  rather than narrate beyond the observer's knowledge.
+- Generated prose is not the authority for *meaning*, but it IS durably stored as the
+  experienced record. See "Durable records" above for the three-way split.


### PR DESCRIPTION
## Summary

Docs only. Names two proposed coarse-grid nouns — **`Vantage`** and **`Observation`** — plus the description protocol and prose pipeline over them. Design artifact for review, **not a migration plan**; no code changes and no existing behaviour touched.

Also adds the `observation` devref topic (with symmetric back-references, per the #281 review lesson).

## Why now

The same question is answered three unrelated ways today, and none of the three knows about the others:

| Encoding | Shape | Vantage |
|---|---|---|
| `describe()` convention (presence, assembly — 14 methods) | prose | **implicit** ("the narrator, now") |
| credentials `Observation` types / `visible_parts` | data, `neutral`/`visible` | explicit but local |
| `SandboxVisibilityRule` | booleans (`suppress_*`) | implicit, ns-predicate driven |

No `Vantage` or observer concept exists in the engine. That's one coarse-level gap wearing three costumes — reconciling the three locally would regenerate the same finding every pass.

## Key positions

- **`describe()` stays primary**; `observe(vantage)` is opt-in and consulted when present, so the 14 existing sites keep working. Near-zero, strictly opt-in migration.
- **Vantage = third-person limited, pinned at the cursor, one per namespace** — so multi-lane (#346) falls out rather than needing mechanism. Carries knowledge state, not just sightlines (`"Dave"` vs `"a guy with a backpack"`).
- **Disclosure becomes a type boundary.** If `describe()` consumes only `Observation`s, prose *cannot* leak — a leak must occur inside `observe()`, one auditable place per concept. Makes #337's "no hidden mechanic state" structural instead of disciplinary.
- **Stage 3 is constrained re-realization of authored prose**, not generation: parse → un-substitute → adopt → re-substitute. Un-substitute is `detangl` at sentence scale. Vantage, PoV/tense, voice/register, and skin (#220) are **one mechanism with four constraint sources**; #241 is a fifth.
- **Adoption ladder with a defined floor:** rung 0 (string → fragment) is the only commitment; rungs 2–5 are optional and each degrades to the rung below. **Rung 2** — declared-cast compile-time lift, `Jane` → `{{ role.jane.name() }}` by name matching, no parser — is the cheapest next step and is *detangl easy mode*.
- **LLMs collapse rung 4 but sharpen rungs 0–2 and stage 2.** A model can't be redacted after the fact, so `observe()` constructs its input set. The durable record is the observation; generated prose is a projection — which keeps replay-as-reskin intact.

## Prior art recorded

`scratch/discourse/refrazer/` (~v2.1.1): `Document → Statement → Word` with dependency heads (the substrate for agreement propagation) and `gens` (the substrate for most-recent-referent tracking), `adopt_voices(*voices)` composition, `eurynym` sense sets, `sample_lingo.yaml`. Partly migrated already (`lang/pos/treebank_symbols.py`, `lang/apis/`). The missing piece is the **"expression razor"** — the selection policy the original name already anticipated.

## Verification

`tangl-devref build` clean; `find observation` ranks this doc first and links it to the existing "Observer Roles" section in `docs/src/design/story/philosophy.md`.

## Open questions (in the doc, for review)

Typed-per-domain vs generic `Observation`; whether `Vantage` carries or references a `PoV`; where vantage comes from at a call site; whether `nominal()` belongs to lang or story; retrofit shape for `SandboxVisibilityRule`.

Refs #241, #283, #337, #340, #346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the “Observation & Vantage” topic, covering perception, vantage points, descriptions, references, and disclosure.
  - Expanded related topic coverage for Journal, Presence, Credentials, Media, and Widget Vocabulary.

- **Documentation**
  - Added comprehensive guidance for observations, detail levels, prose rendering, perspective, disclosure rules, and incremental adoption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->