### PR TITLE
Verify Hall Monitor playable vertical

### DIFF
--- a/apps/renpy/tests/test_integration.py
+++ b/apps/renpy/tests/test_integration.py
@@ -7,14 +7,17 @@ import pytest
 from tangl.persistence import PersistenceManagerFactory
 from tangl.renpy import RenPyChoice, RenPySessionBridge
 from tangl.service import build_service_manager
+from tangl.service.world_registry import clear_discovered_world_registries
 from tangl.story.fabula.world import World
 
 
 @pytest.fixture(autouse=True)
 def reset_worlds() -> None:
+    clear_discovered_world_registries()
     World.clear_instances()
     yield
     World.clear_instances()
+    clear_discovered_world_registries()
 
 
 def _service_manager():

--- a/apps/server/src/tangl/rest/dependencies_gateway.py
+++ b/apps/server/src/tangl/rest/dependencies_gateway.py
@@ -10,6 +10,7 @@ from fastapi import HTTPException
 
 from tangl.rest.dependencies import get_persistence
 from tangl.service import ServiceAccess, ServiceManager, UserAuthInfo, build_service_manager, user_id_by_key
+from tangl.service.world_registry import clear_discovered_world_registries
 
 _service_manager: ServiceManager | None = None
 _user_locks: defaultdict[UUID, asyncio.Lock] = defaultdict(asyncio.Lock)
@@ -91,4 +92,4 @@ def reset_service_manager_for_testing() -> None:
     _service_manager = None
     _user_locks.clear()
     _api_key_index.clear()
-
+    clear_discovered_world_registries()

--- a/apps/server/src/tangl/rest/routers/user_router.py
+++ b/apps/server/src/tangl/rest/routers/user_router.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from uuid import UUID
+
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
 
 from tangl.config import settings
@@ -10,7 +12,7 @@ from tangl.rest.dependencies_gateway import (
     resolve_user_auth,
 )
 from tangl.service import ServiceManager
-from tangl.service.exceptions import AccessDeniedError, AuthMismatchError
+from tangl.service.exceptions import AccessDeniedError, AuthMismatchError, InvalidOperationError
 from tangl.service.response import RuntimeInfo, UserInfo, UserSecret
 from tangl.type_hints import UniqueLabel
 from tangl.utils.hash_secret import key_for_secret
@@ -34,7 +36,11 @@ def _call_service_method(
 @router.get("/info")
 async def get_user_info(
     service_manager: ServiceManager = Depends(get_service_manager),
-    api_key: UniqueLabel = Header(example=key_for_secret(settings.client.secret), default=None),
+    api_key: UniqueLabel = Header(
+        alias="X-API-Key",
+        example=key_for_secret(settings.client.secret),
+        default=None,
+    ),
     render_profile: str = Query(default="raw", description="Response rendering profile."),
 ) -> UserInfo:
     """Return profile information for the authenticated user."""
@@ -65,7 +71,10 @@ async def create_user(
         raise HTTPException(status_code=500, detail="Failed to create user")
     if created.status != "ok":
         raise HTTPException(status_code=500, detail=created.message or "Failed to create user")
-    return service_manager.get_key_for_secret(secret=secret)
+    credentials = service_manager.get_key_for_secret(secret=secret)
+    return credentials.model_copy(
+        update={"user_id": UUID(str(created.details["user_id"]))},
+    )
 
 
 @router.put("/world")
@@ -79,7 +88,11 @@ async def set_user_world():
 async def update_user_secret(
     service_manager: ServiceManager = Depends(get_service_manager),
     user_locks=Depends(get_user_locks),
-    api_key: UniqueLabel = Header(example=key_for_secret(settings.client.secret), default=None),
+    api_key: UniqueLabel = Header(
+        alias="X-API-Key",
+        example=key_for_secret(settings.client.secret),
+        default=None,
+    ),
     secret: str = Query(example=settings.client.secret, default=None),
     render_profile: str = Query(default="raw", description="Response rendering profile."),
 ) -> UserSecret:
@@ -89,13 +102,16 @@ async def update_user_secret(
     user_auth = resolve_user_auth(api_key, service_manager=service_manager)
     require_service_access("update_user", user_auth=user_auth)
     async with user_locks[user_auth.user_id]:
-        _call_service_method(
-            service_manager,
-            "update_user",
-            user_id=user_auth.user_id,
-            user_auth=user_auth,
-            secret=secret,
-        )
+        try:
+            _call_service_method(
+                service_manager,
+                "update_user",
+                user_id=user_auth.user_id,
+                user_auth=user_auth,
+                secret=secret,
+            )
+        except InvalidOperationError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
     return UserSecret(
         user_secret=secret,
         api_key=key_for_secret(secret),
@@ -106,7 +122,11 @@ async def update_user_secret(
 @router.delete("/drop")
 async def drop_user(
     service_manager: ServiceManager = Depends(get_service_manager),
-    api_key: UniqueLabel = Header(example=key_for_secret(settings.client.secret), default=None),
+    api_key: UniqueLabel = Header(
+        alias="X-API-Key",
+        example=key_for_secret(settings.client.secret),
+        default=None,
+    ),
     render_profile: str = Query(default="raw", description="Response rendering profile."),
 ) -> RuntimeInfo:
     """Remove the authenticated user and purge persisted resources."""

--- a/apps/server/src/tangl/rest/routers/user_router.py
+++ b/apps/server/src/tangl/rest/routers/user_router.py
@@ -71,7 +71,8 @@ async def create_user(
         raise HTTPException(status_code=500, detail="Failed to create user")
     if created.status != "ok":
         raise HTTPException(status_code=500, detail=created.message or "Failed to create user")
-    credentials = service_manager.get_key_for_secret(secret=secret)
+    user_secret = str(created.details["user_secret"])
+    credentials = service_manager.get_key_for_secret(secret=user_secret)
     return credentials.model_copy(
         update={"user_id": UUID(str(created.details["user_id"]))},
     )

--- a/apps/server/tests/test_hall_monitor_playable_vertical.py
+++ b/apps/server/tests/test_hall_monitor_playable_vertical.py
@@ -1,0 +1,130 @@
+"""HTTP smoke coverage for the Hall Monitor credentials worked vertical."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tangl.config import settings
+from tangl.rest.app import app
+from tangl.rest.dependencies import reset_service_state_for_testing
+from tangl.rest.dependencies_gateway import (
+    get_service_manager,
+    reset_service_manager_for_testing,
+)
+from tangl.service.user.user import User
+from tangl.service.world_registry import resolve_world
+from tangl.story.fabula.world import World
+from tangl.utils.hash_secret import key_for_secret, uuid_for_secret
+
+
+def _repo_worlds_dir() -> Path:
+    return Path(__file__).resolve().parents[3] / "worlds"
+
+
+def _choice_id(payload: dict[str, object], text: str) -> str:
+    fragments = payload["fragments"]
+    assert isinstance(fragments, list)
+    for fragment in fragments:
+        if isinstance(fragment, dict) and fragment.get("fragment_type") == "choice":
+            if fragment.get("text") == text:
+                edge_id = fragment.get("edge_id")
+                assert isinstance(edge_id, str)
+                return edge_id
+    raise AssertionError(f"No {text!r} choice in {fragments!r}")
+
+
+@pytest.fixture()
+def hall_monitor_client(monkeypatch: pytest.MonkeyPatch) -> Iterator[tuple[TestClient, dict[str, str]]]:
+    """Serve the compiled repository Hall Monitor world through FastAPI."""
+
+    monkeypatch.setattr(
+        "tangl.service.world_registry.get_world_dirs",
+        lambda: [_repo_worlds_dir()],
+    )
+    reset_service_state_for_testing()
+    reset_service_manager_for_testing()
+    World.clear_instances()
+
+    service_manager = get_service_manager()
+    secret = settings.client.secret
+    user = User(uid=uuid_for_secret(secret))
+    user.set_secret(secret)
+    service_manager.persistence.save(user)
+
+    client = TestClient(app, base_url="http://test/api/v2/")
+    try:
+        yield client, {"X-API-Key": key_for_secret(secret)}
+    finally:
+        client.close()
+        World.clear_instances()
+        reset_service_manager_for_testing()
+        reset_service_state_for_testing()
+
+
+def test_hall_monitor_inspection_survives_http_session_reload(
+    hall_monitor_client: tuple[TestClient, dict[str, str]],
+) -> None:
+    """The public HTTP transcript retains its text floor after credential inspection."""
+
+    client, headers = hall_monitor_client
+    created = client.post(
+        "story/story/create",
+        params={"world_id": "hall_monitor", "init_mode": "EAGER"},
+        headers=headers,
+    )
+    assert created.status_code == 200
+    assert _choice_id(created.json(), "Monitor the morning halls")
+
+    entered = client.post(
+        "story/do",
+        json={"edge_id": _choice_id(created.json(), "Monitor the morning halls")},
+        headers=headers,
+    )
+    assert entered.status_code == 200
+    entered_payload = entered.json()
+    entered_text = json.dumps(entered_payload)
+    assert "Mira Quill steps forward." in entered_text
+    assert "doctor's note" in entered_text
+    assert "correct_disposition" not in entered_text
+
+    inspected = client.post(
+        "story/do",
+        json={
+            "edge_id": _choice_id(entered_payload, "Inspect a document"),
+            "payload": {"piece_ids": ["0:doctor's note"]},
+        },
+        headers=headers,
+    )
+    assert inspected.status_code == 200
+    inspected_text = json.dumps(inspected.json())
+    assert "The required nurse signature is missing." in inspected_text
+    assert "Send back to class" in inspected_text
+    assert "correct_disposition" not in inspected_text
+
+    denied = client.post(
+        "story/do",
+        json={"edge_id": _choice_id(inspected.json(), "Send back to class")},
+        headers=headers,
+    )
+    assert denied.status_code == 200
+
+    reloaded = client.get("story/update", headers=headers)
+    assert reloaded.status_code == 200
+    reloaded_text = json.dumps(reloaded.json())
+    assert "Mira Quill steps forward." in reloaded_text
+    assert "The required nurse signature is missing." in reloaded_text
+
+
+def test_hall_monitor_world_resolution_reuses_the_compiled_world(
+    hall_monitor_client: tuple[TestClient, dict[str, str]],
+) -> None:
+    """Repeated service lookups keep one compiled singleton world per directory set."""
+
+    _client, _headers = hall_monitor_client
+
+    assert resolve_world("hall_monitor") is resolve_world("hall_monitor")

--- a/apps/server/tests/test_hall_monitor_playable_vertical.py
+++ b/apps/server/tests/test_hall_monitor_playable_vertical.py
@@ -18,7 +18,9 @@ from tangl.rest.dependencies_gateway import (
 )
 from tangl.service.user.user import User
 from tangl.service.world_registry import resolve_world
+from tangl.story import InitMode
 from tangl.story.fabula.world import World
+from tangl.story.story_graph import StoryGraph
 from tangl.utils.hash_secret import key_for_secret, uuid_for_secret
 
 
@@ -120,11 +122,25 @@ def test_hall_monitor_inspection_survives_http_session_reload(
     assert "The required nurse signature is missing." in reloaded_text
 
 
-def test_hall_monitor_world_resolution_reuses_the_compiled_world(
+def test_hall_monitor_world_resolution_reuses_until_service_reset(
     hall_monitor_client: tuple[TestClient, dict[str, str]],
 ) -> None:
-    """Repeated service lookups keep one compiled singleton world per directory set."""
+    """A reset recompiles and registers worlds used by persisted story graphs."""
 
     _client, _headers = hall_monitor_client
+    first = resolve_world("hall_monitor")
+    assert resolve_world("hall_monitor") is first
+    graph_payload = first.create_story(
+        "hall_monitor",
+        init_mode=InitMode.EAGER,
+    ).graph.unstructure()
 
-    assert resolve_world("hall_monitor") is resolve_world("hall_monitor")
+    reset_service_state_for_testing()
+    World.clear_instances()
+
+    second = resolve_world("hall_monitor")
+    assert second is not first
+    assert World.get_instance("hall_monitor") is second
+
+    restored = StoryGraph.structure(graph_payload)
+    assert restored.world is second

--- a/apps/server/tests/test_user_recovery_endpoints.py
+++ b/apps/server/tests/test_user_recovery_endpoints.py
@@ -1,0 +1,56 @@
+"""Public recovery-secret transport contracts."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tangl.rest.app import app
+from tangl.rest.dependencies import reset_service_state_for_testing
+from tangl.rest.dependencies_gateway import reset_service_manager_for_testing
+
+
+@pytest.fixture()
+def client() -> Iterator[TestClient]:
+    reset_service_state_for_testing()
+    reset_service_manager_for_testing()
+    test_client = TestClient(app, base_url="http://test/api/v2/")
+    try:
+        yield test_client
+    finally:
+        test_client.close()
+        reset_service_manager_for_testing()
+        reset_service_state_for_testing()
+
+
+def test_create_user_restores_one_user_for_a_recovery_secret(client: TestClient) -> None:
+    first = client.post("user/create", params={"secret": "recovery-secret"})
+    second = client.post("user/create", params={"secret": "recovery-secret"})
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["user_id"] == second.json()["user_id"]
+
+
+def test_secret_rotation_rejects_another_players_recovery_secret(client: TestClient) -> None:
+    first = client.post("user/create", params={"secret": "first-secret"})
+    second = client.post("user/create", params={"secret": "second-secret"})
+    assert first.status_code == 200
+    assert second.status_code == 200
+
+    conflict = client.put(
+        "user/secret",
+        params={"secret": "second-secret"},
+        headers={"X-API-Key": first.json()["api_key"]},
+    )
+    no_op = client.put(
+        "user/secret",
+        params={"secret": "first-secret"},
+        headers={"X-API-Key": first.json()["api_key"]},
+    )
+
+    assert conflict.status_code == 409
+    assert no_op.status_code == 200
+    assert no_op.json()["user_id"] == first.json()["user_id"]

--- a/apps/server/tests/test_user_recovery_endpoints.py
+++ b/apps/server/tests/test_user_recovery_endpoints.py
@@ -34,6 +34,16 @@ def test_create_user_restores_one_user_for_a_recovery_secret(client: TestClient)
     assert first.json()["user_id"] == second.json()["user_id"]
 
 
+def test_create_user_assigns_a_recovery_codename_when_none_is_supplied(client: TestClient) -> None:
+    created = client.post("user/create")
+    restored = client.post("user/create", params={"secret": created.json()["user_secret"]})
+
+    assert created.status_code == 200
+    assert created.json()["user_secret"]
+    assert restored.status_code == 200
+    assert restored.json()["user_id"] == created.json()["user_id"]
+
+
 def test_secret_rotation_rejects_another_players_recovery_secret(client: TestClient) -> None:
     first = client.post("user/create", params={"secret": "first-secret"})
     second = client.post("user/create", params={"secret": "second-secret"})

--- a/apps/web/notes/ARCHITECTURE.md
+++ b/apps/web/notes/ARCHITECTURE.md
@@ -64,6 +64,7 @@
 │  │  useStore()                                                │ │
 │  │  - current_world_uid                                       │ │
 │  │  - current_world_info                                      │ │
+│  │  - current_user                                             │ │
 │  │  - user_secret                                             │ │
 │  │  - user_api_key                                            │ │
 │  └────────────────────────────────────────────────────────────┘ │
@@ -80,6 +81,11 @@
 │  │  - $debug / $verbose - Dev flags                           │ │
 │  └────────────────────────────────────────────────────────────┘ │
 └─────────────────────────────────────────────────────────────────┘
+
+`App.vue` gates authenticated story children until the browser player session
+has been created or restored. `playerSession.ts` owns the local recovery
+codename; the complete transport contract is in
+[Player Session Bootstrap](PLAYER_SESSION_BOOTSTRAP.md).
 
 ═══════════════════════════════════════════════════════════════════
                          TYPE SYSTEM FLOW

--- a/apps/web/notes/PLAYER_SESSION_BOOTSTRAP.md
+++ b/apps/web/notes/PLAYER_SESSION_BOOTSTRAP.md
@@ -1,0 +1,46 @@
+# Player Session Bootstrap
+
+**Status:** Current browser/session transport contract.
+
+The web client provides one small persistence capability for a single-player
+story session. It is not an authentication or account framework.
+
+## Ownership
+
+- On a first visit, `POST /user/create` without a secret makes the server choose
+  an unused memorable codename with `get_code_name()`. The response carries the
+  plaintext codename and its stable user UUID.
+- The browser owns that plaintext recovery codename and persists it in
+  `localStorage`. The backend stores only its derived hash and the stable user
+  UUID.
+- A derived API key is a transport detail. It is derived from the codename,
+  bound to requests, and validated with `GET /user/info`; it is not a second
+  identity or an independent sign-in state.
+
+## Lifecycle
+
+1. A normal first visit silently creates a player and persists the returned
+   codename before mounting the story application.
+2. A normal return silently derives and validates the stored codename before
+   mounting the application.
+3. Missing or invalid browser state exposes the recovery surface. The player
+   may recover with a codename, start a new player, or explicitly switch.
+4. Recovery uses `POST /user/create?secret=...`: an existing codename restores
+   its existing user; a new one creates a user. The operation supplies the
+   intent, so identical bearer values are not treated as an error here.
+5. Authenticated rotation uses `PUT /user/secret?secret=...`. It preserves the
+   current UUID; a codename owned by another user conflicts rather than merging
+   identities. Rotating to the current codename is a no-op.
+
+The account surface displays and copies the browser-held recovery codename. It
+does not fetch a plaintext secret from backend storage.
+
+## Scope and follow-up
+
+These codenames are memorable recovery capabilities, not passwords or a claim
+of cryptographic account protection. Authentication/security policy, identity
+providers, expiry, and permissions are explicitly outside this contract.
+
+[Issue #352](https://github.com/derekmerck/storytangl/issues/352) owns the
+remaining collision hardening, persistent-restart coverage, browser E2E,
+`RemoteServiceManager` parity, and world-themed namebank follow-ups.

--- a/apps/web/notes/STATUS.md
+++ b/apps/web/notes/STATUS.md
@@ -59,6 +59,7 @@ release bump.
 
 **Documentation references:**
 - `apps/web/notes/ARCHITECTURE.md` - System design
+- `apps/web/notes/PLAYER_SESSION_BOOTSTRAP.md` - Browser player-session contract
 - `apps/web/AGENTS.md` - Coding conventions
 - `apps/web/notes/TESTING_PATTERNS.md` - Test recipes
 - `apps/web/notes/SETUP_GUIDE.md` - Installation details

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -6,6 +6,7 @@ import * as directives from 'vuetify/directives'
 import { setActivePinia, createPinia } from 'pinia'
 
 import App from '@/App.vue'
+import { useStore } from '@/store'
 import { HttpResponse, http, server } from '@tests/setup'
 import { crossroadsRuntimeEnvelope, sandboxInfoAffordances, sandboxInfoState } from '@tests/fixtures'
 
@@ -40,6 +41,29 @@ describe('App.vue', () => {
     expect(wrapper.find('.v-navigation-drawer').exists()).toBe(true)
     expect(wrapper.find('.v-main').exists()).toBe(true)
     expect(wrapper.find('.v-footer').exists()).toBe(true)
+  })
+
+  it('waits for authentication before mounting API-backed children', async () => {
+    let resolveAuthentication: (() => void) | undefined
+    const store = useStore()
+    store.user_secret = 'delayed-secret'
+    vi.spyOn(store, 'getApiKey').mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveAuthentication = resolve
+        }),
+    )
+
+    const wrapper = mountApp()
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="storyflow-progress"]').exists()).toBe(false)
+    expect(wrapper.find('.v-app-bar').exists()).toBe(false)
+
+    resolveAuthentication?.()
+    await flushPromises()
+
+    expect(wrapper.find('.v-app-bar').exists()).toBe(true)
   })
 
   it('toggles drawer when menu clicked', async () => {

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -66,6 +66,27 @@ describe('App.vue', () => {
     expect(wrapper.find('.v-app-bar').exists()).toBe(true)
   })
 
+  it('keeps API-backed children unmounted after failed authentication until retry', async () => {
+    const store = useStore()
+    store.user_secret = 'invalid-secret'
+    vi.spyOn(store, 'getApiKey')
+      .mockRejectedValueOnce(new Error('Unauthorized'))
+      .mockResolvedValueOnce()
+
+    const wrapper = mountApp()
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="authentication-error"]').exists()).toBe(true)
+    expect(wrapper.find('.v-app-bar').exists()).toBe(false)
+
+    await wrapper.find('[data-testid="authentication-retry"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="authentication-error"]').exists()).toBe(false)
+    expect(wrapper.find('.v-app-bar').exists()).toBe(true)
+    expect(store.getApiKey).toHaveBeenCalledTimes(2)
+  })
+
   it('toggles drawer when menu clicked', async () => {
     const wrapper = mountApp()
     await flushPromises()

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -67,9 +67,22 @@ describe('App.vue', () => {
     expect(wrapper.find('.v-app-bar').exists()).toBe(true)
   })
 
+  it('restores the browser-local player secret before any configured default', async () => {
+    const store = useStore()
+    store.user_secret = 'configured-secret'
+    localStorage.setItem('storytangl.player-secret', 'returning-secret')
+    vi.spyOn(store, 'authenticateWithSecret').mockResolvedValue()
+
+    mountApp()
+    await flushPromises()
+
+    expect(store.authenticateWithSecret).toHaveBeenCalledWith('returning-secret')
+  })
+
   it('keeps API-backed children at the gate when an existing secret is invalid', async () => {
     const store = useStore()
-    store.user_secret = 'invalid-secret'
+    store.user_secret = ''
+    localStorage.setItem('storytangl.player-secret', 'invalid-secret')
     vi.spyOn(console, 'error').mockImplementation(() => undefined)
     server.use(
       http.get(`${DEFAULT_API_URL}/user/info`, () =>
@@ -82,14 +95,24 @@ describe('App.vue', () => {
 
     expect(wrapper.find('[data-testid="authentication-error"]').exists()).toBe(true)
     expect(wrapper.find('.v-app-bar').exists()).toBe(false)
+    expect(localStorage.getItem('storytangl.player-secret')).toBeNull()
   })
 
   it('mounts API-backed children after authenticating an existing secret', async () => {
     const store = useStore()
     store.user_secret = ''
+    localStorage.setItem('storytangl.player-secret', 'invalid-secret')
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    server.use(
+      http.get(`${DEFAULT_API_URL}/user/info`, () =>
+        HttpResponse.json({ detail: 'Invalid API key' }, { status: 401 }),
+      ),
+    )
 
     const wrapper = mountApp()
     await flushPromises()
+
+    server.resetHandlers()
 
     await wrapper.find('[data-testid="authentication-secret"] input').setValue('valid-secret')
     await wrapper.find('[data-testid="authentication-existing"]').trigger('click')
@@ -99,19 +122,16 @@ describe('App.vue', () => {
     expect(store.current_user?.user_id).toBe('test-user-id')
   })
 
-  it('creates a user before mounting API-backed children', async () => {
+  it('silently creates and stores a player on first visit', async () => {
     const store = useStore()
     store.user_secret = ''
 
     const wrapper = mountApp()
     await flushPromises()
 
-    await wrapper.find('[data-testid="authentication-secret"] input').setValue('new-secret')
-    await wrapper.find('[data-testid="authentication-create"]').trigger('click')
-    await flushPromises()
-
     expect(wrapper.find('.v-app-bar').exists()).toBe(true)
-    expect(store.user_secret).toBe('new-secret')
+    expect(store.user_secret).not.toBe('')
+    expect(localStorage.getItem('storytangl.player-secret')).toBe(store.user_secret)
   })
 
   it('toggles drawer when menu clicked', async () => {

--- a/apps/web/src/App.test.ts
+++ b/apps/web/src/App.test.ts
@@ -18,6 +18,7 @@ describe('App.vue', () => {
     setActivePinia(createPinia())
     vi.unstubAllEnvs()
     vi.stubEnv('VITE_DEFAULT_API_URL', DEFAULT_API_URL)
+    vi.stubEnv('VITE_DEFAULT_USER_SECRET', 'dev-secret-123')
     vi.resetModules()
     vi.spyOn(window, 'open').mockImplementation(() => null)
   })
@@ -47,7 +48,7 @@ describe('App.vue', () => {
     let resolveAuthentication: (() => void) | undefined
     const store = useStore()
     store.user_secret = 'delayed-secret'
-    vi.spyOn(store, 'getApiKey').mockImplementation(
+    vi.spyOn(store, 'authenticateWithSecret').mockImplementation(
       () =>
         new Promise<void>((resolve) => {
           resolveAuthentication = resolve
@@ -66,25 +67,51 @@ describe('App.vue', () => {
     expect(wrapper.find('.v-app-bar').exists()).toBe(true)
   })
 
-  it('keeps API-backed children unmounted after failed authentication until retry', async () => {
+  it('keeps API-backed children at the gate when an existing secret is invalid', async () => {
     const store = useStore()
     store.user_secret = 'invalid-secret'
-    vi.spyOn(store, 'getApiKey')
-      .mockRejectedValueOnce(new Error('Unauthorized'))
-      .mockResolvedValueOnce()
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    server.use(
+      http.get(`${DEFAULT_API_URL}/user/info`, () =>
+        HttpResponse.json({ detail: 'Invalid API key' }, { status: 401 }),
+      ),
+    )
 
     const wrapper = mountApp()
     await flushPromises()
 
     expect(wrapper.find('[data-testid="authentication-error"]').exists()).toBe(true)
     expect(wrapper.find('.v-app-bar').exists()).toBe(false)
+  })
 
-    await wrapper.find('[data-testid="authentication-retry"]').trigger('click')
+  it('mounts API-backed children after authenticating an existing secret', async () => {
+    const store = useStore()
+    store.user_secret = ''
+
+    const wrapper = mountApp()
     await flushPromises()
 
-    expect(wrapper.find('[data-testid="authentication-error"]').exists()).toBe(false)
+    await wrapper.find('[data-testid="authentication-secret"] input').setValue('valid-secret')
+    await wrapper.find('[data-testid="authentication-existing"]').trigger('click')
+    await flushPromises()
+
     expect(wrapper.find('.v-app-bar').exists()).toBe(true)
-    expect(store.getApiKey).toHaveBeenCalledTimes(2)
+    expect(store.current_user?.user_id).toBe('test-user-id')
+  })
+
+  it('creates a user before mounting API-backed children', async () => {
+    const store = useStore()
+    store.user_secret = ''
+
+    const wrapper = mountApp()
+    await flushPromises()
+
+    await wrapper.find('[data-testid="authentication-secret"] input').setValue('new-secret')
+    await wrapper.find('[data-testid="authentication-create"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('.v-app-bar').exists()).toBe(true)
+    expect(store.user_secret).toBe('new-secret')
   })
 
   it('toggles drawer when menu clicked', async () => {

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -7,6 +7,7 @@ import AppFooter from '@/components/AppFooter.vue'
 import StoryStatus from '@/components/StoryStatus.vue'
 import StoryFlow from '@/components/story/StoryFlow.vue'
 import type { InfoAffordance, InfoState, RuntimeEnvelope } from '@/types'
+import { clearPlayerSecret, createPlayerSecret, loadPlayerSecret } from '@/playerSession'
 import { useStore } from '@/store'
 
 const drawer = ref(true)
@@ -40,20 +41,35 @@ const authenticate = async (action: (secret: string) => Promise<void>) => {
 }
 
 const useExistingSecret = async () => {
+  await authenticate((secret) => store.ensurePlayer(secret))
+}
+
+const startNewPlayer = async () => {
+  authenticationSecret.value = createPlayerSecret()
+  await authenticate((secret) => store.ensurePlayer(secret))
+}
+
+const restoreStoredPlayer = async () => {
   await authenticate((secret) => store.authenticateWithSecret(secret))
 }
 
-const createUser = async () => {
-  await authenticate((secret) => store.createUser(secret))
-}
-
 const initializeClient = async () => {
-  authenticationSecret.value = store.user_secret
+  const storedSecret = loadPlayerSecret()
+  authenticationSecret.value = storedSecret ?? store.user_secret
   if (!authenticationSecret.value) {
-    clientState.value = 'needs-auth'
+    await startNewPlayer()
     return
   }
-  await useExistingSecret()
+  await restoreStoredPlayer()
+  if (clientState.value !== 'ready' && storedSecret) {
+    clearPlayerSecret()
+  }
+}
+
+const recoverPlayer = () => {
+  authenticationSecret.value = ''
+  authenticationError.value = null
+  clientState.value = 'needs-auth'
 }
 
 onMounted(() => {
@@ -129,13 +145,13 @@ const handleStoryUpdate = (envelope: RuntimeEnvelope) => {
     <v-main v-if="clientState === 'needs-auth'">
       <v-container class="py-6" fluid>
         <v-card class="mx-auto" max-width="480">
-          <v-card-title>Connect to StoryTangl</v-card-title>
+          <v-card-title>Recover Player</v-card-title>
           <v-card-text>
-            <p class="mb-4">Use an existing user secret or create a new local user.</p>
+            <p class="mb-4">Use a recovery secret from another browser, or start a new player.</p>
             <v-text-field
               v-model="authenticationSecret"
               data-testid="authentication-secret"
-              label="User Secret"
+              label="Recovery Secret"
               type="password"
             />
             <v-alert
@@ -154,11 +170,11 @@ const handleStoryUpdate = (envelope: RuntimeEnvelope) => {
               variant="text"
               @click="useExistingSecret"
             >
-              Use Existing Secret
+              Use Recovery Secret
             </v-btn>
             <v-spacer />
-            <v-btn data-testid="authentication-create" color="primary" @click="createUser">
-              Create User
+            <v-btn data-testid="authentication-create" color="primary" @click="startNewPlayer">
+              Start New Player
             </v-btn>
           </v-card-actions>
         </v-card>
@@ -166,7 +182,7 @@ const handleStoryUpdate = (envelope: RuntimeEnvelope) => {
     </v-main>
 
     <template v-else-if="clientState === 'ready'">
-      <AppNavbar @toggle-drawer="toggleDrawer" />
+      <AppNavbar @toggle-drawer="toggleDrawer" @recover-player="recoverPlayer" />
 
       <v-navigation-drawer
         v-model="drawer"

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -14,22 +14,30 @@ const statusRefreshKey = ref(0)
 const infoAffordances = ref<InfoAffordance[]>([])
 const infoState = ref<InfoState | null>(null)
 const clientReady = ref(false)
+const authenticationError = ref(false)
 const store = useStore()
 const display = useDisplay()
 
 const isDesktop = computed(() => display.mdAndUp.value)
 
-onMounted(async () => {
-  drawer.value = isDesktop.value
-
+const initializeClient = async () => {
+  clientReady.value = false
+  authenticationError.value = false
   if (store.user_secret) {
     try {
       await store.getApiKey()
     } catch (error) {
       console.error('Failed to initialize authentication:', error)
+      authenticationError.value = true
+      return
     }
   }
   clientReady.value = true
+}
+
+onMounted(() => {
+  drawer.value = isDesktop.value
+  void initializeClient()
 })
 
 const toggleDrawer = () => {
@@ -97,7 +105,24 @@ const handleStoryUpdate = (envelope: RuntimeEnvelope) => {
 
 <template>
   <v-app id="webtangl">
-    <template v-if="clientReady">
+    <v-main v-if="authenticationError">
+      <v-container class="py-6" fluid>
+        <v-alert data-testid="authentication-error" type="error" variant="tonal">
+          Unable to authenticate with the story service.
+          <template #append>
+            <v-btn
+              data-testid="authentication-retry"
+              variant="text"
+              @click="initializeClient"
+            >
+              Retry
+            </v-btn>
+          </template>
+        </v-alert>
+      </v-container>
+    </v-main>
+
+    <template v-else-if="clientReady">
       <AppNavbar @toggle-drawer="toggleDrawer" />
 
       <v-navigation-drawer

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -13,26 +13,47 @@ const drawer = ref(true)
 const statusRefreshKey = ref(0)
 const infoAffordances = ref<InfoAffordance[]>([])
 const infoState = ref<InfoState | null>(null)
-const clientReady = ref(false)
-const authenticationError = ref(false)
+const clientState = ref<'initializing' | 'needs-auth' | 'ready'>('initializing')
+const authenticationError = ref<string | null>(null)
+const authenticationSecret = ref('')
 const store = useStore()
 const display = useDisplay()
 
 const isDesktop = computed(() => display.mdAndUp.value)
 
-const initializeClient = async () => {
-  clientReady.value = false
-  authenticationError.value = false
-  if (store.user_secret) {
-    try {
-      await store.getApiKey()
-    } catch (error) {
-      console.error('Failed to initialize authentication:', error)
-      authenticationError.value = true
-      return
-    }
+const authenticate = async (action: (secret: string) => Promise<void>) => {
+  if (!authenticationSecret.value) {
+    authenticationError.value = 'Enter a user secret.'
+    return
   }
-  clientReady.value = true
+
+  clientState.value = 'initializing'
+  authenticationError.value = null
+  try {
+    await action(authenticationSecret.value)
+    clientState.value = 'ready'
+  } catch (error) {
+    console.error('Failed to initialize authentication:', error)
+    authenticationError.value = 'Unable to authenticate with the story service.'
+    clientState.value = 'needs-auth'
+  }
+}
+
+const useExistingSecret = async () => {
+  await authenticate((secret) => store.authenticateWithSecret(secret))
+}
+
+const createUser = async () => {
+  await authenticate((secret) => store.createUser(secret))
+}
+
+const initializeClient = async () => {
+  authenticationSecret.value = store.user_secret
+  if (!authenticationSecret.value) {
+    clientState.value = 'needs-auth'
+    return
+  }
+  await useExistingSecret()
 }
 
 onMounted(() => {
@@ -105,24 +126,46 @@ const handleStoryUpdate = (envelope: RuntimeEnvelope) => {
 
 <template>
   <v-app id="webtangl">
-    <v-main v-if="authenticationError">
+    <v-main v-if="clientState === 'needs-auth'">
       <v-container class="py-6" fluid>
-        <v-alert data-testid="authentication-error" type="error" variant="tonal">
-          Unable to authenticate with the story service.
-          <template #append>
-            <v-btn
-              data-testid="authentication-retry"
-              variant="text"
-              @click="initializeClient"
+        <v-card class="mx-auto" max-width="480">
+          <v-card-title>Connect to StoryTangl</v-card-title>
+          <v-card-text>
+            <p class="mb-4">Use an existing user secret or create a new local user.</p>
+            <v-text-field
+              v-model="authenticationSecret"
+              data-testid="authentication-secret"
+              label="User Secret"
+              type="password"
+            />
+            <v-alert
+              v-if="authenticationError"
+              data-testid="authentication-error"
+              density="compact"
+              type="error"
+              variant="tonal"
             >
-              Retry
+              {{ authenticationError }}
+            </v-alert>
+          </v-card-text>
+          <v-card-actions>
+            <v-btn
+              data-testid="authentication-existing"
+              variant="text"
+              @click="useExistingSecret"
+            >
+              Use Existing Secret
             </v-btn>
-          </template>
-        </v-alert>
+            <v-spacer />
+            <v-btn data-testid="authentication-create" color="primary" @click="createUser">
+              Create User
+            </v-btn>
+          </v-card-actions>
+        </v-card>
       </v-container>
     </v-main>
 
-    <template v-else-if="clientReady">
+    <template v-else-if="clientState === 'ready'">
       <AppNavbar @toggle-drawer="toggleDrawer" />
 
       <v-navigation-drawer

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -13,6 +13,7 @@ const drawer = ref(true)
 const statusRefreshKey = ref(0)
 const infoAffordances = ref<InfoAffordance[]>([])
 const infoState = ref<InfoState | null>(null)
+const clientReady = ref(false)
 const store = useStore()
 const display = useDisplay()
 
@@ -28,6 +29,7 @@ onMounted(async () => {
       console.error('Failed to initialize authentication:', error)
     }
   }
+  clientReady.value = true
 })
 
 const toggleDrawer = () => {
@@ -95,36 +97,40 @@ const handleStoryUpdate = (envelope: RuntimeEnvelope) => {
 
 <template>
   <v-app id="webtangl">
-    <AppNavbar @toggle-drawer="toggleDrawer" />
+    <template v-if="clientReady">
+      <AppNavbar @toggle-drawer="toggleDrawer" />
 
-    <v-navigation-drawer
-      v-model="drawer"
-      :permanent="isDesktop"
-      width="260"
-      border="0"
-    >
-      <v-list density="compact">
-        <v-list-item>
-          <v-list-item-title class="text-h6">Status</v-list-item-title>
-        </v-list-item>
-      </v-list>
-      <v-divider class="mb-2" />
-      <StoryStatus
-        :refresh-key="statusRefreshKey"
-        :info-affordances="infoAffordances"
-        :info-state="infoState"
-      />
-    </v-navigation-drawer>
+      <v-navigation-drawer
+        v-model="drawer"
+        :permanent="isDesktop"
+        width="260"
+        border="0"
+      >
+        <v-list density="compact">
+          <v-list-item>
+            <v-list-item-title class="text-h6">Status</v-list-item-title>
+          </v-list-item>
+        </v-list>
+        <v-divider class="mb-2" />
+        <StoryStatus
+          :refresh-key="statusRefreshKey"
+          :info-affordances="infoAffordances"
+          :info-state="infoState"
+        />
+      </v-navigation-drawer>
 
-    <v-main>
-      <v-container class="py-6" fluid>
-        <v-row justify="center">
-          <v-col cols="12" lg="9">
-            <StoryFlow @story-update="handleStoryUpdate" />
-          </v-col>
-        </v-row>
-        <AppFooter />
-      </v-container>
-    </v-main>
+      <v-main>
+        <v-container class="py-6" fluid>
+          <v-row justify="center">
+            <v-col cols="12" lg="9">
+              <StoryFlow @story-update="handleStoryUpdate" />
+            </v-col>
+          </v-row>
+          <AppFooter />
+        </v-container>
+      </v-main>
+    </template>
+
+    <v-progress-linear v-else color="primary" indeterminate />
   </v-app>
 </template>

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -7,7 +7,7 @@ import AppFooter from '@/components/AppFooter.vue'
 import StoryStatus from '@/components/StoryStatus.vue'
 import StoryFlow from '@/components/story/StoryFlow.vue'
 import type { InfoAffordance, InfoState, RuntimeEnvelope } from '@/types'
-import { clearPlayerSecret, createPlayerSecret, loadPlayerSecret } from '@/playerSession'
+import { clearPlayerSecret, loadPlayerSecret } from '@/playerSession'
 import { useStore } from '@/store'
 
 const drawer = ref(true)
@@ -22,16 +22,11 @@ const display = useDisplay()
 
 const isDesktop = computed(() => display.mdAndUp.value)
 
-const authenticate = async (action: (secret: string) => Promise<void>) => {
-  if (!authenticationSecret.value) {
-    authenticationError.value = 'Enter a user secret.'
-    return
-  }
-
+const bootstrapPlayer = async (action: () => Promise<void>) => {
   clientState.value = 'initializing'
   authenticationError.value = null
   try {
-    await action(authenticationSecret.value)
+    await action()
     clientState.value = 'ready'
   } catch (error) {
     console.error('Failed to initialize authentication:', error)
@@ -41,16 +36,19 @@ const authenticate = async (action: (secret: string) => Promise<void>) => {
 }
 
 const useExistingSecret = async () => {
-  await authenticate((secret) => store.ensurePlayer(secret))
+  if (!authenticationSecret.value) {
+    authenticationError.value = 'Enter a recovery secret.'
+    return
+  }
+  await bootstrapPlayer(() => store.ensurePlayer(authenticationSecret.value))
 }
 
 const startNewPlayer = async () => {
-  authenticationSecret.value = createPlayerSecret()
-  await authenticate((secret) => store.ensurePlayer(secret))
+  await bootstrapPlayer(() => store.ensurePlayer())
 }
 
 const restoreStoredPlayer = async () => {
-  await authenticate((secret) => store.authenticateWithSecret(secret))
+  await bootstrapPlayer(() => store.authenticateWithSecret(authenticationSecret.value))
 }
 
 const initializeClient = async () => {

--- a/apps/web/src/components/AppNavbar.vue
+++ b/apps/web/src/components/AppNavbar.vue
@@ -11,6 +11,7 @@ import { useStore } from '@/store'
 
 const emit = defineEmits<{
   'toggle-drawer': []
+  'recover-player': []
 }>()
 
 const { $http, remapURL } = useGlobal()
@@ -105,6 +106,9 @@ const worldStyle = (world: WorldList[number]): CSSProperties => {
           </v-list-item>
           <v-list-item @click="showSecretDialog = true">
             <v-list-item-title>Change Secret</v-list-item-title>
+          </v-list-item>
+          <v-list-item @click="emit('recover-player')">
+            <v-list-item-title>Switch or Recover Player</v-list-item-title>
           </v-list-item>
         </v-list>
       </v-menu>

--- a/apps/web/src/components/AppNavbar.vue
+++ b/apps/web/src/components/AppNavbar.vue
@@ -100,8 +100,11 @@ const worldStyle = (world: WorldList[number]): CSSProperties => {
           </v-btn>
         </template>
         <v-list density="compact">
+          <v-list-item v-if="store.current_user">
+            <v-list-item-title>{{ store.current_user.user_id }}</v-list-item-title>
+          </v-list-item>
           <v-list-item @click="showSecretDialog = true">
-            <v-list-item-title>Set Secret</v-list-item-title>
+            <v-list-item-title>Change Secret</v-list-item-title>
           </v-list-item>
         </v-list>
       </v-menu>

--- a/apps/web/src/components/dialogs/SecretDialog.test.ts
+++ b/apps/web/src/components/dialogs/SecretDialog.test.ts
@@ -112,7 +112,9 @@ describe('SecretDialog', () => {
     expect(dialog.emitted('update:modelValue')?.[0]).toEqual([false])
   })
 
-  it('calls store.setApiKey when save clicked', async () => {
+  it('rotates the authenticated user secret when save clicked', async () => {
+    const store = useStore()
+    await store.authenticateWithSecret(store.user_secret)
     const wrapper = mountDialog(true)
     await flushPromises()
     await nextTick()
@@ -127,7 +129,6 @@ describe('SecretDialog', () => {
     await saveButton?.trigger('click')
     await flushPromises()
 
-    const store = useStore()
     expect(store.user_secret).toBe('new-secret')
     expect(dialog.emitted('update:modelValue')).toBeTruthy()
   })

--- a/apps/web/src/components/dialogs/SecretDialog.vue
+++ b/apps/web/src/components/dialogs/SecretDialog.vue
@@ -36,7 +36,7 @@ const save = async () => {
 
   loading.value = true
   try {
-    await store.setApiKey(secret.value)
+    await store.rotateSecret(secret.value)
     close()
   } catch (error) {
     console.error('Failed to set API key:', error)
@@ -49,12 +49,12 @@ const save = async () => {
 <template>
   <v-dialog :model-value="modelValue" max-width="480" persistent>
     <v-card>
-      <v-card-title>Set User Secret</v-card-title>
+      <v-card-title>Change User Secret</v-card-title>
       <v-card-text>
         <v-text-field
           v-model="secret"
           label="User Secret"
-          hint="Enter your user secret to authenticate"
+          hint="Choose a new secret for the current user"
           persistent-hint
           :disabled="loading"
           autofocus

--- a/apps/web/src/components/dialogs/SecretDialog.vue
+++ b/apps/web/src/components/dialogs/SecretDialog.vue
@@ -28,6 +28,10 @@ const close = () => {
   emit('update:modelValue', false)
 }
 
+const copySecret = async () => {
+  await navigator.clipboard.writeText(secret.value)
+}
+
 const save = async () => {
   if (!secret.value) {
     close()
@@ -49,18 +53,21 @@ const save = async () => {
 <template>
   <v-dialog :model-value="modelValue" max-width="480" persistent>
     <v-card>
-      <v-card-title>Change User Secret</v-card-title>
+      <v-card-title>Recovery Secret</v-card-title>
       <v-card-text>
         <v-text-field
           v-model="secret"
-          label="User Secret"
-          hint="Choose a new secret for the current user"
+          label="Recovery Secret"
+          hint="Keep this secret to recover the current player on another browser"
           persistent-hint
           :disabled="loading"
           autofocus
         />
       </v-card-text>
       <v-card-actions>
+        <v-btn variant="text" @click="copySecret" :disabled="loading">
+          Copy
+        </v-btn>
         <v-spacer />
         <v-btn variant="text" @click="close" :disabled="loading">
           Cancel

--- a/apps/web/src/components/story/StoryFlow.test.ts
+++ b/apps/web/src/components/story/StoryFlow.test.ts
@@ -219,6 +219,10 @@ describe('StoryFlow', () => {
 
     const scenes = wrapper.findAllComponents(StoryBlock)
     expect(scenes.length).toBeGreaterThan(initialCount)
+    expect(scenes[0]!.props('disabled')).toBe(true)
+    const latestScene = scenes[scenes.length - 1]
+    expect(latestScene).toBeDefined()
+    expect(latestScene!.props('disabled')).toBe(false)
     expect(wrapper.text()).toContain('The stranger slides the folded vellum')
     expect(wrapper.findAll('[data-testid="interrupt-ux-event"]')).toHaveLength(1)
     expect(wrapper.emitted('storyUpdate')!.length).toBeGreaterThanOrEqual(2)

--- a/apps/web/src/components/story/StoryFlow.vue
+++ b/apps/web/src/components/story/StoryFlow.vue
@@ -250,13 +250,13 @@ const doCommand = async (command: string) => {
     </div>
 
     <StoryBlock
-      v-for="scene in scenes"
+      v-for="(scene, index) in scenes"
       :key="scene.key"
       ref="sceneRefs"
       :scene="scene"
       :fragments="fragmentRegistry"
       :metadata="scene.metadata"
-      :disabled="loading"
+      :disabled="loading || index !== scenes.length - 1"
       @doAction="doAction"
     />
 

--- a/apps/web/src/playerSession.ts
+++ b/apps/web/src/playerSession.ts
@@ -12,6 +12,3 @@ export const savePlayerSecret = (secret: string): void => {
 export const clearPlayerSecret = (): void => {
   localStorage.removeItem(PLAYER_SECRET_KEY)
 }
-
-/** Create a transport secret for a first-visit player. */
-export const createPlayerSecret = (): string => crypto.randomUUID()

--- a/apps/web/src/playerSession.ts
+++ b/apps/web/src/playerSession.ts
@@ -1,0 +1,17 @@
+const PLAYER_SECRET_KEY = 'storytangl.player-secret'
+
+/** Return the browser-local recovery secret for the current player. */
+export const loadPlayerSecret = (): string | null => localStorage.getItem(PLAYER_SECRET_KEY)
+
+/** Persist the recovery secret that reconnects this browser to its player. */
+export const savePlayerSecret = (secret: string): void => {
+  localStorage.setItem(PLAYER_SECRET_KEY, secret)
+}
+
+/** Forget a stale browser-local recovery secret. */
+export const clearPlayerSecret = (): void => {
+  localStorage.removeItem(PLAYER_SECRET_KEY)
+}
+
+/** Create a transport secret for a first-visit player. */
+export const createPlayerSecret = (): string => crypto.randomUUID()

--- a/apps/web/src/store/index.test.ts
+++ b/apps/web/src/store/index.test.ts
@@ -52,18 +52,20 @@ describe('Store', () => {
     expect(store.current_world_info?.world_id).toBe('new_world')
   })
 
-  it('gets API key from user secret', async () => {
+  it('authenticates a persisted user from a user secret', async () => {
     const store = useStore()
-    await store.getApiKey()
+    await store.authenticateWithSecret(store.user_secret)
 
     const { $http } = useGlobal()
+    expect(store.current_user?.user_id).toBe('test-user-id')
     expect(store.user_api_key).toBeDefined()
     expect($http.value.defaults.headers.common['X-Api-Key']).toBe(store.user_api_key)
   })
 
-  it('sets new API key when secret changes', async () => {
+  it('rotates the authenticated user secret through the query-parameter route', async () => {
     const store = useStore()
-    await store.setApiKey('new-secret-123')
+    await store.authenticateWithSecret(store.user_secret)
+    await store.rotateSecret('new-secret-123')
 
     const { $http } = useGlobal()
     expect(store.user_secret).toBe('new-secret-123')

--- a/apps/web/src/store/index.test.ts
+++ b/apps/web/src/store/index.test.ts
@@ -60,6 +60,7 @@ describe('Store', () => {
     expect(store.current_user?.user_id).toBe('test-user-id')
     expect(store.user_api_key).toBeDefined()
     expect($http.value.defaults.headers.common['X-Api-Key']).toBe(store.user_api_key)
+    expect(localStorage.getItem('storytangl.player-secret')).toBe(store.user_secret)
   })
 
   it('rotates the authenticated user secret through the query-parameter route', async () => {
@@ -71,5 +72,6 @@ describe('Store', () => {
     expect(store.user_secret).toBe('new-secret-123')
     expect(store.user_api_key).toBeDefined()
     expect($http.value.defaults.headers.common['X-Api-Key']).toBe(store.user_api_key)
+    expect(localStorage.getItem('storytangl.player-secret')).toBe('new-secret-123')
   })
 })

--- a/apps/web/src/store/index.ts
+++ b/apps/web/src/store/index.ts
@@ -66,9 +66,9 @@ export const useStore = defineStore('main', {
       savePlayerSecret(this.user_secret)
     },
 
-    async ensurePlayer(secret: string) {
+    async ensurePlayer(secret?: string) {
       const response = await $http.value.post<UserSecretResponse>('/user/create', undefined, {
-        params: { secret },
+        params: secret ? { secret } : undefined,
       })
       $http.value.defaults.headers.common['X-Api-Key'] = response.data.api_key
       try {

--- a/apps/web/src/store/index.ts
+++ b/apps/web/src/store/index.ts
@@ -1,18 +1,14 @@
 import { defineStore } from 'pinia'
 
-import type { WorldInfo } from '@/types'
+import type { UserInfo, UserSecretResponse, WorldInfo } from '@/types'
 import { useGlobal } from '@/composables/globals'
 
 interface StoreState {
   current_world_uid: string
   current_world_info?: WorldInfo
+  current_user?: UserInfo
   user_secret: string
   user_api_key?: string
-}
-
-interface ApiKeyResponse {
-  secret: string
-  api_key: string
 }
 
 const { $http, makeMediaDict } = useGlobal()
@@ -49,20 +45,49 @@ export const useStore = defineStore('main', {
       this.current_world_info = world
     },
 
-    async getApiKey() {
-      const response = await $http.value.get<ApiKeyResponse>('/system/secret', {
-        params: { secret: this.user_secret },
+    async authenticateWithSecret(secret: string) {
+      delete $http.value.defaults.headers.common['X-Api-Key']
+      const response = await $http.value.get<UserSecretResponse>('/system/secret', {
+        params: { secret },
       })
-
-      this.user_secret = response.data.secret
-      this.user_api_key = response.data.api_key
       $http.value.defaults.headers.common['X-Api-Key'] = response.data.api_key
+
+      try {
+        const user = await $http.value.get<UserInfo>('/user/info')
+        this.current_user = user.data
+      } catch (error) {
+        delete $http.value.defaults.headers.common['X-Api-Key']
+        throw error
+      }
+
+      this.user_secret = response.data.user_secret
+      this.user_api_key = response.data.api_key
     },
 
-    async setApiKey(secret: string) {
-      const response = await $http.value.put<ApiKeyResponse>('/user/secret', { secret })
+    async createUser(secret: string) {
+      const response = await $http.value.post<UserSecretResponse>('/user/create', undefined, {
+        params: { secret },
+      })
+      $http.value.defaults.headers.common['X-Api-Key'] = response.data.api_key
+      try {
+        const user = await $http.value.get<UserInfo>('/user/info')
 
-      this.user_secret = response.data.secret
+        this.current_user = user.data
+      } catch (error) {
+        delete $http.value.defaults.headers.common['X-Api-Key']
+        throw error
+      }
+
+      this.user_secret = response.data.user_secret
+      this.user_api_key = response.data.api_key
+    },
+
+    async rotateSecret(secret: string) {
+      const response = await $http.value.put<UserSecretResponse>('/user/secret', undefined, {
+        params: { secret },
+      })
+
+      this.user_secret = response.data.user_secret
       this.user_api_key = response.data.api_key
       $http.value.defaults.headers.common['X-Api-Key'] = response.data.api_key
     },

--- a/apps/web/src/store/index.ts
+++ b/apps/web/src/store/index.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 
 import type { UserInfo, UserSecretResponse, WorldInfo } from '@/types'
 import { useGlobal } from '@/composables/globals'
+import { savePlayerSecret } from '@/playerSession'
 
 interface StoreState {
   current_world_uid: string
@@ -62,9 +63,10 @@ export const useStore = defineStore('main', {
 
       this.user_secret = response.data.user_secret
       this.user_api_key = response.data.api_key
+      savePlayerSecret(this.user_secret)
     },
 
-    async createUser(secret: string) {
+    async ensurePlayer(secret: string) {
       const response = await $http.value.post<UserSecretResponse>('/user/create', undefined, {
         params: { secret },
       })
@@ -80,6 +82,7 @@ export const useStore = defineStore('main', {
 
       this.user_secret = response.data.user_secret
       this.user_api_key = response.data.api_key
+      savePlayerSecret(this.user_secret)
     },
 
     async rotateSecret(secret: string) {
@@ -90,6 +93,7 @@ export const useStore = defineStore('main', {
       this.user_secret = response.data.user_secret
       this.user_api_key = response.data.api_key
       $http.value.defaults.headers.common['X-Api-Key'] = response.data.api_key
+      savePlayerSecret(this.user_secret)
     },
   },
 })

--- a/apps/web/src/types/tangl_typedefs.ts
+++ b/apps/web/src/types/tangl_typedefs.ts
@@ -89,7 +89,7 @@ export interface UserInfo {
   user_id: string
   user_secret: string
   created_dt: string
-  last_played_dt: string
+  last_played_dt?: string | null
   worlds_played: string[]
   stories_finished: number
   turns_played: number
@@ -97,8 +97,9 @@ export interface UserInfo {
 }
 
 export interface UserSecretResponse {
-  user_id: string
+  api_key: string
   user_secret: string
+  user_id?: string
 }
 
 /**

--- a/apps/web/tests/mocks/handlers.ts
+++ b/apps/web/tests/mocks/handlers.ts
@@ -8,6 +8,7 @@ import {
 import {
   mockSystemInfo,
   mockUpdatedSecretResponse,
+  mockUserInfo,
   mockUserSecretResponse,
   mockWorldInfo,
   mockWorldList,
@@ -19,7 +20,6 @@ const apiBase = (import.meta.env?.VITE_DEFAULT_API_URL ?? 'http://localhost:8000
 )
 
 type UserWorldRequest = { uid?: string }
-type UserSecretRequest = { secret?: string }
 type StoryDoRequest = {
   edge_id?: unknown
   find_edge?: { kind?: unknown; command?: unknown }
@@ -73,11 +73,26 @@ export const handlers = [
     return HttpResponse.json(mockUserSecretResponse)
   }),
 
-  http.put(`${apiBase}/user/secret`, async ({ request }) => {
-    const body = (await request.json()) as UserSecretRequest | null
+  http.get(`${apiBase}/user/info`, () => {
+    return HttpResponse.json(mockUserInfo)
+  }),
+
+  http.post(`${apiBase}/user/create`, ({ request }) => {
+    const secret = new URL(request.url).searchParams.get('secret')
+    return HttpResponse.json({
+      ...mockUserSecretResponse,
+      user_secret: secret ?? mockUserSecretResponse.user_secret,
+    })
+  }),
+
+  http.put(`${apiBase}/user/secret`, ({ request }) => {
+    const secret = new URL(request.url).searchParams.get('secret')
+    if (!secret || request.headers.get('X-Api-Key') !== mockUserSecretResponse.api_key) {
+      return HttpResponse.json({ detail: 'Invalid secret rotation request' }, { status: 400 })
+    }
     return HttpResponse.json({
       ...mockUpdatedSecretResponse,
-      secret: body?.secret ?? mockUpdatedSecretResponse.secret,
+      user_secret: secret,
     })
   }),
 ]

--- a/apps/web/tests/mocks/mockData.ts
+++ b/apps/web/tests/mocks/mockData.ts
@@ -22,13 +22,23 @@ export const mockWorldInfo: WorldInfo = {
 }
 
 export const mockUserSecretResponse = {
-  secret: 'dev-secret-123',
+  user_secret: 'dev-secret-123',
   api_key: 'mock-api-key-123',
 }
 
 export const mockUpdatedSecretResponse = {
-  secret: 'updated-secret-456',
+  user_secret: 'updated-secret-456',
   api_key: 'updated-api-key-456',
+}
+
+export const mockUserInfo = {
+  user_id: 'test-user-id',
+  user_secret: 'dev-secret-123',
+  created_dt: '2026-01-01T00:00:00Z',
+  last_played_dt: '2026-01-01T00:00:00Z',
+  worlds_played: [],
+  stories_finished: 0,
+  turns_played: 0,
 }
 
 export const mockSystemInfo = {

--- a/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
+++ b/engine/src/tangl/mechanics/games/CREDENTIALS_LOOP_DESIGN.md
@@ -1184,6 +1184,22 @@ bearer's current graph presentation at use time.
 This is deliberately one-story, one-authored-return proof. It is not a
 candidate dossier, recurrence scheduler, or cross-session identity system.
 
+### Hall Monitor playable vertical (landed 2026-08-05)
+
+The reference service and web client now witness the complete disclosure
+contract. The client receives packet/document text, public inspection findings,
+and labelled actions; it does not receive expected disposition, validity truth,
+or a credentials-specific widget. When a generated card is absent, pending, or
+unavailable, the text and piece fragments remain the decision floor.
+
+The Hall Monitor runbook records the complete observable arc: a rules-correct
+harsh ruling and rules-incorrect compassionate ruling lead to distinct later
+world-authored inhaler facts, and only consequence-producing paths offer the
+prepared same-bearer return. The client gates initial reads on authentication
+and disables prior transcript choices so a player acts only on the current
+frontier. See `worlds/hall_monitor/README.md` for the repeatable local pass and
+remaining service/client friction.
+
 A procedural candidate today is generated for one shift and disappears at
 terminal. A *real* checkpoint story wants candidates to return: the
 procedurally-sampled traveler you wrongly admitted on day 1 walks back through

--- a/engine/src/tangl/service/SERVICE_DESIGN.md
+++ b/engine/src/tangl/service/SERVICE_DESIGN.md
@@ -192,6 +192,15 @@ and returns concrete user identity plus privilege state.
 Writeback metadata is likewise authoritative for deciding whether a method
 should persist user/session state on exit.
 
+### Browser player-session bootstrap
+
+The web client owns a deliberately small, codename-backed persistence
+capability: the server stores a derived secret hash and stable user UUID, while
+the browser retains the plaintext codename needed to restore that user. The
+derived API key is request transport, not a second identity. See the canonical
+[player-session bootstrap note](../../../../apps/web/notes/PLAYER_SESSION_BOOTSTRAP.md)
+for create-or-restore, rotation, and explicitly deferred security policy.
+
 ## World Support
 
 `WorldRegistry` is the canonical world discovery/loading path.

--- a/engine/src/tangl/service/service_manager.py
+++ b/engine/src/tangl/service/service_manager.py
@@ -16,6 +16,7 @@ from tangl.journal.fragments import ChoiceFragment, PieceFragment
 from tangl.persistence import PersistenceManager
 from tangl.story import InitMode, World, do_find_edges
 from tangl.type_hints import Identifier, UnstructuredData
+from tangl.utils.get_code_name import get_code_name
 from tangl.utils.hash_secret import key_for_secret
 from tangl.vm.runtime.ledger import Ledger
 
@@ -650,22 +651,24 @@ class ServiceManager:
         """Create or restore the service user named by a recovery secret."""
 
         persistence = self._require_persistence()
+        if not secret:
+            secret = get_code_name()
+            while user_id_by_key(key_for_secret(secret), persistence) is not None:
+                secret = get_code_name()
         if isinstance(secret, str) and secret:
             existing = user_id_by_key(key_for_secret(secret), persistence)
             if existing is not None:
                 return RuntimeInfo.ok(
                     message="User restored",
                     user_id=str(existing.user_id),
+                    user_secret=secret,
                 )
 
         user = User(**kwargs)
         if isinstance(secret, str) and secret:
             user.set_secret(secret)
         self._save(user)
-        return RuntimeInfo.ok(
-            message="User created",
-            user_id=str(user.uid),
-        )
+        return RuntimeInfo.ok(message="User created", user_id=str(user.uid), user_secret=secret)
 
     @service_method(
         access=ServiceAccess.CLIENT,

--- a/engine/src/tangl/service/service_manager.py
+++ b/engine/src/tangl/service/service_manager.py
@@ -19,7 +19,8 @@ from tangl.type_hints import Identifier, UnstructuredData
 from tangl.utils.hash_secret import key_for_secret
 from tangl.vm.runtime.ledger import Ledger
 
-from .exceptions import AuthMismatchError
+from .auth import user_id_by_key
+from .exceptions import AuthMismatchError, InvalidOperationError
 from ._user_support import parse_bool_flag, parse_datetime_field
 from .diagnostics import diagnostics_from_codec_state, diagnostics_from_compile_issues
 from .dispatch import do_advertise_info_channels, do_get_story_info
@@ -646,7 +647,16 @@ class ServiceManager:
         operation_id="user.create",
     )
     def create_user(self, *, secret: str | None = None, **kwargs: Any) -> RuntimeInfo:
-        """Create and persist a service user."""
+        """Create or restore the service user named by a recovery secret."""
+
+        persistence = self._require_persistence()
+        if isinstance(secret, str) and secret:
+            existing = user_id_by_key(key_for_secret(secret), persistence)
+            if existing is not None:
+                return RuntimeInfo.ok(
+                    message="User restored",
+                    user_id=str(existing.user_id),
+                )
 
         user = User(**kwargs)
         if isinstance(secret, str) and secret:
@@ -677,6 +687,9 @@ class ServiceManager:
             secret = kwargs.pop("secret", None)
             api_key: str | None = None
             if isinstance(secret, str) and secret:
+                existing = user_id_by_key(key_for_secret(secret), self._require_persistence())
+                if existing is not None and existing.user_id != user_id:
+                    raise InvalidOperationError("Recovery secret belongs to a different user")
                 user.set_secret(secret)
                 api_key = key_for_secret(secret)
 

--- a/engine/src/tangl/service/world_registry.py
+++ b/engine/src/tangl/service/world_registry.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 _MANUAL_WORLDS: dict[str, World] = {}
+_DISCOVERED_REGISTRIES: dict[tuple[Path, ...], "WorldRegistry"] = {}
 
 
 def _get_world_dirs() -> list[Path]:
@@ -70,7 +71,11 @@ def resolve_world(world_id: str) -> World:
     if world_id in _MANUAL_WORLDS:
         return _MANUAL_WORLDS[world_id]
 
-    registry = WorldRegistry()
+    world_dirs = tuple(_get_world_dirs())
+    registry = _DISCOVERED_REGISTRIES.get(world_dirs)
+    if registry is None:
+        registry = WorldRegistry(list(world_dirs))
+        _DISCOVERED_REGISTRIES[world_dirs] = registry
     world = registry.get_world(world_id)
     if not isinstance(world, World):
         raise TypeError(f"Expected Story world for '{world_id}', got {type(world)!r}")

--- a/engine/src/tangl/service/world_registry.py
+++ b/engine/src/tangl/service/world_registry.py
@@ -65,6 +65,12 @@ def clear_manual_worlds() -> None:
     _MANUAL_WORLDS.clear()
 
 
+def clear_discovered_world_registries() -> None:
+    """Clear cached discovered registries between isolated service runs."""
+
+    _DISCOVERED_REGISTRIES.clear()
+
+
 def resolve_world(world_id: str) -> World:
     """Resolve a world from manual overrides or configured registries."""
 

--- a/engine/tests/conftest.py
+++ b/engine/tests/conftest.py
@@ -93,8 +93,11 @@ def extract_fragments():
 @pytest.fixture(autouse=True)
 def clear_story_world_instances() -> None:
     """Keep story world singletons isolated between tests."""
+    from tangl.service.world_registry import clear_discovered_world_registries
     from tangl.story import World
 
+    clear_discovered_world_registries()
     World.clear_instances()
     yield
     World.clear_instances()
+    clear_discovered_world_registries()

--- a/engine/tests/service/test_service_manager.py
+++ b/engine/tests/service/test_service_manager.py
@@ -422,3 +422,14 @@ def test_user_world_and_system_methods_return_typed_models(
 
     system_info = manager.get_system_info()
     assert system_info.engine
+
+
+def test_create_user_restores_an_existing_recovery_secret(
+    manager: ServiceManager,
+    persistence,
+) -> None:
+    first = manager.create_user(secret="recovery-secret")
+    second = manager.create_user(secret="recovery-secret")
+
+    assert first.details["user_id"] == second.details["user_id"]
+    assert len([item for item in persistence.values() if isinstance(item, User)]) == 1

--- a/worlds/hall_monitor/README.md
+++ b/worlds/hall_monitor/README.md
@@ -21,3 +21,60 @@ The attendance note also prepares one authored return encounter. That encounter
 uses a fresh packet with the same graph-owned bearer UUID and receives the first
 case receipt as semantic prior context. Its recognition prose resolves the
 bearer's current presence only when the return is entered.
+
+## Playable-vertical acceptance
+
+The playable invariant is that a player can understand a school-paperwork
+decision without being told the evaluator's answer: inspect Mira Quill's note,
+make a ruling from its visible missing signature, and later understand the
+world-authored inhaler consequence and return encounter.
+
+The worked vertical has parity at these surfaces:
+
+- **Mechanical:** the credentials loop scores the ruling; the Hall Monitor
+  authority records only an attributable receipt-derived consequence.
+- **Narrative:** the attendance note exposes the later school-specific outcome,
+  and the return resolves the current presentation of the same bearer.
+- **Text/media floor:** packet and document prose remains sufficient when no
+  generated card is available; media is additive rather than a prerequisite for
+  deciding.
+- **Playable client:** the reference web client renders packet pieces,
+  inspection findings, and public action labels without receiving an expected
+  disposition or hidden validity field.
+
+### Repeatable local pass
+
+Start the service and client in separate terminals. The client is a rendering
+witness; create the local session through the documented REST API first.
+
+```bash
+poetry run tangl-serve
+curl -X POST 'http://127.0.0.1:8000/api/v2/user/create?secret=dev-secret-123'
+curl -X POST \
+  'http://127.0.0.1:8000/api/v2/story/story/create?world_id=hall_monitor&init_mode=EAGER' \
+  -H "X-API-Key: $(curl -s 'http://127.0.0.1:8000/api/v2/system/secret?secret=dev-secret-123' | jq -r .api_key)"
+cd apps/web
+VITE_DEFAULT_API_URL=http://127.0.0.1:8000/api/v2 \
+VITE_DEFAULT_WORLD=hall_monitor \
+VITE_DEFAULT_USER_SECRET=dev-secret-123 \
+yarn dev
+```
+
+In the browser, enter the morning shift, inspect the doctor’s note, and choose
+one of the public rulings. A rules-correct `Send back to class` path reveals the
+inhaler outcome at the attendance note and offers `Meet the returning student`.
+An incorrect compassionate `Allow onward` path produces the contrasting
+world-authored outcome without changing the underlying score rule. An arrest
+does not offer a return. The return is an ordinary new credential encounter:
+its packet is fresh, while its bearer is the same live graph subject.
+
+### Current framework friction
+
+- The REST creation route is currently `/story/story/create`; the web client
+  consumes an existing session rather than owning session/world selection.
+- The web client gates API-backed components until authentication completes and
+  disables prior transcript choices, so the current live frontier remains the
+  only submit surface.
+- Service world resolution reuses one compiled world per configured directory
+  set. This prevents repeated service reads from recompiling the same singleton
+  world during media and journal delivery.


### PR DESCRIPTION
Closes #337.

## What changed
- Added a live HTTP smoke for the compiled Hall Monitor world: entry, public document inspection, a public ruling, and session reload.
- Deferred web API-backed children until configured authentication is ready, and disabled historical transcript choice surfaces.
- Reused one compiled service world per configured world-directory set, avoiding repeated singleton compilation during delivery.
- Documented the local service-plus-client witness and the remaining framework friction.

## Why
The worked vertical must remain understandable from public text/pieces when media is unavailable, keep hidden credential truth out of delivery, and make the current frontier the only live client submit surface.

## Validation
- poetry run pytest apps/server/tests/test_hall_monitor_playable_vertical.py engine/tests/loaders/test_hall_monitor_world.py -q (12 passed)
- yarn test App.test.ts StoryFlow.test.ts --run (18 passed)
- yarn type-check
- git diff --check

The FastAPI suite emits existing Query example deprecation warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loading state that keeps the application UI hidden until initialization and authentication are complete.
  * Disabled previously viewed story scenes after advancing, while keeping the latest scene interactive.
  * Improved reuse and reset behavior for discovered story worlds.

* **Documentation**
  * Added setup instructions, acceptance criteria, expected outcomes, and known limitations for the Hall Monitor playable experience.

* **Tests**
  * Added end-to-end coverage for authentication gating, story creation, choice execution, transcript persistence, and world resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->