### PR TITLE
Add Hall Monitor credential media witness

### DIFF
--- a/apps/server/tests/test_hall_monitor_playable_vertical.py
+++ b/apps/server/tests/test_hall_monitor_playable_vertical.py
@@ -58,6 +58,7 @@ def _fragments(payload: dict[str, object], fragment_type: str) -> list[dict[str,
 def hall_monitor_client(monkeypatch: pytest.MonkeyPatch) -> Iterator[tuple[TestClient, dict[str, str]]]:
     """Serve the compiled repository Hall Monitor world through FastAPI."""
 
+    monkeypatch.setattr("tangl.utils.shelved2.SHELVED_CACHE_ENABLED", False)
     monkeypatch.setattr(
         "tangl.service.world_registry.get_world_dirs",
         lambda: [_repo_worlds_dir()],

--- a/apps/server/tests/test_hall_monitor_playable_vertical.py
+++ b/apps/server/tests/test_hall_monitor_playable_vertical.py
@@ -10,6 +10,8 @@ import pytest
 from fastapi.testclient import TestClient
 
 from tangl.config import settings
+from tangl.media.media_resource import MediaDep
+from tangl.media.media_resource.media_resource_inv_tag import MediaRITStatus
 from tangl.rest.app import app
 from tangl.rest.dependencies import reset_service_state_for_testing
 from tangl.rest.dependencies_gateway import (
@@ -31,13 +33,25 @@ def _repo_worlds_dir() -> Path:
 def _choice_id(payload: dict[str, object], text: str) -> str:
     fragments = payload["fragments"]
     assert isinstance(fragments, list)
-    for fragment in fragments:
+    for fragment in reversed(fragments):
         if isinstance(fragment, dict) and fragment.get("fragment_type") == "choice":
             if fragment.get("text") == text:
                 edge_id = fragment.get("edge_id")
                 assert isinstance(edge_id, str)
                 return edge_id
     raise AssertionError(f"No {text!r} choice in {fragments!r}")
+
+
+def _fragments(payload: dict[str, object], fragment_type: str) -> list[dict[str, object]]:
+    """Return one response's client-visible fragments of ``fragment_type``."""
+
+    fragments = payload["fragments"]
+    assert isinstance(fragments, list)
+    return [
+        fragment
+        for fragment in fragments
+        if isinstance(fragment, dict) and fragment.get("fragment_type") == fragment_type
+    ]
 
 
 @pytest.fixture()
@@ -120,6 +134,143 @@ def test_hall_monitor_inspection_survives_http_session_reload(
     reloaded_text = json.dumps(reloaded.json())
     assert "Mira Quill steps forward." in reloaded_text
     assert "The required nurse signature is missing." in reloaded_text
+
+
+def test_hall_monitor_delivers_subject_mismatch_card_without_hidden_truth(
+    hall_monitor_client: tuple[TestClient, dict[str, str]],
+) -> None:
+    """The public next frontier compares the live bearer with the bound ID portrait."""
+
+    client, headers = hall_monitor_client
+    created = client.post(
+        "story/story/create",
+        params={"world_id": "hall_monitor", "init_mode": "EAGER"},
+        headers=headers,
+    )
+    entered = client.post(
+        "story/do",
+        json={"edge_id": _choice_id(created.json(), "Monitor the morning halls")},
+        headers=headers,
+    )
+    inspected = client.post(
+        "story/do",
+        json={
+            "edge_id": _choice_id(entered.json(), "Inspect a document"),
+            "payload": {"piece_ids": ["0:doctor's note"]},
+        },
+        headers=headers,
+    )
+    advanced = client.post(
+        "story/do",
+        json={"edge_id": _choice_id(inspected.json(), "Send back to class")},
+        headers=headers,
+    )
+
+    assert advanced.status_code == 200
+    payload = advanced.json()
+    text = json.dumps(payload)
+    candidate = next(
+        fragment
+        for fragment in _fragments(payload, "piece")
+        if fragment.get("content") == "Rowan Vale"
+    )
+    identity = next(
+        fragment
+        for fragment in _fragments(payload, "piece")
+        if fragment.get("hints", {}).get("label_text") == "student ID"
+    )
+    media = _fragments(payload, "media")
+    relation = next(
+        fragment
+        for fragment in _fragments(payload, "group")
+        if fragment.get("group_type") == "piece_media"
+    )
+
+    assert candidate["properties"]["look_description"] == "with red hair"
+    assert identity["properties"]["look_description"] == "with blonde hair"
+    assert len(media) == 1
+    assert media[0]["media_role"] == "credential_card"
+    assert isinstance(media[0].get("url"), str)
+    assert relation["member_ids"] == [identity["uid"], media[0]["uid"]]
+    assert "correct_disposition" not in text
+    assert "subject_mismatch" not in text
+
+    reloaded = client.get("story/update", headers=headers)
+    assert reloaded.status_code == 200
+    reloaded_media = _fragments(reloaded.json(), "media")
+    assert [fragment["uid"] for fragment in reloaded_media] == [media[0]["uid"]]
+
+
+def test_hall_monitor_keeps_the_text_floor_when_card_becomes_pending(
+    hall_monitor_client: tuple[TestClient, dict[str, str]],
+) -> None:
+    """A real service response omits unavailable card media without losing its papers."""
+
+    client, headers = hall_monitor_client
+    created = client.post(
+        "story/story/create",
+        params={"world_id": "hall_monitor", "init_mode": "EAGER"},
+        headers=headers,
+    )
+    entered = client.post(
+        "story/do",
+        json={"edge_id": _choice_id(created.json(), "Monitor the morning halls")},
+        headers=headers,
+    )
+    inspected = client.post(
+        "story/do",
+        json={
+            "edge_id": _choice_id(entered.json(), "Inspect a document"),
+            "payload": {"piece_ids": ["0:doctor's note"]},
+        },
+        headers=headers,
+    )
+    advanced = client.post(
+        "story/do",
+        json={"edge_id": _choice_id(inspected.json(), "Send back to class")},
+        headers=headers,
+    )
+    identity = next(
+        fragment
+        for fragment in _fragments(advanced.json(), "piece")
+        if fragment.get("hints", {}).get("label_text") == "student ID"
+    )
+
+    service_manager = get_service_manager()
+    with service_manager.open_session(
+        user_id=uuid_for_secret(settings.client.secret),
+        write_back=True,
+    ) as session:
+        card = next(
+            dependency
+            for dependency in session.ledger.graph.values()
+            if isinstance(dependency, MediaDep)
+            and dependency.label == "credential-card-card"
+            and dependency.provider is not None
+        )
+        card.provider.status = MediaRITStatus.PENDING
+
+    inspected_pending = client.post(
+        "story/do",
+        json={
+            "edge_id": _choice_id(advanced.json(), "Inspect a document"),
+            "payload": {"piece_ids": [identity["piece_id"]]},
+        },
+        headers=headers,
+    )
+
+    assert inspected_pending.status_code == 200, inspected_pending.json()
+    payload = inspected_pending.json()
+    assert "Rowan Vale" in json.dumps(payload)
+    assert any(
+        fragment.get("hints", {}).get("label_text") == "student ID"
+        for fragment in _fragments(payload, "piece")
+    )
+    assert _fragments(payload, "media") == []
+    assert not any(
+        fragment.get("group_type") == "piece_media"
+        for fragment in _fragments(payload, "group")
+    )
 
 
 def test_hall_monitor_world_resolution_reuses_until_service_reset(

--- a/apps/web/src/components/story/GroupFragmentView.vue
+++ b/apps/web/src/components/story/GroupFragmentView.vue
@@ -8,15 +8,10 @@ import type {
   MediaStoryFragment,
   StoryFragment,
 } from '@/types'
-import {
-  fragmentText,
-  isMediaFragment,
-  isPieceFragment,
-  mediaContentUrl,
-} from './fragmentUtils'
+import { fragmentText, isMediaFragment, mediaContentUrl } from './fragmentUtils'
 import { mediaRole } from './fragmentViewUtils'
 import MediaFragmentView from './MediaFragmentView.vue'
-import PieceFragmentView from './PieceFragmentView.vue'
+import PieceMediaGroupView from './PieceMediaGroupView.vue'
 import UnknownFragmentFallback from './UnknownFragmentFallback.vue'
 import ZoneFragmentView from './ZoneFragmentView.vue'
 
@@ -64,16 +59,6 @@ const mediaUrl = (fragment: MediaStoryFragment): string | undefined => {
 const avatarMedia = (media: MediaStoryFragment[]): MediaStoryFragment | undefined =>
   media.find((item) => mediaRole(item) === 'avatar_im')
 
-const associatedPiece = computed(() =>
-  groupType.value === 'piece_media'
-    ? groupMembers.value.find(isPieceFragment)
-    : undefined,
-)
-const associatedMedia = computed(() =>
-  groupType.value === 'piece_media'
-    ? groupMembers.value.filter(isMediaFragment)
-    : [],
-)
 </script>
 
 <template>
@@ -114,18 +99,11 @@ const associatedMedia = computed(() =>
       :fragments="fragments"
     />
 
-    <section v-else-if="groupType === 'piece_media'" class="piece-media-group">
-      <PieceFragmentView
-        v-if="associatedPiece"
-        :fragment="associatedPiece"
-      />
-      <MediaFragmentView
-        v-for="media in associatedMedia"
-        :key="media.uid"
-        :fragment="media"
-        compact
-      />
-    </section>
+    <PieceMediaGroupView
+      v-else-if="groupType === 'piece_media'"
+      :group="group"
+      :fragments="fragments"
+    />
 
     <div v-else-if="groupType === 'status_sidecar'" class="kv-strip">
       <span v-for="member in groupMembers" :key="member.uid">
@@ -149,13 +127,6 @@ const associatedMedia = computed(() =>
   border-left: 3px solid rgba(var(--v-theme-primary), 0.45);
   margin: 8px 16px;
   padding-left: 12px;
-}
-
-.piece-media-group {
-  align-items: flex-start;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
 }
 
 .dialog-line {

--- a/apps/web/src/components/story/GroupFragmentView.vue
+++ b/apps/web/src/components/story/GroupFragmentView.vue
@@ -8,9 +8,15 @@ import type {
   MediaStoryFragment,
   StoryFragment,
 } from '@/types'
-import { fragmentText, isMediaFragment, mediaContentUrl } from './fragmentUtils'
+import {
+  fragmentText,
+  isMediaFragment,
+  isPieceFragment,
+  mediaContentUrl,
+} from './fragmentUtils'
 import { mediaRole } from './fragmentViewUtils'
 import MediaFragmentView from './MediaFragmentView.vue'
+import PieceFragmentView from './PieceFragmentView.vue'
 import UnknownFragmentFallback from './UnknownFragmentFallback.vue'
 import ZoneFragmentView from './ZoneFragmentView.vue'
 
@@ -57,6 +63,17 @@ const mediaUrl = (fragment: MediaStoryFragment): string | undefined => {
 
 const avatarMedia = (media: MediaStoryFragment[]): MediaStoryFragment | undefined =>
   media.find((item) => mediaRole(item) === 'avatar_im')
+
+const associatedPiece = computed(() =>
+  groupType.value === 'piece_media'
+    ? groupMembers.value.find(isPieceFragment)
+    : undefined,
+)
+const associatedMedia = computed(() =>
+  groupType.value === 'piece_media'
+    ? groupMembers.value.filter(isMediaFragment)
+    : [],
+)
 </script>
 
 <template>
@@ -97,6 +114,19 @@ const avatarMedia = (media: MediaStoryFragment[]): MediaStoryFragment | undefine
       :fragments="fragments"
     />
 
+    <section v-else-if="groupType === 'piece_media'" class="piece-media-group">
+      <PieceFragmentView
+        v-if="associatedPiece"
+        :fragment="associatedPiece"
+      />
+      <MediaFragmentView
+        v-for="media in associatedMedia"
+        :key="media.uid"
+        :fragment="media"
+        compact
+      />
+    </section>
+
     <div v-else-if="groupType === 'status_sidecar'" class="kv-strip">
       <span v-for="member in groupMembers" :key="member.uid">
         {{ member.fragment_type }}
@@ -119,6 +149,13 @@ const avatarMedia = (media: MediaStoryFragment[]): MediaStoryFragment | undefine
   border-left: 3px solid rgba(var(--v-theme-primary), 0.45);
   margin: 8px 16px;
   padding-left: 12px;
+}
+
+.piece-media-group {
+  align-items: flex-start;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
 .dialog-line {

--- a/apps/web/src/components/story/PieceFragmentView.vue
+++ b/apps/web/src/components/story/PieceFragmentView.vue
@@ -52,6 +52,8 @@ const pieceKind = computed(() => {
   const kind = stringValue(props.fragment.kind)
   return kind ? readableValue(kind) : undefined
 })
+
+const lookDescription = computed(() => stringValue(props.fragment.properties?.look_description))
 </script>
 
 <template>
@@ -62,6 +64,7 @@ const pieceKind = computed(() => {
   >
     <span class="piece-label">{{ pieceLabel }}</span>
     <span v-if="pieceKind" class="piece-meta">{{ pieceKind }}</span>
+    <span v-if="lookDescription" class="piece-description">{{ lookDescription }}</span>
     <span v-if="displayState" class="piece-state" data-testid="piece-state">
       {{ displayState }}
     </span>
@@ -103,7 +106,8 @@ const pieceKind = computed(() => {
 }
 
 .piece-meta,
-.piece-state {
+.piece-state,
+.piece-description {
   border-radius: 4px;
   color: rgb(var(--v-theme-on-surface-variant));
   font-size: 0.75rem;
@@ -113,6 +117,10 @@ const pieceKind = computed(() => {
 
 .piece-meta {
   background: rgba(var(--v-theme-surface-variant), 0.62);
+}
+
+.piece-description {
+  flex-basis: 100%;
 }
 
 .piece-state {

--- a/apps/web/src/components/story/PieceMediaGroupView.vue
+++ b/apps/web/src/components/story/PieceMediaGroupView.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import type {
+  GroupStoryFragment,
+  MediaStoryFragment,
+  PieceStoryFragment,
+  StoryFragment,
+} from '@/types'
+import { isMediaFragment, isPieceFragment } from './fragmentUtils'
+import MediaFragmentView from './MediaFragmentView.vue'
+import PieceFragmentView from './PieceFragmentView.vue'
+
+const props = defineProps<{
+  group: GroupStoryFragment
+  fragments: Record<string, StoryFragment>
+}>()
+
+const members = computed(() =>
+  props.group.member_ids
+    .map((id) => props.fragments[id])
+    .filter((fragment): fragment is StoryFragment => Boolean(fragment)),
+)
+const associatedPiece = computed<PieceStoryFragment | undefined>(() =>
+  members.value.find(isPieceFragment),
+)
+const associatedMedia = computed<MediaStoryFragment[]>(() =>
+  members.value.filter(isMediaFragment),
+)
+</script>
+
+<template>
+  <section class="piece-media-group d-flex flex-wrap align-start ga-2">
+    <PieceFragmentView v-if="associatedPiece" :fragment="associatedPiece" />
+    <MediaFragmentView
+      v-for="media in associatedMedia"
+      :key="media.uid"
+      :fragment="media"
+      compact
+    />
+  </section>
+</template>

--- a/apps/web/src/components/story/StoryBlock.test.ts
+++ b/apps/web/src/components/story/StoryBlock.test.ts
@@ -89,6 +89,47 @@ describe('StoryBlock', () => {
     expect(img.props('src')).toBe('https://example.com/portrait.svg')
   })
 
+  it('renders published presence prose and associated piece media', () => {
+    const fragments: Record<string, StoryFragment> = {
+      candidate: {
+        uid: 'candidate',
+        fragment_type: 'piece',
+        piece_id: 'candidate-1',
+        kind: 'candidate',
+        content: 'Rowan Vale',
+        properties: { look_description: 'with red hair' },
+      },
+      identity: {
+        uid: 'identity',
+        fragment_type: 'piece',
+        piece_id: 'student-id',
+        kind: 'document',
+        content: 'Student ID',
+      },
+      card: {
+        uid: 'card',
+        fragment_type: 'media',
+        content: 'https://example.com/student-id.svg',
+        content_format: 'url',
+        media_role: 'credential_card',
+      },
+      relation: {
+        uid: 'relation',
+        fragment_type: 'group',
+        group_type: 'piece_media',
+        member_ids: ['identity', 'card'],
+      },
+    }
+
+    const wrapper = mountBlock(fragments, ['candidate', 'relation'])
+    const image = wrapper.findComponent({ name: 'VImg' })
+
+    expect(wrapper.text()).toContain('Rowan Vale')
+    expect(wrapper.text()).toContain('with red hair')
+    expect(wrapper.find('.piece-media-group').exists()).toBe(true)
+    expect(image.props('src')).toBe('https://example.com/student-id.svg')
+  })
+
   it('renders pending RIT media placeholders', () => {
     const fragments: Record<string, StoryFragment> = {
       media: {

--- a/apps/web/src/components/story/StoryBlock.test.ts
+++ b/apps/web/src/components/story/StoryBlock.test.ts
@@ -89,7 +89,7 @@ describe('StoryBlock', () => {
     expect(img.props('src')).toBe('https://example.com/portrait.svg')
   })
 
-  it('renders published presence prose and associated piece media', () => {
+  it('renders published presence prose and associated piece media', (): void => {
     const fragments: Record<string, StoryFragment> = {
       candidate: {
         uid: 'candidate',

--- a/engine/src/tangl/journal/fragments.py
+++ b/engine/src/tangl/journal/fragments.py
@@ -202,14 +202,55 @@ class MediaFragment(ContentFragment, extra="allow"):
     """Media fragment that defers dereference and transport shaping to service."""
 
     content_type: MediaDataType = MediaDataType.MEDIA
-    content: MediaRIT | Pathlike | bytes | str | dict = Field(
-        json_schema_extra={"unstructurable": True},
-    )
+    content: MediaRIT | Pathlike | bytes | str | dict
     content_format: ContentFormatType
+    rit_id: UUID | None = None
     staging_hints: StagingHints | None = None
     media_role: str | None = None
     scope: str | None = "world"
     fragment_type: Literal["media"] = "media"
+
+    @model_validator(mode="before")
+    @classmethod
+    def _capture_rit_reference(cls, data: Any) -> Any:
+        """Record graph-owned RIT identity while fresh fragments carry the object."""
+
+        if not isinstance(data, dict):
+            return data
+        payload = dict(data)
+        content = payload.get("content")
+        if payload.get("content_format") == "rit" and isinstance(content, MediaRIT):
+            payload.setdefault("rit_id", content.uid)
+        return payload
+
+    def unstructure(self) -> UnstructuredData:
+        """Persist generated media as a graph RIT reference, never a detached copy."""
+
+        data = super().unstructure()
+        if self.content_format == "rit":
+            if self.rit_id is None:
+                raise ValueError("RIT media fragments require a MediaRIT reference")
+            data.pop("content", None)
+            data["rit_id"] = self.rit_id
+        return data
+
+    @classmethod
+    def structure(cls, data: UnstructuredData, _ctx: Any = None) -> "MediaFragment":
+        """Rebind persisted RIT media through the restored owning graph."""
+
+        payload = dict(data)
+        if payload.get("content_format") == "rit" and "content" not in payload:
+            graph = getattr(_ctx, "graph", _ctx)
+            rit_id = payload.get("rit_id")
+            if graph is None or not hasattr(graph, "get"):
+                raise ValueError("Restoring RIT media fragments requires an owning graph")
+            if not isinstance(rit_id, UUID):
+                rit_id = UUID(str(rit_id))
+            rit = graph.get(rit_id)
+            if not isinstance(rit, MediaRIT):
+                raise LookupError(f"Media fragment RIT {rit_id} is not present in the graph")
+            payload["content"] = rit
+        return super().structure(payload, _ctx=_ctx)
 
     @field_serializer("content")
     def _encode_binary_content(self, content: Any) -> str:

--- a/engine/src/tangl/journal/fragments.py
+++ b/engine/src/tangl/journal/fragments.py
@@ -202,7 +202,9 @@ class MediaFragment(ContentFragment, extra="allow"):
     """Media fragment that defers dereference and transport shaping to service."""
 
     content_type: MediaDataType = MediaDataType.MEDIA
-    content: Pathlike | bytes | str | dict | MediaRIT
+    content: MediaRIT | Pathlike | bytes | str | dict = Field(
+        json_schema_extra={"unstructurable": True},
+    )
     content_format: ContentFormatType
     staging_hints: StagingHints | None = None
     media_role: str | None = None

--- a/engine/src/tangl/journal/fragments.py
+++ b/engine/src/tangl/journal/fragments.py
@@ -10,12 +10,12 @@ from __future__ import annotations
 from base64 import b64encode
 from collections.abc import Mapping
 from enum import Enum
-from typing import Any, Literal
+from typing import Any, Literal, Self
 from uuid import UUID
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_serializer, model_validator
 
-from tangl.core import BaseFragment, Registry, Selector
+from tangl.core import BaseFragment, Graph, Registry, Selector
 from tangl.journal.intent import Accepts, Blocker, KvRow, UIHints
 from tangl.media.media_data_type import MediaDataType
 from tangl.media.media_resource import MediaResourceInventoryTag as MediaRIT
@@ -235,22 +235,30 @@ class MediaFragment(ContentFragment, extra="allow"):
         return data
 
     @classmethod
-    def structure(cls, data: UnstructuredData, _ctx: Any = None) -> "MediaFragment":
+    def structure(
+        cls,
+        data: UnstructuredData,
+        _ctx: Graph | None = None,
+    ) -> "MediaFragment":
         """Rebind persisted RIT media through the restored owning graph."""
 
         payload = dict(data)
         if payload.get("content_format") == "rit" and "content" not in payload:
-            graph = getattr(_ctx, "graph", _ctx)
             rit_id = payload.get("rit_id")
-            if graph is None or not hasattr(graph, "get"):
+            if _ctx is None:
                 raise ValueError("Restoring RIT media fragments requires an owning graph")
             if not isinstance(rit_id, UUID):
                 rit_id = UUID(str(rit_id))
-            rit = graph.get(rit_id)
+            rit = _ctx.get(rit_id)
             if not isinstance(rit, MediaRIT):
                 raise LookupError(f"Media fragment RIT {rit_id} is not present in the graph")
             payload["content"] = rit
         return super().structure(payload, _ctx=_ctx)
+
+    def evolve(self, **updates: Any) -> Self:
+        """Copy a live fragment without serializing its graph-owned RIT."""
+
+        return self.model_copy(update=updates)
 
     @field_serializer("content")
     def _encode_binary_content(self, content: Any) -> str:

--- a/engine/src/tangl/journal/fragments.py
+++ b/engine/src/tangl/journal/fragments.py
@@ -220,7 +220,10 @@ class MediaFragment(ContentFragment, extra="allow"):
         payload = dict(data)
         content = payload.get("content")
         if payload.get("content_format") == "rit" and isinstance(content, MediaRIT):
-            payload.setdefault("rit_id", content.uid)
+            rit_id = payload.get("rit_id")
+            if rit_id is not None and UUID(str(rit_id)) != content.uid:
+                raise ValueError("MediaRIT content and rit_id must refer to the same resource")
+            payload["rit_id"] = content.uid
         return payload
 
     def unstructure(self) -> UnstructuredData:
@@ -245,6 +248,8 @@ class MediaFragment(ContentFragment, extra="allow"):
         payload = dict(data)
         if payload.get("content_format") == "rit" and "content" not in payload:
             rit_id = payload.get("rit_id")
+            if rit_id is None:
+                raise ValueError("Restoring RIT media fragments requires a RIT reference")
             if _ctx is None:
                 raise ValueError("Restoring RIT media fragments requires an owning graph")
             if not isinstance(rit_id, UUID):
@@ -258,7 +263,10 @@ class MediaFragment(ContentFragment, extra="allow"):
     def evolve(self, **updates: Any) -> Self:
         """Copy a live fragment without serializing its graph-owned RIT."""
 
-        return self.model_copy(update=updates)
+        data = {**self.__dict__, **(self.__pydantic_extra__ or {}), **updates}
+        if "content" in updates and "rit_id" not in updates:
+            data["rit_id"] = None
+        return type(self).model_validate(data)
 
     @field_serializer("content")
     def _encode_binary_content(self, content: Any) -> str:

--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
@@ -373,7 +373,10 @@ PLANNING without changing the active case. UPDATE then selects the already
 prepared successor; it does not JIT-provision presentation. The text
 ``PieceFragment`` remains unconditional, and an ordinary associated
 ``MediaFragment`` appears only when the complete card is resolved. Complete
-authored replacements suppress that generated card.
+authored replacements suppress that generated card. Hall Monitor now exercises
+that path as a visual witness: a red-haired presenter and a blond, distinct
+document subject are projected through the ordinary candidate prose and card
+portrait surfaces without exposing the resulting subject-mismatch defect.
 Authored alternatives/replacements and world-scoped media selection remain the
 next slice. Credentials must consume the resulting ``MediaSpec →
 MediaSpecProvisioner → MediaRIT → MediaFragment`` path; it must not invent a

--- a/engine/src/tangl/service/media.py
+++ b/engine/src/tangl/service/media.py
@@ -218,7 +218,12 @@ def _resolve_fallback_rit(
     return None
 
 
-def _base_payload(fragment: MediaFragment, *, scope: str, media_type: MediaDataType | None) -> dict[str, Any]:
+def _base_payload(
+    fragment: MediaFragment,
+    *,
+    scope: str,
+    media_type: MediaDataType | str | None,
+) -> dict[str, Any]:
     source_id = getattr(fragment, "source_id", None)
     return {
         "uid": str(fragment.uid),
@@ -227,7 +232,9 @@ def _base_payload(fragment: MediaFragment, *, scope: str, media_type: MediaDataT
         "text": getattr(fragment, "text", None),
         "source_id": str(source_id) if source_id is not None else None,
         "scope": scope,
-        "media_type": media_type.value if media_type is not None else None,
+        "media_type": (
+            media_type.value if isinstance(media_type, MediaDataType) else media_type
+        ),
         "content_format": getattr(fragment, "content_format", None),
     }
 
@@ -446,19 +453,14 @@ def media_fragment_to_payload(
                 system_media_root=system_media_root,
             )
 
-        source_id = getattr(fragment, "source_id", None)
-        payload: dict[str, Any] = {
-            "fragment_type": "media",
-            "media_role": getattr(fragment, "media_role", None),
-            "text": getattr(fragment, "text", None),
-            "source_id": str(source_id) if source_id is not None else None,
-            "scope": scope,
-            "content_format": fragment.content_format,
-        }
+        payload = _base_payload(
+            fragment,
+            scope=scope,
+            media_type=getattr(fragment.content_type, "value", fragment.content_type),
+        )
 
         if fragment.content_format == "url":
             payload["url"] = str(fragment.content)
-            payload["media_type"] = getattr(fragment.content_type, "value", fragment.content_type)
             return payload
 
         if fragment.content_format == "data":
@@ -467,16 +469,12 @@ def media_fragment_to_payload(
                 payload["data"] = b64encode(content).decode("ascii")
             else:
                 payload["data"] = content
-            payload["media_type"] = getattr(fragment.content_type, "value", fragment.content_type)
             return payload
 
         if fragment.content_format == "json" and isinstance(fragment.content, dict):
-            payload.update(fragment.content)
-            payload["media_type"] = getattr(fragment.content_type, "value", fragment.content_type)
-            return payload
+            return {**fragment.content, **payload}
 
         payload["content"] = fragment.content
-        payload["media_type"] = getattr(fragment.content_type, "value", fragment.content_type)
         return payload
 
     if getattr(fragment, "fragment_type", None) == "media" and hasattr(fragment, "payload"):

--- a/engine/src/tangl/service/media.py
+++ b/engine/src/tangl/service/media.py
@@ -221,6 +221,7 @@ def _resolve_fallback_rit(
 def _base_payload(fragment: MediaFragment, *, scope: str, media_type: MediaDataType | None) -> dict[str, Any]:
     source_id = getattr(fragment, "source_id", None)
     return {
+        "uid": str(fragment.uid),
         "fragment_type": "media",
         "media_role": getattr(fragment, "media_role", None),
         "text": getattr(fragment, "text", None),

--- a/engine/src/tangl/vm/runtime/ledger.py
+++ b/engine/src/tangl/vm/runtime/ledger.py
@@ -762,6 +762,8 @@ class Ledger(Entity):
                     not isinstance(record, dict)
                     or record.get("fragment_type") != "media"
                     or record.get("content_format") != "rit"
+                    or "rit_id" not in record
+                    or "content" in record
                 ):
                     continue
                 rit_id = _coerce_uuid(record["rit_id"])

--- a/engine/src/tangl/vm/runtime/ledger.py
+++ b/engine/src/tangl/vm/runtime/ledger.py
@@ -754,8 +754,26 @@ class Ledger(Entity):
                 return [_coerce_kind_refs(item) for item in value]
             return value
 
+        def _bind_media_fragment_refs(output_data: UnstructuredData, graph: Graph) -> None:
+            """Bind persisted RIT media records to their restored graph resource."""
+
+            for record in output_data.get("members", []):
+                if (
+                    not isinstance(record, dict)
+                    or record.get("fragment_type") != "media"
+                    or record.get("content_format") != "rit"
+                ):
+                    continue
+                rit_id = _coerce_uuid(record["rit_id"])
+                rit = graph.get(rit_id)
+                if rit is None:
+                    raise LookupError(f"Media fragment RIT {rit_id} is not present in the graph")
+                record["content"] = rit
+
         graph = Graph.structure(_coerce_kind_refs(data["graph"]))
-        output_stream = OrderedRegistry.structure(_coerce_kind_refs(data.get("output_stream", {})))
+        output_data = _coerce_kind_refs(data.get("output_stream", {}))
+        _bind_media_fragment_refs(output_data, graph)
+        output_stream = OrderedRegistry.structure(output_data, _ctx=graph)
 
         return cls(
             uid=_coerce_uuid(data["uid"]),

--- a/engine/tests/media/test_media_fragment.py
+++ b/engine/tests/media/test_media_fragment.py
@@ -3,6 +3,8 @@
 from base64 import b64encode
 
 from tangl.journal.media import MediaFragment, StagingHints
+from tangl.media import MediaDataType
+from tangl.media.media_resource import MediaResourceInventoryTag as MediaRIT
 
 def test_media_fragment_with_url():
     # Test media fragment with URL
@@ -37,3 +39,19 @@ def test_media_fragment_with_binary_data():
     # Binary should be properly encoded
     assert serialized["content"] != binary_data
     assert serialized["content"] == b64encode(binary_data).decode("utf-8")
+
+
+def test_media_fragment_round_trip_keeps_rit_content():
+    """Journal persistence retains a dereferenceable generated-media RIT."""
+
+    rit = MediaRIT(data="<svg/>", data_type=MediaDataType.VECTOR)
+    fragment = MediaFragment(
+        content=rit,
+        content_type=MediaDataType.VECTOR,
+        content_format="rit",
+    )
+
+    restored = MediaFragment.structure(fragment.unstructure())
+
+    assert isinstance(restored.content, MediaRIT)
+    assert restored.content.uid == rit.uid

--- a/engine/tests/media/test_media_fragment.py
+++ b/engine/tests/media/test_media_fragment.py
@@ -64,6 +64,23 @@ def test_media_fragment_rit_round_trip_requires_an_owning_graph():
         MediaFragment.structure(payload)
 
 
+def test_rit_media_fragment_evolves_without_losing_its_live_resource():
+    """Step stamping preserves the graph-owned resource during live execution."""
+
+    rit = MediaRIT(data="<svg/>", data_type=MediaDataType.VECTOR)
+    fragment = MediaFragment(
+        content=rit,
+        content_type=MediaDataType.VECTOR,
+        content_format="rit",
+    )
+
+    evolved = fragment.evolve(step=4)
+
+    assert evolved.content is rit
+    assert evolved.rit_id == rit.uid
+    assert evolved.step == 4
+
+
 def test_ledger_round_trip_rebinds_media_fragment_to_the_restored_rit():
     """Persisted journal media observes the restored graph resource lifecycle."""
 
@@ -88,6 +105,39 @@ def test_ledger_round_trip_rebinds_media_fragment_to_the_restored_rit():
     assert restored_fragment.content is restored_rit
     restored_rit.status = MediaRITStatus.PENDING
     assert media_fragment_to_payload(restored_fragment) is None
+
+
+def test_ledger_round_trip_preserves_legacy_inline_rit_media():
+    """Pre-reference journal records retain their inline media payload on restore."""
+
+    graph = Graph()
+    start = graph.add_node(label="start")
+    rit = MediaRIT(data="<svg/>", data_type=MediaDataType.VECTOR)
+    graph.add(rit)
+    ledger = Ledger.from_graph(graph=graph, entry_id=start.uid)
+    fragment = MediaFragment(
+        content=rit,
+        content_type=MediaDataType.VECTOR,
+        content_format="rit",
+    )
+    ledger.output_stream.append(fragment)
+
+    payload = ledger.unstructure()
+    record = next(
+        item
+        for item in payload["output_stream"]["members"]
+        if item.get("fragment_type") == "media"
+    )
+    record["content"] = rit.unstructure()
+    record.pop("rit_id")
+
+    restored = Ledger.structure(payload)
+    restored_fragment = next(
+        item for item in restored.output_stream.values() if isinstance(item, MediaFragment)
+    )
+
+    assert isinstance(restored_fragment.content, MediaRIT)
+    assert restored_fragment.content.data == "<svg/>"
 
 
 @pytest.mark.parametrize(

--- a/engine/tests/media/test_media_fragment.py
+++ b/engine/tests/media/test_media_fragment.py
@@ -2,9 +2,14 @@
 
 from base64 import b64encode
 
+import pytest
+
+from tangl.core import Graph
 from tangl.journal.media import MediaFragment, StagingHints
 from tangl.media import MediaDataType
-from tangl.media.media_resource import MediaResourceInventoryTag as MediaRIT
+from tangl.media.media_resource import MediaRITStatus, MediaResourceInventoryTag as MediaRIT
+from tangl.service.media import media_fragment_to_payload
+from tangl.vm import Ledger
 
 def test_media_fragment_with_url():
     # Test media fragment with URL
@@ -41,8 +46,8 @@ def test_media_fragment_with_binary_data():
     assert serialized["content"] == b64encode(binary_data).decode("utf-8")
 
 
-def test_media_fragment_round_trip_keeps_rit_content():
-    """Journal persistence retains a dereferenceable generated-media RIT."""
+def test_media_fragment_rit_round_trip_requires_an_owning_graph():
+    """A standalone persisted fragment cannot fabricate a graph-owned RIT."""
 
     rit = MediaRIT(data="<svg/>", data_type=MediaDataType.VECTOR)
     fragment = MediaFragment(
@@ -51,7 +56,64 @@ def test_media_fragment_round_trip_keeps_rit_content():
         content_format="rit",
     )
 
-    restored = MediaFragment.structure(fragment.unstructure())
+    payload = fragment.unstructure()
 
-    assert isinstance(restored.content, MediaRIT)
-    assert restored.content.uid == rit.uid
+    assert payload["rit_id"] == rit.uid
+    assert "content" not in payload
+    with pytest.raises(ValueError, match="requires an owning graph"):
+        MediaFragment.structure(payload)
+
+
+def test_ledger_round_trip_rebinds_media_fragment_to_the_restored_rit():
+    """Persisted journal media observes the restored graph resource lifecycle."""
+
+    graph = Graph()
+    start = graph.add_node(label="start")
+    rit = MediaRIT(data="<svg/>", data_type=MediaDataType.VECTOR)
+    graph.add(rit)
+    ledger = Ledger.from_graph(graph=graph, entry_id=start.uid)
+    fragment = MediaFragment(
+        content=rit,
+        content_type=MediaDataType.VECTOR,
+        content_format="rit",
+    )
+    ledger.output_stream.append(fragment)
+
+    restored = Ledger.structure(ledger.unstructure())
+    restored_fragment = next(
+        item for item in restored.output_stream.values() if isinstance(item, MediaFragment)
+    )
+    restored_rit = restored.graph.get(rit.uid)
+
+    assert restored_fragment.content is restored_rit
+    restored_rit.status = MediaRITStatus.PENDING
+    assert media_fragment_to_payload(restored_fragment) is None
+
+
+@pytest.mark.parametrize(
+    ("content_format", "content", "expected_key"),
+    [
+        ("url", "https://example.com/card.svg", "url"),
+        ("data", b"card-data", "data"),
+        ("json", {"url": "https://example.com/card.svg"}, "url"),
+        ("xml", "<svg/>", "content"),
+    ],
+)
+def test_direct_media_payloads_keep_fragment_uid(
+    content_format: str,
+    content: str | bytes | dict[str, str],
+    expected_key: str,
+) -> None:
+    """Every direct media transport shape preserves the fragment relationship ID."""
+
+    fragment = MediaFragment(
+        content=content,
+        content_type=MediaDataType.VECTOR,
+        content_format=content_format,
+    )
+
+    payload = media_fragment_to_payload(fragment)
+
+    assert payload is not None
+    assert payload["uid"] == str(fragment.uid)
+    assert expected_key in payload

--- a/engine/tests/media/test_media_fragment.py
+++ b/engine/tests/media/test_media_fragment.py
@@ -64,6 +64,43 @@ def test_media_fragment_rit_round_trip_requires_an_owning_graph():
         MediaFragment.structure(payload)
 
 
+def test_rit_media_fragment_requires_a_persisted_reference():
+    """Reference-form RIT media cannot be restored without its RIT identifier."""
+
+    rit = MediaRIT(data="<svg/>", data_type=MediaDataType.VECTOR)
+    fragment = MediaFragment(
+        content=rit,
+        content_type=MediaDataType.VECTOR,
+        content_format="rit",
+    )
+    payload = fragment.unstructure()
+    payload.pop("rit_id")
+
+    with pytest.raises(ValueError, match="requires a RIT reference"):
+        MediaFragment.structure(payload)
+
+
+def test_rit_media_fragment_normalizes_and_validates_its_reference():
+    """Live RIT content and persisted identity must always agree."""
+
+    rit = MediaRIT(data="<svg/>", data_type=MediaDataType.VECTOR)
+    matching = MediaFragment(
+        content=rit,
+        content_type=MediaDataType.VECTOR,
+        content_format="rit",
+        rit_id=rit.uid,
+    )
+
+    assert matching.rit_id == rit.uid
+    with pytest.raises(ValueError, match="must refer to the same resource"):
+        MediaFragment(
+            content=rit,
+            content_type=MediaDataType.VECTOR,
+            content_format="rit",
+            rit_id=MediaRIT(data="other", data_type=MediaDataType.VECTOR).uid,
+        )
+
+
 def test_rit_media_fragment_evolves_without_losing_its_live_resource():
     """Step stamping preserves the graph-owned resource during live execution."""
 
@@ -79,6 +116,25 @@ def test_rit_media_fragment_evolves_without_losing_its_live_resource():
     assert evolved.content is rit
     assert evolved.rit_id == rit.uid
     assert evolved.step == 4
+
+
+def test_rit_media_fragment_evolution_revalidates_changed_content():
+    """Changing the live RIT recaptures its reference and rejects conflicts."""
+
+    rit = MediaRIT(data="<svg/>", data_type=MediaDataType.VECTOR)
+    replacement = MediaRIT(data="<svg id='replacement'/>", data_type=MediaDataType.VECTOR)
+    fragment = MediaFragment(
+        content=rit,
+        content_type=MediaDataType.VECTOR,
+        content_format="rit",
+    )
+
+    evolved = fragment.evolve(content=replacement)
+
+    assert evolved.content is replacement
+    assert evolved.rit_id == replacement.uid
+    with pytest.raises(ValueError, match="must refer to the same resource"):
+        fragment.evolve(content=replacement, rit_id=rit.uid)
 
 
 def test_ledger_round_trip_rebinds_media_fragment_to_the_restored_rit():

--- a/worlds/hall_monitor/README.md
+++ b/worlds/hall_monitor/README.md
@@ -38,6 +38,10 @@ The worked vertical has parity at these surfaces:
 - **Text/media floor:** packet and document prose remains sufficient when no
   generated card is available; media is additive rather than a prerequisite for
   deciding.
+- **Visual witness:** the second fixed encounter presents Rowan Vale with red
+  hair while the generated student-ID card depicts its distinct blond recorded
+  subject. The ordinary subject-binding defect remains undisclosed until the
+  player inspects or verifies the ID.
 - **Playable client:** the reference web client renders packet pieces,
   inspection findings, and public action labels without receiving an expected
   disposition or hidden validity field.

--- a/worlds/hall_monitor/hall_monitor/domain.py
+++ b/worlds/hall_monitor/hall_monitor/domain.py
@@ -200,6 +200,7 @@ class HallMonitorCredentialsGame(CredentialsGame):
     presentation: CredentialPresentationProfile = Field(
         default_factory=lambda: HALL_PRESENTATION.model_copy(deep=True)
     )
+
     def prepare_case(self, case_index: int) -> CredentialCase:
         """Materialize the world-owned visual mismatch with distinct live looks."""
 

--- a/worlds/hall_monitor/hall_monitor/domain.py
+++ b/worlds/hall_monitor/hall_monitor/domain.py
@@ -9,15 +9,17 @@ from tangl.core import Selector
 from tangl.core.bases import BaseModelPlus
 from tangl.journal.fragments import ContentFragment
 from tangl.mechanics.credentials import (
+    CREDENTIAL_ID_SLOT,
     CredentialDefinition,
     CredentialStatus,
     FailureMode,
     Restrictions,
     RestrictionLevel,
 )
-from tangl.mechanics.presence.look import HasSimpleLook
+from tangl.mechanics.presence.look import HairColor, HasSimpleLook
 from tangl.mechanics.games import HasGame
 from tangl.mechanics.games.credentials_game import (
+    CredentialCase,
     CredentialCaseResult,
     CredentialDisposition,
     CredentialPresentationProfile,
@@ -126,6 +128,7 @@ _HALL_FAILURES = (
     FailureMode.EXPIRED_ID,
     FailureMode.FAKE_ID,
 )
+_MEDIA_WITNESS_CASE_INDEX = 1
 
 
 def _special_student() -> ScenarioOffer:
@@ -150,6 +153,18 @@ def _special_student() -> ScenarioOffer:
     )
 
 
+def _media_witness_student() -> ScenarioOffer:
+    """Return the fixed visual subject-mismatch encounter for this world."""
+
+    return ScenarioOffer(
+        target_disposition=CredentialDisposition.ARREST,
+        candidate_name="Rowan Vale",
+        region="lower",
+        purpose="medicine",
+        failure_modes=[FailureMode.FAKE_ID],
+    )
+
+
 def _hall_offers(
     *,
     encounters: int,
@@ -158,18 +173,21 @@ def _hall_offers(
 ) -> list[ScenarioOffer]:
     """Generate one configured school shift through the shared roster funnel."""
 
-    return generate_roster(
+    pinned = [_special_student(), _media_witness_student()]
+    if encounters <= len(pinned):
+        return pinned[:encounters]
+    sampled = generate_roster(
         ShiftSpec(
             rules=Restrictions.from_map(HALL_RULES),
-            encounters=encounters,
+            encounters=encounters - len(pinned),
             origin_distribution={"upper": 0.4, "lower": 0.4, "exchange": 0.2},
             disposition_distribution=disposition_distribution,
             purpose_pool=("academic", "activity", "off_campus"),
             allowed_failure_modes=_HALL_FAILURES,
-            pinned=(_special_student(),),
             seed=seed,
         )
     )
+    return [*pinned, *sampled]
 
 
 class HallMonitorCredentialsGame(CredentialsGame):
@@ -182,6 +200,21 @@ class HallMonitorCredentialsGame(CredentialsGame):
     presentation: CredentialPresentationProfile = Field(
         default_factory=lambda: HALL_PRESENTATION.model_copy(deep=True)
     )
+    def prepare_case(self, case_index: int) -> CredentialCase:
+        """Materialize the world-owned visual mismatch with distinct live looks."""
+
+        case = super().prepare_case(case_index)
+        if case_index != _MEDIA_WITNESS_CASE_INDEX:
+            return case
+
+        bearer = case.packet_manager.resolve_subject(case.packet_manager.bearer_id)
+        id_card = case.packet_manager.get_slot(CREDENTIAL_ID_SLOT)[0]
+        id_subject = case.packet_manager.resolve_subject(id_card.subject_id)
+        if id_subject.uid == bearer.uid:
+            raise ValueError("Hall Monitor media witness requires a mismatched ID subject")
+        bearer.look.hair_color = HairColor.RED
+        id_subject.look.hair_color = HairColor.BLONDE
+        return case
 
 
 class HallMonitorConsequence(BaseModelPlus):


### PR DESCRIPTION
## Summary

- Pin a red-haired presenter with a blond, distinct document subject as the second Hall Monitor encounter.
- Deliver the existing credential-card MediaFragment and piece_media relation through persisted service responses and the reference web client.
- Preserve the text floor when card media is pending; retain no hidden disposition or defect state in the client payload.

## Root cause fixed

Journal persistence previously flattened MediaFragment RIT content, and service media DTOs omitted the fragment UUID needed by relationship groups.

## Validation

- poetry run pytest engine/tests/loaders/test_hall_monitor_world.py engine/tests/loaders/test_credential_gate_world.py engine/tests/mechanics/credentials/test_credential_card_media.py engine/tests/mechanics/credentials/test_credential_card_projection.py engine/tests/mechanics/credentials/test_credential_packet_manager.py engine/tests/mechanics/credentials/test_credential_text_presentation.py engine/tests/mechanics/games/test_credentials_game.py apps/server/tests/test_hall_monitor_playable_vertical.py -q (108 passed)
- poetry run pytest engine/tests/media/test_media_fragment.py engine/tests/mechanics/credentials/test_credential_card_media.py apps/server/tests/test_hall_monitor_playable_vertical.py -q (18 passed)
- yarn test StoryBlock.test.ts --run
- yarn type-check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Hall Monitor encounter featuring a red-haired presenter and a student ID showing a distinct blond subject.
  - Added support for displaying associated media alongside story pieces.
  - Added descriptions beneath story piece metadata.
  - Media remains available after saving and reloading story content.

- **Bug Fixes**
  - Improved pending-card handling so unavailable media is removed while relevant text remains visible.
  - Corrected credential-card delivery and subject-mismatch behavior.
  - Preserved media identifiers across supported content formats and reloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->