### PR TITLE
devref: index GitHub issues via `devref:<topic>` labels (#282, Thread 3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,8 +219,11 @@ full type map and rationale.**
   `journal`. The index lives under `tmp/devref/` and is disposable.
 - `tangl-devref sync-issues` folds GitHub issues into that index by their
   `devref:<topic>` labels, so `map <topic>` returns the governing design docs,
-  the key code, and the open issues together. It is the only devref command that
-  reaches the network; `build` only reads the snapshot it leaves in
+  the key code, and the open issues together. It captures open issues only:
+  retrieval shows an issue's title and topics but not its state, so indexing
+  closed work would present finished business as outstanding. Pass
+  `--state all` when you specifically want that history. It is the only devref
+  command that reaches the network; `build` only reads the snapshot it leaves in
   `tmp/devref/issues.json`, and indexes no issues when that file is absent.
 - The legacy `scripts/dump_code.py` script predates the curated Repomix bundles;
   prefer `repomix_bundle.py` or `tangl-devref` unless you specifically need the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,11 @@ full type map and rationale.**
   `poetry run tangl-devref build`, then use `tangl-devref find`, `map`, or `pack`
   for compact context around concepts such as `phase_ctx`, `provisioning`, or
   `journal`. The index lives under `tmp/devref/` and is disposable.
+- `tangl-devref sync-issues` folds GitHub issues into that index by their
+  `devref:<topic>` labels, so `map <topic>` returns the governing design docs,
+  the key code, and the open issues together. It is the only devref command that
+  reaches the network; `build` only reads the snapshot it leaves in
+  `tmp/devref/issues.json`, and indexes no issues when that file is absent.
 - The legacy `scripts/dump_code.py` script predates the curated Repomix bundles;
   prefer `repomix_bundle.py` or `tangl-devref` unless you specifically need the
   older dump format.

--- a/apps/cli/tests/test_devref_cli.py
+++ b/apps/cli/tests/test_devref_cli.py
@@ -6,7 +6,9 @@ import json
 
 from typer.testing import CliRunner
 
+from tangl.devref import cli as devref_cli
 from tangl.devref.cli import app as devref_app
+from tangl.devref.models import IssueSyncReport
 
 
 runner = CliRunner()
@@ -36,6 +38,36 @@ def test_status_does_not_create_or_fake_an_unbuilt_database(tmp_path) -> None:
     assert payload["built"] is False
     assert payload["state"] == "missing"
     assert not db_path.exists()
+
+
+def test_sync_issues_command_renders_its_report(tmp_path, monkeypatch) -> None:
+    cache_path = tmp_path / "issues.json"
+    monkeypatch.setattr(
+        devref_cli,
+        "sync_issues",
+        lambda *args, **kwargs: IssueSyncReport(
+            cache_path=str(cache_path), fetched=9, indexed=2, topics=["entity"]
+        ),
+    )
+
+    result = runner.invoke(devref_app, ["sync-issues", "--limit", "9"])
+
+    assert result.exit_code == 0
+    assert "indexed: 2" in result.output
+
+
+def test_sync_issues_command_reports_an_unusable_gh(tmp_path, monkeypatch) -> None:
+    """A missing or unauthenticated ``gh`` must fail loudly, not silently."""
+
+    def explode(*args, **kwargs):
+        raise RuntimeError("gh issue list failed with exit code 1: not authenticated")
+
+    monkeypatch.setattr(devref_cli, "sync_issues", explode)
+
+    result = runner.invoke(devref_app, ["sync-issues"])
+
+    assert result.exit_code == 1
+    assert "not authenticated" in result.output
 
 
 def test_find_command_renders_json(tmp_path) -> None:

--- a/engine/src/tangl/devref/__init__.py
+++ b/engine/src/tangl/devref/__init__.py
@@ -17,17 +17,20 @@ Key Features
 API
 ---
 - :func:`build_index` - Build or refresh the local SQLite index.
+- :func:`sync_issues` - Refresh the offline GitHub issue snapshot.
 - :func:`search_topics` - Search topics and ranked artifacts.
 - :func:`get_topic_map` - Show one topic with related topics and artifacts.
 - :func:`build_context_pack` - Assemble a compact context pack for agents.
 """
 
 from .builder import build_index
+from .issues import sync_issues
 from .models import (
     ArtifactHit,
     BuildReport,
     ContextPack,
     ContextPackItem,
+    IssueSyncReport,
     SearchResponse,
     TopicDefinition,
     TopicHit,
@@ -41,6 +44,7 @@ __all__ = [
     "BuildReport",
     "ContextPack",
     "ContextPackItem",
+    "IssueSyncReport",
     "SearchResponse",
     "TopicDefinition",
     "TopicHit",
@@ -50,4 +54,5 @@ __all__ = [
     "get_topic_map",
     "load_topics",
     "search_topics",
+    "sync_issues",
 ]

--- a/engine/src/tangl/devref/builder.py
+++ b/engine/src/tangl/devref/builder.py
@@ -15,6 +15,13 @@ from pathlib import Path
 from typing import Any
 
 from .annotations import extract_storytangl_topic_annotations
+from .issues import (
+    ISSUE_CACHE_RELPATH,
+    is_governing,
+    issue_cache_path,
+    load_issue_cache,
+    topic_labels,
+)
 from .models import (
     BuildReport,
     DevTopicFacet,
@@ -321,6 +328,11 @@ def iter_source_paths(repo_root: Path) -> list[Path]:
     found: set[Path] = set()
     for pattern in patterns:
         found.update(path for path in repo_root.glob(pattern) if path.is_file())
+    # The issue snapshot is a build source like any other file, so tracking it
+    # in the manifest is what makes a refreshed snapshot invalidate incrementally.
+    cache_path = issue_cache_path(repo_root)
+    if cache_path.is_file():
+        found.add(cache_path)
     return sorted(
         path for path in found
         if "__pycache__" not in path.parts and ".pytest_cache" not in path.parts
@@ -516,6 +528,49 @@ def extract_text_source(path: Path, source_hash: str, repo_root: Path) -> list[E
     return artifacts
 
 
+def extract_issue_source(path: Path, source_hash: str) -> list[ExtractedArtifact]:
+    """Extract one artifact per ``devref:``-labelled issue in the snapshot.
+
+    Each artifact carries the issue URL as its source path, so ``find`` and
+    ``pack`` hand back something addressable rather than the snapshot file.
+    Issue bodies are prose written against GitHub, not against the repository
+    tree, so no cross-artifact link metadata is derived from their links.
+    """
+
+    artifacts: list[ExtractedArtifact] = []
+    for issue in load_issue_cache(path).issues:
+        topic_ids = topic_labels(issue.labels)
+        if not topic_ids:
+            continue
+        governing = is_governing(issue.labels)
+        facet: DevTopicFacet = "governance" if governing else "notes"
+        relation: DevTopicRelation = "governs" if governing else "mentions"
+        annotation = TopicAnnotation(topics=topic_ids, facets=[facet], relation=relation)
+        artifacts.append(
+            ExtractedArtifact(
+                source_path=issue.url,
+                source_hash=source_hash,
+                artifact_key=f"issue:{issue.number}",
+                title=f"#{issue.number} {issue.title}",
+                kind="issue",
+                facet=facet,
+                relation=relation,
+                anchor=f"issue-{issue.number}",
+                summary=summarize_text(first_paragraph(issue.body) or issue.title),
+                content=issue.body,
+                metadata={
+                    "annotations": [annotation.model_dump(mode="python")],
+                    "related_paths": [],
+                    "symbol_refs": [],
+                    "issue_number": issue.number,
+                    "issue_state": issue.state,
+                    "issue_labels": issue.labels,
+                },
+            )
+        )
+    return artifacts
+
+
 def extract_source_file(
     path: Path,
     source_hash: str,
@@ -525,6 +580,8 @@ def extract_source_file(
 ) -> tuple[list[ExtractedArtifact], list[ExtractedSymbol]]:
     """Extract all supported artifacts and symbols from one source path."""
 
+    if path.relative_to(repo_root).as_posix() == ISSUE_CACHE_RELPATH:
+        return extract_issue_source(path, source_hash), []
     if path.suffix.lower() == ".py":
         return extract_python_source(
             path,
@@ -822,7 +879,13 @@ def build_index(
                 used_fts=used_fts,
             )
         build_mode = "incremental"
-        db.delete_source_paths(tuple(sorted(set(changed_paths + removed_paths))))
+        stale_paths = set(changed_paths) | set(removed_paths)
+        db.delete_source_paths(tuple(sorted(stale_paths)))
+        # Issue artifacts are keyed by GitHub URL rather than by the snapshot
+        # path, so path-based deletion cannot reach them: refreshing or dropping
+        # the snapshot clears the whole kind before the survivors are re-read.
+        if ISSUE_CACHE_RELPATH in stale_paths:
+            db.delete_artifact_kinds(("issue",))
 
     extracted_artifacts: list[ExtractedArtifact] = []
     extracted_symbols: list[ExtractedSymbol] = []

--- a/engine/src/tangl/devref/cli.py
+++ b/engine/src/tangl/devref/cli.py
@@ -63,10 +63,14 @@ def build_command(
 @app.command("sync-issues")
 def sync_issues_command(
     limit: int = typer.Option(500, help="Maximum number of issues to request from GitHub."),
-    state: str = typer.Option("all", help="Issue state to fetch: open, closed, or all."),
+    state: str = typer.Option(
+        "open",
+        help="Issue state to fetch: open, closed, or all. Retrieval does not show "
+        "state, so indexing closed issues presents finished work as outstanding.",
+    ),
     output_format: FormatOption = "yaml",
 ) -> None:
-    """Refresh the offline snapshot of ``devref:``-labelled issues.
+    """Refresh the offline snapshot of open ``devref:``-labelled issues.
 
     This is the only devref command that reaches the network. It writes
     ``tmp/devref/issues.json``; ``build`` reads whatever snapshot is on disk,

--- a/engine/src/tangl/devref/cli.py
+++ b/engine/src/tangl/devref/cli.py
@@ -10,7 +10,8 @@ import typer
 import yaml
 from pydantic import BaseModel
 
-from .builder import DEFAULT_DB_PATH, build_index
+from .builder import DEFAULT_DB_PATH, REPO_ROOT, build_index
+from .issues import issue_cache_path, load_issue_cache, sync_issues
 from .query import build_context_pack, get_topic_map, search_topics
 from .storage import DevRefDatabase
 
@@ -56,6 +57,27 @@ def build_command(
     """Build or refresh the local dev topic index."""
 
     report = build_index(db_path=db or DEFAULT_DB_PATH, incremental=not full)
+    _render(report, output_format=output_format)
+
+
+@app.command("sync-issues")
+def sync_issues_command(
+    limit: int = typer.Option(500, help="Maximum number of issues to request from GitHub."),
+    state: str = typer.Option("all", help="Issue state to fetch: open, closed, or all."),
+    output_format: FormatOption = "yaml",
+) -> None:
+    """Refresh the offline snapshot of ``devref:``-labelled issues.
+
+    This is the only devref command that reaches the network. It writes
+    ``tmp/devref/issues.json``; ``build`` reads whatever snapshot is on disk,
+    so the build itself stays offline and deterministic.
+    """
+
+    try:
+        report = sync_issues(REPO_ROOT, limit=limit, state=state)
+    except (OSError, RuntimeError) as exc:
+        typer.secho(f"Could not sync issues: {exc}", err=True, fg=typer.colors.RED)
+        raise typer.Exit(1) from exc
     _render(report, output_format=output_format)
 
 
@@ -119,6 +141,8 @@ def status_command(
         state = "schema_only"
     elif built:
         state = "built"
+    cache_path = issue_cache_path(REPO_ROOT)
+    issue_cache = load_issue_cache(cache_path) if cache_path.exists() else None
     payload = {
         "db_path": str(database.path),
         "exists": exists,
@@ -132,6 +156,10 @@ def status_command(
         "symbols": database.symbol_count() if has_schema else 0,
         "topic_links": database.topic_link_count() if has_schema else 0,
         "artifact_links": database.artifact_link_count() if has_schema else 0,
+        "issue_cache_path": str(cache_path),
+        "issue_cache_synced_at": issue_cache.generated_at.isoformat() if issue_cache else None,
+        "issues_cached": len(issue_cache.issues) if issue_cache else 0,
+        "issues_indexed": database.artifact_kind_count("issue") if has_schema else 0,
     }
     _render(payload, output_format=output_format)
 

--- a/engine/src/tangl/devref/issues.py
+++ b/engine/src/tangl/devref/issues.py
@@ -145,9 +145,13 @@ def sync_issues(repo_root: Path, *, limit: int = 500, state: str = "open") -> Is
     cache = IssueCache(generated_at=datetime.now(UTC), issues=records)
     # Write through a sibling and rename, so an interrupted sync leaves the
     # previous snapshot intact rather than truncated JSON the builder cannot read.
+    # A successful rename consumes the sibling, so the cleanup only fires on failure.
     staged = target.with_suffix(".json.tmp")
-    staged.write_text(cache.model_dump_json(indent=2) + "\n", encoding="utf-8")
-    staged.replace(target)
+    try:
+        staged.write_text(cache.model_dump_json(indent=2) + "\n", encoding="utf-8")
+        staged.replace(target)
+    finally:
+        staged.unlink(missing_ok=True)
 
     truncated = len(payload) >= limit
     if truncated:

--- a/engine/src/tangl/devref/issues.py
+++ b/engine/src/tangl/devref/issues.py
@@ -1,0 +1,158 @@
+"""GitHub issue snapshot used as a devref build source.
+
+Why
+---
+Issues are the third surface of the issues <-> design-docs <-> code triangle,
+but a build that reaches the network is neither offline, deterministic, nor
+disposable. Issues therefore reach the index through an on-disk snapshot:
+:func:`sync_issues` shells out to the GitHub CLI and writes the snapshot,
+and the builder reads whatever is on disk, indexing nothing when absent.
+
+Key Features
+------------
+- The ``devref:<topic>`` label is the convention. Each such label names a
+  topic from the same curated vocabulary that docs and code annotate with
+  ``storytangl-topic``, so both sides join on one registry.
+- Umbrella issues, marked with ``kind:milestone``, ``govern`` their topics.
+  Ordinary issues merely ``mention`` them.
+
+Notes
+-----
+GitHub search cannot match a label prefix, so the snapshot is filtered
+locally: fetch the issue list once, then keep the records that carry at
+least one ``devref:`` label.
+
+See also
+--------
+:mod:`tangl.devref.builder` : turns the snapshot into ``issue`` artifacts.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import json
+import logging
+from pathlib import Path
+import subprocess
+from typing import Any
+
+from .models import IssueCache, IssueRecord, IssueSyncReport
+from .topics import load_topics
+
+
+logger = logging.getLogger(__name__)
+
+ISSUE_CACHE_RELPATH = "tmp/devref/issues.json"
+TOPIC_LABEL_PREFIX = "devref:"
+GOVERNING_LABELS = frozenset({"kind:milestone"})
+GH_JSON_FIELDS = "number,title,body,labels,state,url"
+
+
+def issue_cache_path(repo_root: Path) -> Path:
+    """Return the issue snapshot path for one checkout."""
+
+    return repo_root / ISSUE_CACHE_RELPATH
+
+
+def topic_labels(labels: list[str]) -> list[str]:
+    """Return the topic ids named by an issue's ``devref:<topic>`` labels."""
+
+    return sorted(
+        {
+            label[len(TOPIC_LABEL_PREFIX):]
+            for label in labels
+            if label.startswith(TOPIC_LABEL_PREFIX) and label != TOPIC_LABEL_PREFIX
+        }
+    )
+
+
+def is_governing(labels: list[str]) -> bool:
+    """Return whether an issue is an umbrella that governs its topics."""
+
+    return any(label in GOVERNING_LABELS for label in labels)
+
+
+def load_issue_cache(path: Path) -> IssueCache:
+    """Load one issue snapshot from disk."""
+
+    return IssueCache.model_validate_json(path.read_text(encoding="utf-8"))
+
+
+def _to_record(payload: dict[str, Any]) -> IssueRecord:
+    """Narrow one raw ``gh issue list`` record to the fields devref indexes."""
+
+    return IssueRecord(
+        number=int(payload["number"]),
+        title=str(payload["title"]),
+        body=str(payload.get("body") or ""),
+        state=str(payload.get("state") or ""),
+        url=str(payload.get("url") or ""),
+        labels=sorted(str(label["name"]) for label in payload.get("labels") or []),
+    )
+
+
+def fetch_issues(repo_root: Path, *, limit: int, state: str) -> list[dict[str, Any]]:
+    """Fetch raw issue records from the GitHub CLI.
+
+    The command runs inside ``repo_root`` so ``gh`` resolves the repository from
+    that checkout's own remote.
+    """
+
+    command = [
+        "gh",
+        "issue",
+        "list",
+        "--state",
+        state,
+        "--limit",
+        str(limit),
+        "--json",
+        GH_JSON_FIELDS,
+    ]
+    logger.debug("Fetching issues with the GitHub CLI: %s", " ".join(command))
+    result = subprocess.run(
+        command,
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"gh issue list failed with exit code {result.returncode}: {result.stderr.strip()}"
+        )
+    return json.loads(result.stdout)
+
+
+def sync_issues(repo_root: Path, *, limit: int = 500, state: str = "all") -> IssueSyncReport:
+    """Refresh the offline issue snapshot that the builder indexes."""
+
+    payload = fetch_issues(repo_root, limit=limit, state=state)
+    records = [
+        record
+        for record in (_to_record(item) for item in payload)
+        if topic_labels(record.labels)
+    ]
+    records.sort(key=lambda record: record.number)
+
+    target = issue_cache_path(repo_root)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    cache = IssueCache(generated_at=datetime.now(UTC), issues=records)
+    target.write_text(cache.model_dump_json(indent=2) + "\n", encoding="utf-8")
+
+    known_topic_ids = {topic.topic_id for topic in load_topics()}
+    seen = sorted({topic_id for record in records for topic_id in topic_labels(record.labels)})
+    unknown = [topic_id for topic_id in seen if topic_id not in known_topic_ids]
+    if unknown:
+        logger.warning(
+            "Ignoring devref labels that name no registered topic: %s",
+            ", ".join(unknown),
+        )
+    logger.info("Wrote %d issues to the devref issue snapshot at %s", len(records), target)
+    return IssueSyncReport(
+        cache_path=str(target),
+        fetched=len(payload),
+        indexed=len(records),
+        topics=[topic_id for topic_id in seen if topic_id in known_topic_ids],
+        unknown_topics=unknown,
+    )

--- a/engine/src/tangl/devref/issues.py
+++ b/engine/src/tangl/devref/issues.py
@@ -124,8 +124,13 @@ def fetch_issues(repo_root: Path, *, limit: int, state: str) -> list[dict[str, A
     return json.loads(result.stdout)
 
 
-def sync_issues(repo_root: Path, *, limit: int = 500, state: str = "all") -> IssueSyncReport:
-    """Refresh the offline issue snapshot that the builder indexes."""
+def sync_issues(repo_root: Path, *, limit: int = 500, state: str = "open") -> IssueSyncReport:
+    """Refresh the offline issue snapshot that the builder indexes.
+
+    Only open issues are captured by default. Retrieval surfaces an issue's
+    title and topics but not its state, so indexing closed work would present
+    finished business as outstanding. Pass ``state="all"`` for archaeology.
+    """
 
     payload = fetch_issues(repo_root, limit=limit, state=state)
     records = [
@@ -138,8 +143,19 @@ def sync_issues(repo_root: Path, *, limit: int = 500, state: str = "all") -> Iss
     target = issue_cache_path(repo_root)
     target.parent.mkdir(parents=True, exist_ok=True)
     cache = IssueCache(generated_at=datetime.now(UTC), issues=records)
-    target.write_text(cache.model_dump_json(indent=2) + "\n", encoding="utf-8")
+    # Write through a sibling and rename, so an interrupted sync leaves the
+    # previous snapshot intact rather than truncated JSON the builder cannot read.
+    staged = target.with_suffix(".json.tmp")
+    staged.write_text(cache.model_dump_json(indent=2) + "\n", encoding="utf-8")
+    staged.replace(target)
 
+    truncated = len(payload) >= limit
+    if truncated:
+        logger.warning(
+            "GitHub returned the full requested page of %d issues; the snapshot may be "
+            "incomplete. Re-run with a higher --limit.",
+            limit,
+        )
     known_topic_ids = {topic.topic_id for topic in load_topics()}
     seen = sorted({topic_id for record in records for topic_id in topic_labels(record.labels)})
     unknown = [topic_id for topic_id in seen if topic_id not in known_topic_ids]
@@ -153,6 +169,7 @@ def sync_issues(repo_root: Path, *, limit: int = 500, state: str = "all") -> Iss
         cache_path=str(target),
         fetched=len(payload),
         indexed=len(records),
+        truncated=truncated,
         topics=[topic_id for topic_id in seen if topic_id in known_topic_ids],
         unknown_topics=unknown,
     )

--- a/engine/src/tangl/devref/models.py
+++ b/engine/src/tangl/devref/models.py
@@ -207,6 +207,7 @@ class IssueSyncReport(BaseModelPlus):
     cache_path: str
     fetched: int
     indexed: int
+    truncated: bool = False
     topics: list[str] = Field(default_factory=list)
     unknown_topics: list[str] = Field(default_factory=list)
 

--- a/engine/src/tangl/devref/models.py
+++ b/engine/src/tangl/devref/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
@@ -180,6 +181,34 @@ class ExtractedSymbol(BaseModelPlus):
     line: int | None = None
     signature: str | None = None
     summary: str = ""
+
+
+class IssueRecord(BaseModelPlus):
+    """One GitHub issue captured in the offline devref issue snapshot."""
+
+    number: int
+    title: str
+    body: str = ""
+    state: str = ""
+    url: str = ""
+    labels: list[str] = Field(default_factory=list)
+
+
+class IssueCache(BaseModelPlus):
+    """Offline snapshot of ``devref:``-labelled issues read by the builder."""
+
+    generated_at: datetime
+    issues: list[IssueRecord] = Field(default_factory=list)
+
+
+class IssueSyncReport(BaseModelPlus):
+    """Summary of one issue-snapshot refresh."""
+
+    cache_path: str
+    fetched: int
+    indexed: int
+    topics: list[str] = Field(default_factory=list)
+    unknown_topics: list[str] = Field(default_factory=list)
 
 
 class BuildConfig(BaseModelPlus):

--- a/engine/src/tangl/devref/storage.py
+++ b/engine/src/tangl/devref/storage.py
@@ -168,6 +168,20 @@ class DevRefDatabase:
                     chunk,
                 )
 
+    def delete_artifact_kinds(self, kinds: Iterable[str]) -> None:
+        """Remove every artifact of the given kinds.
+
+        Kind-scoped deletion is how a source whose artifacts are not addressed
+        by repo path, such as the GitHub issue snapshot, is re-ingested cleanly.
+        """
+
+        values = tuple(kinds)
+        if not values:
+            return
+        placeholders = ", ".join("?" for _ in values)
+        with self.connect() as conn:
+            conn.execute(f"DELETE FROM artifacts WHERE kind IN ({placeholders})", values)
+
     def upsert_topics(self, topics: list[TopicDefinition], *, normalize_alias) -> None:
         with self.connect() as conn:
             conn.execute("DELETE FROM topic_aliases")
@@ -360,6 +374,11 @@ class DevRefDatabase:
         if not self.table_exists("artifacts"):
             return 0
         return self.scalar("SELECT COUNT(*) FROM artifacts")
+
+    def artifact_kind_count(self, kind: str) -> int:
+        if not self.table_exists("artifacts"):
+            return 0
+        return self.scalar("SELECT COUNT(*) FROM artifacts WHERE kind = ?", (kind,))
 
     def symbol_count(self) -> int:
         if not self.table_exists("symbols"):

--- a/engine/tests/devref/test_issues.py
+++ b/engine/tests/devref/test_issues.py
@@ -1,0 +1,289 @@
+"""GitHub issue snapshot ingestion.
+
+Every test here writes its own snapshot fixture: the build must stay offline,
+so nothing in this module is allowed to reach the network.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tangl.devref import issues as issues_module
+from tangl.devref.builder import build_index
+from tangl.devref.issues import ISSUE_CACHE_RELPATH, sync_issues
+from tangl.devref.query import build_context_pack, search_topics
+from tangl.devref.storage import DevRefDatabase
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _issue(
+    number: int,
+    title: str,
+    labels: list[str],
+    *,
+    body: str = "",
+    state: str = "OPEN",
+) -> dict[str, Any]:
+    return {
+        "number": number,
+        "title": title,
+        "body": body,
+        "state": state,
+        "url": f"https://github.com/derekmerck/storytangl/issues/{number}",
+        "labels": labels,
+    }
+
+
+def _repo(tmp_path: Path, issues: list[dict[str, Any]] | None = None) -> Path:
+    """Build a miniature checkout with one design doc and an optional snapshot."""
+
+    repo = tmp_path / "mini_repo"
+    _write(
+        repo / "docs" / "src" / "design" / "entity_model.md",
+        "# Entity Model\n\nHow the entity primitive is layered.\n",
+    )
+    if issues is not None:
+        _write(
+            repo / ISSUE_CACHE_RELPATH,
+            json.dumps({"generated_at": "2026-08-06T00:00:00Z", "issues": issues}),
+        )
+    return repo
+
+
+def _issue_hits(topic: str, db_path: Path) -> list:
+    return [
+        artifact
+        for artifact in search_topics(topic, db_path=db_path).artifacts
+        if artifact.kind == "issue"
+    ]
+
+
+def test_labelled_issue_is_indexed_alongside_docs(tmp_path) -> None:
+    """A ``devref:<topic>`` label joins an issue to the same topic as the docs."""
+
+    # The wording deliberately avoids topic aliases, so the only thing that can
+    # link this issue to ``entity`` is its label.
+    repo_root = _repo(
+        tmp_path,
+        [
+            _issue(
+                101,
+                "Stale pointer handed back after teardown",
+                ["kind:bug", "devref:entity"],
+                body="The lookup table returns a freed object.\n\nMore detail follows.",
+            )
+        ],
+    )
+    db_path = tmp_path / "mini.sqlite3"
+
+    build_index(repo_root=repo_root, db_path=db_path, incremental=False)
+    hits = _issue_hits("entity", db_path)
+    kinds = {artifact.kind for artifact in search_topics("entity", db_path=db_path).artifacts}
+
+    assert len(hits) == 1
+    assert hits[0].title == "#101 Stale pointer handed back after teardown"
+    assert hits[0].relation == "mentions"
+    assert hits[0].facet == "notes"
+    assert hits[0].topic_ids == ["entity"]
+    assert hits[0].evidence_sources == ["manual_annotation"]
+    # The issue is addressable on GitHub, not at a path inside the checkout.
+    assert hits[0].source_path == "https://github.com/derekmerck/storytangl/issues/101"
+    assert hits[0].summary == "The lookup table returns a freed object."
+    # The point of the feature: issues arrive next to the docs, not instead.
+    assert {"doc_section", "issue"} <= kinds
+
+
+def test_milestone_issue_governs_its_topics(tmp_path) -> None:
+    """``kind:milestone`` is the cheap umbrella signal, so the issue governs."""
+
+    repo_root = _repo(
+        tmp_path,
+        [_issue(102, "Identity rework roadmap", ["kind:milestone", "devref:entity"])],
+    )
+    db_path = tmp_path / "mini.sqlite3"
+
+    build_index(repo_root=repo_root, db_path=db_path, incremental=False)
+    hits = _issue_hits("entity", db_path)
+
+    assert len(hits) == 1
+    assert hits[0].relation == "governs"
+    assert hits[0].facet == "governance"
+    # An empty body still needs a usable summary, so the title stands in.
+    assert hits[0].summary == "Identity rework roadmap"
+
+
+def test_issue_reaches_the_context_pack(tmp_path) -> None:
+    """``pack`` is the agent surface, so issues have to land in it too."""
+
+    repo_root = _repo(
+        tmp_path,
+        [_issue(103, "Ownership handoff is ambiguous", ["devref:entity"])],
+    )
+    db_path = tmp_path / "mini.sqlite3"
+
+    build_index(repo_root=repo_root, db_path=db_path, incremental=False)
+    pack = build_context_pack(["entity"], db_path=db_path)
+    titles = [item.title for item in pack.items]
+
+    assert "#103 Ownership handoff is ambiguous" in titles
+    # Design docs outrank issues, so the governing doc still leads the bundle.
+    assert titles.index("Entity Model") < titles.index("#103 Ownership handoff is ambiguous")
+
+
+def test_unlabelled_and_unknown_topic_issues_are_not_linked(tmp_path) -> None:
+    """Only registered ``devref:`` topics create links; the rest are inert."""
+
+    repo_root = _repo(
+        tmp_path,
+        [
+            _issue(104, "Tidy up the changelog", ["kind:bug"]),
+            _issue(105, "Revisit the release checklist", ["devref:not_a_real_topic"]),
+        ],
+    )
+    db_path = tmp_path / "mini.sqlite3"
+
+    build_index(repo_root=repo_root, db_path=db_path, incremental=False)
+    db = DevRefDatabase(db_path)
+    keys = {row["artifact_key"] for row in db.load_rows("SELECT artifact_key FROM artifacts")}
+
+    # An issue with no devref label produces no artifact at all.
+    assert "issue:104" not in keys
+    # An unknown topic still yields an artifact, but its label links nothing.
+    assert "issue:105" in keys
+    assert not _issue_hits("entity", db_path)
+    assert db.scalar(
+        """
+        SELECT COUNT(*) FROM artifact_topics
+        JOIN artifacts USING (artifact_id)
+        WHERE artifacts.kind = 'issue' AND artifact_topics.evidence_source = 'manual_annotation'
+        """
+    ) == 0
+
+
+def test_build_without_a_snapshot_indexes_no_issues(tmp_path) -> None:
+    """Absent snapshot means the existing build behaviour is untouched."""
+
+    repo_root = _repo(tmp_path)
+    db_path = tmp_path / "mini.sqlite3"
+
+    report = build_index(repo_root=repo_root, db_path=db_path, incremental=False)
+
+    assert report.artifacts > 0
+    assert DevRefDatabase(db_path).artifact_kind_count("issue") == 0
+
+
+def test_incremental_build_tracks_snapshot_refresh_and_removal(tmp_path) -> None:
+    """Refreshing or dropping the snapshot must not strand stale issues."""
+
+    repo_root = _repo(
+        tmp_path,
+        [
+            _issue(106, "Alpha follow-up", ["devref:entity"]),
+            _issue(107, "Beta follow-up", ["devref:entity"]),
+        ],
+    )
+    db_path = tmp_path / "mini.sqlite3"
+    cache_path = repo_root / ISSUE_CACHE_RELPATH
+    db = DevRefDatabase(db_path)
+
+    build_index(repo_root=repo_root, db_path=db_path, incremental=False)
+    assert db.artifact_kind_count("issue") == 2
+
+    # A refresh that closes out one issue drops it from the index.
+    _write(
+        cache_path,
+        json.dumps(
+            {
+                "generated_at": "2026-08-07T00:00:00Z",
+                "issues": [_issue(106, "Alpha follow-up, revised", ["devref:entity"])],
+            }
+        ),
+    )
+    refreshed = build_index(repo_root=repo_root, db_path=db_path, incremental=True)
+
+    assert refreshed.build_mode == "incremental"
+    assert db.artifact_kind_count("issue") == 1
+    assert _issue_hits("entity", db_path)[0].title == "#106 Alpha follow-up, revised"
+
+    # Deleting the snapshot clears the issues but leaves the rest of the index.
+    cache_path.unlink()
+    dropped = build_index(repo_root=repo_root, db_path=db_path, incremental=True)
+
+    assert dropped.build_mode == "incremental"
+    assert db.artifact_kind_count("issue") == 0
+    assert db.artifact_count() > 0
+
+
+def test_sync_issues_writes_a_snapshot_the_builder_can_read(tmp_path, monkeypatch) -> None:
+    """``sync-issues`` is the only networked step, so its output is the contract."""
+
+    repo_root = _repo(tmp_path)
+    db_path = tmp_path / "mini.sqlite3"
+    captured: dict[str, Any] = {}
+
+    def fake_fetch(root: Path, *, limit: int, state: str):
+        captured.update(root=root, limit=limit, state=state)
+        return [
+            {
+                "number": 108,
+                "title": "Ownership is unclear",
+                "body": "Who owns the freed handle?",
+                "state": "OPEN",
+                "url": "https://github.com/derekmerck/storytangl/issues/108",
+                "labels": [{"name": "devref:entity"}, {"name": "kind:feature"}],
+            },
+            {
+                "number": 109,
+                "title": "Unrelated chore",
+                "body": "",
+                "state": "CLOSED",
+                "url": "https://github.com/derekmerck/storytangl/issues/109",
+                "labels": [{"name": "kind:docs"}],
+            },
+            {
+                "number": 110,
+                "title": "Mystery topic",
+                "body": "",
+                "state": "OPEN",
+                "url": "https://github.com/derekmerck/storytangl/issues/110",
+                "labels": [{"name": "devref:not_a_real_topic"}],
+            },
+        ]
+
+    monkeypatch.setattr(issues_module, "fetch_issues", fake_fetch)
+    report = sync_issues(repo_root, limit=50, state="open")
+
+    assert captured == {"root": repo_root, "limit": 50, "state": "open"}
+    assert report.cache_path == str(repo_root / ISSUE_CACHE_RELPATH)
+    assert report.fetched == 3
+    # Only devref-labelled issues are cached, whether or not the topic resolves.
+    assert report.indexed == 2
+    assert report.topics == ["entity"]
+    assert report.unknown_topics == ["not_a_real_topic"]
+
+    build_index(repo_root=repo_root, db_path=db_path, incremental=False)
+    hits = _issue_hits("entity", db_path)
+
+    assert [artifact.title for artifact in hits] == ["#108 Ownership is unclear"]
+
+
+def test_fetch_issues_reports_a_failing_gh_invocation(tmp_path, monkeypatch) -> None:
+    """A missing or unauthenticated ``gh`` has to surface, not silently no-op."""
+
+    class _Result:
+        returncode = 1
+        stdout = ""
+        stderr = "gh: not authenticated\n"
+
+    monkeypatch.setattr(issues_module.subprocess, "run", lambda *a, **k: _Result())
+
+    with pytest.raises(RuntimeError, match="not authenticated"):
+        issues_module.fetch_issues(tmp_path, limit=10, state="all")

--- a/engine/tests/devref/test_issues.py
+++ b/engine/tests/devref/test_issues.py
@@ -302,19 +302,40 @@ def test_sync_issues_flags_a_full_page_as_truncated(tmp_path, monkeypatch) -> No
     assert sync_issues(repo_root, limit=500).truncated is True
 
 
-def test_sync_issues_leaves_the_previous_snapshot_intact_when_it_fails(tmp_path, monkeypatch) -> None:
-    """An interrupted sync must not strand truncated JSON the builder chokes on."""
+def test_sync_issues_survives_a_failure_after_the_snapshot_is_staged(tmp_path, monkeypatch) -> None:
+    """The staged write only earns its keep if a *late* failure cannot corrupt the snapshot.
+
+    Failing the fetch would prove nothing, since no file is written that early.
+    The interesting moment is after the replacement is on disk but before it is
+    swapped in, which is exactly what a direct write would have already clobbered.
+    """
 
     repo_root = _repo(tmp_path, [_issue(111, "Original entry", ["devref:entity"])])
     cache_path = repo_root / ISSUE_CACHE_RELPATH
     original = cache_path.read_text(encoding="utf-8")
 
-    def explode(*args, **kwargs):
-        raise RuntimeError("gh issue list failed with exit code 1: interrupted")
+    monkeypatch.setattr(
+        issues_module,
+        "fetch_issues",
+        lambda root, *, limit, state: [
+            {
+                "number": 112,
+                "title": "Replacement entry",
+                "body": "",
+                "state": "OPEN",
+                "url": "https://github.com/derekmerck/storytangl/issues/112",
+                "labels": [{"name": "devref:entity"}],
+            }
+        ],
+    )
 
-    monkeypatch.setattr(issues_module, "fetch_issues", explode)
+    def failing_replace(self: Path, target: Path) -> Path:
+        assert self.read_text(encoding="utf-8"), "the staged snapshot should exist by now"
+        raise OSError("rename interrupted")
 
-    with pytest.raises(RuntimeError):
+    monkeypatch.setattr(Path, "replace", failing_replace)
+
+    with pytest.raises(OSError, match="rename interrupted"):
         sync_issues(repo_root)
 
     assert cache_path.read_text(encoding="utf-8") == original

--- a/engine/tests/devref/test_issues.py
+++ b/engine/tests/devref/test_issues.py
@@ -259,9 +259,12 @@ def test_sync_issues_writes_a_snapshot_the_builder_can_read(tmp_path, monkeypatc
         ]
 
     monkeypatch.setattr(issues_module, "fetch_issues", fake_fetch)
-    report = sync_issues(repo_root, limit=50, state="open")
+    report = sync_issues(repo_root, limit=50)
 
+    # Open by default: retrieval never shows an issue's state, so closed work
+    # would read as outstanding.
     assert captured == {"root": repo_root, "limit": 50, "state": "open"}
+    assert report.truncated is False
     assert report.cache_path == str(repo_root / ISSUE_CACHE_RELPATH)
     assert report.fetched == 3
     # Only devref-labelled issues are cached, whether or not the topic resolves.
@@ -273,6 +276,49 @@ def test_sync_issues_writes_a_snapshot_the_builder_can_read(tmp_path, monkeypatc
     hits = _issue_hits("entity", db_path)
 
     assert [artifact.title for artifact in hits] == ["#108 Ownership is unclear"]
+
+
+def test_sync_issues_flags_a_full_page_as_truncated(tmp_path, monkeypatch) -> None:
+    """A page that comes back full may have dropped issues, so say so."""
+
+    repo_root = _repo(tmp_path)
+    monkeypatch.setattr(
+        issues_module,
+        "fetch_issues",
+        lambda root, *, limit, state: [
+            {
+                "number": number,
+                "title": f"Item {number}",
+                "body": "",
+                "state": "OPEN",
+                "url": f"https://github.com/derekmerck/storytangl/issues/{number}",
+                "labels": [{"name": "devref:entity"}],
+            }
+            for number in range(limit)
+        ],
+    )
+
+    assert sync_issues(repo_root, limit=3).truncated is True
+    assert sync_issues(repo_root, limit=500).truncated is True
+
+
+def test_sync_issues_leaves_the_previous_snapshot_intact_when_it_fails(tmp_path, monkeypatch) -> None:
+    """An interrupted sync must not strand truncated JSON the builder chokes on."""
+
+    repo_root = _repo(tmp_path, [_issue(111, "Original entry", ["devref:entity"])])
+    cache_path = repo_root / ISSUE_CACHE_RELPATH
+    original = cache_path.read_text(encoding="utf-8")
+
+    def explode(*args, **kwargs):
+        raise RuntimeError("gh issue list failed with exit code 1: interrupted")
+
+    monkeypatch.setattr(issues_module, "fetch_issues", explode)
+
+    with pytest.raises(RuntimeError):
+        sync_issues(repo_root)
+
+    assert cache_path.read_text(encoding="utf-8") == original
+    assert not list(cache_path.parent.glob("*.tmp"))
 
 
 def test_fetch_issues_reports_a_failing_gh_invocation(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
Thread 3 of the v3.8.4 Barracuda annealing pass (#354). This is **review infrastructure**: the later topic-partitioned up-sweep needs to query issues alongside docs and code.

`ArtifactKind` in `devref/models.py` already included `"issue"` — the data model anticipated this. What was missing was a builder *source* that produces issue artifacts. This PR adds one.

## What landed

**`tangl-devref sync-issues`** — shells `gh issue list --state all --limit N --json number,title,body,labels,state,url`, keeps the records carrying at least one `devref:` label, and writes `tmp/devref/issues.json`. It is the only devref command that touches the network. GitHub search cannot match a label *prefix*, so the filter is applied locally after one fetch.

**Builder source** (`extract_issue_source`) — each `devref:<topic>` label becomes a topic link with `manual_annotation` evidence (weight 120), joining the same curated vocabulary that docs and code annotate with `storytangl-topic`. Unknown topics are dropped by the existing `_annotation_links` filter; `sync-issues` reports them so typos surface.

- Ordinary issues: `relation: mentions`, facet `notes`.
- Umbrella issues (`kind:milestone`, already used in this repo): `relation: governs`, facet `governance`.

Each artifact's `source_path` is the issue URL, so `find`/`pack`/`map` hand back something addressable. The `artifact_key` stays `issue:{number}`, following the existing `symbol:{qualified_name}` convention.

**Offline and deterministic build.** `build` never calls `gh`. The snapshot is registered in the source manifest like any other file, so a refresh invalidates incrementally. Because an issue artifact's `source_path` is a URL rather than a repo path, `delete_source_paths` cannot reach it — `DevRefDatabase.delete_artifact_kinds` clears the kind whenever the snapshot changes or disappears.

## Verifying the loop

```
$ tangl-devref sync-issues
fetched: 43
indexed: 27
truncated: false
topics: [assembly, authoring_validation, codec, credentials, demographics,
         journal, media, multi_lane, open_link, presence, sandbox, widget]
unknown_topics: []
```

`map assembly` — the triangle in one bundle, ordered by evidence weight:

```
doc_section  design      documents  Presence / Body-Attachment & the Assembly Instrument
doc_section  design      documents  Components as Facet Bundles
issue        notes       mentions   #283 Presence/body-attachment convergence over the ass...
issue        notes       mentions   #333 Automata chop-shop convergence demo: assembly, ve...
symbol       code        defines    BudgetTracker
symbol       code        defines    Slot
symbol       code        defines    SlottedContainer
symbol       code        defines    assemble_slots
```

`map credentials` similarly leads with the `kind:milestone` umbrella (#246 `governs`), then the open credentials issues, then `PickingGame` and friends.

### Sync captures open issues only

Retrieval surfaces an issue's title and topics but never its state, so indexing closed issues presents finished work as outstanding. `sync-issues` therefore defaults to `--state open`; pass `--state all` for archaeology. `sync-issues` also reports `truncated: true` when GitHub returns a full page, so the 500-issue ceiling is visible rather than a silent drop.

### One thing worth knowing

`map <topic>` orders by evidence weight, so labelled issues rank high — that is the surface where the triangle actually shows up. **Plain `find`/`pack` rank issues below design docs** by facet priority (`notes` = 30 vs `design` = 90), which is deliberate — docs govern, issues annotate — but on a well-documented topic the default `--limit 20` fills with docs before any issue appears. Use `map <topic>`, `find <topic> --facet notes`, or a larger limit. I did not touch `FACET_PRIORITY`: changing it would reorder every existing `docs/notes/**` artifact too, well beyond this feature.

Also: `find observation` returns no issues because no `devref:observation` label exists yet (`observation` is a new topic from the just-merged design pass). That is a label gap, not a code gap — creating labels is left to you.

## Scope notes

- `topics.json` is untouched (another thread may be proposing topic changes).
- `build` behaviour is unchanged when no snapshot exists — covered by a test.
- Issues only, not PRs. The cache shape would carry PR records fine; adding `gh pr list` is a small follow-up rather than surface added speculatively here.
- Part 2 of #282 (governing-context on PRs via `.coderabbit.yaml`) is not in this PR.

## Tests

`engine/tests/devref/test_issues.py` (10 tests) — no network: every test writes its own snapshot fixture and `sync_issues` is exercised against a monkeypatched fetch. Covers label→topic linking, the milestone `governs` path, pack membership and doc-before-issue ordering, unlabelled/unknown-topic rejection, the untouched no-snapshot build, the incremental refresh/removal lifecycle, full-page truncation, a failed sync leaving the previous snapshot intact, and a failing `gh` invocation. Fixture wording deliberately avoids topic aliases so the tests prove the *label* mechanism rather than the pre-existing title/content heuristics.

Two CLI tests in `apps/cli/tests/test_devref_cli.py` cover command wiring and the unusable-`gh` exit path.

```
poetry run pytest engine/tests/devref apps/cli/tests/test_devref_cli.py   # 37 passed
poetry run pytest engine/tests                # 2897 passed, 69 skipped, 9 xfailed
```

Clean-slate `sync-issues` → `build` → `build` gives `full` then `noop`; dropping the snapshot and rebuilding removes exactly the issue artifacts and restoring returns the count.

Refs #282, #354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub issue synchronization through the `sync-issues` command, with configurable limits, states, and output formats.
  * Indexed labeled issues as governance or notes content, including topic and metadata links.
  * Added offline issue snapshots for builds and context packs.
  * Extended status information with issue-cache and indexed issue counts.

* **Bug Fixes**
  * Stale issue content is removed during incremental refreshes.
  * Unlabeled or unknown-topic issues are excluded from indexing.
  * Synchronization errors are surfaced clearly without replacing existing snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
