### PR TITLE
docs: canon/realization negotiation method + dispatch layer semantics

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -564,10 +564,13 @@ infrastructure.
   In core, `graph.factory` means singleton graph authority. In story,
   `StoryGraph.factory` is still used as a template-registry back-pointer for
   runtime scope recovery. Do not assume those surfaces are unified.
-- **World round-tripping is still label-based shim logic.** `StoryGraph`
-  currently serializes `world` as a label reference and restores it through
-  `World.get_instance(...)`. This exists because world has not yet been moved
-  onto the singleton graph-authority pattern.
+- **World round-trips by label, and that is the designed behaviour.**
+  `StoryGraph` serializes `world` as a label reference and restores it through
+  `World.get_instance(...)`. This follows from the singleton authority model:
+  `GraphFactory` is a `Singleton`, `World` is a `TraversableGraphFactory`
+  subclass, so world identity *is* `(World, label)`. Treat this as a seam only
+  in the sense that `StoryGraph.factory` and `Graph.factory` still differ (see
+  above) — not as a pending migration.
 - **Some VM/provider hooks are still story-colored.** Use existing seams
   carefully, but do not extend them into a parallel discovery framework.
 
@@ -587,5 +590,3 @@ infrastructure.
 - No custom reference-tracking serializers for `Singleton`s.
 - No second speculative VM factory layer beyond `TraversableGraphFactory`
   without a concrete new use case.
-- No wrapper layer that pretends `World` is already a `GraphFactory`
-  subclass when it is not.

--- a/docs/src/design/CANON_AND_REALIZATION.md
+++ b/docs/src/design/CANON_AND_REALIZATION.md
@@ -1,0 +1,154 @@
+# Canon, Realization, and Residue
+
+**Status:** ACTIVE METHOD NOTE
+**Use:** how StoryTangl's conceptual vocabulary stays true as the code moves
+**Companion:** [SIMPLIFICATION_SPEC.md](SIMPLIFICATION_SPEC.md) holds the *what* —
+the concepts a reimplementation would need to preserve. This note holds the *how* —
+the method by which that stays honest.
+
+---
+
+## Why this exists
+
+Canonical documents rot in a specific way: they record *where* a concept is realized,
+and then the realization moves. Most drift found in review is of exactly this shape —
+a document names a symbol that no longer exists. Repairing the instances is endless;
+the fix is to separate the registers so canon has nothing to rot.
+
+## Three registers
+
+| Register | Answers | Rots? |
+|---|---|---|
+| **Portable canon** | what must be true in *any* implementation | no — it names no symbols |
+| **Realization** | where this codebase currently makes it true | constantly — and should be **generated**, not hand-maintained |
+| **Residue** | transitional paths, compatibility shims, migrations in flight | yes, by design — it is scheduled for deletion |
+
+Canon is implementation-free by construction. Realization is a map produced from the
+index (`tangl-devref`), not a column an author keeps up to date. Residue is tracked
+because it is operationally live, and excluded from the algebra because it is not part
+of what the system *is*.
+
+## The negotiation
+
+The registers are not three filing buckets. Canon and realization are in continuous
+negotiation, and **both directions are legitimate**:
+
+```text
+canon  ──▶ realization      normative:  "this must hold; make the code conform"
+canon  ◀── realization      evidential: "this turned out to be necessary; canon is
+                                         incomplete or wrong"
+```
+
+A mismatch is therefore **not automatically a defect in the code**. `Fanout` entered
+canon because the taxonomy had an unnamed cell — realization pressing upward, correctly.
+`Requirement is-a Selector` is a won convergence discovered in code that canon never
+recorded. Conversely, a canonical chapter describing deleted modules is canon that
+failed to move.
+
+The review question is never "which one is broken" but **"which direction wins here."**
+
+### Three mismatch classes
+
+Naming them matters because two are mechanical and one is not:
+
+| Signal | Direction | Resolution |
+|---|---|---|
+| Canon names a symbol that does not exist | canon decayed | mechanical — fix canon |
+| A public symbol or behaviour exists that canon never mentions | realization pressing up | apply the promotion gate |
+| Both exist and disagree on meaning | genuine negotiation | judgment; the expensive, rare case |
+
+The first two are detectable by tooling — the index already stores symbols. Automating
+them does not remove the review; it **concentrates** the review on the third class,
+which is the only one that needs a person.
+
+### The upward admission test
+
+When realization presses up, the question is whether the pattern joins canon. Consumer
+count is the wrong test — a demo is an instrumented probe, not a sample. Use two keys:
+
+1. its invariants state **without reference to the demo it emerged in**; and
+2. there is positive reason to predict multiple future mechanism-consumers.
+
+There is a third exit that is often correct: **name without promoting** — give the
+pattern a canonical term and recorded invariants, without lifting it into core
+mechanism. Naming is itself a coarsening operation, and most mid-band work ends here.
+
+## Residue is not citable
+
+Residue is important now and irrelevant to the algebra. That implies something stronger
+than a label: **residue must be unreachable from a canon read.** Otherwise a future
+reader — human or agent — takes it as precedent.
+
+The failure mode is live in the tree. `ARCHITECTURE.md:446` states that `World` is a
+singleton `TraversableGraphFactory` subclass, which is true (`story/fabula/world.py:205`).
+`ARCHITECTURE.md:590` forbids "any wrapper layer that pretends `World` is already a
+`GraphFactory` subclass **when it is not**." That prohibition was residue — a guardrail
+for a migration — and it outlived the migration that made it moot. It now sits
+canon-shaped, 144 lines from the canon it contradicts.
+
+Residue belongs in a marked section (ARCHITECTURE's "Transitional Seams" is the right
+shape), never inline with canon, and always with the condition that retires it.
+
+## Worked example: presence, story, and the dispatch layers
+
+The most useful negotiations sharpen canon rather than merely confirming it.
+
+**The signal.** `story/presentation.py` imports `tangl.mechanics.presence`. Read
+naively against the four-layer DAG (`core ← vm ← story ← service`), this is realization
+saying the layer model is wrong — 20 sites import `mechanics → story`, and here is
+`story → mechanics` in the other direction. That reading would have amended canon to
+admit eight layers.
+
+**The examination.** The three imports exist for one purpose: supplying concrete types
+to `wants_caller_kind=` on five `@on_render_text` registrations. There is no functional
+dependency. Meanwhile `mechanics/credentials/presentation.py` registers its own handlers
+from the mechanics side and imports only `on_render_text` from story — the same job,
+correct direction, already in the tree.
+
+**The finding.** The imports were residue (type-checking artifacts) covering a real
+defect: story was *wiring* a mechanic on behalf of every world. Because worlds are the
+composition root, importing `story` should not transitively load presence.
+
+**The result — canon sharpened, not merely upheld.** We began with "story must not
+import mechanics" and ended with a stronger, testable law:
+
+> **The engine wires nothing.** Mechanics register themselves on import; **worlds choose
+> which mechanics to import**. Story knows only that it calls `x`; anything wishing to
+> participate registers with `x` and produces something `x`-shaped.
+
+Note what did *not* change: presence is still legitimately an APPLICATION-layer mechanic,
+because application scope means *available everywhere*, not *used everywhere*. A world
+that never imports presence never loads it, and a single-world server can run with it as
+dead code. The defect was never the layer — it was who caused the import.
+
+## Review rhythm
+
+Conceptual integrity is maintained continuously at several periods, not by episodic
+audits alone. Each scale is the same reconciliation at a different grain:
+
+| Scale | Trigger | Unit | Result |
+|---|---|---|---|
+| **Change** | every substantial PR | "does this introduce or redefine a noun, verb, lifecycle, extension seam, or wire shape?" | accept · rename · update canon |
+| **Topic** | routine | one devref topic | one bounded dossier, at most one correction |
+| **Layer** | periodic | core / vm / story / service / mechanics | primitive census; duplicates and leaked policy |
+| **Coarse** | **triggered** by a canon-level change | whole coarse grid | reconcile canon before any detailed sweep |
+
+The change-scale question is the cheapest guard and prevents more drift than any sweep
+repairs. The topic sweep is the normal working unit. The coarse pass is rare and
+*triggered* — running one against a canon that has not moved is relaxing against a
+reference that is not changing.
+
+**Dossiers are disposable.** A topic review produces a working artifact; only its
+conclusions land in canon. Do not accumulate a second encyclopedia that itself needs
+maintenance.
+
+## What this asks of a reviewer
+
+- State which register a claim belongs to before arguing about it.
+- On a mismatch, decide the *direction* before proposing a fix.
+- Never cite residue as precedent; if residue is load-bearing, it is not residue.
+- Prefer naming to promoting; prefer promoting to inventing.
+- A null result — "this zone is already coherent" — is a successful review.
+- Fix passes are the highest-risk edits in the process: they arrive with momentum and
+  skip the verification the original claims received. Re-verify them at the same
+  standard, then sweep for contradictions introduced by the fix itself.

--- a/docs/src/design/CANON_AND_REALIZATION.md
+++ b/docs/src/design/CANON_AND_REALIZATION.md
@@ -144,7 +144,7 @@ Note what is *not* the defect: presence is legitimately a *shipped default mecha
 whose handlers land in the shared story registry, and that is fine. Once de-wired, a world
 that never imports presence will not load it, and a single-world server can run with it as
 dead code. The defect is neither the layer nor the shared registry — it is **who causes
-the import**. (Layer confers no visibility at all — see *Layers order; registries scope*
+the import**. (Layer confers no visibility at all — see *Layers order; registries scope; folds decide*
 in the [glossary](glossary.md).)
 
 ## Review rhythm

--- a/docs/src/design/CANON_AND_REALIZATION.md
+++ b/docs/src/design/CANON_AND_REALIZATION.md
@@ -116,10 +116,12 @@ import mechanics" and ended with a stronger, testable law:
 > which mechanics to import**. Story knows only that it calls `x`; anything wishing to
 > participate registers with `x` and produces something `x`-shaped.
 
-Note what did *not* change: presence is still legitimately an APPLICATION-layer mechanic,
-because application scope means *available everywhere*, not *used everywhere*. A world
-that never imports presence never loads it, and a single-world server can run with it as
-dead code. The defect was never the layer — it was who caused the import.
+Note what did *not* change: presence is still legitimately a *shipped default mechanic*
+whose handlers land in the shared story registry, and that is fine — a world that never
+imports presence never loads it, and a single-world server can run with it as dead code.
+The defect was never the layer, nor even the shared registry; it was **who caused the
+import**. (Layer confers no visibility at all — see *Layers order; registries scope* in
+the [glossary](glossary.md).)
 
 ## Review rhythm
 

--- a/docs/src/design/CANON_AND_REALIZATION.md
+++ b/docs/src/design/CANON_AND_REALIZATION.md
@@ -23,10 +23,16 @@ the fix is to separate the registers so canon has nothing to rot.
 | **Realization** | where this codebase currently makes it true | constantly — and should be **generated**, not hand-maintained |
 | **Residue** | transitional paths, compatibility shims, migrations in flight | yes, by design — it is scheduled for deletion |
 
-Canon is implementation-free by construction. Realization is a map produced from the
-index (`tangl-devref`), not a column an author keeps up to date. Residue is tracked
-because it is operationally live, and excluded from the algebra because it is not part
-of what the system *is*.
+Canon is implementation-free by construction. Residue is tracked because it is
+operationally live, and excluded from the algebra because it is not part of what the
+system *is*.
+
+**Realization should be generated rather than hand-maintained — this is the target, not
+today's state.** `tangl-devref` indexes symbols and topic-annotated artifacts, which is
+what makes generation *feasible*; it does not yet map canonical claims onto symbols.
+`map` returns a topic's indexed artifacts, nothing more. Closing that gap is the
+proposed `devref audit` (issue #282 lineage), and until it exists the realization column
+is maintained by hand and will keep drifting.
 
 ## The negotiation
 
@@ -57,9 +63,12 @@ Naming them matters because two are mechanical and one is not:
 | A public symbol or behaviour exists that canon never mentions | realization pressing up | apply the promotion gate |
 | Both exist and disagree on meaning | genuine negotiation | judgment; the expensive, rare case |
 
-The first two are detectable by tooling — the index already stores symbols. Automating
-them does not remove the review; it **concentrates** the review on the third class,
-which is the only one that needs a person.
+The first two are *mechanizable* — the index already stores symbols, so a checker could
+verify referenced symbols exist and surface public symbols canon never mentions. No such
+command exists yet, and prose references would need to be annotated (or restricted to a
+recognizable form) for it to work. When it does exist, automating those two will not
+remove the review; it will **concentrate** the review on the third class, which is the
+only one that needs a person.
 
 ### The upward admission test
 
@@ -79,12 +88,18 @@ Residue is important now and irrelevant to the algebra. That implies something s
 than a label: **residue must be unreachable from a canon read.** Otherwise a future
 reader — human or agent — takes it as precedent.
 
-The failure mode is live in the tree. `ARCHITECTURE.md:446` states that `World` is a
-singleton `TraversableGraphFactory` subclass, which is true (`story/fabula/world.py:205`).
-`ARCHITECTURE.md:590` forbids "any wrapper layer that pretends `World` is already a
-`GraphFactory` subclass **when it is not**." That prohibition was residue — a guardrail
-for a migration — and it outlived the migration that made it moot. It now sits
-canon-shaped, 144 lines from the canon it contradicts.
+The specimen this note was written from: `ARCHITECTURE.md` stated that `World` is a
+singleton `TraversableGraphFactory` subclass — true (`story/fabula/world.py:205`) — while
+144 lines later forbidding "any wrapper layer that pretends `World` is already a
+`GraphFactory` subclass **when it is not**." That prohibition was residue, a guardrail for
+a migration, and it outlived the migration that made it moot. Sitting canon-shaped and
+unmarked, it contradicted the canon above it. A neighbouring transitional bullet had the
+same defect, describing the label-based world round-trip as a *pending* migration when it
+is in fact the designed consequence of singleton identity.
+
+**Both were repaired in the change that introduced this note** — canon decay, fixed
+mechanically, which is the whole point. A method note that identifies live decay and
+declines to repair it is arguing against itself.
 
 Residue belongs in a marked section (ARCHITECTURE's "Transitional Seams" is the right
 shape), never inline with canon, and always with the condition that retires it.
@@ -106,22 +121,31 @@ from the mechanics side and imports only `on_render_text` from story — the sam
 correct direction, already in the tree.
 
 **The finding.** The imports were residue (type-checking artifacts) covering a real
-defect: story was *wiring* a mechanic on behalf of every world. Because worlds are the
+defect: story *wires* a mechanic on behalf of every world. Because worlds are the
 composition root, importing `story` should not transitively load presence.
 
 **The result — canon sharpened, not merely upheld.** We began with "story must not
 import mechanics" and ended with a stronger, testable law:
 
-> **The engine wires nothing.** Mechanics register themselves on import; **worlds choose
-> which mechanics to import**. Story knows only that it calls `x`; anything wishing to
-> participate registers with `x` and produces something `x`-shaped.
+> **Engine layers do not wire optional mechanics.** Engine layers legitimately register
+> their own system handlers — VM and story both do, deliberately. What they must not do
+> is wire *optional* mechanics on another party's behalf. Mechanics register themselves
+> on import; **worlds choose which mechanics to import**. Story knows only that it calls
+> `x`; anything wishing to participate registers with `x` and produces something
+> `x`-shaped.
 
-Note what did *not* change: presence is still legitimately a *shipped default mechanic*
-whose handlers land in the shared story registry, and that is fine — a world that never
-imports presence never loads it, and a single-world server can run with it as dead code.
-The defect was never the layer, nor even the shared registry; it was **who caused the
-import**. (Layer confers no visibility at all — see *Layers order; registries scope* in
-the [glossary](glossary.md).)
+**Status: the law is stated, the code does not yet satisfy it.** `story/presentation.py`
+still imports presence at HEAD, so a world that never imports presence still loads it
+through story. The de-wiring — relocating those five `@on_render_text` handlers into
+`mechanics/presence/` — is a pending follow-up, and it needs a sweep of worlds currently
+inheriting presence rendering for free.
+
+Note what is *not* the defect: presence is legitimately a *shipped default mechanic*
+whose handlers land in the shared story registry, and that is fine. Once de-wired, a world
+that never imports presence will not load it, and a single-world server can run with it as
+dead code. The defect is neither the layer nor the shared registry — it is **who causes
+the import**. (Layer confers no visibility at all — see *Layers order; registries scope*
+in the [glossary](glossary.md).)
 
 ## Review rhythm
 

--- a/docs/src/design/glossary.md
+++ b/docs/src/design/glossary.md
@@ -203,9 +203,14 @@ to `seq` — the monotonic registration counter, last key of `sort_key` — so a
 **first registered wins**, which is the expected declaration-order reading. The rare
 override and the ordinary case are served by one rule.
 
-The practical consequence is only that *abstention is the contract*: a redirect handler
-that has no opinion must return `None`, not a default edge. Returning something
-unconditionally at an early layer silently claims every traversal.
+The practical consequence is that *abstention is the contract*: a redirect handler with
+no opinion must return `None`, not a default edge. Returning something unconditionally at
+an early layer silently claims every traversal.
+
+One consequence is worth knowing before choosing a layer: the declarative
+`trigger_phase` edge scanner is itself a `SYSTEM`-layer handler, so it preempts anything
+registered at `APPLICATION`. A redirect meant to trump story-level ones belongs at
+`GLOBAL`. See [Redirect precedence](traversal/NAV_DESIGN.md#redirect-precedence-who-claims-the-jump).
 
 **Folds select results; they do not gate execution.** Every matching handler in the
 assembled chain runs, whatever the fold. All live sites drain the receipt iterator

--- a/docs/src/design/glossary.md
+++ b/docs/src/design/glossary.md
@@ -132,7 +132,8 @@ that distinction.
 | **Behavior** | plugin | Callable registered for a specific task at a specific priority | `core.behavior.Behavior` |
 | **Task** | hook point | Named extension point in the pipeline (e.g., `validate_edge`, `render_journal`) | Task name string |
 | **Priority** | ordering | Execution order within a task, applied *after* layer: FIRST → EARLY → NORMAL → LATE → LAST | `Priority` enum (`core.behavior`) |
-| **Layer** | override scope **and** visibility scope | Two orthogonal meanings — see *Dispatch layers* below. Ladder: GLOBAL < SYSTEM < APPLICATION < AUTHOR < USER < LOCAL | `DispatchLayer` enum (`core.behavior`) |
+| **Layer** | ordering band | Execution order only — the first key of `Behavior.sort_key`. Confers no visibility. Ladder: GLOBAL < SYSTEM < APPLICATION < AUTHOR < USER < LOCAL | `DispatchLayer` enum (`core.behavior`) |
+| **Authority chain** | visibility scope | Which registries are in play for a call — assembled by `chain_execute_all` from explicit args, `ctx.get_authorities()` (graph → world), then inline. **This** is what scopes a handler | `BehaviorRegistry.chain_execute_all`, `World.get_authorities()` |
 | **Aggregation mode** | fold strategy | How multiple handler results combine: `all_true`, `gather`, `merge`, `first`, `last` | `AggregationMode` enum |
 | **Receipt** | audit record | Record of what a handler did: blame_id, result, timing | `JobReceipt` |
 | **on_* / do_*** | event / handler | Hook pair: `on_*` fires registered behaviors; `do_*` is the task implementation | `dispatch.py` in each layer |

--- a/docs/src/design/glossary.md
+++ b/docs/src/design/glossary.md
@@ -134,14 +134,15 @@ that distinction.
 | **Priority** | ordering | Execution order within a task, applied *after* layer: FIRST → EARLY → NORMAL → LATE → LAST | `Priority` enum (`core.behavior`) |
 | **Layer** | ordering band | Execution order only — the first key of `Behavior.sort_key`. Confers no visibility. Ladder: GLOBAL < SYSTEM < APPLICATION < AUTHOR < USER < LOCAL | `DispatchLayer` enum (`core.behavior`) |
 | **Authority chain** | visibility scope | Which registries are in play for a call — assembled by `chain_execute_all` from explicit args, `ctx.get_authorities()` (graph → world), then inline. **This** is what scopes a handler | `BehaviorRegistry.chain_execute_all`, `World.get_authorities()` |
-| **Aggregation mode** | fold strategy | How multiple handler results combine: `all_true`, `gather`, `merge`, `first`, `last` | `AggregationMode` enum |
+| **Fold** (aggregation) | reduction strategy | How the receipts of a task reduce to one result. Chosen **per task at the `do_*` site**, not by the handlers. Decides *who wins* — see below | `CallReceipt.first_result` / `last_result` / `all_true` / `gather_results` / `merge_results`; `AggregationMode` enum names them |
 | **Receipt** | audit record | Record of what a handler did: blame_id, result, timing | `JobReceipt` |
 | **on_* / do_*** | event / handler | Hook pair: `on_*` fires registered behaviors; `do_*` is the task implementation | `dispatch.py` in each layer |
 
-### Layers order; registries scope
+### Layers order; registries scope; folds decide
 
-Two **independent** axes, commonly conflated because the layer *names* suggest scopes.
-They are not scopes.
+Three **independent** axes. The first two are commonly conflated because the layer
+*names* suggest scopes — they are not scopes. The third is missed entirely: order alone
+never determines who wins.
 
 **1 · Registry membership determines visibility.** A behaviour is reachable when the
 registry holding it is in the assembled chain. `BehaviorRegistry.chain_execute_all`
@@ -169,7 +170,38 @@ sorts after the application default, not because it is scoped.
 
 Compounding this, `BehaviorRegistry.default_dispatch_layer` is `APPLICATION`, so a
 registration that omits the layer gets `APPLICATION` **regardless of which registry it
-lands in** — which is exactly how the two axes come to look like one.
+lands in** — which is exactly how the first two axes come to look like one.
+
+**3 · The fold decides who wins.** Sorting fixes the *sequence*; the aggregator chosen at
+the `do_*` site fixes what that sequence *means*. "Later wins" is a property of the fold,
+not of the ladder — and under `first_result` **the ladder inverts**:
+
+| Fold | Winner | Effect on the ladder | Live tasks |
+|---|---|---|---|
+| `last_result` | last non-`None` | `LOCAL` beats `GLOBAL` — the override reading | `do_add_item`, `do_get_item`, `finalize_step`, `do_render_text`, media spec adaptation |
+| `first_result` | first non-`None` | **`GLOBAL` beats `LOCAL` — inverted** | `get_prereqs`, `get_postreqs` |
+| `all_true` | no winner — gate | order does not affect the outcome | `validate_edge` |
+| `gather_results` | no winner — collects | order sets list order | `provision_node`, `apply_update` |
+| `merge_results` | no winner — flattens | lists concatenate in order; on dict-key collision **later wins** (`ChainMap` over reversed results) | `do_create`, step dispatch |
+
+So a claim like "the `LOCAL` handler overrides the others" is only true for a
+`last_result` task. Registering a `LOCAL` prereq handler expecting it to override the
+default gets the opposite: `get_prereqs` folds with `first_result`, so the earliest
+non-`None` result wins and the `LOCAL` handler is reached only if everything before it
+abstained.
+
+**Folds select results; they do not gate execution.** Every matching handler in the
+assembled chain runs, whatever the fold. All live sites drain the receipt iterator
+through varargs (`CallReceipt.first_result(*receipts)`), so `first_result` is a *selection*
+over completed calls, not an early exit — side effects of later handlers still happen.
+The way a handler declines is to **return `None`**: its receipt is retained for audit but
+takes no part in the reduction.
+
+*Realization note.* `AggregationMode` and `CallReceipt.aggregate()` are exported and unit
+tested but have no live production call site — every `do_*` calls the `CallReceipt`
+classmethods directly, and the `PhaseSpec` table that would have consumed the enum is
+commented out in `vm/resolution_phase.py`. Treat the enum as the vocabulary for these
+folds, not as the dispatch path.
 
 **Related invariant:** the engine wires no mechanics. Mechanics register themselves on
 import, and worlds choose which to import — see

--- a/docs/src/design/glossary.md
+++ b/docs/src/design/glossary.md
@@ -137,34 +137,38 @@ that distinction.
 | **Receipt** | audit record | Record of what a handler did: blame_id, result, timing | `JobReceipt` |
 | **on_* / do_*** | event / handler | Hook pair: `on_*` fires registered behaviors; `do_*` is the task implementation | `dispatch.py` in each layer |
 
-### Dispatch layers carry two orthogonal meanings
+### Layers order; registries scope
 
-`DispatchLayer` is usually read as ordering alone. It is also an **isolation scope**, and
-choosing a layer is therefore an authoring decision about visibility, not only about
-override precedence.
+Two **independent** axes, commonly conflated because the layer *names* suggest scopes.
+They are not scopes.
 
-```text
-GLOBAL < SYSTEM < APPLICATION < AUTHOR < USER < LOCAL
-```
+**1 · Registry membership determines visibility.** A behaviour is reachable when the
+registry holding it is in the assembled chain. `BehaviorRegistry.chain_execute_all`
+assembles registries from explicit arguments, then `ctx.get_authorities()` (which
+cascades graph → world, with `World.get_authorities()` returning the world's own
+`dispatch` registry plus any extra authorities), then inline behaviours — deduplicated by
+identity. Handlers from *all* assembled registries are then pooled together.
 
-**1 · Execution order.** Layer sorts before per-layer `Priority`. `LOCAL` sorts *last*
-so it can observe and aggregate what earlier layers produced.
+**2 · `DispatchLayer` determines order only.** It is simply the first element of
+`Behavior.sort_key` — `(dispatch_layer, priority, wants_exact_kind, seq)` — applied across
+that pooled set. It confers no visibility of any kind. `LOCAL` sorts last so it can
+observe and aggregate what earlier layers produced.
 
-**2 · Visibility scope.** Handlers reach a call through the authority chain assembled by
-`BehaviorRegistry` from `ctx.get_authorities()` (`core.behavior`), which cascades
-graph → world:
-
-| Layer | Scope | Meaning |
+| Where it is registered | Visible | Layer's role there |
 |---|---|---|
-| `APPLICATION` | process-wide once imported | **available everywhere, not used everywhere.** A shipped mechanic registers here; a world that never imports it never loads it, and it stays dead code in that process |
-| `AUTHOR` | world-private | supplied by one world, reached only via that world's authority chain; other worlds do not see it |
-| `USER` / `LOCAL` | narrower still | per-session and per-call overrides, applied last |
+| shared module registry (e.g. `story_dispatch`) | everywhere that registry is consulted | ordering only — an `AUTHOR`-layer handler here is still global, just sorted later |
+| a world's own `dispatch` registry | only when that world's authorities are in the chain | ordering only — a `SYSTEM`-layer handler here is still world-private, just sorted first |
 
-**Consequence authors should know:** an `APPLICATION`-level registration made *by a
-world* becomes visible to every other world in the same process. In a single-world
-process this is harmless. In a multi-tenant process it is an export — deliberate if you
-meant it, and your responsibility if you did not. Register world-specific behaviour at
-`AUTHOR` to keep it private.
+**The practical trap.** The module-level decorators (`@on_render_text`, `@on_gather_ns`,
+…) register into the **shared** story registry. Passing `dispatch_layer=AUTHOR` to one of
+them does **not** make a handler world-private — it only makes it sort later. To get
+world-privacy, register into the world's own registry. `worlds/composed_beat_demo` is a
+live example of the ordering use: its `AUTHOR`-layer namespace override wins because it
+sorts after the application default, not because it is scoped.
+
+Compounding this, `BehaviorRegistry.default_dispatch_layer` is `APPLICATION`, so a
+registration that omits the layer gets `APPLICATION` **regardless of which registry it
+lands in** — which is exactly how the two axes come to look like one.
 
 **Related invariant:** the engine wires no mechanics. Mechanics register themselves on
 import, and worlds choose which to import — see

--- a/docs/src/design/glossary.md
+++ b/docs/src/design/glossary.md
@@ -210,7 +210,7 @@ an early layer silently claims every traversal.
 One consequence is worth knowing before choosing a layer: the declarative
 `trigger_phase` edge scanner is itself a `SYSTEM`-layer handler, so it preempts anything
 registered at `APPLICATION`. A redirect meant to trump story-level ones belongs at
-`GLOBAL`. See [Redirect precedence](traversal/NAV_DESIGN.md#redirect-precedence-who-claims-the-jump).
+`GLOBAL`. See {ref}`Redirect precedence <redirect-precedence>`.
 
 **Folds select results; they do not gate execution.** Every matching handler in the
 assembled chain runs, whatever the fold. All live sites drain the receipt iterator

--- a/docs/src/design/glossary.md
+++ b/docs/src/design/glossary.md
@@ -174,7 +174,15 @@ lands in** — which is exactly how the first two axes come to look like one.
 
 **3 · The fold decides who wins.** Sorting fixes the *sequence*; the aggregator chosen at
 the `do_*` site fixes what that sequence *means*. "Later wins" is a property of the fold,
-not of the ladder — and under `first_result` **the ladder inverts**:
+not of the ladder. The two single-winner folds encode two different **kinds of decision**,
+and they read the ladder in opposite directions on purpose:
+
+- **Refinement** (`last_result`) — every layer contributes and the most specific one
+  stands. Later layers *see* what earlier ones produced, so `LOCAL` sorting last is what
+  makes an override possible.
+- **Interception** (`first_result`) — the first authority to claim the decision takes it,
+  and nothing downstream can un-claim it. Here `GLOBAL` sorting first is exactly right:
+  the broadest authority gets first refusal.
 
 | Fold | Winner | Effect on the ladder | Live tasks |
 |---|---|---|---|
@@ -184,11 +192,20 @@ not of the ladder — and under `first_result` **the ladder inverts**:
 | `gather_results` | no winner — collects | order sets list order | `provision_node`, `apply_update` |
 | `merge_results` | no winner — flattens | lists concatenate in order; on dict-key collision **later wins** (`ChainMap` over reversed results) | `do_create`, step dispatch |
 
-So a claim like "the `LOCAL` handler overrides the others" is only true for a
-`last_result` task. Registering a `LOCAL` prereq handler expecting it to override the
-default gets the opposite: `get_prereqs` folds with `first_result`, so the earliest
-non-`None` result wins and the `LOCAL` handler is reached only if everything before it
-abstained.
+So "the `LOCAL` handler overrides the others" is only true for a `last_result` task.
+
+**Why redirects intercept.** `get_prereqs` / `get_postreqs` return an optional redirect
+edge, which is a *claim on where the traversal goes next* — not a value to refine. An
+application-wide redirect is rare, but when one exists it should trump any story-level
+redirect, and interception gives that for free without a precedence table. Meanwhile the
+common case is several redirects registered at the **same** layer, where the fold degrades
+to `seq` — the monotonic registration counter, last key of `sort_key` — so among peers
+**first registered wins**, which is the expected declaration-order reading. The rare
+override and the ordinary case are served by one rule.
+
+The practical consequence is only that *abstention is the contract*: a redirect handler
+that has no opinion must return `None`, not a default edge. Returning something
+unconditionally at an early layer silently claims every traversal.
 
 **Folds select results; they do not gate execution.** Every matching handler in the
 assembled chain runs, whatever the fold. All live sites drain the receipt iterator

--- a/docs/src/design/glossary.md
+++ b/docs/src/design/glossary.md
@@ -131,11 +131,44 @@ that distinction.
 |------|----------|------------|----------------|
 | **Behavior** | plugin | Callable registered for a specific task at a specific priority | `core.behavior.Behavior` |
 | **Task** | hook point | Named extension point in the pipeline (e.g., `validate_edge`, `render_journal`) | Task name string |
-| **Priority** | ordering | Execution order within a task: EARLY → NORMAL → LATE | `HandlerPriority` enum |
-| **Layer** | override scope | Dispatch tier: SYSTEM < APPLICATION < DOMAIN < INSTANCE | `DispatchLayer` enum |
+| **Priority** | ordering | Execution order within a task, applied *after* layer: FIRST → EARLY → NORMAL → LATE → LAST | `Priority` enum (`core.behavior`) |
+| **Layer** | override scope **and** visibility scope | Two orthogonal meanings — see *Dispatch layers* below. Ladder: GLOBAL < SYSTEM < APPLICATION < AUTHOR < USER < LOCAL | `DispatchLayer` enum (`core.behavior`) |
 | **Aggregation mode** | fold strategy | How multiple handler results combine: `all_true`, `gather`, `merge`, `first`, `last` | `AggregationMode` enum |
 | **Receipt** | audit record | Record of what a handler did: blame_id, result, timing | `JobReceipt` |
 | **on_* / do_*** | event / handler | Hook pair: `on_*` fires registered behaviors; `do_*` is the task implementation | `dispatch.py` in each layer |
+
+### Dispatch layers carry two orthogonal meanings
+
+`DispatchLayer` is usually read as ordering alone. It is also an **isolation scope**, and
+choosing a layer is therefore an authoring decision about visibility, not only about
+override precedence.
+
+```text
+GLOBAL < SYSTEM < APPLICATION < AUTHOR < USER < LOCAL
+```
+
+**1 · Execution order.** Layer sorts before per-layer `Priority`. `LOCAL` sorts *last*
+so it can observe and aggregate what earlier layers produced.
+
+**2 · Visibility scope.** Handlers reach a call through the authority chain assembled by
+`BehaviorRegistry` from `ctx.get_authorities()` (`core.behavior`), which cascades
+graph → world:
+
+| Layer | Scope | Meaning |
+|---|---|---|
+| `APPLICATION` | process-wide once imported | **available everywhere, not used everywhere.** A shipped mechanic registers here; a world that never imports it never loads it, and it stays dead code in that process |
+| `AUTHOR` | world-private | supplied by one world, reached only via that world's authority chain; other worlds do not see it |
+| `USER` / `LOCAL` | narrower still | per-session and per-call overrides, applied last |
+
+**Consequence authors should know:** an `APPLICATION`-level registration made *by a
+world* becomes visible to every other world in the same process. In a single-world
+process this is harmless. In a multi-tenant process it is an export — deliberate if you
+meant it, and your responsibility if you did not. Register world-specific behaviour at
+`AUTHOR` to keep it private.
+
+**Related invariant:** the engine wires no mechanics. Mechanics register themselves on
+import, and worlds choose which to import — see
+[CANON_AND_REALIZATION.md](CANON_AND_REALIZATION.md).
 
 ## Content and Presentation
 

--- a/docs/src/design/index.rst
+++ b/docs/src/design/index.rst
@@ -15,6 +15,7 @@ See also
 
    story/philosophy
    SIMPLIFICATION_SPEC
+   CANON_AND_REALIZATION
 
    core/CONTENT_ADDRESSABLE
    core/DEREF_DESIGN

--- a/docs/src/design/story/BEAT_COMPOSITION.md
+++ b/docs/src/design/story/BEAT_COMPOSITION.md
@@ -75,7 +75,7 @@ channel per assertion. Mapping:
 | Channel | Demo element |
 | --- | --- |
 | data-scope chunk override | `dock_mood` in story vs block `locals:` |
-| handler-scope chunk override | `porter_greeting`, APPLICATION vs AUTHOR `gather_ns` |
+| dispatch-order chunk override | `porter_greeting`, APPLICATION vs AUTHOR `gather_ns` |
 | conditional render enrichment | Maro's reaction, gated on `reputation` |
 | cross-phase enrichment | manifest incident injected during UPDATE |
 | composition | slot ordering, fog substitution, beat overlay |

--- a/docs/src/design/traversal/NAV_DESIGN.md
+++ b/docs/src/design/traversal/NAV_DESIGN.md
@@ -43,3 +43,48 @@ def navigation_assistant(frame: Frame) -> ChoiceEdge | None:
         return choices[0]
     return None
 ```
+## Redirect precedence: who claims the jump
+
+Both phases fold with `first_result` (see *Layers order; registries scope; folds decide*
+in the [glossary](../glossary.md)). Redirects **intercept**: the first handler to return
+an edge claims the traversal, and nothing downstream can un-claim it. A handler with no
+opinion must return `None`.
+
+That makes the dispatch layer a statement about **whose concern preempts whose**.
+
+**Application-wide — preemptive, indifferent to local state.** *"You have seen all the
+content; here is how to subscribe for updates."* It does not matter where the player was
+going; they are going to the outro. The condition is orthogonal to the fiction and
+dominates it.
+
+**World — conditional, and abstains when its condition does not hold.** *"The bridge
+collapses under your weight and you tumble into the abyss"* when the crossing
+prerequisites were not met. If they were met, the handler returns `None` and the player
+takes the regular crossing. The redirect is a legitimate alternate destination, not a
+failure — that is what distinguishes it from `validate_edge`, which folds with `all_true`
+and **blocks** the move rather than substituting a different one.
+
+### The layer that actually preempts is `GLOBAL`, not `APPLICATION`
+
+The declarative surface above — edges carrying `trigger_phase` — is itself implemented as
+a handler: `follow_triggered_prereqs` / `follow_triggered_postreqs` in
+`vm/system_handlers.py`, registered through `@on_prereqs` into `vm_dispatch`, whose
+`default_dispatch_layer` is **`SYSTEM`**. Since `SYSTEM` (1) sorts before `APPLICATION`
+(2), and interception gives the decision to whoever gets there first:
+
+| Order | Handler | Claims when |
+|---|---|---|
+| `GLOBAL` (0) | *(nothing registered today)* | — |
+| `SYSTEM` (1) | `follow_triggered_prereqs` | **any** authored `trigger_phase` edge whose guard passes |
+| `APPLICATION` (2) | app-wide redirects | only if no trigger edge fired |
+| `AUTHOR` (3)+ | world/world-instance handlers | only if nothing above claimed |
+
+So an app-wide outro registered at `DispatchLayer.APPLICATION` is **preempted by any
+authored trigger edge** — the bridge would win over the outro, which inverts the intent.
+A redirect that must genuinely trump story-level ones has to register at
+`DispatchLayer.GLOBAL`, the only band below `SYSTEM`.
+
+This is the layer-name trap again: "application-wide" describes *reach*, and the layer
+named `APPLICATION` does not deliver it here because the declarative trigger-edge scanner
+sits below it. Worlds that express their redirects as `trigger_phase` edges (the normal
+path) are effectively redirecting at `SYSTEM`.

--- a/docs/src/design/traversal/NAV_DESIGN.md
+++ b/docs/src/design/traversal/NAV_DESIGN.md
@@ -43,6 +43,7 @@ def navigation_assistant(frame: Frame) -> ChoiceEdge | None:
         return choices[0]
     return None
 ```
+(redirect-precedence)=
 ## Redirect precedence: who claims the jump
 
 Both phases fold with `first_result` (see *Layers order; registries scope; folds decide*

--- a/engine/src/tangl/core/behavior.py
+++ b/engine/src/tangl/core/behavior.py
@@ -83,9 +83,16 @@ class AggregationMode(Enum):
     called; the mode picks among the results that come back. A behavior abstains by
     returning ``None``, which keeps its receipt for audit but drops it from reduction.
 
-    Note that :attr:`FIRST` and :attr:`LAST` read the dispatch ladder in opposite
-    directions: under ``LAST`` a ``LOCAL`` handler overrides earlier layers, while under
-    ``FIRST`` it is reached only if every earlier layer abstained.
+    :attr:`FIRST` and :attr:`LAST` read the dispatch ladder in opposite directions, by
+    design — they encode different kinds of decision:
+
+    - ``LAST`` is *refinement*: every layer contributes and the most specific one stands,
+      so ``LOCAL`` sorting last is what makes an override possible.
+    - ``FIRST`` is *interception*: the first authority to claim the decision takes it, so
+      ``GLOBAL`` sorting first gives the broadest authority first refusal. Used for
+      redirects (``get_prereqs`` / ``get_postreqs``), where a rare application-wide
+      redirect should trump story-level ones, and same-layer peers fall through to
+      registration order. A handler with no opinion must return ``None``.
     """
     FIRST = "first_result"       # First non-None wins (earliest layer)
     LAST = PIPE = "last_result"  # Last non-None wins (latest layer overrides)

--- a/engine/src/tangl/core/behavior.py
+++ b/engine/src/tangl/core/behavior.py
@@ -77,9 +77,18 @@ class RuntimeCtx(DispatchCtx, Protocol):
 
 
 class AggregationMode(Enum):
-    """How to reduce multiple receipts to a result."""
-    FIRST = "first_result"       # Early-exit, first wins
-    LAST = PIPE = "last_result"  # Composite result
+    """How to reduce multiple receipts to a result.
+
+    Selection only — no mode gates execution. Every matching behavior in the chain is
+    called; the mode picks among the results that come back. A behavior abstains by
+    returning ``None``, which keeps its receipt for audit but drops it from reduction.
+
+    Note that :attr:`FIRST` and :attr:`LAST` read the dispatch ladder in opposite
+    directions: under ``LAST`` a ``LOCAL`` handler overrides earlier layers, while under
+    ``FIRST`` it is reached only if every earlier layer abstained.
+    """
+    FIRST = "first_result"       # First non-None wins (earliest layer)
+    LAST = PIPE = "last_result"  # Last non-None wins (latest layer overrides)
     ALL_TRUE = "all_true"        # Validation gate
     GATHER = "gather_results"    # Collect all
     MERGE = "merge_results"      # Flatten/combine, later wins

--- a/engine/tests/vm/test_redirect_precedence.py
+++ b/engine/tests/vm/test_redirect_precedence.py
@@ -1,0 +1,382 @@
+"""Precedence matrix for PREREQS / POSTREQS redirects.
+
+``get_prereqs`` and ``get_postreqs`` fold with :meth:`CallReceipt.first_result`, so a
+redirect **intercepts**: the first handler to return an edge claims the traversal and
+nothing downstream can un-claim it. Which handler gets there first is decided by
+``Behavior.sort_key``, whose first element is the dispatch layer.
+
+Existing tests cover the pieces in isolation — layer sorting, authority-chain assembly,
+``first_result``, handler redirects, declarative trigger edges. This module covers the
+*combination*: several simultaneous redirect claims at different layers, conditional
+abstention, and an assertion about which destination actually wins.
+
+These are **characterization tests**. They pin current behaviour, including the defect
+in issue #360 (the ``SYSTEM``-layer trigger-edge scanner preempts ``APPLICATION``).
+``test_system_trigger_edge_preempts_application_handler`` is the one that is expected to
+change if #360 moves the scanner's layer; it is marked so it is found rather than
+mechanically "fixed".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tangl.core import BehaviorRegistry, DispatchLayer, Selector
+from tangl.vm.dispatch import dispatch as vm_dispatch, do_prereqs, on_prereqs
+from tangl.vm.resolution_phase import ResolutionPhase
+from tangl.vm.system_handlers import follow_triggered_prereqs
+
+from .conftest import _edge, _node
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def crossing(graph):
+    """Origin with two reachable destinations, plus a spare for global redirects.
+
+    Returns ``(origin, regular, collapse, outro)``. No edge is triggered by default.
+    """
+    origin = _node(graph, label="bridge_approach")
+    regular = _node(graph, label="far_side")
+    collapse = _node(graph, label="abyss")
+    outro = _node(graph, label="subscribe_outro")
+    _edge(graph, predecessor_id=origin.uid, successor_id=regular.uid)
+    return origin, regular, collapse, outro
+
+
+@pytest.fixture
+def scanner():
+    """Re-register the real declarative trigger-edge scanner at its own layer.
+
+    The autouse ``clean_vm_dispatch`` fixture clears ``vm_dispatch``, which removes the
+    system handlers. Tests that exercise declarative ``trigger_phase`` edges need the
+    genuine article back. ``BehaviorRegistry.register`` returns the decorated function
+    and stashes the Behavior on ``func._behavior``, so re-adding *that* restores the
+    real registration — including its SYSTEM layer — rather than re-deriving one.
+    """
+    behavior = follow_triggered_prereqs._behavior
+    vm_dispatch.add(behavior)
+    return behavior
+
+
+def _claim(edge, *, layer, calls=None, name=None, when=lambda **kw: True):
+    """Build a redirect handler that claims ``edge`` when ``when`` passes."""
+
+    def handler(*, caller, ctx, **kw):
+        if calls is not None:
+            calls.append(name or layer.name)
+        return edge if when(caller=caller, ctx=ctx, **kw) else None
+
+    handler.__name__ = f"claim_{name or layer.name.lower()}"
+    return handler
+
+
+def _world_registry(label="world_dispatch", layer=DispatchLayer.AUTHOR):
+    """A world's own authority registry, as ``World.get_authorities()`` would supply."""
+    return BehaviorRegistry(label=label, default_dispatch_layer=layer)
+
+
+# ---------------------------------------------------------------------------
+# The ladder
+# ---------------------------------------------------------------------------
+
+
+class TestRedirectLadder:
+    """Which layer's claim survives when several handlers all return an edge."""
+
+    def test_global_beats_every_later_layer(self, graph, crossing, null_ctx):
+        origin, regular, collapse, outro = crossing
+        to_outro = _edge(graph, predecessor_id=origin.uid, successor_id=outro.uid)
+        to_collapse = _edge(graph, predecessor_id=origin.uid, successor_id=collapse.uid)
+
+        on_prereqs(_claim(to_collapse, layer=DispatchLayer.AUTHOR),
+                   dispatch_layer=DispatchLayer.AUTHOR)
+        on_prereqs(_claim(to_collapse, layer=DispatchLayer.APPLICATION),
+                   dispatch_layer=DispatchLayer.APPLICATION)
+        on_prereqs(_claim(to_outro, layer=DispatchLayer.GLOBAL),
+                   dispatch_layer=DispatchLayer.GLOBAL)
+
+        result = do_prereqs(origin, ctx=null_ctx)
+        assert result is to_outro
+        assert result.successor.get_label() == "subscribe_outro"
+
+    def test_application_beats_author(self, graph, crossing, null_ctx):
+        origin, regular, collapse, outro = crossing
+        to_outro = _edge(graph, predecessor_id=origin.uid, successor_id=outro.uid)
+        to_collapse = _edge(graph, predecessor_id=origin.uid, successor_id=collapse.uid)
+
+        on_prereqs(_claim(to_collapse, layer=DispatchLayer.AUTHOR),
+                   dispatch_layer=DispatchLayer.AUTHOR)
+        on_prereqs(_claim(to_outro, layer=DispatchLayer.APPLICATION),
+                   dispatch_layer=DispatchLayer.APPLICATION)
+
+        assert do_prereqs(origin, ctx=null_ctx) is to_outro
+
+    def test_same_layer_falls_through_to_registration_order(self, graph, crossing, null_ctx):
+        """Peers at one layer resolve by ``seq`` — first registered wins."""
+        origin, regular, collapse, outro = crossing
+        first = _edge(graph, predecessor_id=origin.uid, successor_id=collapse.uid)
+        second = _edge(graph, predecessor_id=origin.uid, successor_id=outro.uid)
+
+        on_prereqs(_claim(first, layer=DispatchLayer.AUTHOR, name="first"),
+                   dispatch_layer=DispatchLayer.AUTHOR)
+        on_prereqs(_claim(second, layer=DispatchLayer.AUTHOR, name="second"),
+                   dispatch_layer=DispatchLayer.AUTHOR)
+
+        assert do_prereqs(origin, ctx=null_ctx) is first
+
+
+# ---------------------------------------------------------------------------
+# The declarative scanner's position — issue #360
+# ---------------------------------------------------------------------------
+
+
+class TestTriggerEdgePrecedence:
+    """Where the declarative ``trigger_phase`` surface sits in the ladder."""
+
+    def test_system_trigger_edge_preempts_application_handler(
+        self, graph, crossing, null_ctx, scanner
+    ):
+        """CHARACTERIZATION — pins the issue #360 defect.
+
+        The authored bridge-collapse trigger edge beats the application-wide outro,
+        because the scanner registers at SYSTEM (1) and SYSTEM sorts before
+        APPLICATION (2). This is the inverse of the intended precedence. **Expected to
+        change if #360 relocates the scanner** — update deliberately, do not "fix".
+        """
+        origin, regular, collapse, outro = crossing
+        to_outro = _edge(graph, predecessor_id=origin.uid, successor_id=outro.uid)
+        to_collapse = _edge(
+            graph,
+            predecessor_id=origin.uid,
+            successor_id=collapse.uid,
+            trigger_phase=ResolutionPhase.PREREQS,
+        )
+
+        on_prereqs(_claim(to_outro, layer=DispatchLayer.APPLICATION),
+                   dispatch_layer=DispatchLayer.APPLICATION)
+
+        result = do_prereqs(origin, ctx=null_ctx)
+        assert result is to_collapse, "the bridge currently beats the outro"
+        assert result.successor.get_label() == "abyss"
+
+    def test_global_handler_beats_system_trigger_edge(
+        self, graph, crossing, null_ctx, scanner
+    ):
+        """The documented workaround: GLOBAL is the band that actually preempts."""
+        origin, regular, collapse, outro = crossing
+        to_outro = _edge(graph, predecessor_id=origin.uid, successor_id=outro.uid)
+        _edge(
+            graph,
+            predecessor_id=origin.uid,
+            successor_id=collapse.uid,
+            trigger_phase=ResolutionPhase.PREREQS,
+        )
+
+        on_prereqs(_claim(to_outro, layer=DispatchLayer.GLOBAL),
+                   dispatch_layer=DispatchLayer.GLOBAL)
+
+        result = do_prereqs(origin, ctx=null_ctx)
+        assert result is to_outro
+        assert result.successor.get_label() == "subscribe_outro"
+
+
+# ---------------------------------------------------------------------------
+# Abstention
+# ---------------------------------------------------------------------------
+
+
+class TestAbstention:
+    """Returning ``None`` is how a handler declines to claim the traversal."""
+
+    def test_abstaining_layer_yields_to_the_next(self, graph, crossing, null_ctx):
+        origin, regular, collapse, outro = crossing
+        to_collapse = _edge(graph, predecessor_id=origin.uid, successor_id=collapse.uid)
+
+        on_prereqs(_claim(None, layer=DispatchLayer.GLOBAL, when=lambda **kw: False),
+                   dispatch_layer=DispatchLayer.GLOBAL)
+        on_prereqs(_claim(to_collapse, layer=DispatchLayer.AUTHOR),
+                   dispatch_layer=DispatchLayer.AUTHOR)
+
+        assert do_prereqs(origin, ctx=null_ctx) is to_collapse
+
+    def test_all_abstaining_means_no_redirect(self, graph, crossing, null_ctx):
+        origin, regular, collapse, outro = crossing
+
+        for layer in (DispatchLayer.GLOBAL, DispatchLayer.APPLICATION, DispatchLayer.AUTHOR):
+            on_prereqs(_claim(None, layer=layer, when=lambda **kw: False),
+                       dispatch_layer=layer)
+
+        assert do_prereqs(origin, ctx=null_ctx) is None
+
+    def test_conditional_world_redirect_abstains_when_prerequisite_met(
+        self, graph, crossing, ctx_factory
+    ):
+        """The bridge: collapse when the crossing prerequisite was not met, else abstain.
+
+        Abstention is what lets the regular crossing happen — the redirect is an
+        alternate destination, not a failure.
+        """
+        origin, regular, collapse, outro = crossing
+        to_collapse = _edge(graph, predecessor_id=origin.uid, successor_id=collapse.uid)
+
+        world = _world_registry()
+        world.register(
+            func=_claim(
+                to_collapse,
+                layer=DispatchLayer.AUTHOR,
+                when=lambda *, ctx, **kw: not getattr(ctx, "rope_secured", False),
+            ),
+            task="get_prereqs",
+        )
+
+        unprepared = ctx_factory(registries=[world])
+        unprepared.rope_secured = False
+        assert do_prereqs(origin, ctx=unprepared) is to_collapse
+
+        prepared = ctx_factory(registries=[world])
+        prepared.rope_secured = True
+        assert do_prereqs(origin, ctx=prepared) is None, "prepared crossing is not redirected"
+
+
+# ---------------------------------------------------------------------------
+# Folds select; they do not gate
+# ---------------------------------------------------------------------------
+
+
+class TestFoldDoesNotGateExecution:
+    def test_every_handler_runs_even_after_a_winner_is_found(self, graph, crossing, null_ctx):
+        """``first_result`` selects over completed calls — later handlers still execute."""
+        origin, regular, collapse, outro = crossing
+        to_outro = _edge(graph, predecessor_id=origin.uid, successor_id=outro.uid)
+        to_collapse = _edge(graph, predecessor_id=origin.uid, successor_id=collapse.uid)
+        calls: list[str] = []
+
+        on_prereqs(_claim(to_outro, layer=DispatchLayer.GLOBAL, calls=calls),
+                   dispatch_layer=DispatchLayer.GLOBAL)
+        on_prereqs(_claim(to_collapse, layer=DispatchLayer.APPLICATION, calls=calls),
+                   dispatch_layer=DispatchLayer.APPLICATION)
+        on_prereqs(_claim(to_collapse, layer=DispatchLayer.AUTHOR, calls=calls),
+                   dispatch_layer=DispatchLayer.AUTHOR)
+
+        assert do_prereqs(origin, ctx=null_ctx) is to_outro
+        assert calls == ["GLOBAL", "APPLICATION", "AUTHOR"], (
+            "all handlers execute in ladder order despite GLOBAL winning"
+        )
+
+
+# ---------------------------------------------------------------------------
+# The four scoping patterns
+# ---------------------------------------------------------------------------
+
+
+class TestScopingPatterns:
+    """Each redirect scope reaches its destination when nothing above it claims."""
+
+    def test_world_specific_choice_to_alternate_destination(
+        self, graph, crossing, ctx_factory
+    ):
+        """One world, one situation — a handler in that world's own registry."""
+        origin, regular, collapse, outro = crossing
+        to_collapse = _edge(graph, predecessor_id=origin.uid, successor_id=collapse.uid)
+
+        world = _world_registry()
+        world.register(
+            func=_claim(
+                to_collapse,
+                layer=DispatchLayer.AUTHOR,
+                when=lambda *, caller, **kw: caller.get_label() == "bridge_approach",
+            ),
+            task="get_prereqs",
+        )
+
+        ctx = ctx_factory(registries=[world])
+        assert do_prereqs(origin, ctx=ctx) is to_collapse
+        assert do_prereqs(regular, ctx=ctx) is None, "other nodes are unaffected"
+
+    def test_any_choice_in_one_world_to_common_ending(self, graph, crossing, ctx_factory):
+        """A broad handler in one world's registry — invisible to other worlds."""
+        origin, regular, collapse, outro = crossing
+        to_outro = _edge(graph, predecessor_id=origin.uid, successor_id=outro.uid)
+
+        world = _world_registry()
+        world.register(
+            func=_claim(to_outro, layer=DispatchLayer.AUTHOR), task="get_prereqs"
+        )
+
+        in_world = ctx_factory(registries=[world])
+        assert do_prereqs(origin, ctx=in_world) is to_outro
+        assert do_prereqs(regular, ctx=in_world) is to_outro, "any node in this world"
+
+        other_world = ctx_factory(registries=[_world_registry("other_world")])
+        assert do_prereqs(origin, ctx=other_world) is None, (
+            "registry membership scopes it — a different world never sees this handler"
+        )
+
+    def test_any_choice_in_any_world_to_system_interruption(
+        self, graph, crossing, ctx_factory
+    ):
+        """A shared handler at GLOBAL — preempts everything, in every world."""
+        origin, regular, collapse, outro = crossing
+        to_outro = _edge(graph, predecessor_id=origin.uid, successor_id=outro.uid)
+
+        on_prereqs(_claim(to_outro, layer=DispatchLayer.GLOBAL),
+                   dispatch_layer=DispatchLayer.GLOBAL)
+
+        for registries in ([], [_world_registry()], [_world_registry("another")]):
+            ctx = ctx_factory(registries=registries)
+            assert do_prereqs(origin, ctx=ctx) is to_outro
+
+    def test_specific_choice_in_specific_world_to_system_warning(
+        self, graph, crossing, ctx_factory
+    ):
+        """A shared handler that inspects caller and world before claiming."""
+        origin, regular, collapse, outro = crossing
+        to_outro = _edge(graph, predecessor_id=origin.uid, successor_id=outro.uid)
+
+        target_world = _world_registry("target_world")
+
+        def in_target_world(*, ctx, **kw):
+            return any(r.label == "target_world" for r in ctx.get_authorities())
+
+        on_prereqs(
+            _claim(
+                to_outro,
+                layer=DispatchLayer.GLOBAL,
+                when=lambda *, caller, ctx, **kw: (
+                    caller.get_label() == "bridge_approach" and in_target_world(ctx=ctx)
+                ),
+            ),
+            dispatch_layer=DispatchLayer.GLOBAL,
+        )
+
+        hit = ctx_factory(registries=[target_world])
+        assert do_prereqs(origin, ctx=hit) is to_outro
+
+        wrong_node = ctx_factory(registries=[target_world])
+        assert do_prereqs(regular, ctx=wrong_node) is None
+
+        wrong_world = ctx_factory(registries=[_world_registry("elsewhere")])
+        assert do_prereqs(origin, ctx=wrong_world) is None
+
+
+# ---------------------------------------------------------------------------
+# Guard: the scanner's layer is what the matrix above assumes
+# ---------------------------------------------------------------------------
+
+
+def test_trigger_scanner_registers_at_system_layer(scanner):
+    """If this fails, issue #360 was acted on and the matrix above needs re-reading."""
+    registered = [
+        b for b in vm_dispatch.find_all(Selector(task="get_prereqs"))
+        if b.func is follow_triggered_prereqs
+    ]
+    assert registered, "scanner not registered"
+    # ``DispatchLayer`` is an IntEnum and the field round-trips as a plain int,
+    # so compare by value rather than identity.
+    assert registered[0].dispatch_layer == DispatchLayer.SYSTEM
+    assert scanner.dispatch_layer == DispatchLayer.SYSTEM


### PR DESCRIPTION
## Summary

Docs only. Two additions from the Barracuda down-sweep (#354) that address *why* canonical docs drift, rather than repairing individual instances.

### `docs/src/design/CANON_AND_REALIZATION.md` (new)

The method companion to `SIMPLIFICATION_SPEC.md` — that doc holds the *what* (concepts a reimplementation must preserve); this holds the *how*.

- **Three registers.** Portable canon (implementation-free, so it has nothing to rot) · realization (a map *generated* from the index, not a hand-maintained column) · residue (tracked because operationally live, excluded from the algebra).
- **The negotiation.** Canon presses down normatively; realization presses up evidentially; **both directions are legitimate**. `Fanout` entered canon because the taxonomy had an unnamed cell. A chapter describing deleted modules is canon that failed to move. The review question is never "which is broken" but *which direction wins here*.
- **Three mismatch classes** — canon-decayed and realization-pressing-up are mechanically detectable (the index already stores symbols); only semantic disagreement needs judgment. Automating the first two doesn't remove review, it **concentrates** it on the third.
- **Residue must be non-citable.** Live specimen in the tree: `ARCHITECTURE.md:446` states `World` is a `TraversableGraphFactory` subclass (true — `world.py:205`), while `:590` forbids pretending it is one "when it is not" — a migration guardrail that outlived its migration and now sits canon-shaped 144 lines from the canon it contradicts.
- **Worked example: the `story → mechanics` import.** Read naively it says the four-layer DAG is wrong. Examined: the three imports exist *only* to type `wants_caller_kind=` on five registrations, while `mechanics/credentials/presentation.py` already registers from the mechanics side — same job, correct direction, already in the tree. Canon held *and got sharper*: **the engine wires nothing; mechanics register on import; worlds choose which to import.**
- **Review rhythm** across change / topic / layer / coarse scales, with the per-PR question as the cheapest guard and the coarse pass explicitly *triggered*.

### `docs/src/design/glossary.md`

Dispatch layers carry **two orthogonal meanings** and only ordering was documented.

- Corrected the ladder to `GLOBAL < SYSTEM < APPLICATION < AUTHOR < USER < LOCAL` — the entry shipped an invented `SYSTEM < APPLICATION < DOMAIN < INSTANCE` — and `Priority` to `FIRST/EARLY/NORMAL/LATE/LAST` on the real `Priority` enum. Both verified verbatim against `core/behavior.py:47,56`.
- Documented the second meaning: layer is also an **isolation scope**, resolved through the authority chain `BehaviorRegistry` assembles from `ctx.get_authorities()`, cascading graph → world. **`APPLICATION` means available everywhere, not used everywhere** — a world that never imports a mechanic never loads it, and it stays dead code in that process. `AUTHOR` is world-private.
- Named the authoring consequence: an `APPLICATION`-level registration made *by a world* exports to every other world in the same process. Harmless single-world; deliberate-or-your-responsibility in multi-tenant. Register world-specific behaviour at `AUTHOR` to keep it private.

## Verification

- `sphinx-build -W --keep-going` clean (the strict build caught the missing toctree entry, now added to `design/index.rst`).
- `tangl-devref build` clean; new doc indexed.
- `Priority` and `DispatchLayer` members checked against source before writing.

## Notes

No `storytangl-topic` annotation on the new doc — no existing topic fits a cross-cutting method note, and inventing one would recreate the dangling-annotation problem #354 found in `TRANSACTION_OFFER_DESIGN.md` (whose three declared topics all resolve to nothing). A `governance`/`process` topic may be worth registering separately.

Follow-on, not in this PR: the presence de-wiring (move the five `@on_render_text` handlers into `mechanics/presence/` so importing `story` stops loading presence), which needs a sweep of worlds currently inheriting it.

Refs #354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified architectural guidance for `World`, including singleton identity behavior and its factory relationship.
  * Added guidance for distinguishing canonical design, current implementation, and transitional residue.
  * Expanded dispatch terminology, including registry assembly, ordering, priorities, authority chains, registration, and fold behavior.
  * Added documentation for redirect precedence, interception, abstention, and traversal-layer behavior.
  * Added the canon-and-realization design document to the documentation index.
  * Corrected dispatch-order terminology in a worked example.
  * Clarified aggregation behavior, including result selection, `None` handling, and `FIRST`/`LAST` winner rules.

* **Tests**
  * Added coverage for redirect precedence, scoping, abstention, trigger handling, and fold execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->