### PR TITLE
Credentials custody: retain and reissue one waiver

### DIFF
--- a/apps/server/tests/test_hall_monitor_playable_vertical.py
+++ b/apps/server/tests/test_hall_monitor_playable_vertical.py
@@ -105,7 +105,7 @@ def test_hall_monitor_inspection_survives_http_session_reload(
     assert entered.status_code == 200
     entered_payload = entered.json()
     entered_text = json.dumps(entered_payload)
-    assert "Mira Quill steps forward." in entered_text
+    assert "Tess Alder steps forward." in entered_text
     assert "doctor's note" in entered_text
     assert "correct_disposition" not in entered_text
 
@@ -119,7 +119,7 @@ def test_hall_monitor_inspection_survives_http_session_reload(
     )
     assert inspected.status_code == 200
     inspected_text = json.dumps(inspected.json())
-    assert "The required nurse signature is missing." in inspected_text
+    assert "The required teacher signature is missing." in inspected_text
     assert "Send back to class" in inspected_text
     assert "correct_disposition" not in inspected_text
 
@@ -133,8 +133,8 @@ def test_hall_monitor_inspection_survives_http_session_reload(
     reloaded = client.get("story/update", headers=headers)
     assert reloaded.status_code == 200
     reloaded_text = json.dumps(reloaded.json())
-    assert "Mira Quill steps forward." in reloaded_text
-    assert "The required nurse signature is missing." in reloaded_text
+    assert "Tess Alder steps forward." in reloaded_text
+    assert "The required teacher signature is missing." in reloaded_text
 
 
 def test_hall_monitor_delivers_subject_mismatch_card_without_hidden_truth(

--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
@@ -29,6 +29,11 @@ will not create placeholder cards or a private forge. Media Slices A–C landed
 through PR #326, D1–D3 landed the presentation-safe
 ``CredentialCardProjection`` and its one-level card-media requests, and Slice E
 adds lifecycle-safe provisioning plus JOURNAL association for eligible ID cards.
+Hall Monitor also proves one component-owned document can move through durable
+world custody and return under explicit authority: reissue restores its native
+``VALID`` status and subject binding, so the ordinary evaluator and existing
+validity presentation derive the renewed document state without a second expiry
+calculation.
 **Scope:** the *global* credential mechanic — `Credential → Document → Media`,
 with carrier/bearer binding — that the credentials checkpoint **game**
 (`tangl.mechanics.games.credentials_game`) becomes one consumer of.

--- a/engine/tests/loaders/test_hall_monitor_world.py
+++ b/engine/tests/loaders/test_hall_monitor_world.py
@@ -151,6 +151,13 @@ class TestHallMonitorWorld:
             )
             assert derive_disposition(case.packet_manager, game.restriction_map) is offer.target_disposition
 
+    def test_hall_monitor_requires_all_three_authored_encounters(self) -> None:
+        graph, _ = _started_shift()
+        block = graph.find_one(Selector(label="morning_shift"))
+
+        with pytest.raises(ValueError, match="requires waiver, media, and Mira"):
+            type(block)(encounters=2)
+
     def test_school_projection_and_full_shift_keep_the_shared_loop(self) -> None:
         _, ledger = _started_shift()
         first_case = ledger.cursor.game.active_case
@@ -215,6 +222,7 @@ class TestHallMonitorWorld:
         assert len(game.transaction_receipts) == 1
 
         _choose(ledger, "Send back to class")
+        tess_result = game.case_results[0].model_dump(mode="python")
         _advance_to_inhaler_case(ledger)
         mira_packet = game.active_case.packet_manager
         assert not mira_packet.get_slot(CREDENTIAL_PACKET_SLOT)
@@ -230,14 +238,25 @@ class TestHallMonitorWorld:
         assert completed[0].subject_id == mira_packet.get_slot(CREDENTIAL_ID_SLOT)[0].subject_id
         assert game.expected_disposition(game.active_case) is CredentialDisposition.PASS
         assert len(game.transaction_receipts) == 2
+        move_detail = game.transaction_receipts[1].details[0]
+        assert isinstance(move_detail, dict)
+        assert str(move_detail["asset_id"]) == str(waiver_id)
+
+        _inspect(ledger, "doctor's note")
+        reissued_text = _journal_text(ledger)
+        assert "Valid for this period" in reissued_text
+        assert "signature line is blank" not in reissued_text
+        assert game.case_results[0].model_dump(mode="python") == tess_result
 
         restored = Graph.structure(graph.unstructure())
         restored_game = restored.find_one(Selector(label="morning_shift")).game
-        restored_waiver = restored_game.active_case.packet_manager.get_slot(
-            CREDENTIAL_PACKET_SLOT
-        )[0]
+        restored_packet = restored_game.active_case.packet_manager
+        restored_waiver = restored_packet.get_slot(CREDENTIAL_PACKET_SLOT)[0]
         assert restored_waiver.uid == waiver_id
+        assert restored_waiver.status is CredentialStatus.VALID
+        assert restored_waiver.subject_id == restored_packet.get_slot(CREDENTIAL_ID_SLOT)[0].subject_id
         assert len(restored_game.transaction_receipts) == 2
+        assert restored_game.case_results[0].model_dump(mode="python") == tess_result
 
     def test_mira_has_no_reissue_action_without_the_retained_waiver(self) -> None:
         _, ledger = _started_shift()

--- a/engine/tests/loaders/test_hall_monitor_world.py
+++ b/engine/tests/loaders/test_hall_monitor_world.py
@@ -3,16 +3,27 @@
 from __future__ import annotations
 
 from pathlib import Path
+from uuid import uuid4
+
+import pytest
 
 from tangl.core import Graph, Selector
 from tangl.loaders import WorldBundle
 from tangl.loaders.compiler import WorldCompiler
 from tangl.mechanics.credentials import (
+    CREDENTIAL_ID_SLOT,
     CREDENTIAL_PACKET_SLOT,
     CredentialDefinition,
+    CredentialStatus,
     FailureMode,
 )
 from tangl.mechanics.presence.look import HairColor, HasSimpleLook
+from tangl.mechanics.transaction import (
+    AssetMoveCommitment,
+    CallbackCommitment,
+    ComponentSlotAssetHolder,
+    TransactionOffer,
+)
 from tangl.mechanics.games.credentials_game import CredentialDisposition, derive_disposition
 from tangl.mechanics.games.credentials_roster import materialize
 from tangl.service.world_registry import WorldRegistry
@@ -73,6 +84,16 @@ def _finish_shift_correctly(ledger: Ledger) -> None:
         _choose(ledger, game.presentation.decision_labels[decision])
 
 
+def _advance_to_inhaler_case(ledger: Ledger) -> None:
+    """Settle earlier authored encounters without taking their custody actions."""
+
+    while ledger.cursor.game.case_index < ledger.cursor.game.inhaler_case_index:
+        game = ledger.cursor.game
+        _inspect(ledger, next(iter(game.presented_documents)))
+        decision = game.expected_disposition(game.active_case).value
+        _choose(ledger, game.presentation.decision_labels[decision])
+
+
 class TestHallMonitorWorld:
     """The school skin exercises the shared credentials lifecycle."""
 
@@ -105,7 +126,7 @@ class TestHallMonitorWorld:
         assert block is ledger.cursor
         assert block.encounters == 5
         assert block.seed == 20260719
-        assert block.inhaler_case_index == 0
+        assert block.inhaler_case_index == 2
         assert block.disposition_distribution == {
             CredentialDisposition.PASS: 0.5,
             CredentialDisposition.DENY: 0.3,
@@ -178,17 +199,129 @@ class TestHallMonitorWorld:
         assert len(prepared) == 2
         assert game.active_case is prepared[0]
 
+    def test_retained_waiver_is_completed_and_issued_to_mira(self) -> None:
+        """One graph-owned waiver moves through custody into a fresh packet."""
+
+        graph, ledger = _started_shift()
+        game = ledger.cursor.game
+        waiver = game.active_case.packet_manager.get_slot(CREDENTIAL_PACKET_SLOT)[0]
+        waiver_id = waiver.uid
+
+        _inspect(ledger, "doctor's note")
+        assert "Retain the medical waiver" in [action.label for action in _actions(ledger)]
+        _choose(ledger, "Retain the medical waiver")
+        assert game.desk_custody.get_slot("retained_documents") == [waiver]
+        assert not game.active_case.packet_manager.get_slot(CREDENTIAL_PACKET_SLOT)
+        assert len(game.transaction_receipts) == 1
+
+        _choose(ledger, "Send back to class")
+        _advance_to_inhaler_case(ledger)
+        mira_packet = game.active_case.packet_manager
+        assert not mira_packet.get_slot(CREDENTIAL_PACKET_SLOT)
+
+        _inspect(ledger, "student ID")
+        assert "Complete and issue the medical waiver" in [action.label for action in _actions(ledger)]
+        _choose(ledger, "Complete and issue the medical waiver")
+
+        completed = mira_packet.get_slot(CREDENTIAL_PACKET_SLOT)
+        assert completed == [waiver]
+        assert completed[0].uid == waiver_id
+        assert completed[0].status is CredentialStatus.VALID
+        assert completed[0].subject_id == mira_packet.get_slot(CREDENTIAL_ID_SLOT)[0].subject_id
+        assert game.expected_disposition(game.active_case) is CredentialDisposition.PASS
+        assert len(game.transaction_receipts) == 2
+
+        restored = Graph.structure(graph.unstructure())
+        restored_game = restored.find_one(Selector(label="morning_shift")).game
+        restored_waiver = restored_game.active_case.packet_manager.get_slot(
+            CREDENTIAL_PACKET_SLOT
+        )[0]
+        assert restored_waiver.uid == waiver_id
+        assert len(restored_game.transaction_receipts) == 2
+
+    def test_mira_has_no_reissue_action_without_the_retained_waiver(self) -> None:
+        _, ledger = _started_shift()
+        _advance_to_inhaler_case(ledger)
+
+        _inspect(ledger, "student ID")
+
+        assert "Complete and issue the medical waiver" not in [
+            action.label for action in _actions(ledger)
+        ]
+
+    def test_waiver_retention_rejects_stale_or_duplicate_component_ids(self) -> None:
+        _, ledger = _started_shift()
+        game = ledger.cursor.game
+        handler = ledger.cursor.game_handler
+
+        with pytest.raises(ValueError, match="not visible"):
+            handler._retain_waiver(game, str(uuid4()), {})
+
+        _inspect(ledger, "doctor's note")
+        _choose(ledger, "Retain the medical waiver")
+
+        with pytest.raises(ValueError, match="not visible"):
+            handler._retain_waiver(game, str(uuid4()), {})
+
+    def test_late_reissue_failure_rolls_back_completion_and_custody_move(self) -> None:
+        """The transaction rail reverses both legs when a later commitment fails."""
+
+        _, ledger = _started_shift()
+        game = ledger.cursor.game
+        waiver = game.active_case.packet_manager.get_slot(CREDENTIAL_PACKET_SLOT)[0]
+        original_status = waiver.status
+        original_subject_id = waiver.subject_id
+
+        _inspect(ledger, "doctor's note")
+        _choose(ledger, "Retain the medical waiver")
+        _choose(ledger, "Send back to class")
+        _advance_to_inhaler_case(ledger)
+        packet = game.active_case.packet_manager
+        id_subject_id = packet.get_slot(CREDENTIAL_ID_SLOT)[0].subject_id
+
+        def complete() -> None:
+            waiver.status = CredentialStatus.VALID
+            waiver.subject_id = id_subject_id
+
+        def undo() -> None:
+            waiver.status = original_status
+            waiver.subject_id = original_subject_id
+
+        def fail_late() -> None:
+            raise RuntimeError("late failure")
+
+        offer = TransactionOffer(
+            commitments=[
+                CallbackCommitment(label="complete waiver", apply=complete, undo=undo),
+                AssetMoveCommitment(
+                    giver=ComponentSlotAssetHolder(game.desk_custody, "retained_documents"),
+                    receiver=ComponentSlotAssetHolder(packet, CREDENTIAL_PACKET_SLOT),
+                    asset=waiver,
+                ),
+                CallbackCommitment(label="fail late", apply=fail_late),
+            ]
+        )
+
+        with pytest.raises(RuntimeError, match="late failure"):
+            offer.accept()
+
+        assert game.desk_custody.get_slot("retained_documents") == [waiver]
+        assert not packet.get_slot(CREDENTIAL_PACKET_SLOT)
+        assert waiver.status is original_status
+        assert waiver.subject_id == original_subject_id
+
     def test_hall_monitor_records_and_later_reveals_harsh_inhaler_outcome(self) -> None:
         graph, ledger = _started_shift()
+        _advance_to_inhaler_case(ledger)
         block = ledger.cursor
         game = block.game
         bearer_id = game.active_case.packet_manager.bearer_id
 
-        _inspect(ledger, "doctor's note")
+        _inspect(ledger, next(iter(game.presented_documents)))
         _choose(ledger, "Send back to class")
 
-        assert game.case_results[0].correct is True
-        assert game.score["player"] == 1
+        assert game.case_results[2].correct is True
+        assert game.score["player"] == 3
         assert game.score["opponent"] == 0
         assert len(block.consequences) == 1
         consequence = block.consequences[0]
@@ -213,7 +346,7 @@ class TestHallMonitorWorld:
         restored_block = restored.find_one(Selector(label="morning_shift"))
         assert restored_block is not None
         assert restored_block.consequences == [consequence]
-        restored_result = restored_block.game.case_results[0]
+        restored_result = restored_block.game.case_results[2]
         assert restored_result.case_index == consequence.source_case_index
         assert restored_result.bearer_id == consequence.bearer_id
         assert restored.get(restored_result.bearer_id) is not None
@@ -222,15 +355,16 @@ class TestHallMonitorWorld:
         self,
     ) -> None:
         _, ledger = _started_shift()
+        _advance_to_inhaler_case(ledger)
         block = ledger.cursor
         game = block.game
 
-        _inspect(ledger, "doctor's note")
+        _inspect(ledger, next(iter(game.presented_documents)))
         _choose(ledger, "Allow onward")
 
-        assert game.case_results[0].correct is False
+        assert game.case_results[2].correct is False
         assert game.score["opponent"] == 1
-        assert game.score["player"] == 0
+        assert game.score["player"] == 2
         assert [fact.outcome for fact in block.consequences] == ["inhaler_allowed"]
         assert "reached the nurse's office" not in _journal_text(ledger)
 
@@ -245,14 +379,15 @@ class TestHallMonitorWorld:
 
     def test_attendance_note_prepares_a_returning_bearer_with_prior_receipt(self) -> None:
         graph, ledger = _started_shift()
+        _advance_to_inhaler_case(ledger)
         source = ledger.cursor
         source_game = source.game
         first_packet = source_game.active_case.packet_manager
         bearer_id = first_packet.bearer_id
 
-        _inspect(ledger, "doctor's note")
+        _inspect(ledger, next(iter(source_game.presented_documents)))
         _choose(ledger, "Send back to class")
-        first_result = source_game.case_results[0].model_dump(mode="python")
+        first_result = source_game.case_results[2].model_dump(mode="python")
         _finish_shift_correctly(ledger)
         assert ledger.cursor.label == "victory"
 
@@ -271,7 +406,7 @@ class TestHallMonitorWorld:
         returning_packet = returning_case.packet_manager
         assert returning_packet is not first_packet
         assert returning_packet.bearer_id == bearer_id
-        assert returning_case.prior_case_results == source_game.case_results[:1]
+        assert returning_case.prior_case_results == [source_game.case_results[2]]
         assert not any(case.prior_case_results for case in source_game.materialized[1:])
         assert sum(isinstance(item, HasSimpleLook) for item in graph.members.values()) == (
             subjects_before_return
@@ -327,12 +462,14 @@ class TestHallMonitorWorld:
         _choose(restored_ledger, "Allow onward")
         assert restored_returning.game.case_results[0].correct is True
         assert len(restored_returning.game.case_results) == 1
-        assert restored_source.game.case_results[0].model_dump(mode="python") == first_result
+        assert restored_source.game.case_results[2].model_dump(mode="python") == first_result
 
     def test_arrest_does_not_offer_or_prepare_a_returning_student(self) -> None:
         graph, ledger = _started_shift()
 
-        _inspect(ledger, "doctor's note")
+        _advance_to_inhaler_case(ledger)
+
+        _inspect(ledger, next(iter(ledger.cursor.game.presented_documents)))
         _choose(ledger, "Send to the office")
         _finish_shift_correctly(ledger)
         assert ledger.cursor.label == "defeat"

--- a/engine/tests/loaders/test_hall_monitor_world.py
+++ b/engine/tests/loaders/test_hall_monitor_world.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from importlib import import_module
 from pathlib import Path
 from uuid import uuid4
 
@@ -18,12 +19,7 @@ from tangl.mechanics.credentials import (
     FailureMode,
 )
 from tangl.mechanics.presence.look import HairColor, HasSimpleLook
-from tangl.mechanics.transaction import (
-    AssetMoveCommitment,
-    CallbackCommitment,
-    ComponentSlotAssetHolder,
-    TransactionOffer,
-)
+from tangl.mechanics.transaction import CallbackCommitment, TransactionOffer
 from tangl.mechanics.games.credentials_game import CredentialDisposition, derive_disposition
 from tangl.mechanics.games.credentials_roster import materialize
 from tangl.service.world_registry import WorldRegistry
@@ -74,6 +70,12 @@ def _journal_text(ledger: Ledger) -> str:
         for fragment in ledger.get_journal()
         if isinstance(fragment.content, str)
     )
+
+
+def _desk_custody_slot() -> str:
+    """Load the world-owned custody slot after the bundle has imported its domain."""
+
+    return import_module("hall_monitor.domain").HALL_DESK_CUSTODY_SLOT
 
 
 def _finish_shift_correctly(ledger: Ledger) -> None:
@@ -215,9 +217,11 @@ class TestHallMonitorWorld:
         waiver_id = waiver.uid
 
         _inspect(ledger, "doctor's note")
-        assert "Retain the medical waiver" in [action.label for action in _actions(ledger)]
+        assert "Retain the medical waiver" in [
+            action.label for action in _actions(ledger)
+        ]
         _choose(ledger, "Retain the medical waiver")
-        assert game.desk_custody.get_slot("retained_documents") == [waiver]
+        assert game.desk_custody.get_slot(_desk_custody_slot()) == [waiver]
         assert not game.active_case.packet_manager.get_slot(CREDENTIAL_PACKET_SLOT)
         assert len(game.transaction_receipts) == 1
 
@@ -236,6 +240,7 @@ class TestHallMonitorWorld:
         assert completed[0].uid == waiver_id
         assert completed[0].status is CredentialStatus.VALID
         assert completed[0].subject_id == mira_packet.get_slot(CREDENTIAL_ID_SLOT)[0].subject_id
+        assert not game.desk_custody.get_slot(_desk_custody_slot())
         assert game.expected_disposition(game.active_case) is CredentialDisposition.PASS
         assert len(game.transaction_receipts) == 2
         move_detail = game.transaction_receipts[1].details[0]
@@ -254,7 +259,9 @@ class TestHallMonitorWorld:
         restored_waiver = restored_packet.get_slot(CREDENTIAL_PACKET_SLOT)[0]
         assert restored_waiver.uid == waiver_id
         assert restored_waiver.status is CredentialStatus.VALID
-        assert restored_waiver.subject_id == restored_packet.get_slot(CREDENTIAL_ID_SLOT)[0].subject_id
+        assert restored_waiver.subject_id == restored_packet.get_slot(
+            CREDENTIAL_ID_SLOT
+        )[0].subject_id
         assert len(restored_game.transaction_receipts) == 2
         assert restored_game.case_results[0].model_dump(mode="python") == tess_result
 
@@ -282,7 +289,10 @@ class TestHallMonitorWorld:
         with pytest.raises(ValueError, match="not visible"):
             handler._retain_waiver(game, str(uuid4()), {})
 
-    def test_late_reissue_failure_rolls_back_completion_and_custody_move(self) -> None:
+    def test_late_reissue_failure_rolls_back_completion_and_custody_move(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """The transaction rail reverses both legs when a later commitment fails."""
 
         _, ledger = _started_shift()
@@ -296,35 +306,24 @@ class TestHallMonitorWorld:
         _choose(ledger, "Send back to class")
         _advance_to_inhaler_case(ledger)
         packet = game.active_case.packet_manager
-        id_subject_id = packet.get_slot(CREDENTIAL_ID_SLOT)[0].subject_id
-
-        def complete() -> None:
-            waiver.status = CredentialStatus.VALID
-            waiver.subject_id = id_subject_id
-
-        def undo() -> None:
-            waiver.status = original_status
-            waiver.subject_id = original_subject_id
+        _inspect(ledger, "student ID")
 
         def fail_late() -> None:
             raise RuntimeError("late failure")
 
-        offer = TransactionOffer(
-            commitments=[
-                CallbackCommitment(label="complete waiver", apply=complete, undo=undo),
-                AssetMoveCommitment(
-                    giver=ComponentSlotAssetHolder(game.desk_custody, "retained_documents"),
-                    receiver=ComponentSlotAssetHolder(packet, CREDENTIAL_PACKET_SLOT),
-                    asset=waiver,
-                ),
-                CallbackCommitment(label="fail late", apply=fail_late),
-            ]
-        )
+        original_accept = TransactionOffer.accept
+
+        def accept_with_late_failure(offer: TransactionOffer):
+            if offer.label == "complete medical waiver":
+                offer.commitments.append(CallbackCommitment(label="fail late", apply=fail_late))
+            return original_accept(offer)
+
+        monkeypatch.setattr(TransactionOffer, "accept", accept_with_late_failure)
 
         with pytest.raises(RuntimeError, match="late failure"):
-            offer.accept()
+            _choose(ledger, "Complete and issue the medical waiver")
 
-        assert game.desk_custody.get_slot("retained_documents") == [waiver]
+        assert game.desk_custody.get_slot(_desk_custody_slot()) == [waiver]
         assert not packet.get_slot(CREDENTIAL_PACKET_SLOT)
         assert waiver.status is original_status
         assert waiver.subject_id == original_subject_id

--- a/engine/tests/loaders/test_hall_monitor_world.py
+++ b/engine/tests/loaders/test_hall_monitor_world.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from importlib import import_module
 from pathlib import Path
 from uuid import uuid4
 
@@ -19,7 +18,11 @@ from tangl.mechanics.credentials import (
     FailureMode,
 )
 from tangl.mechanics.presence.look import HairColor, HasSimpleLook
-from tangl.mechanics.transaction import CallbackCommitment, TransactionOffer
+from tangl.mechanics.transaction import (
+    CallbackCommitment,
+    TransactionOffer,
+    TransactionReceipt,
+)
 from tangl.mechanics.games.credentials_game import CredentialDisposition, derive_disposition
 from tangl.mechanics.games.credentials_roster import materialize
 from tangl.service.world_registry import WorldRegistry
@@ -28,6 +31,9 @@ from tangl.vm import Ledger
 from tangl.vm.dispatch import do_provision
 from tangl.vm.resolution_phase import ResolutionPhase
 from tangl.vm.runtime.frame import PhaseCtx
+
+
+_DESK_CUSTODY_SLOT = "retained_documents"
 
 
 def _repo_worlds_dir() -> Path:
@@ -70,12 +76,6 @@ def _journal_text(ledger: Ledger) -> str:
         for fragment in ledger.get_journal()
         if isinstance(fragment.content, str)
     )
-
-
-def _desk_custody_slot() -> str:
-    """Load the world-owned custody slot after the bundle has imported its domain."""
-
-    return import_module("hall_monitor.domain").HALL_DESK_CUSTODY_SLOT
 
 
 def _finish_shift_correctly(ledger: Ledger) -> None:
@@ -221,7 +221,7 @@ class TestHallMonitorWorld:
             action.label for action in _actions(ledger)
         ]
         _choose(ledger, "Retain the medical waiver")
-        assert game.desk_custody.get_slot(_desk_custody_slot()) == [waiver]
+        assert game.desk_custody.get_slot(_DESK_CUSTODY_SLOT) == [waiver]
         assert not game.active_case.packet_manager.get_slot(CREDENTIAL_PACKET_SLOT)
         assert len(game.transaction_receipts) == 1
 
@@ -232,7 +232,9 @@ class TestHallMonitorWorld:
         assert not mira_packet.get_slot(CREDENTIAL_PACKET_SLOT)
 
         _inspect(ledger, "student ID")
-        assert "Complete and issue the medical waiver" in [action.label for action in _actions(ledger)]
+        assert "Complete and issue the medical waiver" in [
+            action.label for action in _actions(ledger)
+        ]
         _choose(ledger, "Complete and issue the medical waiver")
 
         completed = mira_packet.get_slot(CREDENTIAL_PACKET_SLOT)
@@ -240,7 +242,7 @@ class TestHallMonitorWorld:
         assert completed[0].uid == waiver_id
         assert completed[0].status is CredentialStatus.VALID
         assert completed[0].subject_id == mira_packet.get_slot(CREDENTIAL_ID_SLOT)[0].subject_id
-        assert not game.desk_custody.get_slot(_desk_custody_slot())
+        assert not game.desk_custody.get_slot(_DESK_CUSTODY_SLOT)
         assert game.expected_disposition(game.active_case) is CredentialDisposition.PASS
         assert len(game.transaction_receipts) == 2
         move_detail = game.transaction_receipts[1].details[0]
@@ -313,7 +315,7 @@ class TestHallMonitorWorld:
 
         original_accept = TransactionOffer.accept
 
-        def accept_with_late_failure(offer: TransactionOffer):
+        def accept_with_late_failure(offer: TransactionOffer) -> TransactionReceipt:
             if offer.label == "complete medical waiver":
                 offer.commitments.append(CallbackCommitment(label="fail late", apply=fail_late))
             return original_accept(offer)
@@ -323,7 +325,7 @@ class TestHallMonitorWorld:
         with pytest.raises(RuntimeError, match="late failure"):
             _choose(ledger, "Complete and issue the medical waiver")
 
-        assert game.desk_custody.get_slot(_desk_custody_slot()) == [waiver]
+        assert game.desk_custody.get_slot(_DESK_CUSTODY_SLOT) == [waiver]
         assert not packet.get_slot(CREDENTIAL_PACKET_SLOT)
         assert waiver.status is original_status
         assert waiver.subject_id == original_subject_id

--- a/worlds/hall_monitor/README.md
+++ b/worlds/hall_monitor/README.md
@@ -64,13 +64,18 @@ VITE_DEFAULT_USER_SECRET=dev-secret-123 \
 yarn dev
 ```
 
-In the browser, enter the morning shift, inspect the doctor’s note, and choose
-one of the public rulings. A rules-correct `Send back to class` path reveals the
-inhaler outcome at the attendance note and offers `Meet the returning student`.
-An incorrect compassionate `Allow onward` path produces the contrasting
-world-authored outcome without changing the underlying score rule. An arrest
-does not offer a return. The return is an ordinary new credential encounter:
-its packet is fresh, while its bearer is the same live graph subject.
+In the browser, first meet Tess Alder and inspect her incomplete medical waiver.
+You may retain that visible document at the desk or settle her case normally.
+Later, Mira Quill has no medical waiver: without the retained document, the
+ordinary deny/compassionate branches remain available and no reissue action
+appears. With the retained document, the authorized reissue completes the same
+component and issues it into Mira's fresh packet; the ordinary credential
+evaluator then derives `PASS`. A rules-correct `Send back to class` path still
+reveals the inhaler outcome at the attendance note and offers `Meet the
+returning student`. An incorrect compassionate `Allow onward` path produces the
+contrasting world-authored outcome without changing the underlying score rule.
+An arrest does not offer a return. The return is an ordinary new credential
+encounter: its packet is fresh, while its bearer is the same live graph subject.
 
 ### Current framework friction
 

--- a/worlds/hall_monitor/hall_monitor/domain.py
+++ b/worlds/hall_monitor/hall_monitor/domain.py
@@ -29,6 +29,7 @@ from tangl.mechanics.games.credentials_game import (
     CredentialsMove,
     CredentialsGame,
     CredentialsGameHandler,
+    derive_defects,
 )
 from tangl.mechanics.games.enums import RoundResult
 from tangl.mechanics.transaction import (
@@ -142,6 +143,7 @@ _HALL_FAILURES = (
 )
 _MEDIA_WITNESS_CASE_INDEX = 1
 _WAIVER_CASE_INDEX = 0
+_INHALER_CASE_INDEX = 2
 HALL_DESK_CUSTODY_SLOT = "retained_documents"
 
 
@@ -257,7 +259,7 @@ class HallMonitorCredentialsGame(CredentialsGame):
         json_schema_extra={"include": True},
     )
     waiver_case_index: int = _WAIVER_CASE_INDEX
-    inhaler_case_index: int = 2
+    inhaler_case_index: int = _INHALER_CASE_INDEX
     waiver_reissue_authorized: bool = True
 
     def bind_component_managers(self, owner: object) -> None:
@@ -376,7 +378,7 @@ class HallMonitorCredentialsHandler(CredentialsGameHandler):
         receipt = offer.accept()
         game.transaction_receipts.append(receipt)
         detail["outcome"] = "waiver_retained"
-        detail["component_id"] = component.uid
+        detail["component_id"] = str(component.uid)
         return RoundResult.CONTINUE
 
     def _reissue_waiver(
@@ -430,9 +432,13 @@ class HallMonitorCredentialsHandler(CredentialsGameHandler):
             ],
         )
         receipt = offer.accept()
+        game.presentation.render_case(
+            game.active_case,
+            derive_defects(packet, game.restriction_map),
+        )
         game.transaction_receipts.append(receipt)
         detail["outcome"] = "waiver_reissued"
-        detail["component_id"] = component.uid
+        detail["component_id"] = str(component.uid)
         return RoundResult.CONTINUE
 
     def _prose_fragments(
@@ -476,7 +482,7 @@ class HallMonitorBlock(HasGame, Block):
         }
     )
     seed: int = 20260719
-    inhaler_case_index: int = 2
+    inhaler_case_index: ClassVar[int] = _INHALER_CASE_INDEX
     consequences: list[HallMonitorConsequence] = Field(
         default_factory=list,
         json_schema_extra={"include": True},
@@ -487,6 +493,8 @@ class HallMonitorBlock(HasGame, Block):
 
     @model_validator(mode="after")
     def _configure_game(self) -> HallMonitorBlock:
+        if self.encounters < 3:
+            raise ValueError("Hall Monitor requires waiver, media, and Mira encounters")
         if self.game_state is None:
             self.game_state = HallMonitorCredentialsGame(
                 roster=[],
@@ -638,7 +646,7 @@ def render_hall_monitor_consequence(
     if consequence.outcome == "inhaler_withheld":
         content = (
             f"{subject} was sent back to class. Their inhaler remained at the "
-            "hall desk while the nurse's unsigned note was checked."
+            "hall desk while the missing medical waiver was recorded."
         )
     else:
         content = f"{subject} reached the nurse's office with their inhaler."

--- a/worlds/hall_monitor/hall_monitor/domain.py
+++ b/worlds/hall_monitor/hall_monitor/domain.py
@@ -235,7 +235,7 @@ class HallMonitorDeskCustodyManager(ComponentManager[CredentialComponent]):
         HALL_DESK_CUSTODY_SLOT: Slot.for_predicate(
             HALL_DESK_CUSTODY_SLOT,
             _is_document,
-            max_count=100,
+            max_count=1,
         ),
     }
 

--- a/worlds/hall_monitor/hall_monitor/domain.py
+++ b/worlds/hall_monitor/hall_monitor/domain.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import ClassVar, Literal
 from uuid import UUID
 
 from pydantic import Field, model_validator
@@ -10,12 +10,15 @@ from tangl.core.bases import BaseModelPlus
 from tangl.journal.fragments import ContentFragment
 from tangl.mechanics.credentials import (
     CREDENTIAL_ID_SLOT,
+    CREDENTIAL_PACKET_SLOT,
+    CredentialComponent,
     CredentialDefinition,
     CredentialStatus,
     FailureMode,
     Restrictions,
     RestrictionLevel,
 )
+from tangl.mechanics.assembly import ComponentManager, Slot
 from tangl.mechanics.presence.look import HairColor, HasSimpleLook
 from tangl.mechanics.games import HasGame
 from tangl.mechanics.games.credentials_game import (
@@ -23,8 +26,17 @@ from tangl.mechanics.games.credentials_game import (
     CredentialCaseResult,
     CredentialDisposition,
     CredentialPresentationProfile,
+    CredentialsMove,
     CredentialsGame,
     CredentialsGameHandler,
+)
+from tangl.mechanics.games.enums import RoundResult
+from tangl.mechanics.transaction import (
+    AssetMoveCommitment,
+    CallbackCommitment,
+    ComponentSlotAssetHolder,
+    TransactionOffer,
+    TransactionReceipt,
 )
 from tangl.mechanics.games.credentials_roster import (
     ScenarioOffer,
@@ -129,6 +141,8 @@ _HALL_FAILURES = (
     FailureMode.FAKE_ID,
 )
 _MEDIA_WITNESS_CASE_INDEX = 1
+_WAIVER_CASE_INDEX = 0
+HALL_DESK_CUSTODY_SLOT = "retained_documents"
 
 
 def _special_student() -> ScenarioOffer:
@@ -139,13 +153,9 @@ def _special_student() -> ScenarioOffer:
         candidate_name="Mira Quill",
         region="lower",
         purpose="medicine",
-        failure_modes=[FailureMode.UNSEALED_PERMIT],
+        failure_modes=[FailureMode.MISSING_PERMIT],
         presented_documents_override={
             "student ID": "A laminated lower-school student identification card.",
-            "doctor's note": "A doctor's note for an inhaler, lacking the nurse's signature.",
-        },
-        hidden_facts_override={
-            "doctor's note": "The required nurse signature is missing.",
         },
         packet_hidden_facts_override={
             "packet consistency": "The student's papers do not satisfy the hall rules.",
@@ -165,6 +175,22 @@ def _media_witness_student() -> ScenarioOffer:
     )
 
 
+def _waiver_student() -> ScenarioOffer:
+    """Return the earlier incomplete waiver that Hall Monitor may retain."""
+
+    return ScenarioOffer(
+        target_disposition=CredentialDisposition.DENY,
+        candidate_name="Tess Alder",
+        region="lower",
+        purpose="medicine",
+        failure_modes=[FailureMode.UNSEALED_PERMIT],
+        presented_documents_override={
+            "student ID": "A laminated lower-school student identification card.",
+            "doctor's note": "A nurse waiver awaiting its completed signature.",
+        },
+    )
+
+
 def _hall_offers(
     *,
     encounters: int,
@@ -173,7 +199,7 @@ def _hall_offers(
 ) -> list[ScenarioOffer]:
     """Generate one configured school shift through the shared roster funnel."""
 
-    pinned = [_special_student(), _media_witness_student()]
+    pinned = [_waiver_student(), _media_witness_student(), _special_student()]
     if encounters <= len(pinned):
         return pinned[:encounters]
     sampled = generate_roster(
@@ -190,6 +216,28 @@ def _hall_offers(
     return [*pinned, *sampled]
 
 
+def _is_document(component: CredentialComponent) -> bool:
+    return component.document_kind == "document"
+
+
+class HallMonitorDeskCustodyManager(ComponentManager[CredentialComponent]):
+    """Hall Monitor's durable desk custody for retained credential documents.
+
+    Why
+    ---
+    The retained waiver remains a graph-owned credential component while it is
+    no longer in its first candidate's packet.
+    """
+
+    slots: ClassVar[dict[str, Slot]] = {
+        HALL_DESK_CUSTODY_SLOT: Slot.for_predicate(
+            HALL_DESK_CUSTODY_SLOT,
+            _is_document,
+            max_count=100,
+        ),
+    }
+
+
 class HallMonitorCredentialsGame(CredentialsGame):
     """School-specific credentials shift with the bounded school catalog."""
 
@@ -200,6 +248,23 @@ class HallMonitorCredentialsGame(CredentialsGame):
     presentation: CredentialPresentationProfile = Field(
         default_factory=lambda: HALL_PRESENTATION.model_copy(deep=True)
     )
+    desk_custody: HallMonitorDeskCustodyManager = Field(
+        default_factory=HallMonitorDeskCustodyManager,
+        json_schema_extra={"include": True, "unstructurable": True},
+    )
+    transaction_receipts: list[TransactionReceipt] = Field(
+        default_factory=list,
+        json_schema_extra={"include": True},
+    )
+    waiver_case_index: int = _WAIVER_CASE_INDEX
+    inhaler_case_index: int = 2
+    waiver_reissue_authorized: bool = True
+
+    def bind_component_managers(self, owner: object) -> None:
+        """Bind both candidate packets and the world-owned custody manager."""
+
+        super().bind_component_managers(owner)
+        self.desk_custody.bind_owner(owner)
 
     def prepare_case(self, case_index: int) -> CredentialCase:
         """Materialize the world-owned visual mismatch with distinct live looks."""
@@ -216,6 +281,173 @@ class HallMonitorCredentialsGame(CredentialsGame):
         bearer.look.hair_color = HairColor.RED
         id_subject.look.hair_color = HairColor.BLONDE
         return case
+
+
+class HallMonitorCredentialsHandler(CredentialsGameHandler):
+    """Add Hall Monitor's narrow custody and authorized-reissue actions.
+
+    Why
+    ---
+    The world owns when a visible document may be retained and reissued; the
+    shared credential game continues to own evaluation and scoring.
+    """
+
+    def get_available_moves(self, game: HallMonitorCredentialsGame) -> list[CredentialsMove]:
+        moves = super().get_available_moves(game)
+        if game.current_stage == "documents":
+            return moves
+
+        if game.case_index == game.waiver_case_index:
+            for component in game.active_case.packet_manager.get_slot(CREDENTIAL_PACKET_SLOT):
+                if component.indication == "medicine":
+                    moves.append(
+                        CredentialsMove(kind="retain_waiver", target=str(component.uid))
+                    )
+        elif game.case_index == game.inhaler_case_index and game.waiver_reissue_authorized:
+            for component in game.desk_custody.get_slot(HALL_DESK_CUSTODY_SLOT):
+                if component.indication == "medicine":
+                    moves.append(
+                        CredentialsMove(kind="reissue_waiver", target=str(component.uid))
+                    )
+        return moves
+
+    def get_move_label(self, game: HallMonitorCredentialsGame, move: CredentialsMove) -> str:
+        if move.kind == "retain_waiver":
+            return "Retain the medical waiver"
+        if move.kind == "reissue_waiver":
+            return "Complete and issue the medical waiver"
+        return super().get_move_label(game, move)
+
+    def resolve_move_kind(
+        self,
+        kind: str,
+        game: HallMonitorCredentialsGame,
+        player_move: CredentialsMove,
+        detail: dict[str, object],
+    ) -> RoundResult:
+        if kind == "retain_waiver":
+            return self._retain_waiver(game, player_move.target, detail)
+        if kind == "reissue_waiver":
+            return self._reissue_waiver(game, player_move.target, detail)
+        return super().resolve_move_kind(kind, game, player_move, detail)
+
+    @staticmethod
+    def _active_waiver(
+        game: HallMonitorCredentialsGame,
+        component_id: str,
+    ) -> CredentialComponent | None:
+        return next(
+            (
+                component
+                for component in game.active_case.packet_manager.get_slot(CREDENTIAL_PACKET_SLOT)
+                if str(component.uid) == component_id and component.indication == "medicine"
+            ),
+            None,
+        )
+
+    def _retain_waiver(
+        self,
+        game: HallMonitorCredentialsGame,
+        component_id: str,
+        detail: dict[str, object],
+    ) -> RoundResult:
+        if game.case_index != game.waiver_case_index:
+            raise ValueError("Medical waiver retention is not available for this candidate")
+        component = self._active_waiver(game, component_id)
+        if component is None:
+            raise ValueError("The submitted waiver is not visible in this packet")
+        offer = TransactionOffer(
+            label="retain medical waiver",
+            commitments=[
+                AssetMoveCommitment(
+                    giver=ComponentSlotAssetHolder(
+                        game.active_case.packet_manager,
+                        CREDENTIAL_PACKET_SLOT,
+                    ),
+                    receiver=ComponentSlotAssetHolder(
+                        game.desk_custody,
+                        HALL_DESK_CUSTODY_SLOT,
+                    ),
+                    asset=component,
+                    label="retain medical waiver",
+                ),
+            ],
+        )
+        receipt = offer.accept()
+        game.transaction_receipts.append(receipt)
+        detail["outcome"] = "waiver_retained"
+        detail["component_id"] = component.uid
+        return RoundResult.CONTINUE
+
+    def _reissue_waiver(
+        self,
+        game: HallMonitorCredentialsGame,
+        component_id: str,
+        detail: dict[str, object],
+    ) -> RoundResult:
+        if game.case_index != game.inhaler_case_index or not game.waiver_reissue_authorized:
+            raise ValueError("Medical waiver reissue is not authorized here")
+        component = next(
+            (
+                item
+                for item in game.desk_custody.get_slot(HALL_DESK_CUSTODY_SLOT)
+                if str(item.uid) == component_id and item.indication == "medicine"
+            ),
+            None,
+        )
+        if component is None:
+            raise ValueError("The submitted waiver is not in desk custody")
+        packet = game.active_case.packet_manager
+        id_card = packet.get_slot(CREDENTIAL_ID_SLOT)[0]
+        original_status = component.status
+        original_subject_id = component.subject_id
+
+        def apply_completion() -> None:
+            component.status = CredentialStatus.VALID
+            component.subject_id = id_card.subject_id
+
+        def undo_completion() -> None:
+            component.status = original_status
+            component.subject_id = original_subject_id
+
+        offer = TransactionOffer(
+            label="complete medical waiver",
+            commitments=[
+                CallbackCommitment(
+                    label="complete medical waiver",
+                    apply=apply_completion,
+                    undo=undo_completion,
+                ),
+                AssetMoveCommitment(
+                    giver=ComponentSlotAssetHolder(game.desk_custody, HALL_DESK_CUSTODY_SLOT),
+                    receiver=ComponentSlotAssetHolder(
+                        game.active_case.packet_manager,
+                        CREDENTIAL_PACKET_SLOT,
+                    ),
+                    asset=component,
+                    label="issue medical waiver",
+                ),
+            ],
+        )
+        receipt = offer.accept()
+        game.transaction_receipts.append(receipt)
+        detail["outcome"] = "waiver_reissued"
+        detail["component_id"] = component.uid
+        return RoundResult.CONTINUE
+
+    def _prose_fragments(
+        self,
+        game: HallMonitorCredentialsGame,
+        last_round: object,
+        action: str,
+        target: str,
+        notes: dict[str, object],
+    ) -> list[ContentFragment]:
+        if action == "retain_waiver":
+            return [ContentFragment(content="You retain the medical waiver at the hall desk.")]
+        if action == "reissue_waiver":
+            return [ContentFragment(content="You complete and issue the medical waiver.")]
+        return super()._prose_fragments(game, last_round, action, target, notes)
 
 
 class HallMonitorConsequence(BaseModelPlus):
@@ -244,20 +476,21 @@ class HallMonitorBlock(HasGame, Block):
         }
     )
     seed: int = 20260719
-    inhaler_case_index: int = 0
+    inhaler_case_index: int = 2
     consequences: list[HallMonitorConsequence] = Field(
         default_factory=list,
         json_schema_extra={"include": True},
     )
 
     _game_class = HallMonitorCredentialsGame
-    _game_handler_class = CredentialsGameHandler
+    _game_handler_class = HallMonitorCredentialsHandler
 
     @model_validator(mode="after")
     def _configure_game(self) -> HallMonitorBlock:
         if self.game_state is None:
             self.game_state = HallMonitorCredentialsGame(
                 roster=[],
+                inhaler_case_index=self.inhaler_case_index,
                 offers=_hall_offers(
                     encounters=self.encounters,
                     disposition_distribution=self.disposition_distribution,

--- a/worlds/hall_monitor/script.yaml
+++ b/worlds/hall_monitor/script.yaml
@@ -25,7 +25,7 @@ scenes:
           deny: 0.30
           arrest: 0.20
         seed: 20260719
-        inhaler_case_index: 0
+        inhaler_case_index: 2
         content: |
           Check each student’s identification and pass before deciding whether
           to allow them onward, send them back to class, or refer them to office.

--- a/worlds/hall_monitor/script.yaml
+++ b/worlds/hall_monitor/script.yaml
@@ -25,7 +25,6 @@ scenes:
           deny: 0.30
           arrest: 0.20
         seed: 20260719
-        inhaler_case_index: 2
         content: |
           Check each student’s identification and pass before deciding whether
           to allow them onward, send them back to class, or refer them to office.


### PR DESCRIPTION
## Summary

Implements the bounded Hall Monitor custody proof for #348.

- retains a visible, graph-owned medical waiver into a desk `ComponentManager` through `AssetMoveCommitment`
- exposes an authorized, later reissue that atomically restores native `VALID` status, rebinds the document to Mira's ID subject, and moves the same component into her fresh packet
- keeps scoring and disposition wholly in the existing credential evaluator
- persists custody and transaction receipts through graph round-trip; validates stale/duplicate submissions and late transactional rollback

The authored waiver encounter is now before Mira, so it can become an actual prior dependency. The existing visual-mismatch encounter remains pinned between them.

## Validation

`poetry run pytest engine/tests/mechanics/test_transaction_offer.py engine/tests/mechanics/test_assembly.py engine/tests/mechanics/credentials/test_credential_packet_manager.py engine/tests/mechanics/games/test_credentials_game.py engine/tests/mechanics/games/test_credentials_fragments.py engine/tests/loaders/test_hall_monitor_world.py -q`

Result: `154 passed` (four pre-existing pytest collection warnings in assembly tests).

`git diff --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retaining an incomplete medical waiver and completing it later with explicit authorization.
  * Reissued waivers regain valid status and remain bound to their original subject.
  * Added safeguards against stale or duplicate retention attempts.
  * Failed reissue operations now roll back related changes.

* **Bug Fixes**
  * Corrected Hall Monitor encounter sequencing for inhaler evaluations.
  * Updated walkthrough and story text for the revised medical waiver scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->