### PR TITLE
Credentials: add ID response window

### DIFF
--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_MECHANIC.md
@@ -34,6 +34,9 @@ world custody and return under explicit authority: reissue restores its native
 ``VALID`` status and subject binding, so the ordinary evaluator and existing
 validity presentation derive the renewed document state without a second expiry
 calculation.
+The response-window proof adds a separate unpresented packet slot: missing
+native components remain graph-owned but do not participate in visible document
+or evaluator projection until an explicit response move presents them.
 **Scope:** the *global* credential mechanic — `Credential → Document → Media`,
 with carrier/bearer binding — that the credentials checkpoint **game**
 (`tangl.mechanics.games.credentials_game`) becomes one consumer of.

--- a/engine/src/tangl/mechanics/credentials/__init__.py
+++ b/engine/src/tangl/mechanics/credentials/__init__.py
@@ -3,6 +3,7 @@
 from .assembly import (
     CREDENTIAL_ID_SLOT,
     CREDENTIAL_PACKET_SLOT,
+    CREDENTIAL_UNPRESENTED_SLOT,
     CredentialComponent,
     CredentialComponentToken,
     CredentialDefinition,
@@ -55,6 +56,7 @@ __all__ = [
     "CONTRABAND",
     "CREDENTIAL_ID_SLOT",
     "CREDENTIAL_PACKET_SLOT",
+    "CREDENTIAL_UNPRESENTED_SLOT",
     "CredentialComponent",
     "CredentialComponentToken",
     "CredentialAttestationObservation",

--- a/engine/src/tangl/mechanics/credentials/assembly.py
+++ b/engine/src/tangl/mechanics/credentials/assembly.py
@@ -23,6 +23,7 @@ from .domain import (
 
 CREDENTIAL_ID_SLOT = "id"
 CREDENTIAL_PACKET_SLOT = "credentials"
+CREDENTIAL_UNPRESENTED_SLOT = "unpresented"
 _DEFAULT_DOCUMENT_KINDS = ("id", "document")
 
 
@@ -100,6 +101,10 @@ def _is_packet_document(component: CredentialComponentToken) -> bool:
     return component.document_kind != "id"
 
 
+def _is_credential(component: CredentialComponentToken) -> bool:
+    return component.document_kind in _DEFAULT_DOCUMENT_KINDS
+
+
 class CredentialPacketManager(ComponentManager[CredentialComponent]):
     """Owner-bound packet manager over credential graph components."""
 
@@ -112,6 +117,11 @@ class CredentialPacketManager(ComponentManager[CredentialComponent]):
         CREDENTIAL_PACKET_SLOT: Slot.for_predicate(
             CREDENTIAL_PACKET_SLOT,
             _is_packet_document,
+            max_count=100,
+        ),
+        CREDENTIAL_UNPRESENTED_SLOT: Slot.for_predicate(
+            CREDENTIAL_UNPRESENTED_SLOT,
+            _is_credential,
             max_count=100,
         ),
     }
@@ -426,6 +436,7 @@ def materialize_packet(
 __all__ = [
     "CREDENTIAL_ID_SLOT",
     "CREDENTIAL_PACKET_SLOT",
+    "CREDENTIAL_UNPRESENTED_SLOT",
     "CredentialComponent",
     "CredentialComponentToken",
     "CredentialDefinition",

--- a/engine/src/tangl/mechanics/games/credentials_factory.py
+++ b/engine/src/tangl/mechanics/games/credentials_factory.py
@@ -23,6 +23,7 @@ from tangl.core import TokenCatalog
 from tangl.mechanics.credentials import (
     CREDENTIAL_ID_SLOT,
     CREDENTIAL_PACKET_SLOT,
+    CREDENTIAL_UNPRESENTED_SLOT,
     ContrabandItem,
     CredentialComponent,
     CredentialDefect,
@@ -173,6 +174,7 @@ def apply_failure(mode: FailureMode, case: CredentialCase) -> None:
                 id_component = id_components[0]
                 if mode is FailureMode.MISSING_ID:
                     case.packet_manager.unassign(CREDENTIAL_ID_SLOT, id_component)
+                    case.packet_manager.assign(CREDENTIAL_UNPRESENTED_SLOT, id_component)
                 elif mode is FailureMode.EXPIRED_ID:
                     id_component.status = CredentialStatus.EXPIRED
                 else:

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -1212,7 +1212,9 @@ class CredentialsGame(PickingGame):
         else:
             self.shift_complete = True
 
-        self.current_stage = "documents"
+        self.current_stage = (
+            "documents" if not self.shift_complete and self.presented_documents else "packet"
+        )
         self.inspected_targets = []
         self.revealed_findings = {}
         self.inspected_packet_targets = []
@@ -1268,6 +1270,8 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
 
         if game.has_component_manager_owner and game.offers:
             game.prepare_case(game.case_index)
+        if not game.presented_documents:
+            game.current_stage = "packet"
 
     def provision_presentation(self, game: CredentialsGame, *, ctx: VmPhaseCtx) -> None:
         """Prepare the current and sequential successor card frontiers."""
@@ -1834,7 +1838,7 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                     ),
                 ],
             ).accept()
-            game.finding_status[FindingKey.ID] = Finding.VERIFIED
+            game.finding_status[FindingKey.ID] = Finding.CLEARED
             detail["outcome"] = "id_request_complied"
             detail["component_id"] = str(id_card.uid)
             game.presentation.render_case(

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -45,13 +45,13 @@ from tangl.media.media_resource import MediaDep, MediaResourceInventoryTag as Me
 from tangl.mechanics.credentials.assembly import (
     CREDENTIAL_ID_SLOT,
     CREDENTIAL_PACKET_SLOT,
+    CREDENTIAL_UNPRESENTED_SLOT,
     CredentialComponent,
     CredentialDefinition,
     CredentialPacketManager as AssemblyCredentialPacketManager,
     default_credential_catalog,
     materialize_packet,
 )
-
 from tangl.mechanics.credentials import (
     DEFAULT_RESTRICTIONS,
     ContrabandItem,
@@ -73,6 +73,11 @@ from tangl.mechanics.credentials import (
     credential_card_composition_spec,
     credential_card_portrait_spec,
     credential_card_text_spec,
+)
+from tangl.mechanics.transaction import (
+    AssetMoveCommitment,
+    ComponentSlotAssetHolder,
+    TransactionOffer,
 )
 from tangl.prose import TextRenderSession
 from tangl.story.presentation import render_text_as
@@ -207,6 +212,7 @@ class CredentialCase(Unstructurable):
     whitelist: bool = False
     blacklist: bool = False
     bribe_offer: int = 0
+    id_request_response: Literal["comply", "refuse"] = "comply"
 
     # ----- Discovery API ----------------------------------------------------
     # The only surface the game loop and derive_disposition may use to ask the
@@ -373,6 +379,7 @@ class Finding:
     DECLARED = "declared"    # contraband voluntarily disclosed
     TOO_LATE = "too_late"    # disclosure after a confirming search; no rescue
     YIELDED = "yielded"      # contraband surrendered
+    REFUSED = "refused"      # candidate declined a requested response
 
 
 class FindingKey:
@@ -390,7 +397,9 @@ class FindingKey:
 # recovered contraband (YIELDED). A plain VERIFIED (checked, sound) is not adverse
 # evidence, so it is excluded. Behavioral evidence (a declined search, a bribe
 # attempt) extends this set in Phase B.3.
-_EVIDENCE_FINDINGS = frozenset({Finding.CONFIRMED, Finding.CLEARED, Finding.YIELDED})
+_EVIDENCE_FINDINGS = frozenset(
+    {Finding.CONFIRMED, Finding.CLEARED, Finding.YIELDED, Finding.REFUSED}
+)
 
 
 # Time cost of each action, in shift-budget units. Cheap probes (a glance at a
@@ -1402,6 +1411,8 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         # verify_id: offer whenever an id is presented and not yet verified.
         if case.id_status() is not None and FindingKey.ID not in game.finding_status:
             moves.append(CredentialsMove(kind="verify_id", target=""))
+        if self._id_required_and_absent(game) and FindingKey.ID not in game.finding_status:
+            moves.append(CredentialsMove(kind="request_id", target=""))
         # request_search: single move, once per case.
         if FindingKey.SEARCH not in game.finding_status:
             moves.append(CredentialsMove(kind="request_search", target=""))
@@ -1414,6 +1425,17 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         if FindingKey.RELINQUISH not in game.finding_status and self._has_declared_contraband(game):
             moves.append(CredentialsMove(kind="request_relinquish", target=""))
         return moves
+
+    @staticmethod
+    def _id_required_and_absent(game: CredentialsGame) -> bool:
+        """Whether visible packet state lacks an ID required by today's rules."""
+
+        level = game.restriction_map.level_for(
+            game.active_case.get_region(),
+            game.active_case.get_purpose(),
+            RestrictionLevel.ANONYMOUS,
+        )
+        return level.requires_id and game.active_case.id_status() is None
 
     @staticmethod
     def _request_document_indications(case: CredentialCase) -> list[IndicationId]:
@@ -1532,6 +1554,8 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             )
         if move.kind == "verify_id":
             return "Verify identity"
+        if move.kind == "request_id":
+            return "Request ID"
         if move.kind == "request_search":
             return "Request search"
         if move.kind == "request_disclosure":
@@ -1774,6 +1798,8 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             return self._resolve_request_document(game, player_move.target, detail)
         if kind == "verify_id":
             return self._resolve_verify_id(game, detail)
+        if kind == "request_id":
+            return self._resolve_request_id(game, detail)
         if kind == "request_search":
             return self._resolve_request_search(game, detail)
         if kind == "request_disclosure":
@@ -1781,6 +1807,44 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
         if kind == "request_relinquish":
             return self._resolve_request_relinquish(game, detail)
         return super().resolve_move_kind(kind, game, player_move, detail)
+
+    def _resolve_request_id(
+        self,
+        game: CredentialsGame,
+        detail: dict[str, object],
+    ) -> RoundResult:
+        """Request one native but currently unpresented identity component."""
+
+        if not self._id_required_and_absent(game):
+            detail["outcome"] = "id_request_not_applicable"
+            return RoundResult.CONTINUE
+        case = game.active_case
+        manager = case.packet_manager
+        id_components = manager.get_slot(CREDENTIAL_UNPRESENTED_SLOT)
+        id_card = next((item for item in id_components if item.document_kind == "id"), None)
+        if case.id_request_response == "comply" and id_card is not None:
+            TransactionOffer(
+                label="present id",
+                commitments=[
+                    AssetMoveCommitment(
+                        giver=ComponentSlotAssetHolder(manager, CREDENTIAL_UNPRESENTED_SLOT),
+                        receiver=ComponentSlotAssetHolder(manager, CREDENTIAL_ID_SLOT),
+                        asset=id_card,
+                        label="present id",
+                    ),
+                ],
+            ).accept()
+            game.finding_status[FindingKey.ID] = Finding.VERIFIED
+            detail["outcome"] = "id_request_complied"
+            detail["component_id"] = str(id_card.uid)
+            game.presentation.render_case(
+                case,
+                derive_defects(manager, game.restriction_map, game.finding_status),
+            )
+        else:
+            game.finding_status[FindingKey.ID] = Finding.REFUSED
+            detail["outcome"] = "id_request_refused"
+        return RoundResult.CONTINUE
 
     def _resolve_request_document(
         self,
@@ -2037,6 +2101,17 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
                 line = "The id matches the bearer."
             return [
                 ContentFragment(content="You verify the bearer's identity."),
+                ContentFragment(content=line),
+            ]
+        if action == "request_id":
+            if notes.get("outcome") == "id_request_complied":
+                line = "The candidate produces their identification."
+            elif notes.get("outcome") == "id_request_refused":
+                line = "The candidate does not produce identification."
+            else:
+                line = "There is no identification to request."
+            return [
+                ContentFragment(content="You request the candidate's identification."),
                 ContentFragment(content=line),
             ]
         if action == "request_search":

--- a/engine/src/tangl/mechanics/games/credentials_game.py
+++ b/engine/src/tangl/mechanics/games/credentials_game.py
@@ -1212,9 +1212,12 @@ class CredentialsGame(PickingGame):
         else:
             self.shift_complete = True
 
-        self.current_stage = (
-            "documents" if not self.shift_complete and self.presented_documents else "packet"
-        )
+        if self.shift_complete:
+            self.current_stage = "packet"
+        elif not self.offers or len(self.materialized) > self.case_index:
+            self.current_stage = "documents" if self.presented_documents else "packet"
+        else:
+            self.current_stage = "documents"
         self.inspected_targets = []
         self.revealed_findings = {}
         self.inspected_packet_targets = []
@@ -1266,11 +1269,13 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
     game_cls: ClassVar[type[Game]] = CredentialsGame
 
     def on_setup(self, game: CredentialsGame) -> None:
-        """Prepare the first sampled packet before move provisioning begins."""
+        """Prepare graph-owned offers, without sampling an unresolved lazy roster."""
 
         if game.has_component_manager_owner and game.offers:
-            game.prepare_case(game.case_index)
-        if not game.presented_documents:
+            case = game.prepare_case(game.case_index)
+            if not case.presented_documents:
+                game.current_stage = "packet"
+        elif not game.offers and not game.presented_documents:
             game.current_stage = "packet"
 
     def provision_presentation(self, game: CredentialsGame, *, ctx: VmPhaseCtx) -> None:
@@ -1283,6 +1288,8 @@ class CredentialsGameHandler(PickingGameHandler[CredentialsGame]):
             indices.append(game.case_index + 1)
         for case_index in indices:
             case = game.prepare_case(case_index)
+            if case_index == game.case_index and not case.presented_documents:
+                game.current_stage = "packet"
             self._provision_case_presentation(
                 game,
                 case=case,

--- a/engine/src/tangl/mechanics/games/credentials_roster.py
+++ b/engine/src/tangl/mechanics/games/credentials_roster.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import random
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
+from typing import Literal
 from uuid import UUID
 
 from pydantic import Field
@@ -77,6 +78,7 @@ class ScenarioOffer(Unstructurable):
     packet_hidden_facts_override: dict[str, str] | None = None
     bearer_id: UUID | None = None
     prior_case_results: list[CredentialCaseResult] = Field(default_factory=list)
+    id_request_response: Literal["comply", "refuse"] = "comply"
 
 
 @dataclass(frozen=True)
@@ -342,6 +344,7 @@ def materialize(
         bearer_id=offer.bearer_id,
     )
     case.prior_case_results = list(offer.prior_case_results)
+    case.id_request_response = offer.id_request_response
     degrade(case, offer.failure_modes)
     defects = derive_defects(case.packet_manager, rules)
     (narrative_renderer or render_narrative)(case, defects)

--- a/engine/tests/loaders/test_hall_monitor_world.py
+++ b/engine/tests/loaders/test_hall_monitor_world.py
@@ -13,6 +13,7 @@ from tangl.loaders.compiler import WorldCompiler
 from tangl.mechanics.credentials import (
     CREDENTIAL_ID_SLOT,
     CREDENTIAL_PACKET_SLOT,
+    CREDENTIAL_UNPRESENTED_SLOT,
     CredentialDefinition,
     CredentialStatus,
     FailureMode,
@@ -231,7 +232,7 @@ class TestHallMonitorWorld:
         mira_packet = game.active_case.packet_manager
         assert not mira_packet.get_slot(CREDENTIAL_PACKET_SLOT)
 
-        _inspect(ledger, "student ID")
+        _inspect(ledger, "inhaler")
         assert "Complete and issue the medical waiver" in [
             action.label for action in _actions(ledger)
         ]
@@ -241,14 +242,24 @@ class TestHallMonitorWorld:
         assert completed == [waiver]
         assert completed[0].uid == waiver_id
         assert completed[0].status is CredentialStatus.VALID
-        assert completed[0].subject_id == mira_packet.get_slot(CREDENTIAL_ID_SLOT)[0].subject_id
+        assert completed[0].subject_id == mira_packet.bearer_id
         assert not game.desk_custody.get_slot(_DESK_CUSTODY_SLOT)
-        assert game.expected_disposition(game.active_case) is CredentialDisposition.PASS
+        assert game.expected_disposition(game.active_case) is CredentialDisposition.DENY
         assert len(game.transaction_receipts) == 2
         move_detail = game.transaction_receipts[1].details[0]
         assert isinstance(move_detail, dict)
         assert str(move_detail["asset_id"]) == str(waiver_id)
 
+        before_response = Graph.structure(graph.unstructure())
+        pre_response_game = before_response.find_one(
+            Selector(label="morning_shift")
+        ).game
+        pre_response_packet = pre_response_game.active_case.packet_manager
+        assert not pre_response_packet.get_slot(CREDENTIAL_ID_SLOT)
+        assert len(pre_response_packet.get_slot(CREDENTIAL_UNPRESENTED_SLOT)) == 1
+
+        _choose(ledger, "Request student ID")
+        assert game.expected_disposition(game.active_case) is CredentialDisposition.PASS
         _inspect(ledger, "doctor's note")
         reissued_text = _journal_text(ledger)
         assert "Valid for this period" in reissued_text
@@ -261,9 +272,11 @@ class TestHallMonitorWorld:
         restored_waiver = restored_packet.get_slot(CREDENTIAL_PACKET_SLOT)[0]
         assert restored_waiver.uid == waiver_id
         assert restored_waiver.status is CredentialStatus.VALID
-        assert restored_waiver.subject_id == restored_packet.get_slot(
-            CREDENTIAL_ID_SLOT
-        )[0].subject_id
+        assert restored_waiver.subject_id == restored_packet.bearer_id
+        restored_id = restored_packet.get_slot(CREDENTIAL_ID_SLOT)[0]
+        assert restored_id.subject_id == restored_packet.bearer_id
+        assert not restored_packet.get_slot(CREDENTIAL_UNPRESENTED_SLOT)
+        assert restored_game.finding_status["id"] == "verified"
         assert len(restored_game.transaction_receipts) == 2
         assert restored_game.case_results[0].model_dump(mode="python") == tess_result
 
@@ -271,7 +284,7 @@ class TestHallMonitorWorld:
         _, ledger = _started_shift()
         _advance_to_inhaler_case(ledger)
 
-        _inspect(ledger, "student ID")
+        _inspect(ledger, "inhaler")
 
         assert "Complete and issue the medical waiver" not in [
             action.label for action in _actions(ledger)
@@ -308,7 +321,7 @@ class TestHallMonitorWorld:
         _choose(ledger, "Send back to class")
         _advance_to_inhaler_case(ledger)
         packet = game.active_case.packet_manager
-        _inspect(ledger, "student ID")
+        _inspect(ledger, "inhaler")
 
         def fail_late() -> None:
             raise RuntimeError("late failure")

--- a/engine/tests/loaders/test_hall_monitor_world.py
+++ b/engine/tests/loaders/test_hall_monitor_world.py
@@ -276,7 +276,7 @@ class TestHallMonitorWorld:
         restored_id = restored_packet.get_slot(CREDENTIAL_ID_SLOT)[0]
         assert restored_id.subject_id == restored_packet.bearer_id
         assert not restored_packet.get_slot(CREDENTIAL_UNPRESENTED_SLOT)
-        assert restored_game.finding_status["id"] == "verified"
+        assert restored_game.finding_status["id"] == "cleared"
         assert len(restored_game.transaction_receipts) == 2
         assert restored_game.case_results[0].model_dump(mode="python") == tess_result
 

--- a/engine/tests/mechanics/games/test_credentials_game.py
+++ b/engine/tests/mechanics/games/test_credentials_game.py
@@ -114,7 +114,6 @@ class TestCredentialsCore:
         game = CredentialsGame(roster=[case], restriction_map=restrictions)
         handler = CredentialsGameHandler()
         handler.setup(game)
-        game.current_stage = "packet"
         return game, handler, native_id
 
     def test_request_id_compliance_restores_the_native_component(self) -> None:
@@ -137,7 +136,7 @@ class TestCredentialsCore:
             native_id
         ]
         assert not game.active_case.packet_manager.get_slot(CREDENTIAL_UNPRESENTED_SLOT)
-        assert game.finding_status[FindingKey.ID] == Finding.VERIFIED
+        assert game.finding_status[FindingKey.ID] == Finding.CLEARED
         assert game.last_round is not None
         assert game.last_round.notes["outcome"] == "id_request_complied"
         assert game.last_round.notes["component_id"] == str(native_id.uid)
@@ -148,6 +147,7 @@ class TestCredentialsCore:
         assert not any(
             move.kind == "request_id" for move in handler.get_available_moves(game)
         )
+        assert any(move.kind == "decide" for move in handler.get_available_moves(game))
 
     def test_request_id_refusal_keeps_the_native_component_unpresented(self) -> None:
         game, handler, native_id = self._missing_id_game("refuse")
@@ -172,6 +172,27 @@ class TestCredentialsCore:
         assert not any(
             move.kind == "request_id" for move in handler.get_available_moves(game)
         )
+        assert any(move.kind == "decide" for move in handler.get_available_moves(game))
+
+    def test_id_response_repair_supplies_justification_for_remaining_denial(self) -> None:
+        restrictions = Restrictions.from_map(
+            {Region.LOCAL: {Indication.TRAVEL: RestrictionLevel.WITH_PERMIT}}
+        )
+        case = build_valid(Region.LOCAL, Indication.TRAVEL, restrictions)
+        degrade(case, [FailureMode.MISSING_ID, FailureMode.MISSING_PERMIT])
+        game = CredentialsGame(
+            roster=[case],
+            restriction_map=restrictions,
+            no_evidence_penalty=1,
+        )
+        handler = CredentialsGameHandler()
+        handler.setup(game)
+
+        handler.receive_move(game, ("request_id", ""))
+        handler.receive_move(game, ("decide", "deny"))
+
+        assert game.case_results[0].correct is True
+        assert game.case_results[0].unjustified is False
 
     def test_inspect_reveals_hidden_finding(self) -> None:
         game, handler = _ready_game()
@@ -398,6 +419,43 @@ class TestCredentialsIntegration:
             "Inspect a document",
             choice_payload={"piece_ids": [f"{game.case_index}:{target}"]},
         )
+
+    def test_empty_packet_enters_the_response_window_in_live_provisioning(self) -> None:
+        restrictions = Restrictions.from_map(
+            {Region.LOCAL: {Indication.TRAVEL: RestrictionLevel.WITH_ID}}
+        )
+        case = build_valid(Region.LOCAL, Indication.TRAVEL, restrictions)
+        degrade(case, [FailureMode.MISSING_ID])
+
+        graph = Graph(label="credential_id_response")
+        intro = graph.add_node(kind=Block, label="intro")
+        victory = graph.add_node(kind=Block, label="victory")
+        defeat = graph.add_node(kind=Block, label="defeat")
+        block = CredentialsBlock.create_game_block(
+            graph=graph,
+            game_class=CredentialsGame,
+            handler_class=CredentialsGameHandler,
+            victory_dest=victory,
+            defeat_dest=defeat,
+            label="checkpoint",
+        )
+        block.game.roster = [case]
+        block.game.restriction_map = restrictions
+        block.game_handler.setup(block.game)
+        assert block.game.current_stage == "packet"
+
+        ChoiceEdge(
+            graph=graph,
+            predecessor_id=intro.uid,
+            successor_id=block.uid,
+            label="Open the gate ledger",
+        )
+        ledger = Ledger.from_graph(graph=graph, entry_id=intro.uid)
+        ledger.resolve_choice(next(edge.uid for edge in intro.edges_out()))
+
+        assert "Request ID" in self._labels(ledger)
+        self._choose(ledger, "Request ID")
+        assert "Choose pass" in self._labels(ledger)
 
     def test_walk_full_roster_to_victory(self) -> None:
         graph = Graph(label="credential_shift")

--- a/engine/tests/mechanics/games/test_credentials_game.py
+++ b/engine/tests/mechanics/games/test_credentials_game.py
@@ -2,11 +2,21 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import pytest
 
 from tangl.core import Graph
 from tangl.journal.fragments import ContentFragment, PieceFragment
-from tangl.mechanics.credentials import CREDENTIAL_ID_SLOT, materialize_packet
+from tangl.mechanics.credentials import (
+    CREDENTIAL_ID_SLOT,
+    CREDENTIAL_UNPRESENTED_SLOT,
+    CredentialComponent,
+    FailureMode,
+    RestrictionLevel,
+    Restrictions,
+    materialize_packet,
+)
 from tangl.mechanics.games import (
     CredentialStatus,
     CredentialToken,
@@ -15,11 +25,15 @@ from tangl.mechanics.games import (
     Indication,
     Region,
 )
+from tangl.mechanics.games.credentials_factory import build_valid, degrade
 from tangl.mechanics.games.credentials_game import (
     CredentialPresentationProfile,
     CredentialDisposition,
     CredentialsGame,
     CredentialsGameHandler,
+    Finding,
+    FindingKey,
+    derive_disposition,
 )
 from engine.tests.mechanics.games.credentials_helpers import make_credential_case as CredentialCase
 from tangl.mechanics.games.handlers import inject_game_context
@@ -80,6 +94,84 @@ def test_presentation_requires_text_for_every_invalid_status() -> None:
 
 class TestCredentialsCore:
     """Core shift behavior without the VM."""
+
+    @staticmethod
+    def _missing_id_game(
+        response: Literal["comply", "refuse"],
+    ) -> tuple[CredentialsGame, CredentialsGameHandler, CredentialComponent]:
+        restrictions = Restrictions.from_map(
+            {Region.LOCAL: {Indication.TRAVEL: RestrictionLevel.WITH_ID}}
+        )
+        case = build_valid(
+            Region.LOCAL,
+            Indication.TRAVEL,
+            restrictions,
+            candidate_name="Mara",
+        )
+        native_id = case.packet_manager.get_slot(CREDENTIAL_ID_SLOT)[0]
+        degrade(case, [FailureMode.MISSING_ID])
+        case.id_request_response = response
+        game = CredentialsGame(roster=[case], restriction_map=restrictions)
+        handler = CredentialsGameHandler()
+        handler.setup(game)
+        game.current_stage = "packet"
+        return game, handler, native_id
+
+    def test_request_id_compliance_restores_the_native_component(self) -> None:
+        game, handler, native_id = self._missing_id_game("comply")
+
+        first_moves = handler.get_available_moves(game)
+        assert handler.get_available_moves(game) == first_moves
+        assert [move.kind for move in first_moves].count("request_id") == 1
+        assert game.active_case.packet_manager.get_slot(
+            CREDENTIAL_UNPRESENTED_SLOT
+        ) == [native_id]
+        assert (
+            derive_disposition(game.active_case.packet_manager, game.restriction_map)
+            is CredentialDisposition.DENY
+        )
+
+        handler.receive_move(game, ("request_id", ""))
+
+        assert game.active_case.packet_manager.get_slot(CREDENTIAL_ID_SLOT) == [
+            native_id
+        ]
+        assert not game.active_case.packet_manager.get_slot(CREDENTIAL_UNPRESENTED_SLOT)
+        assert game.finding_status[FindingKey.ID] == Finding.VERIFIED
+        assert game.last_round is not None
+        assert game.last_round.notes["outcome"] == "id_request_complied"
+        assert game.last_round.notes["component_id"] == str(native_id.uid)
+        assert (
+            derive_disposition(game.active_case.packet_manager, game.restriction_map)
+            is CredentialDisposition.PASS
+        )
+        assert not any(
+            move.kind == "request_id" for move in handler.get_available_moves(game)
+        )
+
+    def test_request_id_refusal_keeps_the_native_component_unpresented(self) -> None:
+        game, handler, native_id = self._missing_id_game("refuse")
+
+        first_moves = handler.get_available_moves(game)
+        assert handler.get_available_moves(game) == first_moves
+        assert [move.kind for move in first_moves].count("request_id") == 1
+
+        handler.receive_move(game, ("request_id", ""))
+
+        assert not game.active_case.packet_manager.get_slot(CREDENTIAL_ID_SLOT)
+        assert game.active_case.packet_manager.get_slot(
+            CREDENTIAL_UNPRESENTED_SLOT
+        ) == [native_id]
+        assert game.finding_status[FindingKey.ID] == Finding.REFUSED
+        assert game.last_round is not None
+        assert game.last_round.notes["outcome"] == "id_request_refused"
+        assert (
+            derive_disposition(game.active_case.packet_manager, game.restriction_map)
+            is CredentialDisposition.DENY
+        )
+        assert not any(
+            move.kind == "request_id" for move in handler.get_available_moves(game)
+        )
 
     def test_inspect_reveals_hidden_finding(self) -> None:
         game, handler = _ready_game()

--- a/worlds/hall_monitor/hall_monitor/domain.py
+++ b/worlds/hall_monitor/hall_monitor/domain.py
@@ -155,9 +155,9 @@ def _special_student() -> ScenarioOffer:
         candidate_name="Mira Quill",
         region="lower",
         purpose="medicine",
-        failure_modes=[FailureMode.MISSING_PERMIT],
+        failure_modes=[FailureMode.MISSING_PERMIT, FailureMode.MISSING_ID],
         presented_documents_override={
-            "student ID": "A laminated lower-school student identification card.",
+            "inhaler": "An inhaler case is held openly at the student's side.",
         },
         packet_hidden_facts_override={
             "packet consistency": "The student's papers do not satisfy the hall rules.",
@@ -311,6 +311,11 @@ class HallMonitorCredentialsHandler(CredentialsGameHandler):
                     moves.append(
                         CredentialsMove(kind="reissue_waiver", target=str(component.uid))
                     )
+        if game.case_index == game.inhaler_case_index and not any(
+            component.indication == "medicine"
+            for component in game.active_case.packet_manager.get_slot(CREDENTIAL_PACKET_SLOT)
+        ):
+            moves = [move for move in moves if move.kind != "request_id"]
         return moves
 
     def get_move_label(self, game: HallMonitorCredentialsGame, move: CredentialsMove) -> str:
@@ -318,6 +323,8 @@ class HallMonitorCredentialsHandler(CredentialsGameHandler):
             return "Retain the medical waiver"
         if move.kind == "reissue_waiver":
             return "Complete and issue the medical waiver"
+        if move.kind == "request_id":
+            return "Request student ID"
         return super().get_move_label(game, move)
 
     def resolve_move_kind(
@@ -400,13 +407,12 @@ class HallMonitorCredentialsHandler(CredentialsGameHandler):
         if component is None:
             raise ValueError("The submitted waiver is not in desk custody")
         packet = game.active_case.packet_manager
-        id_card = packet.get_slot(CREDENTIAL_ID_SLOT)[0]
         original_status = component.status
         original_subject_id = component.subject_id
 
         def apply_completion() -> None:
             component.status = CredentialStatus.VALID
-            component.subject_id = id_card.subject_id
+            component.subject_id = packet.bearer_id
 
         def undo_completion() -> None:
             component.status = original_status
@@ -452,7 +458,15 @@ class HallMonitorCredentialsHandler(CredentialsGameHandler):
         if action == "retain_waiver":
             return [ContentFragment(content="You retain the medical waiver at the hall desk.")]
         if action == "reissue_waiver":
-            return [ContentFragment(content="You complete and issue the medical waiver.")]
+            return [
+                ContentFragment(content="You complete and issue the medical waiver."),
+                ContentFragment(content="Here is a pass; you'll need your ID to use it."),
+            ]
+        if action == "request_id" and notes.get("outcome") == "id_request_complied":
+            return [
+                ContentFragment(content="You request Mira's student ID."),
+                ContentFragment(content="That's okay; I have it here."),
+            ]
         return super()._prose_fragments(game, last_round, action, target, notes)
 
 


### PR DESCRIPTION
## Summary

- preserve native missing IDs in an unpresented packet slot instead of deleting them
- add the generic disclosure-safe `request_id` move with scenario-owned comply/refuse response
- extend Hall Monitor’s harvested-waiver path: reissue remains DENY until Mira presents her native ID, then ordinary evaluation derives PASS

## Guarantees

The request menu depends only on visible rules and missing presentation, not response policy. Compliance moves the original graph-owned component back into the ID slot through the existing transaction rail; refusal records behavioral evidence and leaves it unpresented. The Hall Monitor path preserves prior history and graph identity across round trips.

## Validation

- `poetry run pytest engine/tests/mechanics/credentials engine/tests/mechanics/games/test_credentials_game.py engine/tests/mechanics/games/test_credentials_fragments.py engine/tests/mechanics/test_assembly.py engine/tests/mechanics/test_transaction_offer.py engine/tests/loaders/test_hall_monitor_world.py apps/server/tests/test_hall_monitor_playable_vertical.py -q`
  - `202 passed`
- `git diff --check`

Closes #335.