### PR TITLE
Isolate shared behavior registries between tests

### DIFF
--- a/engine/tests/conftest.py
+++ b/engine/tests/conftest.py
@@ -101,3 +101,72 @@ def clear_story_world_instances() -> None:
     yield
     World.clear_instances()
     clear_discovered_world_registries()
+
+
+#: Module-level ``BehaviorRegistry`` singletons shared by the whole process.
+#:
+#: Layers order, registries scope: ``DispatchLayer`` only sorts handlers within a
+#: chain, so a handler is visible exactly when the registry holding it is in the
+#: chain ``chain_execute_all`` assembles. Registering into one of these therefore
+#: mutates global program state, and no layer value contains it.
+#:
+#: Per-instance registries built by ``default_factory`` (frame/ledger locals, the
+#: per-world ``world_domain_dispatch``) are not listed: they die with their owner.
+_SHARED_BEHAVIOR_REGISTRIES: tuple[tuple[str, str], ...] = (
+    ("tangl.core.dispatch", "dispatch"),
+    ("tangl.vm.dispatch", "dispatch"),
+    ("tangl.story.dispatch", "story_dispatch"),
+    ("tangl.ir.dispatch", "script_dispatch"),
+    ("tangl.service.dispatch", "service_info_dispatch"),
+    ("tangl.mechanics.sandbox.dispatch", "sandbox_dispatch"),
+    ("tangl.media.dispatch", "media_dispatch"),
+    ("tangl.media.media_resource.media_provisioning", "on_provision_media"),
+    ("tangl.media.media_creators.media_spec", "on_adapt_media_spec"),
+    ("tangl.media.media_creators.media_spec", "on_create_media"),
+)
+
+
+def _shared_behavior_registries() -> list:
+    """Resolve the shared behavior registries, importing their modules once."""
+    from importlib import import_module
+
+    return [
+        getattr(import_module(module_name), attr)
+        for module_name, attr in _SHARED_BEHAVIOR_REGISTRIES
+    ]
+
+
+@pytest.fixture(autouse=True)
+def isolate_behavior_registries() -> None:
+    """Undo handler registrations a test *body* makes against shared registries.
+
+    Module-level decorators (``@on_gather_ns``, ``@on_render_text``,
+    ``@vm_dispatch.register``, ...) register into process-global singletons, so a
+    test that registers a handler otherwise keeps it live for every test that
+    follows. Snapshot the member uids, then drop whatever appeared during the
+    test.
+
+    Two things this deliberately does not do:
+
+    * It never calls ``clear()``. Production handlers register at import time and
+      must survive; only the added-during-this-test diff is removed.
+    * It exempts handlers contributed by a module first imported *during* the
+      test. World domain modules (``worlds/*/domain.py``) register into the shared
+      vm/story registries at import time, but are imported lazily by
+      ``WorldCompiler`` rather than at collection. ``importlib.import_module``
+      caches, so a second ``compile()`` never re-runs those decorators — removing
+      them would break every later test that loads the same world. Import-time
+      registration is once-per-process by design, whenever the import happens.
+    """
+    registries = _shared_behavior_registries()
+    snapshots = [(registry, set(registry.members)) for registry in registries]
+    modules_before = set(sys.modules)
+    yield
+    imported_during_test = set(sys.modules) - modules_before
+    for registry, known in snapshots:
+        for uid in set(registry.members) - known:
+            behavior = registry.members[uid]
+            origin = getattr(getattr(behavior, "func", None), "__module__", None)
+            if origin in imported_during_test:
+                continue  # import-time registration; once-per-process by design
+            registry.remove(uid)

--- a/engine/tests/conftest.py
+++ b/engine/tests/conftest.py
@@ -103,39 +103,6 @@ def clear_story_world_instances() -> None:
     clear_discovered_world_registries()
 
 
-#: Module-level ``BehaviorRegistry`` singletons shared by the whole process.
-#:
-#: Layers order, registries scope: ``DispatchLayer`` only sorts handlers within a
-#: chain, so a handler is visible exactly when the registry holding it is in the
-#: chain ``chain_execute_all`` assembles. Registering into one of these therefore
-#: mutates global program state, and no layer value contains it.
-#:
-#: Per-instance registries built by ``default_factory`` (frame/ledger locals, the
-#: per-world ``world_domain_dispatch``) are not listed: they die with their owner.
-_SHARED_BEHAVIOR_REGISTRIES: tuple[tuple[str, str], ...] = (
-    ("tangl.core.dispatch", "dispatch"),
-    ("tangl.vm.dispatch", "dispatch"),
-    ("tangl.story.dispatch", "story_dispatch"),
-    ("tangl.ir.dispatch", "script_dispatch"),
-    ("tangl.service.dispatch", "service_info_dispatch"),
-    ("tangl.mechanics.sandbox.dispatch", "sandbox_dispatch"),
-    ("tangl.media.dispatch", "media_dispatch"),
-    ("tangl.media.media_resource.media_provisioning", "on_provision_media"),
-    ("tangl.media.media_creators.media_spec", "on_adapt_media_spec"),
-    ("tangl.media.media_creators.media_spec", "on_create_media"),
-)
-
-
-def _shared_behavior_registries() -> list:
-    """Resolve the shared behavior registries, importing their modules once."""
-    from importlib import import_module
-
-    return [
-        getattr(import_module(module_name), attr)
-        for module_name, attr in _SHARED_BEHAVIOR_REGISTRIES
-    ]
-
-
 @pytest.fixture(autouse=True)
 def isolate_behavior_registries() -> None:
     """Undo handler registrations a test *body* makes against shared registries.
@@ -143,30 +110,10 @@ def isolate_behavior_registries() -> None:
     Module-level decorators (``@on_gather_ns``, ``@on_render_text``,
     ``@vm_dispatch.register``, ...) register into process-global singletons, so a
     test that registers a handler otherwise keeps it live for every test that
-    follows. Snapshot the member uids, then drop whatever appeared during the
-    test.
-
-    Two things this deliberately does not do:
-
-    * It never calls ``clear()``. Production handlers register at import time and
-      must survive; only the added-during-this-test diff is removed.
-    * It exempts handlers contributed by a module first imported *during* the
-      test. World domain modules (``worlds/*/domain.py``) register into the shared
-      vm/story registries at import time, but are imported lazily by
-      ``WorldCompiler`` rather than at collection. ``importlib.import_module``
-      caches, so a second ``compile()`` never re-runs those decorators — removing
-      them would break every later test that loads the same world. Import-time
-      registration is once-per-process by design, whenever the import happens.
+    follows. See `pytest_helpers.registry_isolation` for what is snapshotted and
+    why import-time registration is exempt.
     """
-    registries = _shared_behavior_registries()
-    snapshots = [(registry, set(registry.members)) for registry in registries]
-    modules_before = set(sys.modules)
-    yield
-    imported_during_test = set(sys.modules) - modules_before
-    for registry, known in snapshots:
-        for uid in set(registry.members) - known:
-            behavior = registry.members[uid]
-            origin = getattr(getattr(behavior, "func", None), "__module__", None)
-            if origin in imported_during_test:
-                continue  # import-time registration; once-per-process by design
-            registry.remove(uid)
+    from pytest_helpers.registry_isolation import restore_shared_behavior_registries
+
+    with restore_shared_behavior_registries():
+        yield

--- a/engine/tests/pytest_helpers/registry_isolation.py
+++ b/engine/tests/pytest_helpers/registry_isolation.py
@@ -64,8 +64,17 @@ def restore_shared_behavior_registries() -> Iterator[None]:
       would break every later test that loads the same world. Import-time
       registration is once-per-process by design, whenever the import happens.
 
-    Callers that deliberately import a registering module inside the block are
-    therefore responsible for removing its handlers themselves.
+    Known limitation. The exemption keys on the handler's defining module, not on
+    a registration timestamp, so it is loose in one direction: a handler defined
+    in a module first imported inside the block is kept even when the *test body*
+    is what registered it (``import probe; on_gather_ns(probe.handler)``).
+    Tightening that needs a registration-time hook — patching
+    ``BehaviorRegistry.add``, which ``_wrap_inline`` already bypasses at
+    ``core/behavior.py:396``, plus an import-depth flag on every test — which is a
+    lot of global machinery for a pattern nothing in the tree uses. Callers that
+    deliberately import a registering module inside the block are responsible for
+    removing its handlers themselves; the contract test in
+    ``test_registry_isolation.py`` does exactly that.
     """
     registries = shared_behavior_registries()
     snapshots = [(registry, set(registry.members)) for registry in registries]

--- a/engine/tests/pytest_helpers/registry_isolation.py
+++ b/engine/tests/pytest_helpers/registry_isolation.py
@@ -1,0 +1,83 @@
+"""Snapshot and restore the process-global behavior registries.
+
+Layers order, registries scope: ``DispatchLayer`` is only the first element of
+``Behavior.sort_key``, so a handler is visible exactly while the registry holding
+it is in the chain ``chain_execute_all`` assembles. Registering into one of the
+module-level singletons below is therefore global mutation, and no layer value
+contains it.
+
+Used by the autouse ``isolate_behavior_registries`` fixture in
+``engine/tests/conftest.py``. Exposed here rather than inlined there so the
+mechanism can be exercised directly by a test instead of only through
+declaration-ordered side effects.
+"""
+
+from __future__ import annotations
+
+import sys
+from contextlib import contextmanager
+from importlib import import_module
+from typing import Iterator
+
+from tangl.core import BehaviorRegistry
+
+#: ``(module, attribute)`` for every ``BehaviorRegistry`` singleton shared by the
+#: whole process.
+#:
+#: Per-instance registries built by ``default_factory`` (frame/ledger locals, the
+#: per-world ``world_domain_dispatch``) are excluded: they die with their owner.
+SHARED_BEHAVIOR_REGISTRIES: tuple[tuple[str, str], ...] = (
+    ("tangl.core.dispatch", "dispatch"),
+    ("tangl.vm.dispatch", "dispatch"),
+    ("tangl.story.dispatch", "story_dispatch"),
+    ("tangl.ir.dispatch", "script_dispatch"),
+    ("tangl.service.dispatch", "service_info_dispatch"),
+    ("tangl.mechanics.sandbox.dispatch", "sandbox_dispatch"),
+    ("tangl.media.dispatch", "media_dispatch"),
+    ("tangl.media.media_resource.media_provisioning", "on_provision_media"),
+    ("tangl.media.media_creators.media_spec", "on_adapt_media_spec"),
+    ("tangl.media.media_creators.media_spec", "on_create_media"),
+)
+
+
+def shared_behavior_registries() -> list[BehaviorRegistry]:
+    """Resolve the shared registries, importing their modules on first use."""
+    return [
+        getattr(import_module(module_name), attr)
+        for module_name, attr in SHARED_BEHAVIOR_REGISTRIES
+    ]
+
+
+@contextmanager
+def restore_shared_behavior_registries() -> Iterator[None]:
+    """Remove handlers registered by the enclosed block's own code.
+
+    Two things this deliberately does not do:
+
+    * It never calls ``clear()``. Production handlers register at import time and
+      must survive; only the added-inside-the-block diff is removed.
+    * It exempts handlers contributed by a module first imported *inside* the
+      block. World domain modules (``worlds/*/domain.py``) register into the
+      shared vm/story registries at import time, but ``WorldCompiler`` imports
+      them lazily rather than at collection. ``importlib.import_module`` caches,
+      so a second ``compile()`` never re-runs those decorators — removing them
+      would break every later test that loads the same world. Import-time
+      registration is once-per-process by design, whenever the import happens.
+
+    Callers that deliberately import a registering module inside the block are
+    therefore responsible for removing its handlers themselves.
+    """
+    registries = shared_behavior_registries()
+    snapshots = [(registry, set(registry.members)) for registry in registries]
+    modules_before = set(sys.modules)
+    try:
+        yield
+    finally:
+        imported_inside = set(sys.modules) - modules_before
+        for registry, known in snapshots:
+            for uid in set(registry.members) - known:
+                behavior = registry.members[uid]
+                origin = getattr(getattr(behavior, "func", None), "__module__", None)
+                if origin in imported_inside:
+                    continue  # import-time registration; once-per-process by design
+                registry.remove(uid)

--- a/engine/tests/test_registry_isolation.py
+++ b/engine/tests/test_registry_isolation.py
@@ -1,15 +1,18 @@
-"""Contract tests for the autouse shared-registry isolation fixture.
+"""Contract tests for shared behavior-registry isolation.
 
-The fixture under test is ``isolate_behavior_registries`` in this directory's
-``conftest.py``. It exists because ``DispatchLayer`` confers no visibility:
-layers order handlers, registries scope them, so a handler is live exactly while
-the registry holding it is in the dispatch chain. Registering into a
-process-global registry is therefore global mutation, and nothing about the layer
-value contains it.
+Covers `pytest_helpers.registry_isolation` and the autouse
+``isolate_behavior_registries`` fixture in this directory's ``conftest.py``.
+The fixture exists because ``DispatchLayer`` confers no visibility: layers order
+handlers, registries scope them, so a handler is live exactly while the registry
+holding it is in the dispatch chain. Registering into a process-global registry
+is global mutation, and nothing about the layer value contains it.
 
-These tests are deliberately at ``engine/tests/`` root rather than under ``vm/``:
-``vm/conftest.py`` has its own ``clean_vm_dispatch`` fixture that clears and
-restores ``vm_dispatch`` wholesale, which would mask what is being proven here.
+Each test drives a cleanup cycle itself rather than reading state left by a
+neighbour, so every one passes when selected alone or in any order.
+
+These live at ``engine/tests/`` root rather than under ``vm/``: ``vm/conftest.py``
+has its own ``clean_vm_dispatch`` fixture that clears and restores ``vm_dispatch``
+wholesale, which would mask what is being proven here.
 
 .. storytangl-topic::
    :topics: dispatch
@@ -19,55 +22,103 @@ restores ``vm_dispatch`` wholesale, which would mask what is being proven here.
 
 from __future__ import annotations
 
-from uuid import UUID
+import importlib
+import sys
 
+from pytest_helpers.registry_isolation import restore_shared_behavior_registries
 from tangl.story.dispatch import on_render_text, story_dispatch
 from tangl.vm.dispatch import dispatch as vm_dispatch, on_gather_ns
 from tangl.vm.traversable import TraversableNode
 
-#: Uids registered by the first test, read back by the second. Module state is the
-#: point: the whole failure mode this guards against is state outliving a test.
-_REGISTERED: dict[str, UUID] = {}
+#: A module that registers on import, standing in for ``worlds/*/domain.py``.
+_PROBE_DOMAIN_SOURCE = '''\
+from tangl.vm.dispatch import on_gather_ns
+from tangl.vm.traversable import TraversableNode
 
 
-def test_broad_handlers_register_into_shared_registries() -> None:
-    """Register on a broad caller kind — the case where type-filtering stops saving us.
+@on_gather_ns(wants_caller_kind=TraversableNode, wants_exact_kind=False)
+def probe_domain_handler(*, caller, ctx, **_kw):
+    return {"probe_domain": True}
+'''
+
+
+def test_isolation_fixture_applies_to_every_test(request) -> None:
+    """The fixture is wired autouse, not opt-in.
+
+    This test never requests it, so finding it among the active fixtures is proof
+    the whole ``engine/tests`` tree is covered — including tests that have no idea
+    the registries exist.
+    """
+    assert "isolate_behavior_registries" in request.fixturenames
+
+
+def test_test_body_registration_is_removed() -> None:
+    """Register on a broad caller kind — where type-filtering stops saving us.
 
     ``TraversableNode`` matches essentially every node the VM walks, so without
     isolation these two handlers would fire for the rest of the session.
     """
+    with restore_shared_behavior_registries():
 
-    @on_gather_ns(wants_caller_kind=TraversableNode, wants_exact_kind=False)
-    def _leaky_ns_contributor(*, caller, ctx, **_kw):
-        return {"isolation_probe": True}
+        @on_gather_ns(wants_caller_kind=TraversableNode, wants_exact_kind=False)
+        def _leaky_ns_contributor(*, caller, ctx, **_kw):
+            return {"isolation_probe": True}
 
-    @on_render_text(wants_caller_kind=TraversableNode, wants_exact_kind=False)
-    def _leaky_text_handler(*, caller, aspect, ctx, **_kw):
-        return "isolation probe"
+        @on_render_text(wants_caller_kind=TraversableNode, wants_exact_kind=False)
+        def _leaky_text_handler(*, caller, aspect, ctx, **_kw):
+            return "isolation probe"
 
-    _REGISTERED["vm"] = _leaky_ns_contributor._behavior.uid
-    _REGISTERED["story"] = _leaky_text_handler._behavior.uid
+        vm_uid = _leaky_ns_contributor._behavior.uid
+        story_uid = _leaky_text_handler._behavior.uid
+        assert vm_uid in vm_dispatch.members
+        assert story_uid in story_dispatch.members
 
-    assert _REGISTERED["vm"] in vm_dispatch.members
-    assert _REGISTERED["story"] in story_dispatch.members
-
-
-def test_broad_handlers_did_not_survive_the_previous_test() -> None:
-    """The fixture removed both without being asked, and without a manual cleanup."""
-    assert _REGISTERED, (
-        "expected the registering test to have run first; this pair asserts "
-        "cross-test isolation and depends on declaration order"
-    )
-
-    assert _REGISTERED["vm"] not in vm_dispatch.members
-    assert _REGISTERED["story"] not in story_dispatch.members
+    assert vm_uid not in vm_dispatch.members
+    assert story_uid not in story_dispatch.members
 
 
-def test_import_time_handlers_survive_the_fixture() -> None:
+def test_import_time_registration_is_preserved(tmp_path, monkeypatch) -> None:
+    """A module first imported inside the block keeps its handlers.
+
+    ``WorldCompiler`` imports ``worlds/*/domain.py`` lazily through
+    ``importlib.import_module``, which caches: a second ``compile()`` never
+    re-runs the decorators. Removing them breaks every later test that loads the
+    same world.
+    """
+    module_name = "isolation_probe_domain"
+    (tmp_path / f"{module_name}.py").write_text(_PROBE_DOMAIN_SOURCE)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    importlib.invalidate_caches()
+
+    module = None
+    try:
+        with restore_shared_behavior_registries():
+            module = importlib.import_module(module_name)
+            probe_uid = module.probe_domain_handler._behavior.uid
+            assert probe_uid in vm_dispatch.members
+
+        assert probe_uid in vm_dispatch.members, (
+            "import-time handler was removed; a second import would not re-register it"
+        )
+    finally:
+        # The autouse fixture exempts this handler for the same reason, so the
+        # test that created it has to be the one to take it back out.
+        sys.modules.pop(module_name, None)
+        if module is not None:
+            vm_dispatch.remove(module.probe_domain_handler._behavior.uid)
+
+
+def test_preexisting_handlers_survive_a_cleanup_cycle() -> None:
     """The fixture is a diff, not a ``clear()``.
 
-    Production handlers register at import time and must still be present, or the
-    fixture would be quietly disarming the engine for every test that follows.
+    Production handlers register at import time; emptying the registries would
+    quietly disarm the engine for every test that follows.
     """
-    assert vm_dispatch.members, "vm_dispatch was emptied; the fixture over-reached"
-    assert story_dispatch.members, "story_dispatch was emptied; the fixture over-reached"
+    before = set(vm_dispatch.members), set(story_dispatch.members)
+    assert all(before), "expected import-time production handlers to be registered"
+
+    with restore_shared_behavior_registries():
+        pass
+
+    assert before[0] <= set(vm_dispatch.members)
+    assert before[1] <= set(story_dispatch.members)

--- a/engine/tests/test_registry_isolation.py
+++ b/engine/tests/test_registry_isolation.py
@@ -1,0 +1,73 @@
+"""Contract tests for the autouse shared-registry isolation fixture.
+
+The fixture under test is ``isolate_behavior_registries`` in this directory's
+``conftest.py``. It exists because ``DispatchLayer`` confers no visibility:
+layers order handlers, registries scope them, so a handler is live exactly while
+the registry holding it is in the dispatch chain. Registering into a
+process-global registry is therefore global mutation, and nothing about the layer
+value contains it.
+
+These tests are deliberately at ``engine/tests/`` root rather than under ``vm/``:
+``vm/conftest.py`` has its own ``clean_vm_dispatch`` fixture that clears and
+restores ``vm_dispatch`` wholesale, which would mask what is being proven here.
+
+.. storytangl-topic::
+   :topics: dispatch
+   :facets: tests
+   :relation: tests
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from tangl.story.dispatch import on_render_text, story_dispatch
+from tangl.vm.dispatch import dispatch as vm_dispatch, on_gather_ns
+from tangl.vm.traversable import TraversableNode
+
+#: Uids registered by the first test, read back by the second. Module state is the
+#: point: the whole failure mode this guards against is state outliving a test.
+_REGISTERED: dict[str, UUID] = {}
+
+
+def test_broad_handlers_register_into_shared_registries() -> None:
+    """Register on a broad caller kind — the case where type-filtering stops saving us.
+
+    ``TraversableNode`` matches essentially every node the VM walks, so without
+    isolation these two handlers would fire for the rest of the session.
+    """
+
+    @on_gather_ns(wants_caller_kind=TraversableNode, wants_exact_kind=False)
+    def _leaky_ns_contributor(*, caller, ctx, **_kw):
+        return {"isolation_probe": True}
+
+    @on_render_text(wants_caller_kind=TraversableNode, wants_exact_kind=False)
+    def _leaky_text_handler(*, caller, aspect, ctx, **_kw):
+        return "isolation probe"
+
+    _REGISTERED["vm"] = _leaky_ns_contributor._behavior.uid
+    _REGISTERED["story"] = _leaky_text_handler._behavior.uid
+
+    assert _REGISTERED["vm"] in vm_dispatch.members
+    assert _REGISTERED["story"] in story_dispatch.members
+
+
+def test_broad_handlers_did_not_survive_the_previous_test() -> None:
+    """The fixture removed both without being asked, and without a manual cleanup."""
+    assert _REGISTERED, (
+        "expected the registering test to have run first; this pair asserts "
+        "cross-test isolation and depends on declaration order"
+    )
+
+    assert _REGISTERED["vm"] not in vm_dispatch.members
+    assert _REGISTERED["story"] not in story_dispatch.members
+
+
+def test_import_time_handlers_survive_the_fixture() -> None:
+    """The fixture is a diff, not a ``clear()``.
+
+    Production handlers register at import time and must still be present, or the
+    fixture would be quietly disarming the engine for every test that follows.
+    """
+    assert vm_dispatch.members, "vm_dispatch was emptied; the fixture over-reached"
+    assert story_dispatch.members, "story_dispatch was emptied; the fixture over-reached"

--- a/worlds/composed_beat_demo/composed_beat_demo/domain.py
+++ b/worlds/composed_beat_demo/composed_beat_demo/domain.py
@@ -36,7 +36,7 @@ class BeatBlock(Block):
 
 @on_gather_ns(wants_caller_kind=BeatBlock, wants_exact_kind=False)
 def contribute_default_porter_chunk(*, caller, ctx, **_kw):
-    """APPLICATION-scope default for the named ``porter_greeting`` chunk."""
+    """APPLICATION-layer default for the named ``porter_greeting`` chunk."""
     return {"porter_greeting": "The porter waves you through without looking up."}
 
 
@@ -46,7 +46,14 @@ def contribute_default_porter_chunk(*, caller, ctx, **_kw):
     dispatch_layer=DispatchLayer.AUTHOR,
 )
 def contribute_author_porter_chunk(*, caller, ctx, **_kw):
-    """AUTHOR-scope override of ``porter_greeting`` — the later layer wins."""
+    """AUTHOR-layer override of ``porter_greeting`` — the later layer wins.
+
+    Layer is ordering, not isolation: this handler wins because ``AUTHOR`` sorts
+    after ``APPLICATION`` in ``Behavior.sort_key``, not because it is scoped to
+    this world. Both handlers register into the same process-global story
+    registry, so both are visible to every story in the process. Visibility comes
+    from which registry is in the dispatch chain, never from the layer value.
+    """
     return {"porter_greeting": "Old Maro looks up from his ledger and grins."}
 
 


### PR DESCRIPTION
Closes #358.

Module-level decorators (`@on_gather_ns`, `@on_render_text`, `@vm_dispatch.register`, …) register into process-global `BehaviorRegistry` singletons. Layers order, registries scope — `DispatchLayer` is just the first element of `Behavior.sort_key` ([`core/behavior.py:281`](engine/src/tangl/core/behavior.py:281)), so visibility comes entirely from *which registry* is in the chain `chain_execute_all` assembles. Registering into one is global mutation and no layer value contains it.

## What the verification pass actually found

Two of the issue's claims are stale at HEAD, and the fix is not the one the issue proposed:

**The headline offenders don't leak.** `test_dispatch.py:118,466,470` are already contained — [`engine/tests/vm/conftest.py:60`](engine/tests/vm/conftest.py:60) has an autouse `clean_vm_dispatch` fixture that clears and restores `vm_dispatch` for the whole `vm/` directory. Directory-scoped, not call-site cleanup, which is why grepping for `remove(behavior.uid)` missed it.

**The real leaks are world domain imports.** Instrumenting every test with a per-test registry diff found exactly 19 surviving registrations, all from `worlds/*/domain.py` modules imported lazily by `WorldCompiler` during a loader test — `adventure_sandbox_slice`, `colony_loop`, `composed_beat_demo`, `coronate_the_regent`, `hall_monitor`, `logic_demo`.

**And those must not be removed.** The fixture as specified in the issue — snapshot uids, drop the diff — **broke 13 loader tests**. `DomainCompiler.load_domain_module` goes through `importlib.import_module` ([`loaders/compiler.py:27`](engine/src/tangl/loaders/compiler.py:27)), which caches, so a second `compile()` never re-runs those decorators. Removing them meant the first test in each loader file worked and every later one in the same file failed.

So the fixture exempts handlers whose defining module was first imported *during* the test. That is the real invariant: import-time registration is once-per-process by design, whenever the import happens to occur. Registration from a test body is not.

## Baseline (established before adding the fixture)

No randomizer plugin is available and none was added. A throwaway diagnostic plugin shuffled the collected items instead:

- Full suite, normal order: **2990 passed**, 69 skipped, 9 xfailed.
- Full suite, reversed file order: identical, green.
- Full suite, **fully shuffled (every test randomized), seeds 1/2/3, fixture disabled**: identical, green.
- Targeted `vm → story → mechanics → loaders` vs. the reverse: identical, green.

**No pre-existing order-dependent failure was surfaced.** The 13 loader failures above were the naive fixture over-reaching, not a latent bug — they do not appear in the shipped version. Type-filtering is still doing the load-bearing work today: every leaked handler is bound to a world-local class, so nothing currently matches a foreign caller. That is luck, not design, which is the point of the fixture.

## Changes

- **[`engine/tests/pytest_helpers/registry_isolation.py`](engine/tests/pytest_helpers/registry_isolation.py)** — the inventory and a `restore_shared_behavior_registries()` context manager. Covers all ten module-level shared registries (`core`, `vm`, `story`, `ir`, `service`, `sandbox`, `media`, `provision_media`, `adapt_media_spec`, `create_media`); per-instance registries built by `default_factory` are excluded since they die with their owner. Lives here rather than inline in `conftest.py` so the mechanism can be tested directly.
- **[`engine/tests/conftest.py`](engine/tests/conftest.py)** — autouse `isolate_behavior_registries`, a thin wrapper over that context manager, next to the existing `World.clear_instances()` fixture and in its style.
- **[`engine/tests/test_registry_isolation.py`](engine/tests/test_registry_isolation.py)** — four order-independent contract tests, each driving its own cleanup cycle: autouse wiring (via `request.fixturenames`, which the test never requests); the removal branch on `wants_caller_kind=TraversableNode`, the broad case where type-filtering stops saving us; the exemption branch, importing a generated module that registers on import as a stand-in for `worlds/*/domain.py`; and a no-over-reach check that pre-existing uids survive a cycle. At `engine/tests/` root because `vm/conftest.py` would otherwise mask them.
- **[`worlds/composed_beat_demo/composed_beat_demo/domain.py:39,49`](worlds/composed_beat_demo/composed_beat_demo/domain.py:39)** — "AUTHOR-scope override" → "AUTHOR-layer", with a note on why it wins (`AUTHOR=3` sorts after `APPLICATION=2`; both register into the same shared story registry). The `data-scope` / `handler-scope` wording elsewhere in that world names a contribution *channel*, not a layer, and already says "layer" where it means layer — left alone.

The five existing manual `remove(behavior.uid)` sites are untouched and are now belt-and-braces.

## Verification

- `pytest` (full default testpaths): **2994 passed**, 70 skipped, 9 xfailed — 2990 baseline + 4 new.
- `pytest engine/tests` reversed file order, and fully shuffled at seeds 1/2/3: green.
- Every contract test passes when selected alone by node ID.
- Negative controls: disabling the removal loop fails only the removal test; disabling the exemption fails only the exemption test; with `autouse` off the suite is back to the 2990 baseline.
- Per-test registry diff after the change: only the 19 exempted world-domain imports remain, zero test-body leaks.
- `tangl-devref build` clean.

## Review feedback adopted

Both bots flagged the same real defect in the first revision: the contract tests were a declaration-ordered pair reading a module-level `_REGISTERED` dict, so `pytest …::test_broad_handlers_did_not_survive_the_previous_test` failed on its own without exercising the fixture. CodeRabbit additionally noted the import-exemption branch had no coverage beyond a nonempty-registry check. Both are fixed by the extraction above. (CodeRabbit's "Linked Issues check" for #39 is a false positive — #39 is an unrelated, long-merged issue that this PR never references.)

## One gap the fixture cannot close

[`engine/tests/mechanics/games/test_game_journal_content.py:31`](engine/tests/mechanics/games/test_game_journal_content.py:31) registers at **module** scope, so it runs at collection — before any test's snapshot — and is in every baseline. No per-test fixture can catch that. It is harmless today (the module is entirely `pytest.mark.skip`ped as retired from the v38 parity gate, and the handler is typed to a test-local `TestGame`), so I left it rather than churn a dead module. Worth a follow-up if that module is ever revived.

Refs #354, #356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `APPLICATION` and `AUTHOR` represent dispatch layers.
  * Documented layer ordering, shared registration behavior, and handler visibility.

* **Tests**
  * Added coverage to verify behavior registries remain isolated between tests.
  * Confirmed temporary handlers are removed while import-time and pre-existing handlers remain available.
  * Added safeguards to preserve consistent registry state across repeated cleanup cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->