### PR TITLE
Move Presence text rendering into mechanics

### DIFF
--- a/docs/src/design/CANON_AND_REALIZATION.md
+++ b/docs/src/design/CANON_AND_REALIZATION.md
@@ -134,11 +134,10 @@ import mechanics" and ended with a stronger, testable law:
 > `x`; anything wishing to participate registers with `x` and produces something
 > `x`-shaped.
 
-**Status: the law is stated, the code does not yet satisfy it.** `story/presentation.py`
-still imports presence at HEAD, so a world that never imports presence still loads it
-through story. The de-wiring — relocating those five `@on_render_text` handlers into
-`mechanics/presence/` — is a pending follow-up, and it needs a sweep of worlds currently
-inheriting presence rendering for free.
+**Status: landed through #368.** `story/presentation.py` now contains only the generic
+controller. Presence owns and registers its five `@on_render_text` handlers through
+`mechanics/presence/presentation.py`, while Credentials explicitly activates that
+intrinsic dependency for its bound-subject rendering.
 
 Note what is *not* the defect: presence is legitimately a *shipped default mechanic*
 whose handlers land in the shared story registry, and that is fine. Once de-wired, a world

--- a/docs/src/design/CANON_AND_REALIZATION.md
+++ b/docs/src/design/CANON_AND_REALIZATION.md
@@ -108,11 +108,11 @@ shape), never inline with canon, and always with the condition that retires it.
 
 The most useful negotiations sharpen canon rather than merely confirming it.
 
-**The signal.** `story/presentation.py` imports `tangl.mechanics.presence`. Read
-naively against the four-layer DAG (`core ← vm ← story ← service`), this is realization
-saying the layer model is wrong — 20 sites import `mechanics → story`, and here is
-`story → mechanics` in the other direction. That reading would have amended canon to
-admit eight layers.
+**The pre-#368 signal.** `story/presentation.py` imported
+`tangl.mechanics.presence`. Read naively against the four-layer DAG
+(`core ← vm ← story ← service`), this was realization saying the layer model was wrong
+— 20 sites import `mechanics → story`, and here was `story → mechanics` in the other
+direction. That reading would have amended canon to admit eight layers.
 
 **The examination.** The three imports exist for one purpose: supplying concrete types
 to `wants_caller_kind=` on five `@on_render_text` registrations. There is no functional
@@ -139,12 +139,13 @@ controller. Presence owns and registers its five `@on_render_text` handlers thro
 `mechanics/presence/presentation.py`, while Credentials explicitly activates that
 intrinsic dependency for its bound-subject rendering.
 
-Note what is *not* the defect: presence is legitimately a *shipped default mechanic*
-whose handlers land in the shared story registry, and that is fine. Once de-wired, a world
-that never imports presence will not load it, and a single-world server can run with it as
-dead code. The defect is neither the layer nor the shared registry — it is **who causes
-the import**. (Layer confers no visibility at all — see *Layers order; registries scope; folds decide*
-in the [glossary](glossary.md).)
+Note what is *not* the defect: Presence is legitimately a *shipped reusable mechanic*
+whose handlers may register in the shared Story registry once explicitly activated. A world
+that neither selects Presence nor a mechanic with an intrinsic Presence dependency does not
+load it, and a single-world server can run with it as dead code. The defect was neither the
+layer nor the shared registry — it was **who caused activation**. (Layer confers no
+visibility at all — see *Layers order; registries scope; folds decide* in the
+[glossary](glossary.md).)
 
 ## Review rhythm
 

--- a/engine/src/tangl/mechanics/credentials/__init__.py
+++ b/engine/src/tangl/mechanics/credentials/__init__.py
@@ -36,6 +36,9 @@ from .domain import (
     Restrictions,
 )
 
+# Credentials requires Presence for bound bearer and document-subject rendering.
+import tangl.mechanics.presence.presentation  # noqa: F401
+
 # Register the credential-owned default text presentation handlers.
 from .presentation import (
     CredentialAttestationObservation,

--- a/engine/src/tangl/mechanics/presence/presentation.py
+++ b/engine/src/tangl/mechanics/presence/presentation.py
@@ -1,0 +1,84 @@
+"""Text-presentation handlers owned by the Presence mechanic."""
+
+from __future__ import annotations
+
+from tangl.story.dispatch import on_render_text
+from tangl.vm.ctx import VmPhaseCtx
+
+from .look import HasLook, HasSimpleLook, Look
+from .ornaments import Ornamentation
+from .outfit import OutfitManager
+
+
+@on_render_text(wants_caller_kind=Look, wants_exact_kind=False)
+def render_look_text(*, caller: Look, aspect: str, ctx: VmPhaseCtx) -> str | None:
+    """Provide the default body-description leaf."""
+    _ = ctx
+    return caller.describe() if aspect == "body_description" else None
+
+
+@on_render_text(wants_caller_kind=OutfitManager, wants_exact_kind=False)
+def render_outfit_text(
+    *,
+    caller: OutfitManager,
+    aspect: str,
+    ctx: VmPhaseCtx,
+) -> str | None:
+    """Provide the default outfit-description leaf."""
+    _ = ctx
+    return caller.describe() if aspect == "outfit_description" else None
+
+
+@on_render_text(wants_caller_kind=Ornamentation, wants_exact_kind=False)
+def render_ornament_text(
+    *,
+    caller: Ornamentation,
+    aspect: str,
+    ctx: VmPhaseCtx,
+) -> str | None:
+    """Provide the default ornament-description leaf."""
+    _ = ctx
+    return caller.describe_summary() if aspect == "ornament_description" else None
+
+
+@on_render_text(wants_caller_kind=HasSimpleLook, wants_exact_kind=False)
+def render_simple_presence_text(
+    *,
+    caller: HasSimpleLook,
+    aspect: str,
+    ctx: VmPhaseCtx,
+) -> str | None:
+    """Render direct presence by delegating to the body-description leaf."""
+    _ = caller, ctx
+    if aspect != "presence_description":
+        return None
+    return "{{ render_as(subject.look, 'body_description') }}"
+
+
+@on_render_text(wants_caller_kind=HasLook, wants_exact_kind=False)
+def render_bundle_presence_text(
+    *,
+    caller: HasLook,
+    aspect: str,
+    ctx: VmPhaseCtx,
+) -> str | None:
+    """Compose a bundled look through the body, outfit, and ornament adapters."""
+    _ = caller, ctx
+    if aspect != "presence_description":
+        return None
+    return (
+        "{% set body = render_as(subject.look, 'body_description') %}"
+        "{% set outfit = render_as(subject.outfit, 'outfit_description') %}"
+        "{% set ornaments = render_as(subject.ornamentation, 'ornament_description') %}"
+        "{{ body }}{% if outfit %}, wearing {{ outfit }}{% endif %}"
+        "{% if ornaments %}, marked by {{ ornaments }}{% endif %}"
+    )
+
+
+__all__ = [
+    "render_bundle_presence_text",
+    "render_look_text",
+    "render_ornament_text",
+    "render_outfit_text",
+    "render_simple_presence_text",
+]

--- a/engine/src/tangl/story/presentation.py
+++ b/engine/src/tangl/story/presentation.py
@@ -4,13 +4,10 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
-from tangl.mechanics.presence.look import HasLook, HasSimpleLook, Look
-from tangl.mechanics.presence.ornaments import Ornamentation
-from tangl.mechanics.presence.outfit import OutfitManager
 from tangl.prose import TextRenderSession
 from tangl.vm.ctx import VmPhaseCtx
 
-from .dispatch import do_render_text, on_render_text
+from .dispatch import do_render_text
 
 
 def render_text_as(
@@ -43,71 +40,5 @@ def render_text_as(
         subject=target,
         bindings=dict(bindings or {}),
     )
-
-
-@on_render_text(wants_caller_kind=Look, wants_exact_kind=False)
-def render_look_text(*, caller: Look, aspect: str, ctx: VmPhaseCtx) -> str | None:
-    """Provide the default body-description leaf."""
-    _ = ctx
-    return caller.describe() if aspect == "body_description" else None
-
-
-@on_render_text(wants_caller_kind=OutfitManager, wants_exact_kind=False)
-def render_outfit_text(
-    *,
-    caller: OutfitManager,
-    aspect: str,
-    ctx: VmPhaseCtx,
-) -> str | None:
-    """Provide the default outfit-description leaf."""
-    _ = ctx
-    return caller.describe() if aspect == "outfit_description" else None
-
-
-@on_render_text(wants_caller_kind=Ornamentation, wants_exact_kind=False)
-def render_ornament_text(
-    *,
-    caller: Ornamentation,
-    aspect: str,
-    ctx: VmPhaseCtx,
-) -> str | None:
-    """Provide the default ornament-description leaf."""
-    _ = ctx
-    return caller.describe_summary() if aspect == "ornament_description" else None
-
-
-@on_render_text(wants_caller_kind=HasSimpleLook, wants_exact_kind=False)
-def render_simple_presence_text(
-    *,
-    caller: HasSimpleLook,
-    aspect: str,
-    ctx: VmPhaseCtx,
-) -> str | None:
-    """Render direct presence by delegating to the body-description leaf."""
-    _ = caller, ctx
-    if aspect != "presence_description":
-        return None
-    return "{{ render_as(subject.look, 'body_description') }}"
-
-
-@on_render_text(wants_caller_kind=HasLook, wants_exact_kind=False)
-def render_bundle_presence_text(
-    *,
-    caller: HasLook,
-    aspect: str,
-    ctx: VmPhaseCtx,
-) -> str | None:
-    """Compose a bundled look through the body, outfit, and ornament adapters."""
-    _ = caller, ctx
-    if aspect != "presence_description":
-        return None
-    return (
-        "{% set body = render_as(subject.look, 'body_description') %}"
-        "{% set outfit = render_as(subject.outfit, 'outfit_description') %}"
-        "{% set ornaments = render_as(subject.ornamentation, 'ornament_description') %}"
-        "{{ body }}{% if outfit %}, wearing {{ outfit }}{% endif %}"
-        "{% if ornaments %}, marked by {{ ornaments }}{% endif %}"
-    )
-
 
 __all__ = ["render_text_as"]

--- a/engine/tests/story/test_presentation_ownership.py
+++ b/engine/tests/story/test_presentation_ownership.py
@@ -1,0 +1,50 @@
+"""Import-ownership tests for Story and mechanic text presentation."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _run_import_check(source: str) -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", source],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_story_presentation_does_not_import_optional_mechanics() -> None:
+    _run_import_check(
+        "import sys; import tangl.story.presentation; "
+        "assert not any(name.startswith('tangl.mechanics.') for name in sys.modules)"
+    )
+
+
+def test_presence_presentation_registers_its_own_handlers() -> None:
+    _run_import_check(
+        "from tangl.mechanics.presence.presentation import ("
+        "render_bundle_presence_text, render_look_text, render_ornament_text, "
+        "render_outfit_text, render_simple_presence_text); "
+        "from tangl.story.dispatch import story_dispatch; "
+        "assert all(handler._behavior.uid in story_dispatch.members for handler in ("
+        "render_bundle_presence_text, render_look_text, render_ornament_text, "
+        "render_outfit_text, render_simple_presence_text))"
+    )
+
+
+def test_credentials_activates_its_presence_presentation_dependency() -> None:
+    _run_import_check(
+        "import sys; import tangl.mechanics.credentials; "
+        "assert 'tangl.mechanics.presence.presentation' in sys.modules"
+    )
+
+
+def test_unrelated_assembly_import_does_not_activate_optional_mechanics() -> None:
+    _run_import_check(
+        "import sys; import tangl.mechanics.assembly; "
+        "assert 'tangl.mechanics.credentials' not in sys.modules; "
+        "assert 'tangl.mechanics.presence.presentation' not in sys.modules"
+    )

--- a/engine/tests/story/test_text_presentation.py
+++ b/engine/tests/story/test_text_presentation.py
@@ -9,6 +9,7 @@ import pytest
 
 from tangl.core import BehaviorRegistry, DispatchLayer
 from tangl.lang.body_parts import BodyPart, BodyRegion
+import tangl.mechanics.presence.presentation  # noqa: F401
 from tangl.mechanics.presence.look import (
     HairColor,
     HairStyle,


### PR DESCRIPTION
## Summary

- move Presence’s five text-presentation handlers out of Story into a Presence-owned module
- keep `render_text_as` and generic dispatch entirely Story-owned
- make Credentials explicitly activate its intrinsic Presence rendering dependency

## Contract

Story no longer imports optional mechanics. Presence registers its own handlers when its presentation surface loads; Credentials brings that surface along because bound-subject rendering is an intrinsic credential dependency. Registry membership remains the reachability mechanism; no loader or dispatch redesign was added.

## Validation

- focused Story/Presence/Credentials/registry suite: `118 passed, 2 xfailed`
- full engine suite: `2942 passed, 69 skipped, 9 xfailed`
- `git diff --check`

Closes #368.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added text descriptions for presence elements, including bodies, outfits, ornaments, and combined appearances.
  * Combined presence descriptions now use conditional wording based on available details.

* **Bug Fixes**
  * Credential rendering now correctly activates presence descriptions.
  * Improved optional mechanic loading to avoid activating unrelated features.

* **Documentation**
  * Updated the design documentation to reflect the completed presence presentation implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->