### PR TITLE
Complete public-contract and documentation consistency sweep

### DIFF
--- a/apps/server/src/tangl/rest/routers/restricted_routes.py
+++ b/apps/server/src/tangl/rest/routers/restricted_routes.py
@@ -40,11 +40,11 @@ def _not_implemented_response(endpoint_name: str) -> JSONResponse:
 async def goto_story_block(
     user_locks=Depends(get_user_locks),
     api_key: UniqueLabel = Header(
-        example=key_for_secret(settings.client.secret),
+        examples=[key_for_secret(settings.client.secret)],
         default=None,
         alias="X-API-Key",
     ),
-    block_id: UniqueLabel = Query(example="scene_1/block_1"),
+    block_id: UniqueLabel = Query(examples=["scene_1/block_1"]),
     render_profile: str = Query(default="raw", description="Response rendering profile."),
 ):
     """Jump the active frame to ``block_id``."""
@@ -58,7 +58,7 @@ async def goto_story_block(
 async def inspect_story_node(
     user_locks=Depends(get_user_locks),
     api_key: UniqueLabel = Header(
-        example=key_for_secret(settings.client.secret),
+        examples=[key_for_secret(settings.client.secret)],
         default=None,
         alias="X-API-Key",
     ),
@@ -80,7 +80,7 @@ async def check_expression(
     request: DebugExprRequest = Body(...),
     user_locks=Depends(get_user_locks),
     api_key: UniqueLabel = Header(
-        example=key_for_secret(settings.client.secret),
+        examples=[key_for_secret(settings.client.secret)],
         default=None,
         alias="X-API-Key",
     ),
@@ -98,7 +98,7 @@ async def apply_effect_post(
     request: DebugExprRequest = Body(...),
     user_locks=Depends(get_user_locks),
     api_key: UniqueLabel = Header(
-        example=key_for_secret(settings.client.secret),
+        examples=[key_for_secret(settings.client.secret)],
         default=None,
         alias="X-API-Key",
     ),
@@ -116,7 +116,7 @@ async def apply_effect_put(
     request: DebugExprRequest = Body(...),
     user_locks=Depends(get_user_locks),
     api_key: UniqueLabel = Header(
-        example=key_for_secret(settings.client.secret),
+        examples=[key_for_secret(settings.client.secret)],
         default=None,
         alias="X-API-Key",
     ),

--- a/apps/server/src/tangl/rest/routers/restricted_routes.py
+++ b/apps/server/src/tangl/rest/routers/restricted_routes.py
@@ -6,13 +6,11 @@ from fastapi import Body, Depends, Header, HTTPException, Path, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
-from tangl.config import settings
 from tangl.rest.dependencies_gateway import (
     get_user_locks,
     resolve_user_auth,
 )
 from tangl.type_hints import UniqueLabel
-from tangl.utils.hash_secret import key_for_secret
 
 from .story_router import router as story_router
 from .system_router import router as system_router
@@ -40,7 +38,7 @@ def _not_implemented_response(endpoint_name: str) -> JSONResponse:
 async def goto_story_block(
     user_locks=Depends(get_user_locks),
     api_key: UniqueLabel = Header(
-        examples=[key_for_secret(settings.client.secret)],
+        examples=["example-api-key"],
         default=None,
         alias="X-API-Key",
     ),
@@ -58,7 +56,7 @@ async def goto_story_block(
 async def inspect_story_node(
     user_locks=Depends(get_user_locks),
     api_key: UniqueLabel = Header(
-        examples=[key_for_secret(settings.client.secret)],
+        examples=["example-api-key"],
         default=None,
         alias="X-API-Key",
     ),
@@ -80,7 +78,7 @@ async def check_expression(
     request: DebugExprRequest = Body(...),
     user_locks=Depends(get_user_locks),
     api_key: UniqueLabel = Header(
-        examples=[key_for_secret(settings.client.secret)],
+        examples=["example-api-key"],
         default=None,
         alias="X-API-Key",
     ),
@@ -98,7 +96,7 @@ async def apply_effect_post(
     request: DebugExprRequest = Body(...),
     user_locks=Depends(get_user_locks),
     api_key: UniqueLabel = Header(
-        examples=[key_for_secret(settings.client.secret)],
+        examples=["example-api-key"],
         default=None,
         alias="X-API-Key",
     ),
@@ -116,7 +114,7 @@ async def apply_effect_put(
     request: DebugExprRequest = Body(...),
     user_locks=Depends(get_user_locks),
     api_key: UniqueLabel = Header(
-        examples=[key_for_secret(settings.client.secret)],
+        examples=["example-api-key"],
         default=None,
         alias="X-API-Key",
     ),

--- a/apps/server/src/tangl/rest/routers/story_router.py
+++ b/apps/server/src/tangl/rest/routers/story_router.py
@@ -344,7 +344,7 @@ async def create_story(
 async def get_story_update(
     service_manager: ServiceManager = Depends(get_service_manager),
     api_key: UniqueLabel = Header(
-        ..., alias="X-API-Key", example=key_for_secret(settings.client.secret)
+        ..., alias="X-API-Key", examples=[key_for_secret(settings.client.secret)]
     ),
     render_profile: str = Query(default="raw", description="Response rendering profile."),
     limit: int = Query(default=0, ge=0),
@@ -382,7 +382,7 @@ async def do_story_action(
     service_manager: ServiceManager = Depends(get_service_manager),
     user_locks=Depends(get_user_locks),
     api_key: UniqueLabel = Header(
-        ..., alias="X-API-Key", example=key_for_secret(settings.client.secret)
+        ..., alias="X-API-Key", examples=[key_for_secret(settings.client.secret)]
     ),
     render_profile: str = Query(default="raw", description="Response rendering profile."),
 ):
@@ -410,7 +410,7 @@ async def do_story_action(
 async def get_story_info(
     service_manager: ServiceManager = Depends(get_service_manager),
     api_key: UniqueLabel = Header(
-        ..., alias="X-API-Key", example=key_for_secret(settings.client.secret)
+        ..., alias="X-API-Key", examples=[key_for_secret(settings.client.secret)]
     ),
     render_profile: str = Query(default="raw", description="Response rendering profile."),
     kind: str | None = Query(default=None, description="Projected-state channel kind."),
@@ -452,7 +452,7 @@ async def reset_story(
     service_manager: ServiceManager = Depends(get_service_manager),
     user_locks=Depends(get_user_locks),
     api_key: UniqueLabel = Header(
-        ..., alias="X-API-Key", example=key_for_secret(settings.client.secret)
+        ..., alias="X-API-Key", examples=[key_for_secret(settings.client.secret)]
     ),
     archive: bool = Query(default=False, description="Retain the ledger if true."),
     render_profile: str = Query(default="raw", description="Response rendering profile."),

--- a/apps/server/src/tangl/rest/routers/story_router.py
+++ b/apps/server/src/tangl/rest/routers/story_router.py
@@ -8,7 +8,7 @@ from uuid import UUID
 from fastapi import APIRouter, Body, Depends, Header, HTTPException, Query
 from markdown_it import MarkdownIt
 
-from tangl.config import get_story_media_dir, get_sys_media_dir, settings
+from tangl.config import get_story_media_dir, get_sys_media_dir
 from tangl.journal.fragments import MediaFragment, fragment_to_dto
 from tangl.rest.dependencies_gateway import (
     get_service_manager,
@@ -32,7 +32,6 @@ from tangl.service.response import (
 )
 from tangl.service.world_registry import resolve_world
 from tangl.type_hints import UniqueLabel
-from tangl.utils.hash_secret import key_for_secret
 
 
 router = APIRouter(tags=["Story"])
@@ -344,7 +343,7 @@ async def create_story(
 async def get_story_update(
     service_manager: ServiceManager = Depends(get_service_manager),
     api_key: UniqueLabel = Header(
-        ..., alias="X-API-Key", examples=[key_for_secret(settings.client.secret)]
+        ..., alias="X-API-Key", examples=["example-api-key"]
     ),
     render_profile: str = Query(default="raw", description="Response rendering profile."),
     limit: int = Query(default=0, ge=0),
@@ -382,7 +381,7 @@ async def do_story_action(
     service_manager: ServiceManager = Depends(get_service_manager),
     user_locks=Depends(get_user_locks),
     api_key: UniqueLabel = Header(
-        ..., alias="X-API-Key", examples=[key_for_secret(settings.client.secret)]
+        ..., alias="X-API-Key", examples=["example-api-key"]
     ),
     render_profile: str = Query(default="raw", description="Response rendering profile."),
 ):
@@ -410,7 +409,7 @@ async def do_story_action(
 async def get_story_info(
     service_manager: ServiceManager = Depends(get_service_manager),
     api_key: UniqueLabel = Header(
-        ..., alias="X-API-Key", examples=[key_for_secret(settings.client.secret)]
+        ..., alias="X-API-Key", examples=["example-api-key"]
     ),
     render_profile: str = Query(default="raw", description="Response rendering profile."),
     kind: str | None = Query(default=None, description="Projected-state channel kind."),
@@ -452,7 +451,7 @@ async def reset_story(
     service_manager: ServiceManager = Depends(get_service_manager),
     user_locks=Depends(get_user_locks),
     api_key: UniqueLabel = Header(
-        ..., alias="X-API-Key", examples=[key_for_secret(settings.client.secret)]
+        ..., alias="X-API-Key", examples=["example-api-key"]
     ),
     archive: bool = Query(default=False, description="Retain the ledger if true."),
     render_profile: str = Query(default="raw", description="Response rendering profile."),

--- a/apps/server/src/tangl/rest/routers/system_router.py
+++ b/apps/server/src/tangl/rest/routers/system_router.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Query
 
-from tangl.config import settings
 from tangl.rest.dependencies_gateway import get_service_manager, require_service_access
 from tangl.service import ServiceManager
 from tangl.service.response import SystemInfo, UserSecret, WorldInfo
@@ -38,7 +37,7 @@ async def get_worlds(
 @router.get("/secret")
 async def get_key_for_secret(
     service_manager: ServiceManager = Depends(get_service_manager),
-    secret: str = Query(examples=[settings.client.secret], default=None),
+    secret: str = Query(examples=["example-user-secret"], default=None),
     render_profile: str = Query(default="raw", description="Response rendering profile."),
 ) -> UserSecret:
     """Encode ``secret`` as an API key for clients."""

--- a/apps/server/src/tangl/rest/routers/system_router.py
+++ b/apps/server/src/tangl/rest/routers/system_router.py
@@ -38,7 +38,7 @@ async def get_worlds(
 @router.get("/secret")
 async def get_key_for_secret(
     service_manager: ServiceManager = Depends(get_service_manager),
-    secret: str = Query(example=settings.client.secret, default=None),
+    secret: str = Query(examples=[settings.client.secret], default=None),
     render_profile: str = Query(default="raw", description="Response rendering profile."),
 ) -> UserSecret:
     """Encode ``secret`` as an API key for clients."""

--- a/apps/server/src/tangl/rest/routers/user_router.py
+++ b/apps/server/src/tangl/rest/routers/user_router.py
@@ -38,7 +38,7 @@ async def get_user_info(
     service_manager: ServiceManager = Depends(get_service_manager),
     api_key: UniqueLabel = Header(
         alias="X-API-Key",
-        example=key_for_secret(settings.client.secret),
+        examples=[key_for_secret(settings.client.secret)],
         default=None,
     ),
     render_profile: str = Query(default="raw", description="Response rendering profile."),
@@ -59,7 +59,7 @@ async def get_user_info(
 @router.post("/create")
 async def create_user(
     service_manager: ServiceManager = Depends(get_service_manager),
-    secret: str = Query(example=settings.client.secret, default=None),
+    secret: str = Query(examples=[settings.client.secret], default=None),
     render_profile: str = Query(default="raw", description="Response rendering profile."),
 ) -> UserSecret:
     """Create a user and return the secret metadata for clients."""
@@ -91,10 +91,10 @@ async def update_user_secret(
     user_locks=Depends(get_user_locks),
     api_key: UniqueLabel = Header(
         alias="X-API-Key",
-        example=key_for_secret(settings.client.secret),
+        examples=[key_for_secret(settings.client.secret)],
         default=None,
     ),
-    secret: str = Query(example=settings.client.secret, default=None),
+    secret: str = Query(examples=[settings.client.secret], default=None),
     render_profile: str = Query(default="raw", description="Response rendering profile."),
 ) -> UserSecret:
     """Update the secret for the authenticated user and surface the new API key."""
@@ -125,7 +125,7 @@ async def drop_user(
     service_manager: ServiceManager = Depends(get_service_manager),
     api_key: UniqueLabel = Header(
         alias="X-API-Key",
-        example=key_for_secret(settings.client.secret),
+        examples=[key_for_secret(settings.client.secret)],
         default=None,
     ),
     render_profile: str = Query(default="raw", description="Response rendering profile."),

--- a/apps/server/src/tangl/rest/routers/user_router.py
+++ b/apps/server/src/tangl/rest/routers/user_router.py
@@ -4,7 +4,6 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
 
-from tangl.config import settings
 from tangl.rest.dependencies_gateway import (
     get_service_manager,
     get_user_locks,
@@ -38,7 +37,7 @@ async def get_user_info(
     service_manager: ServiceManager = Depends(get_service_manager),
     api_key: UniqueLabel = Header(
         alias="X-API-Key",
-        examples=[key_for_secret(settings.client.secret)],
+        examples=["example-api-key"],
         default=None,
     ),
     render_profile: str = Query(default="raw", description="Response rendering profile."),
@@ -59,7 +58,7 @@ async def get_user_info(
 @router.post("/create")
 async def create_user(
     service_manager: ServiceManager = Depends(get_service_manager),
-    secret: str = Query(examples=[settings.client.secret], default=None),
+    secret: str = Query(examples=["example-user-secret"], default=None),
     render_profile: str = Query(default="raw", description="Response rendering profile."),
 ) -> UserSecret:
     """Create a user and return the secret metadata for clients."""
@@ -91,10 +90,10 @@ async def update_user_secret(
     user_locks=Depends(get_user_locks),
     api_key: UniqueLabel = Header(
         alias="X-API-Key",
-        examples=[key_for_secret(settings.client.secret)],
+        examples=["example-api-key"],
         default=None,
     ),
-    secret: str = Query(examples=[settings.client.secret], default=None),
+    secret: str = Query(examples=["example-user-secret"], default=None),
     render_profile: str = Query(default="raw", description="Response rendering profile."),
 ) -> UserSecret:
     """Update the secret for the authenticated user and surface the new API key."""
@@ -125,7 +124,7 @@ async def drop_user(
     service_manager: ServiceManager = Depends(get_service_manager),
     api_key: UniqueLabel = Header(
         alias="X-API-Key",
-        examples=[key_for_secret(settings.client.secret)],
+        examples=["example-api-key"],
         default=None,
     ),
     render_profile: str = Query(default="raw", description="Response rendering profile."),

--- a/apps/server/src/tangl/rest/routers/world_router.py
+++ b/apps/server/src/tangl/rest/routers/world_router.py
@@ -13,7 +13,7 @@ router = APIRouter(tags=["World"])
 @router.get("/{world_id}/info")
 async def get_world_info(
     service_manager: ServiceManager = Depends(get_service_manager),
-    world_id: str = Path(example="my_world"),
+    world_id: str = Path(examples=["my_world"]),
     render_profile: str = Query(default="raw", description="Response rendering profile."),
 ) -> WorldInfo:
     """Return metadata describing ``world_id``."""

--- a/apps/server/tests/test_system_endpoints.py
+++ b/apps/server/tests/test_system_endpoints.py
@@ -1,9 +1,19 @@
+import json
 
 import pytest
 from fastapi.testclient import TestClient
 
 from tangl.config import settings
-from tangl.utils.hash_secret import uuid_for_secret, key_for_secret
+from tangl.utils.hash_secret import key_for_secret
+
+
+def test_openapi_does_not_publish_configured_credentials(client: TestClient) -> None:
+    schema = json.dumps(client.app.openapi())
+
+    if settings.client.secret in schema:
+        pytest.fail("OpenAPI schema contains the configured client secret")
+    if key_for_secret(settings.client.secret) in schema:
+        pytest.fail("OpenAPI schema contains the derived client key")
 
 
 def test_system_get_info(client: TestClient):

--- a/docs/src/api/core/artifacts.rst
+++ b/docs/src/api/core/artifacts.rst
@@ -12,7 +12,7 @@ construction.
 
 .. rubric:: Related notes
 
-- :doc:`../../notes/audits/core38-doc-audit`
+- :doc:`Historical core38 audit <../../notes/audits/core38-doc-audit>`
 
 Artifacts
 ---------

--- a/docs/src/api/core/identity.rst
+++ b/docs/src/api/core/identity.rst
@@ -16,7 +16,7 @@ Identity, selection, and registry primitives used throughout the engine.
 
 .. rubric:: Related notes
 
-- :doc:`../../notes/audits/core38-doc-audit`
+- :doc:`Historical core38 audit <../../notes/audits/core38-doc-audit>`
 
 Identity and lookup
 -------------------

--- a/docs/src/api/service/orchestration.rst
+++ b/docs/src/api/service/orchestration.rst
@@ -16,7 +16,7 @@ service surface.
 .. rubric:: Related notes
 
 - :doc:`../../notes/reference/code_adjacent_design_docs`
-- :doc:`../../notes/migration/v38-phase1-review`
+- :doc:`Historical v38 phase-one review <../../notes/migration/v38-phase1-review>`
 
 Bootstrap
 ---------

--- a/docs/src/api/story/concepts.rst
+++ b/docs/src/api/story/concepts.rst
@@ -12,7 +12,7 @@ contributions.
 
 .. rubric:: Related notes
 
-- :doc:`../../notes/audits/core38-doc-audit`
+- :doc:`Historical core38 audit <../../notes/audits/core38-doc-audit>`
 
 Core concept types
 ------------------

--- a/docs/src/api/story/episode.rst
+++ b/docs/src/api/story/episode.rst
@@ -12,7 +12,7 @@ Traversable node and edge types that define the story cursor vocabulary.
 
 .. rubric:: Related notes
 
-- :doc:`../../notes/migration/v38-parity-matrix`
+- :doc:`Historical v38 parity matrix <../../notes/migration/v38-parity-matrix>`
 
 Episode nodes
 -------------

--- a/docs/src/api/story/fabula.rst
+++ b/docs/src/api/story/fabula.rst
@@ -15,7 +15,7 @@ story graphs.
 .. rubric:: Related notes
 
 - :doc:`../../notes/reference/code_adjacent_design_docs`
-- :doc:`../../notes/audits/vm38-doc-audit`
+- :doc:`Historical vm38 audit <../../notes/audits/vm38-doc-audit>`
 - :doc:`../../notes/migration/script_manager_facade_migration`
 
 Compilation

--- a/docs/src/api/vm/provision.rst
+++ b/docs/src/api/vm/provision.rst
@@ -13,7 +13,7 @@ dependencies.
 
 .. rubric:: Related notes
 
-- :doc:`../../notes/audits/vm38-doc-audit`
+- :doc:`Historical vm38 audit <../../notes/audits/vm38-doc-audit>`
 - :doc:`../../notes/reference/code_adjacent_design_docs`
 
 Constraint types

--- a/docs/src/api/vm/runtime.rst
+++ b/docs/src/api/vm/runtime.rst
@@ -18,7 +18,7 @@ time.
 
 .. rubric:: Related notes
 
-- :doc:`../../notes/migration/v38-phase1-review`
+- :doc:`Historical v38 phase-one review <../../notes/migration/v38-phase1-review>`
 
 Core runtime types
 ------------------

--- a/docs/src/design/planning/COST_MODEL.md
+++ b/docs/src/design/planning/COST_MODEL.md
@@ -1,5 +1,10 @@
 # Cost Model & Offer Selection
 
+> **Historical guidance.** The live resolver no longer uses this fixed numeric
+> cost model or emits phase-level `PlanningReceipt` / `BuildReceipt` records.
+> See [PROVISIONING.md](PROVISIONING.md) for the current deterministic offer
+> ordering and diagnostics contract.
+
 ## Overview
 Provisioning now uses a deterministic cost model so planners can justify every choice. Each offer
 reports its **base cost** (operation type) and a **proximity modifier** derived from the graph

--- a/docs/src/design/planning/COST_MODEL.md
+++ b/docs/src/design/planning/COST_MODEL.md
@@ -1,78 +1,13 @@
 # Cost Model & Offer Selection
 
-> **Historical guidance.** The live resolver no longer uses this fixed numeric
-> cost model or emits phase-level `PlanningReceipt` / `BuildReceipt` records.
-> See [PROVISIONING.md](PROVISIONING.md) for the current deterministic offer
-> ordering and diagnostics contract.
+> **Historical migration note.** StoryTangl formerly ranked provisioning
+> offers through fixed numeric `ProvisionCost` values and emitted
+> `PlanningReceipt` / `BuildReceipt` records for diagnostics. That model, its
+> `PlanningDebugger`, and its numeric troubleshooting guidance have been
+> retired.
 
-## Overview
-Provisioning now uses a deterministic cost model so planners can justify every choice. Each offer
-reports its **base cost** (operation type) and a **proximity modifier** derived from the graph
-structure. Selection sorts by the sum of those two values and breaks ties with the provisioner id,
-making replay stable and debuggable.
-
-## Base Costs
-
-| Operation | Base Cost | Description |
-|-----------|-----------|-------------|
-| `DIRECT`  | 10        | Reuse an existing node without modifications. |
-| `LIGHT_INDIRECT` | 50 | Update an existing node in place. |
-| `HEAVY_INDIRECT` | 100 | Clone and evolve an existing node. |
-| `CREATE`  | 200       | Instantiate a new node from a template. |
-
-These values map to :class:`~tangl.vm.provision.offer.ProvisionCost` and live on
-:class:`~tangl.vm.provision.offer.ProvisionOffer.base_cost`.
-
-## Proximity Modifiers
-
-Graph distance influences the final score for EXISTING offers:
-
-| Relationship  | Modifier | Example |
-|---------------|----------|---------|
-| Same block    | `+0`     | Node already attached to the requesting block. |
-| Same scene    | `+5`     | Node and requester share the same immediate parent subgraph. |
-| Same episode  | `+10`    | Node lives elsewhere in the current episode. |
-| Elsewhere     | `+20`    | Node is outside the current episode hierarchy. |
-
-These values are added on top of the base cost; the sum is stored on `offer.cost`. Template
-provisioning does **not** apply a proximity modifier because it always creates a new instance.
-
-## Selection Algorithm
-
-1. Collect offers from all provisioners and attach metadata (provisioner id, layer, selection
-   criteria).
-2. Deduplicate EXISTING offers per provider so the cheapest proposal survives.
-3. Sort the remaining offers by `(cost, proximity, registration order)`.
-4. Record metadata (reason, all offers, selected provider) for the requirement.
-5. Accept the winning offer and emit :class:`~tangl.vm.provision.offer.BuildReceipt` plus a
-   `selection_audit` entry in :class:`~tangl.vm.provision.offer.PlanningReceipt`.
-
-Because template creation costs `200` and distant reuse tops out at `10 + 20 = 30`, existing entities
-will always win unless the requirement policy is explicitly `CREATE`.
-
-## Debugging & Auditing
-
-Use :class:`tangl.vm.debug.PlanningDebugger` to print audit data during development:
-
-```python
-from tangl.vm.debug import PlanningDebugger
-
-receipt = frame.records[-1]  # last PlanningReceipt emitted by the frame
-PlanningDebugger.print_receipt(receipt)
-```
-
-Each entry lists all offers, their costs, proximity descriptions, and which provisioner won.
-Developers can also call ``PlanningDebugger.compare_offers(offers)`` to compare raw offers before the
-planner runs.
-
-## Troubleshooting
-
-- **“Why did it reuse a distant node?”** – Existing nodes max out at `30`, so they beat template
-  creation unless the requirement policy is `CREATE` or no existing offers qualify.
-- **“Why was my template ignored?”** – Templates only run when the requirement includes
-  `template_ref` or `template`. GraphProvisioner skips those requests.
-- **“How do I force a fresh instance?”** – Set `requirement_policy: CREATE` in the script. The cost
-  model still records the offer but GraphProvisioner will decline to compete.
-- **“The audit trail is empty.”** – Ensure planning handlers returned a
-  :class:`~tangl.vm.provision.offer.PlanningReceipt`. Off-main-thread tests may need to call
-  :func:`tangl.vm.dispatch.planning.plan_collect_offers` / `plan_select_and_apply` to populate it.
+The live resolver uses a deterministic structural ordering rather than summed
+costs. See [PROVISIONING.md](PROVISIONING.md) for the current lifecycle,
+`offer_sort_key()` ranking fields, persistence behavior, and diagnostics
+contract. Historical investigations that mention cost totals or planning
+receipts should not be used as implementation guidance.

--- a/docs/src/design/planning/PROVISIONING.md
+++ b/docs/src/design/planning/PROVISIONING.md
@@ -57,8 +57,9 @@ bindings in place and must return `None`; there is no phase-level
 
 ## Matching and ranking
 
-`Resolver.gather_offers(...)` produces one deterministic ordered set. The
-current sort key prefers, in order:
+`Resolver.gather_offers(...)` produces one deterministic ordered set.
+`tangl.vm.provision.matching.offer_sort_key()` is the canonical ranking
+contract and prefers, in order:
 
 1. provisioning policy tier (`EXISTING`, `UPDATE`, `CLONE`, `CREATE`, then
    debug stubs);
@@ -79,13 +80,18 @@ use.
 Templates become graph entities through the normal `EntityTemplate` and graph
 factory materialization path. Provider identity is stored on the requirement by
 UUID, and graph round trips restore that reference through the owning registry.
-Offer callbacks, transient candidate objects, and preview-only stubs are not
-durable graph state.
+Offer callbacks, transient candidate objects, and unaccepted preview offers are
+not durable graph state. When an explicitly allowed STUB offer is accepted, its
+provider is added to the graph and linked like any other accepted provider; the
+link therefore survives graph persistence.
 
 Planning reads may preview whether a requirement is viable, but ordinary setup
-and rendering must not accidentally materialize lazy candidates. Runtime
-creation belongs at the PLANNING boundary; committed non-topological state
-changes belong in UPDATE.
+and rendering must not accidentally materialize lazy candidates. Provider and
+template materialization normally belongs at the PLANNING boundary. The bounded
+exception is an explicitly episode-latent destination: if a presented action
+still carries a deferred destination plan, selecting it may provision that
+destination before traversal. Entities created as consequences, and other
+committed non-topological state changes, belong in UPDATE.
 
 ## Related contracts
 

--- a/docs/src/design/planning/PROVISIONING.md
+++ b/docs/src/design/planning/PROVISIONING.md
@@ -1,89 +1,96 @@
 # Provisioning Pipeline
 
-## Overview
-Provisioning is the process the VM uses to satisfy :class:`~tangl.core.requirement.Requirement`
-objects before the story advances. Each frontier node exposes requirements for actors,
-locations, or resources. Provisioners compete to satisfy those requirements by producing
-:class:`~tangl.vm.provision.offer.Offer` objects. The planner selects the best offer for each
-requirement, applies it, and records a :class:`~tangl.vm.provision.receipt.BuildReceipt` for auditing.
+```{storytangl-topic}
+:topics: provisioning
+:facets: overview, design
+:relation: defines
+:related: open_link, template, token, phase_ctx
+```
 
-## Provisioner Sequence
+> **Status:** Current runtime contract.
+> **Authority:** `tangl.vm.provision`, `tangl.vm.dispatch.do_provision`, and
+> `tangl.vm.runtime.frame.Frame._run_planning_phase` define the executable
+> behavior. [AFFORDANCE_MODEL.md](AFFORDANCE_MODEL.md) defines the broader
+> open-link vocabulary.
 
-1. **GraphProvisioner** – Finds already-instantiated nodes that satisfy the requirement.
-2. **TemplateProvisioner** – Instantiates templates (see below) if the requirement references one.
-3. **Updating / Cloning Provisioners** – Modify or duplicate existing entities when requested.
+Provisioning binds unresolved requirements on graph edges to providers. It is
+the VM operation that turns a partially specified frontier into traversable
+runtime topology without requiring authored code to choose concrete providers
+in advance.
 
-Provisioners may return zero or more offers. The planner picks the lowest-cost viable offer, so
-custom provisioners should surface clear cost semantics.
+## Runtime shape
 
-## TemplateProvisioner Flow
+- `Requirement` is a serializable `Selector` plus provisioning policy and
+  resolution metadata.
+- `Dependency`, `Affordance`, and `Fanout` are graph edges that carry the open
+  relationship into planning.
+- `ProvisionOffer` is an ephemeral, ranked proposal. Its callback may return an
+  existing provider or materialize one; offers are not persistence records.
+- `Resolver` gathers, filters, ranks, accepts, and binds offers.
+- Provisioners donate candidates from existing graph members, authored
+  templates, token catalogs, inline templates, update/clone formulas, media
+  inventories, and dispatch extensions.
 
-Template provisioning is the most common path for casting roles and populating settings:
+## Lifecycle
 
-1. **Requirement intake:** Requirements coming from story scripts now include `template_ref`
-   when a `RoleScript` or `SettingScript` references a template label. Inline templates are still
-   supported via the legacy `template` dict.
-2. **Template lookup:** The provisioner pulls templates from `world.template_registry`. Templates
-   are :class:`~tangl.ir.core_ir.base_script_model.BaseScriptItem` instances and already include a
-   content-addressed hash (`content_hash`).
-3. **Scope filtering:** Before an offer is created, `_is_in_scope` validates that the template’s
-   `scope` allows it to be used for the current source node. See
-   :doc:`../authoring/TEMPLATE_SCOPE` for examples of block, scene, and ancestor filtering.
-4. **Offer creation:** Offers embed the template, its registry label, and a short content identifier
-   (`template.get_content_identifier()`). No additional hashing is necessary because
-   :class:`~tangl.core.content_addressable.ContentAddressable` handles it.
-5. **Build step:** When selected, the offer is converted into a concrete entity. The provisioner
-   resolves `kind`, hydrates the payload from the template, applies requirement overrides, and
-   writes a build receipt including the template reference and hash for provenance.
+Player input begins a VM cycle. After traversing the selected edge, PLANNING
+prepares both the current node and its immediate successor frontier:
 
-If any step fails—missing template, scope rejection, or unresolved class—the provisioner simply
-returns no offers and logs a debug/warning message, allowing other provisioners or policies to
-handle the requirement.
+```text
+selected edge
+  -> move cursor
+  -> provision current node
+  -> provision each immediate successor
+  -> PREREQS / UPDATE / JOURNAL / FINALIZE / POSTREQS
+  -> present the next live choices
+```
 
-## Scope Semantics
+This one-step-ahead rule is what makes the next choices inspectable before they
+are presented. Normal interactive traversal should not wait until a choice is
+selected to discover what that choice points to. JIT entry at PLANNING is kept
+for startup, debugging, and explicit out-of-order entry.
 
-Template scope determines *where* a template can be used:
+`do_provision(...)` is side-effect-only. Provisioning handlers mutate graph
+bindings in place and must return `None`; there is no phase-level
+`PlanningReceipt` result stream. Accepted-offer summaries live on the
+`Requirement` as resolution metadata for diagnostics.
 
-- **Global templates** (`scope=None`) can satisfy any role/setting.
-- **Scene templates** (inferred `parent_label`) are limited to blocks within that scene.
-- **Block templates** (inferred `source_label`) can only fill roles/settings in the block where the
-  template was declared.
-- **Advanced selectors** like `ancestor_labels` and `ancestor_tags` enforce ancestry constraints.
+## Matching and ranking
 
-Because scope enforcement runs inside the TemplateProvisioner, authors get immediate feedback in
-planning logs when a template reference is out of scope. Refer to :doc:`../authoring/TEMPLATE_SCOPE`
-for author-facing guidance and YAML examples.
+`Resolver.gather_offers(...)` produces one deterministic ordered set. The
+current sort key prefers, in order:
 
-## Debugging Provisioning
+1. provisioning policy tier (`EXISTING`, `UPDATE`, `CLONE`, `CREATE`, then
+   debug stubs);
+2. scope distance;
+3. distance from the caller;
+4. exact kind matches;
+5. selector specificity;
+6. explicit offer priority;
+7. creation sequence.
 
-- Enable debug logging for `tangl.vm.provisioners.template_provisioner` to see why templates are
-  rejected (missing source, parent mismatch, missing tags, etc.).
-- Inspect build receipts in the ledger; each contains `template_ref` and `template_hash` so you can
-  trace exactly which template was instantiated.
-- Use `world.template_registry.find_all(content_hash=...)` to locate duplicate templates if you
-  suspect multiple declarations share the same content.
+This is not the retired fixed-cost model described in the historical
+[COST_MODEL.md](COST_MODEL.md). Code and authoring guidance should name the
+fields above rather than promise numeric costs that the live resolver does not
+use.
 
-## Cost Model & Auditing
+## Materialization and persistence
 
-Offer selection is now deterministic and proximity-aware:
+Templates become graph entities through the normal `EntityTemplate` and graph
+factory materialization path. Provider identity is stored on the requirement by
+UUID, and graph round trips restore that reference through the owning registry.
+Offer callbacks, transient candidate objects, and preview-only stubs are not
+durable graph state.
 
-- **Base costs** come from :class:`~tangl.vm.provision.offer.ProvisionCost` (e.g., `DIRECT=10`,
-  `CREATE=200`).
-- **Graph proximity** adds a modifier before the planner compares offers:
+Planning reads may preview whether a requirement is viable, but ordinary setup
+and rendering must not accidentally materialize lazy candidates. Runtime
+creation belongs at the PLANNING boundary; committed non-topological state
+changes belong in UPDATE.
 
-  | Scenario        | Modifier |
-  |----------------|----------|
-  | Same block     | `+0`
-  | Same scene     | `+5`
-  | Same episode   | `+10`
-  | Elsewhere      | `+20`
+## Related contracts
 
-- **Template offers** use the fixed create cost (`200`) so nearby existing providers almost always
-  win unless the requirement policy is `CREATE`.
-
-Every call to :func:`~tangl.vm.provision.resolver._select_best_offer` records audit metadata. The
-final :class:`~tangl.vm.provision.offer.PlanningReceipt` includes `selection_audit`, a list of the
-offers considered for each requirement plus the reason the winner was chosen. Developers can print
-these decisions with :class:`tangl.vm.debug.PlanningDebugger`.
-
-See :doc:`COST_MODEL` for an extended breakdown of the calculations and troubleshooting tips.
+- [Open Links](AFFORDANCE_MODEL.md) — the requirement-bearing edge model.
+- [Template Scope](TEMPLATE_SCOPE.md) — authored admission and scope rules.
+- [Provisioning Behavior](PROVISIONING_BEHAVIOR.md) — historical author-facing
+  guidance retained for provenance; its cost examples are not current.
+- `engine/src/tangl/vm/VM_DESIGN.md` — VM phase and authority contract.

--- a/docs/src/design/planning/PROVISIONING_BEHAVIOR.md
+++ b/docs/src/design/planning/PROVISIONING_BEHAVIOR.md
@@ -1,5 +1,10 @@
 # Provisioning Behavior for Authors
 
+> **Historical guidance.** This note documents the retired fixed-cost,
+> `GraphProvisioner`, and planning-receipt model. It is retained as migration
+> context, not current authoring guidance. See [PROVISIONING.md](PROVISIONING.md)
+> and [AFFORDANCE_MODEL.md](AFFORDANCE_MODEL.md) for the live contract.
+
 ## Why it Matters
 When you reference actors or locations from scripts, the VM has to decide whether to reuse an
 existing entity or create a new one. Understanding that decision helps you predict narrative

--- a/docs/src/design/story/CONCEPT_PROV_DESIGN.md
+++ b/docs/src/design/story/CONCEPT_PROV_DESIGN.md
@@ -3,7 +3,11 @@ Concept Provisioning Design
 
 **Document Version:** 2.1
 **Last Updated:** December 2025
-**Status:** ✅ IMPLEMENTATION COMPLETE
+**Status:** HISTORICAL DESIGN RECORD — this document captures the December 2025
+provisioning model and uses retired names such as `GraphProvisioner`, fixed
+`ProvisionCost` values, and planning receipts. It is not the current runtime
+contract. See [Provisioning Pipeline](../planning/PROVISIONING.md) and
+[Open Links](../planning/AFFORDANCE_MODEL.md).
 
 ## Core Philosophy
 
@@ -1529,9 +1533,9 @@ templates:
 
 ---
 
-## Implementation Status
+## Historical Implementation Snapshot
 
-### All Core Features: ✅ COMPLETE
+### Features reported complete in the December 2025 model
 
 Verified implementations:
 - Template registry with scope filtering

--- a/docs/src/design/story/CONCEPT_PROV_DESIGN.md
+++ b/docs/src/design/story/CONCEPT_PROV_DESIGN.md
@@ -1533,9 +1533,10 @@ templates:
 
 ---
 
-## Historical Implementation Snapshot
+Historical Implementation Snapshot
+----------------------------------
 
-### Features reported complete in the December 2025 model
+**Features reported complete in the December 2025 model**
 
 Verified implementations:
 - Template registry with scope filtering
@@ -1545,13 +1546,14 @@ Verified implementations:
 - World._wire_roles() and ._wire_settings() functional
 - Test coverage in test_world_materialization.py
 
-Current runtime behavior wires role and setting edges with attached requirements, leaving
-all provisioning to the planning phase:
+The December 2025 implementation wired role and setting edges with attached
+requirements, leaving provisioning to its planning phase:
 
-- GraphProvisioner binds existing affordances that satisfy the requirement.
-- TemplateProvisioner materializes nodes from templates when no affordance is available.
+- `GraphProvisioner` bound existing affordances that satisfied the requirement.
+- `TemplateProvisioner` materialized nodes from templates when no affordance was
+  available.
 
-World creation does not pre-link destinations. The compiler remains lean and the virtual
-machine owns provisioning. A future optimization could add a `pre_plan=True` flag on the
-VM to pre-run planning for faster traversal; this would remain outside the World
-builder.
+In that model, world creation did not pre-link destinations and the VM owned
+provisioning. This is a historical implementation snapshot, not current
+authority. See [Provisioning Pipeline](../planning/PROVISIONING.md) for the
+active contract.

--- a/docs/src/design/story/JOURNAL_COMPOSE_CONTRACT.md
+++ b/docs/src/design/story/JOURNAL_COMPOSE_CONTRACT.md
@@ -1,5 +1,12 @@
 # Journal Compose Contract
 
+```{storytangl-topic}
+:topics: journal
+:facets: overview, design
+:relation: defines
+:related: prose, media, widget, observation
+```
+
 > Status: Current contract
 > Authority: This note defines the current `compose_journal` contract alongside `engine/src/tangl/vm/dispatch.py` and `engine/src/tangl/journal/fragments.py`.
 

--- a/docs/src/notes/audits/core38-doc-audit.md
+++ b/docs/src/notes/audits/core38-doc-audit.md
@@ -1,5 +1,10 @@
 # Core38 Docstring Drift Audit
 
+> **Historical core38 audit note.** This file records transition-era findings
+> against the retired `tangl.core38` package. It is evidence about the migration,
+> not current API or architecture authority. Current contracts live in
+> `engine/src/tangl/core/CORE_DESIGN.md` and the `tangl.core` API pages.
+
 ## Scope
 - Package: `engine/src/tangl/core38`
 - Objective: correctness-first drift detection and docstring contract alignment

--- a/docs/src/notes/audits/index.rst
+++ b/docs/src/notes/audits/index.rst
@@ -1,7 +1,9 @@
 Audit Notes
 ===========
 
-Documentation audits and gap reviews used to drive targeted cleanup work.
+Historical documentation audits and gap reviews retained as migration evidence.
+They do not define the current public contract; use the API and design sections
+for current authority.
 
 .. toctree::
    :maxdepth: 1

--- a/engine/src/tangl/mechanics/assembly/COMPONENT_DESIGN.md
+++ b/engine/src/tangl/mechanics/assembly/COMPONENT_DESIGN.md
@@ -8,8 +8,15 @@
 ```
 
 **Document Version:** 1.0
-**Status:** DESIGN — the bridge spec that routes the assembly/component work
-*through* the facet generalization (`MU_AFFORDANCES.md` v0.3) instead of beside it.
+**Status:** IMPLEMENTED FOUNDATION + ACTIVE EXTENSIONS — owner-bound component
+managers, connector association, transaction integration, outfit/wardrobe,
+vehicle, and credential-packet consumers are landed. The broader facet and
+body-attachment generalizations remain design guidance rather than a second
+runtime mechanism.
+
+The original design revisions below record how the assembly/component work was
+routed *through* the facet generalization (`MU_AFFORDANCES.md` v0.3) instead of
+beside it.
 *v0.2: facet discriminator split into `channel` (relevance) + `facet_type`
 (giver/changer/hider); trinary mapped onto the open-link duality. v0.3: evaluation
 order via a produces/consumes DAG (topo-sort), sharing its acyclicity check with the
@@ -67,9 +74,10 @@ mutates something else. A vehicle garage proof uses component assignment as one
 commitment inside a multi-leg offer, while the manager still owns slot legality
 and persisted identity.
 
-Follow-up retrofit targets remain open: credential packets, domain vehicle managers
-such as CarWars adapters, robot assemblies, and any world-specific full-graph outfit
-manager such as a future `SharedOutfit` / `FashionShowActor` demo.
+The credential packet retrofit is now a landed proof consumer. Remaining extension
+targets include domain vehicle managers such as CarWars adapters, robot assemblies,
+and any world-specific full-graph outfit manager such as a future `SharedOutfit` /
+`FashionShowActor` demo.
 
 ---
 

--- a/engine/src/tangl/mechanics/credentials/CREDENTIAL_ASSEMBLY_RETROFIT.md
+++ b/engine/src/tangl/mechanics/credentials/CREDENTIAL_ASSEMBLY_RETROFIT.md
@@ -7,39 +7,24 @@
 :related: open_link, provisioning, media
 ```
 
-**Status:** PARTIALLY IMPLEMENTED. The first retrofit slice landed the global
-credentials domain import surface, graph-backed credential components, an
-owner-bound assembly packet manager, and a `CredentialCase` bridge behind the
-existing disposition protocol. Phase 5 now materializes sampled offers into an
-authoritative packet manager at setup and case-advance boundaries, and persists
-the hosted game through the normal constructor-form graph path. Phase 6a landed the
-pure credential-token facet bridge, and Phase 6b landed its first consumer:
-`CredentialsGameHandler` derives the existing `request_document` move from the exact
-`choice / giver / request_document` facet on a manager-backed document. The handler
-remains the choice and resolution authority; flat cases remain a temporary fallback.
-Phase 6c landed the corrected catalog authority: generic authored definitions and open
-origin/indication ids compile into named, bounded token catalogs exposed by the bound
-world. A scenario type selects one world-local catalog, and packet materialization
-searches only that catalog rather than a game-owned world namespace or the global
-Singleton population. Qualified definition labels remain an internal persistence detail.
-Phase 6d landed as the real Hall Monitor conformance vertical: a bespoke scenario type
-selects the school catalog, a script-configured shift narrows it to one scenario
-instance, and generated plus pinned student encounters reuse the same logical packet,
-disposition, handler, and persistence path under a school-specific projection.
-Phase 6e then proves the same authority boundary inside one compiled world: distinct
-border and school scenario types each select their own local catalog, policy, and
-presentation while sharing the credentials game and handler lifecycle. Phase 7
-completed the authority cutover: every runtime `CredentialCase` now requires one
-owner-bound assembly packet manager; offer materialization creates it directly with
-the selected catalog; and the flat case fields, packet protocol, game-layer manager,
-and enum compatibility module are gone. Gate and Hall Monitor retain their authored
-wording as narrative overrides on ordinary offers. Phase 8 adds transient,
-normalized `CredentialDefect` observations: the shared domain owns their vocabulary,
-the credentials game derives them from the manager plus mediated findings, and the
-three checkpoint dispositions fold that one result. Renderers consume those defects
-rather than independently interpreting document status.
-Expression narrative beyond that first skin seam, contraband graph identity, and
-document-identity receipts remain future slices.
+**Status:** LANDED RETROFIT RECORD. The current credential assembly, projection,
+media, and game-facing contract is summarized in `CREDENTIAL_MECHANIC.md`. This
+document preserves the reasoning and implementation sequence that produced it;
+prospective wording inside completed phase sections is historical unless the
+section explicitly names a remaining extension.
+
+The cutover now requires every runtime `CredentialCase` to own one graph-backed
+`CredentialPacketManager`. World-local catalogs and scenario types narrow the
+available definitions and policy; facet-backed moves, normalized
+`CredentialDefect` observations, presentation-safe text/card projections,
+presence-bound portraits, and JOURNAL media association all consume that same
+packet state. The flat case fields, packet protocol, game-layer manager, and
+enum compatibility module described by early phases are retired.
+
+Remaining extensions include richer response/consequence loops, cross-encounter
+custody and malfeasance, advanced presence-degradation mediation, and broader
+authored media alternatives. They are additions to the landed packet contract,
+not unfinished compatibility-cutover work.
 
 **Dependency:** the owner-bound manager and wardrobe transaction substrate provides the
 storage and offer semantics this retrofit relies on: `ComponentManager` stores
@@ -402,8 +387,8 @@ Acceptance:
 **Superseded by Phase 7.** The temporary optional-manager/flat-field bridge below
 is retained only as implementation history.
 
-Status: landed. `CredentialCase` can carry the new manager while retaining flat fields
-as compatibility inputs.
+Historical status: this bridge landed and was then removed by Phase 7. Current
+`CredentialCase` instances require the manager and have no flat compatibility inputs.
 
 Recommended temporary shape:
 
@@ -433,13 +418,13 @@ Acceptance:
 **Superseded by Phase 7.** Arrival materialization now creates the manager directly;
 there is no value-shaped case to convert or clear.
 
-Status: landed for sampled offers. Factory generation remains value-based and
-deterministic. A hosted game materializes its arriving offer into graph credential
-components and an owner-bound packet manager during setup or case advance; planning
-only reads that prepared manager. The source case clears its flat packet fields once
-the manager becomes authoritative. `HasGame.game_state` now persists through the
-normal `unstructure()` / `structure()` path, so the embedded manager and its component
-references survive graph restore.
+Historical status: this setup/update staging rule was superseded by the normal
+one-step-ahead VM frontier contract. Current setup prepares the active graph-owned
+case; the credentials PLANNING presentation hook prepares the current and sequential
+successor cases before their choices are shown. Inspection and JOURNAL rendering read
+that prepared state without materializing it. `HasGame.game_state` persists through
+the normal `unstructure()` / `structure()` path, so the embedded manager and its
+component references survive graph restore.
 
 Keep `build_valid()` and `degrade()` value-based initially. Convert their output into
 an owned packet manager at the committed case-arrival boundary, then migrate game-loop
@@ -451,8 +436,8 @@ Important rule: generation remains "start correct, then degrade."
 Acceptance:
 
 - sampled offers still materialize to their target disposition;
-- graph components are created and registered during setup or UPDATE, never on the
-  first PLANNING read;
+- graph components are prepared by setup or the explicit one-step-ahead PLANNING
+  presentation hook, never by inspection or JOURNAL rendering;
 - failure modes mutate credential components or packet membership, not parallel flat
   lists once the owned manager becomes authoritative;
 - narrative rendering reads packet/credential components through projection helpers.

--- a/engine/src/tangl/mechanics/presence/PRESENCE_ASSEMBLY_DESIGN.md
+++ b/engine/src/tangl/mechanics/presence/PRESENCE_ASSEMBLY_DESIGN.md
@@ -7,13 +7,14 @@
 :related: media, open_link, credentials, token
 ```
 
-**Status:** DESIGN + FIRST IMPLEMENTATION SLICE. The question is how to avoid a family
-of parallel systems that all look like "components attached to a body/vehicle/entity,
-with slots, visibility, constraints, and projections."
+**Status:** IMPLEMENTED FOUNDATION + ACTIVE GENERALIZATION. Outfit and wardrobe
+managers use the shared owner-bound assembly path; presence text and portrait
+projections are active consumers, including credential-card composition. Ornament
+coverage and the broader body-attachment unification remain open design work.
 
-> Issue tracking: see the "Presence / body-attachment unification" issue and the
-> assembly-core issues (#131 umbrella → #194/#195/#196). This doc holds the *what
-> and why*; the issues hold the *where-next*.
+> Current issue tracking: #283. The earlier assembly issues #131 and
+> #194/#195/#196 are closed implementation history. This doc holds the *what and
+> why*; the open issue holds the remaining where-next.
 
 ## Implementation status
 

--- a/engine/src/tangl/vm/VM_DESIGN.md
+++ b/engine/src/tangl/vm/VM_DESIGN.md
@@ -95,9 +95,9 @@ redirect, in which case `follow_edge` loops from the top on the new target):
 | Phase | Role | Aggregation |
 |-------|------|-------------|
 | VALIDATE | Is this movement legal? Gate on all-true. | all_true |
-| PLANNING | Provision this node's frontier dependencies. | gather |
+| PLANNING | Provision this node's frontier dependencies. | in-place; returns `None` |
 | PREREQS | Auto-redirect? Container descent? | first_result → edge |
-| UPDATE | Mutate state for arrival. | gather |
+| UPDATE | Mutate state for arrival. | in-place; returns `None` |
 | JOURNAL | Emit content fragments. | merge (all contributions) |
 | FINALIZE | Commit step record, emit patch. | last_result → patch |
 | POSTREQS | Continuation redirect? | first_result → edge |
@@ -390,8 +390,9 @@ the VM dispatch surface.
 
 **Aggregation modes match phase semantics.** PREREQS and POSTREQS use `first_result`
 (first redirect wins, subsequent handlers skipped). VALIDATE uses `all_true` (all
-handlers must pass). JOURNAL uses merge (all handler contributions combined). UPDATE and
-PLANNING use gather (all results collected). These are not arbitrary choices — they
+handlers must pass). JOURNAL uses merge (all handler contributions combined). PLANNING
+and UPDATE execute all matching handlers but require `None` returns; their
+effects are committed in place. These are not arbitrary choices — they
 follow from what each phase does.
 
 **Domain subphases use the same dispatch hygiene.** When a mechanics or story package

--- a/engine/src/tangl/vm/VM_DESIGN.md
+++ b/engine/src/tangl/vm/VM_DESIGN.md
@@ -752,8 +752,10 @@ call, not a hook invocation.
 Every source of non-determinism in the VM is either eliminated or seeded:
 
 - `random` is seeded from `hashing_func(graph.value_hash(), cursor.uid, step_base)`
-- Offer selection is deterministic given a fixed offer list (no tie-breaking by insertion
-  order in the current implementation — priority + distance give a total order)
+- Offer selection is deterministic given a fixed offer list. The canonical
+  `offer_sort_key()` ends with the offer creation sequence, which provides a
+  stable final tie-break after policy, scope, caller distance, exact-kind,
+  specificity, and priority ranking.
 - Namespace assembly is deterministic (ancestor chain is a tree, traversal order is fixed)
 
 Replay works by re-running `resolve_choice` with the same sequence of chosen edges

--- a/engine/src/tangl/vm/provision/SCOPE_MATCHING_DESIGN.md
+++ b/engine/src/tangl/vm/provision/SCOPE_MATCHING_DESIGN.md
@@ -336,11 +336,16 @@ def offer_sort_key(offer):
         policy_tier(offer.policy),
         offer.scope_distance,           # prefer closer scope matches
         offer.distance_from_caller,     # then closer graph proximity
+        0 if offer.exact_kind_match else 1,
         -offer.specificity,
         offer.priority,
         offer.seq,
     )
 ```
+
+The executable and canonical full ranking contract is
+`tangl.vm.provision.matching.offer_sort_key()`. This excerpt shows where scope
+affinity participates in that key.
 
 `TemplateProvisioner` computes admission + distance during offer
 generation. Offers that fail admission are not emitted. Offers for

--- a/engine/src/tangl/vm/runtime/frame.py
+++ b/engine/src/tangl/vm/runtime/frame.py
@@ -22,9 +22,9 @@ current pipeline.
 The pipeline phases in causal order:
 
 - **VALIDATE** — is the movement legal? (all_true)
-- **PLANNING** — provision this node + frontier for availability (gather)
+- **PLANNING** — provision this node + frontier in place (handlers return `None`)
 - **PREREQS** — auto-redirect? container descent? (first_result → edge)
-- **UPDATE** — mutate state for arrival (gather)
+- **UPDATE** — mutate state for arrival in place (handlers return `None`)
 - **JOURNAL** — emit content fragments (merge all handler contributions)
 - **FINALIZE** — commit step record, emit patch (last_result → patch)
 - **POSTREQS** — continuation redirect? (first_result → edge)

--- a/settings.toml
+++ b/settings.toml
@@ -6,7 +6,7 @@ persistence =   "native_in_mem"
 [service.paths]
 worlds      = [ "@path ./worlds/" ]
 client_dist =   "@path ./client/dist/"
-story_media =   "@path ./data/media/"
+story_media =   "@path ./tmp/media/"
 docs        =   "@path ./docs/_build/"
-user_data   =   "@path ./data/user/"
-cache_data  =   "@path ./data/tmp/"
+user_data   =   "@path ./tmp/user/"
+cache_data  =   "@path ./tmp/cache/"


### PR DESCRIPTION
## Summary

- replace the stale fixed-cost provisioning guide with the live one-step-ahead VM contract
- mark transition-era planning and core38/vm38 audit material as historical and label API links accordingly
- reconcile credentials, assembly, and presence status notes with the landed implementation
- make the journal compose contract the canonical `journal` devref result
- update FastAPI example metadata to the supported `examples=` form

## Why

The substantive documentation convergence slices are complete, but the final public surface still mixed current contracts with migration-era notes. In particular, planning documentation advertised retired provisioners, fixed costs, and phase-level planning receipts, while devref ranked incidental documents above the live provisioning and journal contracts.

## Validation

- `poetry run pytest docs/tests/test_sphinx_build.py engine/tests/devref apps/server/tests -q` — 80 passed, 1 skipped
- `poetry run pytest engine/tests/vm -q` — 477 passed
- `poetry run python scripts/audit_cutover_edges.py --mode post-swap --enforce --json-out tmp/cutover_audit_367.json`
- `poetry run tangl-devref build --full`
- `git diff --check`
- local CodeRabbit review against merge base `335de891f97f3216a812caa717fd4be1526d4dc6`

Closes #367.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated API reference examples for clearer, current endpoint documentation.
  - Replaced provisioning guidance with the current runtime contract, including offer ordering, planning, materialization, and persistence behavior.
  - Marked retired designs and audit notes as historical, with links to authoritative documentation.
  - Clarified implemented capabilities and remaining extensions across assembly, credentials, and presence systems.
  - Updated VM documentation to describe in-place planning and update phases.
  - Improved labels for related historical references throughout the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->